### PR TITLE
Adds GROUP BY clause to SelectOptions

### DIFF
--- a/orville.cabal
+++ b/orville.cabal
@@ -37,6 +37,7 @@ library
                      Database.Orville.Internal.FieldUpdate,
                      Database.Orville.Internal.FromClause,
                      Database.Orville.Internal.FromSql,
+                     Database.Orville.Internal.GroupBy,
                      Database.Orville.Internal.IndexDefinition,
                      Database.Orville.Internal.MigrateConstraint,
                      Database.Orville.Internal.MigrateIndex,

--- a/src/Database/Orville/Conduit.hs
+++ b/src/Database/Orville/Conduit.hs
@@ -75,5 +75,5 @@ feedRows builder query = do
   case runFromSql builder <$> row of
      Nothing -> pure ()
      Just (Left _) -> pure ()
-     Just (Right row) -> yield row >> feedRows builder query
+     Just (Right r) -> yield r >> feedRows builder query
 

--- a/src/Database/Orville/Core.hs
+++ b/src/Database/Orville/Core.hs
@@ -54,7 +54,7 @@ module Database.Orville.Core
   , (.==), (.<>), (.<-), (%==), (.>), (.>=), (.<), (.<=)
 
   , SelectOptions(..)
-  , where_, order, limit, offset, group, selectOptClause, selectOptValues
+  , where_, order, limit, offset, groupBy
   , (<>)
 
   , FieldUpdate(..)

--- a/src/Database/Orville/Core.hs
+++ b/src/Database/Orville/Core.hs
@@ -80,7 +80,6 @@ import            Control.Monad.Except
 import            Control.Monad.Reader
 import            Control.Monad.State
 import            Data.Convertible
-import qualified  Data.List as List
 import            Data.Maybe (listToMaybe)
 import qualified  Data.Map.Strict as Map
 import            Data.Monoid
@@ -92,7 +91,7 @@ import            Database.Orville.Internal.Execute
 import            Database.Orville.Internal.FieldDefinition
 import            Database.Orville.Internal.FieldUpdate
 import            Database.Orville.Internal.FromSql
-import            Database.Orville.Internal.GroupBy
+import            Database.Orville.Internal.GroupBy()
 import            Database.Orville.Internal.IndexDefinition
 import            Database.Orville.Internal.Monad
 import            Database.Orville.Internal.MigrateSchema

--- a/src/Database/Orville/Core.hs
+++ b/src/Database/Orville/Core.hs
@@ -54,7 +54,7 @@ module Database.Orville.Core
   , (.==), (.<>), (.<-), (%==), (.>), (.>=), (.<), (.<=)
 
   , SelectOptions(..)
-  , where_, order, limit, offset
+  , where_, order, limit, offset, group, selectOptClause
   , (<>)
 
   , FieldUpdate(..)
@@ -92,6 +92,7 @@ import            Database.Orville.Internal.Execute
 import            Database.Orville.Internal.FieldDefinition
 import            Database.Orville.Internal.FieldUpdate
 import            Database.Orville.Internal.FromSql
+import            Database.Orville.Internal.GroupBy
 import            Database.Orville.Internal.IndexDefinition
 import            Database.Orville.Internal.Monad
 import            Database.Orville.Internal.MigrateSchema

--- a/src/Database/Orville/Core.hs
+++ b/src/Database/Orville/Core.hs
@@ -54,7 +54,7 @@ module Database.Orville.Core
   , (.==), (.<>), (.<-), (%==), (.>), (.>=), (.<), (.<=)
 
   , SelectOptions(..)
-  , where_, order, limit, offset, group, selectOptClause
+  , where_, order, limit, offset, group, selectOptClause, selectOptValues
   , (<>)
 
   , FieldUpdate(..)

--- a/src/Database/Orville/Internal/GroupBy.hs
+++ b/src/Database/Orville/Internal/GroupBy.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE FlexibleInstances #-}
+module Database.Orville.Internal.GroupBy where
+
+import            Database.HDBC
+
+import            Database.Orville.Internal.FieldDefinition
+import            Database.Orville.Internal.Types
+import            Database.Orville.Internal.QueryKey
+
+data GroupByClause = GroupByClause String
+                                   [SqlValue]
+
+instance QueryKeyable GroupByClause where
+  queryKey (GroupByClause sql vals) =
+    QKList [QKField sql, queryKey vals]
+
+groupingSql :: GroupByClause -> String
+groupingSql (GroupByClause sql _) =
+  sql ++ " "
+
+groupingValues :: GroupByClause -> [SqlValue]
+groupingValues (GroupByClause _ values) =
+  values
+
+class ToGroupBy a where
+  toGroupBy :: a -> GroupByClause
+
+instance ToGroupBy FieldDefinition where
+  toGroupBy fieldDef = GroupByClause (fieldName fieldDef) []
+
+instance ToGroupBy (String, [SqlValue]) where
+  toGroupBy (sql, values) = GroupByClause sql values
+

--- a/src/Database/Orville/Internal/MigrateSchema.hs
+++ b/src/Database/Orville/Internal/MigrateSchema.hs
@@ -57,7 +57,7 @@ migrateSchema schemaDef =
           when (not $ constraintName constraintDef `elem` constraints)
                (createConstraint conn constraintDef)
 
-        DropConstraint tableName name ->
+        DropConstraint tablName name ->
           when (name `elem` constraints)
-               (dropConstraint conn tableName name)
+               (dropConstraint conn tablName name)
 

--- a/src/Database/Orville/Internal/QueryCache.hs
+++ b/src/Database/Orville/Internal/QueryCache.hs
@@ -16,7 +16,6 @@ import            Control.Monad.Catch (MonadThrow)
 import            Control.Monad.Trans
 import            Control.Monad.Trans.State
 import            Data.Convertible
-import qualified  Data.List as List
 import qualified  Data.Map as Map
 import qualified  Data.Map.Helpers as Map
 import            Data.Maybe
@@ -29,12 +28,10 @@ import            Database.Orville.Internal.FromSql
 import            Database.Orville.Internal.Monad
 import            Database.Orville.Internal.QueryKey
 import            Database.Orville.Internal.SelectOptions
-import            Database.Orville.Internal.Sql
 import            Database.Orville.Internal.TableDefinition
 import            Database.Orville.Internal.Types
 import            Database.Orville.Internal.Where
 import            Database.Orville.Select
-import            Database.Orville.Raw
 
 type QueryCache = Map.Map QueryKey ResultSet
 

--- a/src/Database/Orville/Internal/Select.hs
+++ b/src/Database/Orville/Internal/Select.hs
@@ -8,6 +8,8 @@ import            Database.Orville.Internal.Expr
 import            Database.Orville.Internal.FromClause
 import            Database.Orville.Internal.SelectOptions
 import            Database.Orville.Internal.Types
+import            Database.Orville.Internal.FieldDefinition (fieldName)
+
 
 data Select row = Select
   { selectBuilder :: FromSql row
@@ -54,3 +56,9 @@ rowFromSql = FromSql
   , runFromSql = Right <$> ask
   }
 
+selectField :: FieldDefinition -> SelectForm
+selectField field = selectColumn (NameForm (fieldName field))
+
+selectFieldAs :: FieldDefinition -> String -> SelectForm
+selectFieldAs field alias = aliased selForm (NameForm alias)
+  where selForm = selectField field

--- a/src/Database/Orville/Internal/Select.hs
+++ b/src/Database/Orville/Internal/Select.hs
@@ -62,3 +62,6 @@ selectField field = selectColumn (NameForm (fieldName field))
 selectFieldAs :: FieldDefinition -> String -> SelectForm
 selectFieldAs field alias = aliased selForm (NameForm alias)
   where selForm = selectField field
+
+selectCustomValue :: String -> SelectForm
+selectCustomValue s = selectColumn (NameForm s)

--- a/src/Database/Orville/Internal/Select.hs
+++ b/src/Database/Orville/Internal/Select.hs
@@ -58,10 +58,3 @@ rowFromSql = FromSql
 
 selectField :: FieldDefinition -> SelectForm
 selectField field = selectColumn (NameForm (fieldName field))
-
-selectFieldAs :: FieldDefinition -> String -> SelectForm
-selectFieldAs field alias = aliased selForm (NameForm alias)
-  where selForm = selectField field
-
-selectCustomValue :: String -> SelectForm
-selectCustomValue s = selectColumn (NameForm s)

--- a/src/Database/Orville/Internal/SelectOptions.hs
+++ b/src/Database/Orville/Internal/SelectOptions.hs
@@ -121,8 +121,8 @@ offset n = SelectOptions mempty
                          (First $ Just n)
                          mempty
 
-group :: ToGroupBy a => a -> SelectOptions
-group groupable = SelectOptions mempty
+groupBy :: ToGroupBy a => a -> SelectOptions
+groupBy groupable = SelectOptions mempty
                                 mempty
                                 mempty
                                 mempty

--- a/src/Database/Orville/Popper.hs
+++ b/src/Database/Orville/Popper.hs
@@ -44,7 +44,6 @@ import qualified  Data.Map.Strict as Map
 import            Data.Maybe
 
 import            Database.Orville.Core
-import            Database.Orville.Internal.FieldDefinition (fieldName)
 import            Database.Orville.Internal.QueryCache
 
 -- Simple helpers and such that make the public API

--- a/src/Database/Orville/Select.hs
+++ b/src/Database/Orville/Select.hs
@@ -20,7 +20,7 @@ module Database.Orville.Select
 import            Control.Monad (void)
 import            Database.HDBC
 
-import            Database.Orville.Internal.ColumnName
+import            Database.Orville.Internal.ColumnName()
 import            Database.Orville.Internal.Execute
 import            Database.Orville.Internal.FromClause
 import            Database.Orville.Internal.FromSql

--- a/src/Database/Orville/Select.hs
+++ b/src/Database/Orville/Select.hs
@@ -8,8 +8,6 @@ module Database.Orville.Select
   , selectQueryRawRows
   , selectQueryColumns
   , selectField
-  , selectFieldAs
-  , selectCustomValue
 
   , FromClause
   , fromClauseRaw

--- a/src/Database/Orville/Select.hs
+++ b/src/Database/Orville/Select.hs
@@ -7,6 +7,8 @@ module Database.Orville.Select
   , selectQueryRaw
   , selectQueryRawRows
   , selectQueryColumns
+  , selectField
+  , selectFieldAs
 
   , FromClause
   , fromClauseRaw

--- a/src/Database/Orville/Select.hs
+++ b/src/Database/Orville/Select.hs
@@ -9,6 +9,7 @@ module Database.Orville.Select
   , selectQueryColumns
   , selectField
   , selectFieldAs
+  , selectCustomValue
 
   , FromClause
   , fromClauseRaw


### PR DESCRIPTION
In order to use the SelectOptions for WHERE I had to add GROUP BY to preserve the expected clause sequence

It's a little dodgy because you can (a la ORDER BY) miss columns in the select and you wont know until run-time, but I felt it was better to stick to the `SelectOption` type in schmods rather than reproducing the various elements separate/ly.

The dodgiest bit is probably exposing the SQL String helpers to public.  Felt that joining custom select columns with SelectOptions was easiest done at the SQL String level.