### PR TITLE
[ch9934] Adds `OccuredAt` Time.UTCTime type alias for new Notes time

### DIFF
--- a/src/Database/Orville/Core.hs
+++ b/src/Database/Orville/Core.hs
@@ -43,6 +43,7 @@ module Database.Orville.Core
   , Record
   , CreatedAt
   , UpdatedAt
+  , OccurredAt
 
   , TableComments
   , noComments, say

--- a/src/Database/Orville/Internal/Types.hs
+++ b/src/Database/Orville/Internal/Types.hs
@@ -19,6 +19,7 @@ import            Database.Orville.Internal.QueryKey
 type Record = Int
 type CreatedAt = Time.UTCTime
 type UpdatedAt = Time.UTCTime
+type OccurredAt = Time.UTCTime
 
 data ColumnType =
     AutomaticId


### PR DESCRIPTION
Becomes one of three Time typedefs, along with `CreatedAt` (original) and `UpdatedAt` (added by me for a Leg change sometime back).  

Begs the question about whether we should continue extending Time semantically in Orville.  On the other hand, each of these has a quite distinct meaning.