### PR TITLE
Beginnings of Haddock and using gh-pages to host

### DIFF
--- a/src/Data/Map/Helpers.hs
+++ b/src/Data/Map/Helpers.hs
@@ -1,3 +1,9 @@
+{-|
+Module    : Data.Map.Helpers
+Copyright : Fliptsone Technology Partners 2016-2018
+License   : MIT
+-}
+
 module Data.Map.Helpers
   ( groupBy
   , groupBy'
@@ -13,4 +19,3 @@ groupBy' :: Ord k => (a -> (k,v)) -> [a] -> Map.Map k [v]
 groupBy' mkEntry as = Map.fromListWith (++) (map mkListEntry as)
   where mkListEntry a = let (k,v) = mkEntry a
                         in (k, [v])
-

--- a/src/Database/Orville.hs
+++ b/src/Database/Orville.hs
@@ -1,3 +1,9 @@
+{-|
+Module    : Database.Orville
+Copyright : Fliptsone Technology Partners 2016-2018
+License   : MIT
+-}
+
 module Database.Orville
   ( module Database.Orville.Core
   , module Database.Orville.Popper
@@ -7,4 +13,3 @@ module Database.Orville
 import            Database.Orville.Core
 import            Database.Orville.Popper
 import            Database.Orville.Tracked
-

--- a/src/Database/Orville/Conduit.hs
+++ b/src/Database/Orville/Conduit.hs
@@ -1,3 +1,9 @@
+{-|
+Module    : Database.Orville.Conduit
+Copyright : Fliptsone Technology Partners 2016-2018
+License   : MIT
+-}
+
 module Database.Orville.Conduit
   ( selectConduit
   ) where
@@ -76,4 +82,3 @@ feedRows builder query = do
      Nothing -> pure ()
      Just (Left _) -> pure ()
      Just (Right r) -> yield r >> feedRows builder query
-

--- a/src/Database/Orville/Core.hs
+++ b/src/Database/Orville/Core.hs
@@ -1,3 +1,9 @@
+{-|
+Module    : Database.Orville.Core
+Copyright : Fliptsone Technology Partners 2016-2018
+License   : MIT
+-}
+
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}
 module Database.Orville.Core
@@ -256,4 +262,3 @@ deleteRecord tableDef record = do
     then error $ "Expected to delete exactly 1 row for deleteRecord\
                  \but actually deleted" ++ show n
     else pure ()
-

--- a/src/Database/Orville/Expr.hs
+++ b/src/Database/Orville/Expr.hs
@@ -1,3 +1,9 @@
+{-|
+Module    : Database.Orville.Expr
+Copyright : Fliptsone Technology Partners 2016-2018
+License   : MIT
+-}
+
 module Database.Orville.Expr
   ( RawExpr
   , rawSql

--- a/src/Database/Orville/Internal/ConstraintDefinition.hs
+++ b/src/Database/Orville/Internal/ConstraintDefinition.hs
@@ -1,3 +1,9 @@
+{-|
+Module    : Database.Orville.Internal.ContraintDefinition
+Copyright : Fliptsone Technology Partners 2016-2018
+License   : MIT
+-}
+
 module Database.Orville.Internal.ConstraintDefinition
   ( uniqueConstraint
   , dropConstraint
@@ -18,4 +24,3 @@ uniqueConstraint name tableDef fields =
 
 dropConstraint :: TableDefinition entity -> String -> SchemaItem
 dropConstraint tableDef = DropConstraint (tableName tableDef)
-

--- a/src/Database/Orville/Internal/Execute.hs
+++ b/src/Database/Orville/Internal/Execute.hs
@@ -1,3 +1,9 @@
+{-|
+Module    : Database.Orville.Internal.Execute
+Copyright : Fliptsone Technology Partners 2016-2018
+License   : MIT
+-}
+
 module Database.Orville.Internal.Execute where
 
 import            Control.Monad.IO.Class
@@ -20,4 +26,3 @@ catchSqlErr sql action =
                                             (seNativeError e)
                                             (seErrorMsg e ++ " SQL: " ++ sql)
                   in throwSqlError updatedErr)
-

--- a/src/Database/Orville/Internal/Expr.hs
+++ b/src/Database/Orville/Internal/Expr.hs
@@ -1,3 +1,9 @@
+{-|
+Module    : Database.Orville.Internal.Expr
+Copyright : Fliptsone Technology Partners 2016-2018
+License   : MIT
+-}
+
 module Database.Orville.Internal.Expr
   ( module Database.Orville.Internal.Expr.Expr
   , module Database.Orville.Internal.Expr.NameExpr

--- a/src/Database/Orville/Internal/Expr/Expr.hs
+++ b/src/Database/Orville/Internal/Expr/Expr.hs
@@ -1,3 +1,9 @@
+{-|
+Module    : Database.Orville.Internal.Expr.Expr
+Copyright : Fliptsone Technology Partners 2016-2018
+License   : MIT
+-}
+
 module Database.Orville.Internal.Expr.Expr where
 
 import            Data.String
@@ -43,4 +49,3 @@ rawSqlExpr = Expr . Left . rawSql
 
 expr :: a -> Expr a
 expr = Expr . Right
-

--- a/src/Database/Orville/Internal/Expr/NameExpr.hs
+++ b/src/Database/Orville/Internal/Expr/NameExpr.hs
@@ -1,3 +1,9 @@
+{-|
+Module    : Database.Orville.Internal.Expr.NameExpr
+Copyright : Fliptsone Technology Partners 2016-2018
+License   : MIT
+-}
+
 {-# LANGUAGE OverloadedStrings #-}
 module Database.Orville.Internal.Expr.NameExpr where
 
@@ -16,4 +22,3 @@ instance GenerateSql NameForm where
 
 unescapedName :: NameForm -> String
 unescapedName (NameForm s) = s
-

--- a/src/Database/Orville/Internal/Expr/SelectExpr.hs
+++ b/src/Database/Orville/Internal/Expr/SelectExpr.hs
@@ -1,3 +1,9 @@
+{-|
+Module    : Database.Orville.Internal.Expr.SelectExpr
+Copyright : Fliptsone Technology Partners 2016-2018
+License   : MIT
+-}
+
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 module Database.Orville.Internal.Expr.SelectExpr where
@@ -41,4 +47,3 @@ qualification (Just name) = generateSql name <> "."
 asOutput :: Maybe NameForm -> RawExpr
 asOutput Nothing = mempty
 asOutput (Just name) = " AS " <> generateSql name
-

--- a/src/Database/Orville/Internal/FieldDefinition.hs
+++ b/src/Database/Orville/Internal/FieldDefinition.hs
@@ -1,3 +1,9 @@
+{-|
+Module    : Database.Orville.Internal.FieldDefintion
+Copyright : Fliptsone Technology Partners 2016-2018
+License   : MIT
+-}
+
 module Database.Orville.Internal.FieldDefinition where
 
 import            Database.Orville.Internal.Types
@@ -37,4 +43,3 @@ isUninsertedField (_, _, flags) = any isUninserted flags
 
 withPrefix :: FieldDefinition -> String -> FieldDefinition
 withPrefix f@(name, _, _) prefix = f `withName` (prefix ++ "_" ++ name)
-

--- a/src/Database/Orville/Internal/FieldUpdate.hs
+++ b/src/Database/Orville/Internal/FieldUpdate.hs
@@ -1,3 +1,9 @@
+{-|
+Module    : Database.Orville.Internal.FieldUpdate
+Copyright : Fliptsone Technology Partners 2016-2018
+License   : MIT
+-}
+
 {-# LANGUAGE FlexibleContexts #-}
 module Database.Orville.Internal.FieldUpdate where
 
@@ -16,4 +22,3 @@ fieldUpdate def = FieldUpdate def . convert
 
 fieldUpdateName :: FieldUpdate -> String
 fieldUpdateName = fieldName . fieldUpdateField
-

--- a/src/Database/Orville/Internal/FromClause.hs
+++ b/src/Database/Orville/Internal/FromClause.hs
@@ -1,3 +1,9 @@
+{-|
+Module    : Database.Orville.Internal.FromClause
+Copyright : Fliptsone Technology Partners 2016-2018
+License   : MIT
+-}
+
 module Database.Orville.Internal.FromClause where
 
 import            Database.Orville.Internal.Sql

--- a/src/Database/Orville/Internal/FromSql.hs
+++ b/src/Database/Orville/Internal/FromSql.hs
@@ -1,3 +1,9 @@
+{-|
+Module    : Database.Orville.Internal.FromSql
+Copyright : Fliptsone Technology Partners 2016-2018
+License   : MIT
+-}
+
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE RankNTypes #-}
@@ -73,4 +79,3 @@ decodeSqlRows builder rows =
         pure Nothing
 
       Left err -> throw err
-

--- a/src/Database/Orville/Internal/GroupBy.hs
+++ b/src/Database/Orville/Internal/GroupBy.hs
@@ -1,3 +1,9 @@
+{-|
+Module    : Database.Orville.Internal.GroupBy
+Copyright : Fliptsone Technology Partners 2016-2018
+License   : MIT
+-}
+
 {-# LANGUAGE FlexibleInstances #-}
 module Database.Orville.Internal.GroupBy where
 
@@ -30,4 +36,3 @@ instance ToGroupBy FieldDefinition where
 
 instance ToGroupBy (String, [SqlValue]) where
   toGroupBy (sql, values) = GroupByClause sql values
-

--- a/src/Database/Orville/Internal/IndexDefinition.hs
+++ b/src/Database/Orville/Internal/IndexDefinition.hs
@@ -1,3 +1,9 @@
+{-|
+Module    : Database.Orville.Internal.IndexDefinition
+Copyright : Fliptsone Technology Partners 2016-2018
+License   : MIT
+-}
+
 module Database.Orville.Internal.IndexDefinition
   ( uniqueIndex, simpleIndex
   ) where

--- a/src/Database/Orville/Internal/MigrateConstraint.hs
+++ b/src/Database/Orville/Internal/MigrateConstraint.hs
@@ -1,3 +1,9 @@
+{-|
+Module    : Database.Orville.Internal.MigrateConstraint
+Copyright : Fliptsone Technology Partners 2016-2018
+License   : MIT
+-}
+
 {-# LANGUAGE RecordWildCards #-}
 module Database.Orville.Internal.MigrateConstraint
   ( createConstraint
@@ -17,9 +23,9 @@ import            Database.Orville.Internal.Types
 createConstraint :: MonadOrville conn m => conn -> ConstraintDefinition -> m ()
 createConstraint conn (ConstraintDefinition {..}) = do
   let ddl = intercalate " " [ "ALTER TABLE"
-                            , "\"" ++ constraintTable ++ "\"" 
+                            , "\"" ++ constraintTable ++ "\""
                             , "ADD CONSTRAINT"
-                            , "\"" ++ constraintName ++ "\"" 
+                            , "\"" ++ constraintName ++ "\""
                             , constraintBody
                             ]
 
@@ -39,4 +45,3 @@ getConstraints conn = do
 
   void $ execute query []
   map (convert . head) <$> fetchAllRows' query
-

--- a/src/Database/Orville/Internal/MigrateIndex.hs
+++ b/src/Database/Orville/Internal/MigrateIndex.hs
@@ -1,3 +1,9 @@
+{-|
+Module    : Database.Orville.Internal.MigrateIndex
+Copyright : Fliptsone Technology Partners 2016-2018
+License   : MIT
+-}
+
 {-# LANGUAGE RecordWildCards #-}
 module Database.Orville.Internal.MigrateIndex
   ( createIndex
@@ -37,4 +43,3 @@ getIndexes conn = do
   query <- prepare conn "SELECT indexname FROM pg_indexes WHERE schemaname = 'public';"
   void $ execute query []
   map (convert . head) <$> fetchAllRows' query
-

--- a/src/Database/Orville/Internal/MigrateSchema.hs
+++ b/src/Database/Orville/Internal/MigrateSchema.hs
@@ -1,3 +1,9 @@
+{-|
+Module    : Database.Orville.Internal.MigrateSchema
+Copyright : Fliptsone Technology Partners 2016-2018
+License   : MIT
+-}
+
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE RankNTypes #-}
 module Database.Orville.Internal.MigrateSchema
@@ -125,4 +131,3 @@ data MigrationError =
   deriving (Data, Typeable, Show)
 
 instance Exception MigrationError
-

--- a/src/Database/Orville/Internal/MigrateTable.hs
+++ b/src/Database/Orville/Internal/MigrateTable.hs
@@ -1,3 +1,9 @@
+{-|
+Module    : Database.Orville.Internal.MigrateTable
+Copyright : Fliptsone Technology Partners 2016-2018
+License   : MIT
+-}
+
 {-# LANGUAGE ExistentialQuantification #-}
 module Database.Orville.Internal.MigrateTable
   ( createTable

--- a/src/Database/Orville/Internal/Monad.hs
+++ b/src/Database/Orville/Internal/Monad.hs
@@ -1,3 +1,9 @@
+{-|
+Module    : Database.Orville.Internal.Monad
+Copyright : Fliptsone Technology Partners 2016-2018
+License   : MIT
+-}
+
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
@@ -128,4 +134,3 @@ instance MonadBaseControl b m => MonadBaseControl b (OrvilleT conn m) where
   type StM (OrvilleT conn m) a = ComposeSt (OrvilleT conn) m a
   liftBaseWith = defaultLiftBaseWith
   restoreM = defaultRestoreM
-

--- a/src/Database/Orville/Internal/OrderBy.hs
+++ b/src/Database/Orville/Internal/OrderBy.hs
@@ -1,3 +1,9 @@
+{-|
+Module    : Database.Orville.Internal.OrderBy
+Copyright : Fliptsone Technology Partners 2016-2018
+License   : MIT
+-}
+
 {-# LANGUAGE FlexibleInstances #-}
 module Database.Orville.Internal.OrderBy where
 
@@ -43,4 +49,3 @@ instance ToOrderBy FieldDefinition where
 
 instance ToOrderBy (String, [SqlValue]) where
   toOrderBy (sql, values) = OrderByClause sql values
-

--- a/src/Database/Orville/Internal/QueryCache.hs
+++ b/src/Database/Orville/Internal/QueryCache.hs
@@ -1,3 +1,9 @@
+{-|
+Module    : Database.Orville.Internal.QueryCache
+Copyright : Fliptsone Technology Partners 2016-2018
+License   : MIT
+-}
+
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}
 module Database.Orville.Internal.QueryCache
@@ -123,5 +129,3 @@ findRecordsByCached tableDef field opts = do
 --
 unsafeLift :: Monad m => m a -> QueryCached m a
 unsafeLift = QueryCached . lift
-
-

--- a/src/Database/Orville/Internal/QueryKey.hs
+++ b/src/Database/Orville/Internal/QueryKey.hs
@@ -1,3 +1,9 @@
+{-|
+Module    : Database.Orville.Internal.QueryKey
+Copyright : Fliptsone Technology Partners 2016-2018
+License   : MIT
+-}
+
 module Database.Orville.Internal.QueryKey where
 
 import            Data.Monoid

--- a/src/Database/Orville/Internal/RelationalMap.hs
+++ b/src/Database/Orville/Internal/RelationalMap.hs
@@ -1,3 +1,9 @@
+{-|
+Module    : Database.Orville.Internal.RelationalMap
+Copyright : Fliptsone Technology Partners 2016-2018
+License   : MIT
+-}
+
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}

--- a/src/Database/Orville/Internal/Select.hs
+++ b/src/Database/Orville/Internal/Select.hs
@@ -1,3 +1,9 @@
+{-|
+Module    : Database.Orville.Internal.Select
+Copyright : Fliptsone Technology Partners 2016-2018
+License   : MIT
+-}
+
 module Database.Orville.Internal.Select where
 
 import            Control.Monad.Reader

--- a/src/Database/Orville/Internal/SelectOptions.hs
+++ b/src/Database/Orville/Internal/SelectOptions.hs
@@ -1,3 +1,9 @@
+{-|
+Module    : Database.Orville.Internal.SelectOptions
+Copyright : Fliptsone Technology Partners 2016-2018
+License   : MIT
+-}
+
 {-# LANGUAGE RecordWildCards #-}
 module Database.Orville.Internal.SelectOptions where
 

--- a/src/Database/Orville/Internal/Sql.hs
+++ b/src/Database/Orville/Internal/Sql.hs
@@ -1,3 +1,9 @@
+{-|
+Module    : Database.Orville.Internal.Sql
+Copyright : Fliptsone Technology Partners 2016-2018
+License   : MIT
+-}
+
 module Database.Orville.Internal.Sql where
 
 import qualified  Data.List as List

--- a/src/Database/Orville/Internal/TableDefinition.hs
+++ b/src/Database/Orville/Internal/TableDefinition.hs
@@ -1,3 +1,9 @@
+{-|
+Module    : Database.Orville.Internal.TableDefinition
+Copyright : Fliptsone Technology Partners 2016-2018
+License   : MIT
+-}
+
 module Database.Orville.Internal.TableDefinition where
 
 import qualified  Data.List as List
@@ -16,4 +22,3 @@ tablePrimaryKey tableDef =
   case List.find isPrimaryKeyField (tableFields tableDef) of
     Just field -> field
     Nothing -> error $ "No primary key defined for " ++ tableName tableDef
-

--- a/src/Database/Orville/Internal/Types.hs
+++ b/src/Database/Orville/Internal/Types.hs
@@ -1,3 +1,9 @@
+{-|
+Module    : Database.Orville.Internal.Types
+Copyright : Fliptsone Technology Partners 2016-2018
+License   : MIT
+-}
+
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleInstances #-}

--- a/src/Database/Orville/Internal/Where.hs
+++ b/src/Database/Orville/Internal/Where.hs
@@ -1,3 +1,9 @@
+{-|
+Module    : Database.Orville.Internal.Where
+Copyright : Fliptsone Technology Partners 2016-2018
+License   : MIT
+-}
+
 {-# LANGUAGE FlexibleContexts #-}
 module Database.Orville.Internal.Where where
 
@@ -126,4 +132,3 @@ whereClause conds = "WHERE " ++ whereConditionSql (whereAnd conds)
 
 whereValues :: [WhereCondition] -> [SqlValue]
 whereValues = List.concatMap whereConditionValues
-

--- a/src/Database/Orville/Popper.hs
+++ b/src/Database/Orville/Popper.hs
@@ -1,3 +1,9 @@
+{-|
+Module    : Database.Orville.Popper
+Copyright : Fliptsone Technology Partners 2016-2018
+License   : MIT
+-}
+
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
@@ -511,4 +517,3 @@ popCached (PopMaybe popper) a =
   case a of
     Nothing -> pure (PoppedValue Nothing)
     Just val -> fmap Just <$> popCached popper val
-

--- a/src/Database/Orville/PostgresSQL.hs
+++ b/src/Database/Orville/PostgresSQL.hs
@@ -1,3 +1,9 @@
+{-|
+Module    : Database.Orville.PostgresSQL
+Copyright : Fliptsone Technology Partners 2016-2018
+License   : MIT
+-}
+
 module Database.Orville.PostgresSQL
   ( createConnectionPool
   , Pool
@@ -20,4 +26,3 @@ createConnectionPool stripes linger maxRes connString =
              stripes
              linger
              maxRes
-

--- a/src/Database/Orville/Raw.hs
+++ b/src/Database/Orville/Raw.hs
@@ -1,3 +1,9 @@
+{-|
+Module    : Database.Orville.Raw
+Copyright : Fliptsone Technology Partners 2016-2018
+License   : MIT
+-}
+
 {-# LANGUAGE RankNTypes #-}
 module Database.Orville.Raw
   ( selectSql
@@ -67,4 +73,3 @@ withTransaction action =
                                     when (not finished) (rollback conn)
 
         doAction `finally` rollbackUncommitted
-

--- a/src/Database/Orville/Select.hs
+++ b/src/Database/Orville/Select.hs
@@ -1,3 +1,9 @@
+{-|
+Module    : Database.Orville.Select
+Copyright : Fliptsone Technology Partners 2016-2018
+License   : MIT
+-}
+
 {-# LANGUAGE RankNTypes #-}
 module Database.Orville.Select
   ( Select
@@ -40,4 +46,3 @@ runSelect select = do
     sql = selectSql select
     values = selectValues select
     builder = selectBuilder select
-

--- a/src/Database/Orville/Tracked.hs
+++ b/src/Database/Orville/Tracked.hs
@@ -1,3 +1,9 @@
+{-|
+Module    : Database.Orville.Tracked
+Copyright : Fliptsone Technology Partners 2016-2018
+License   : MIT
+-}
+
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE ExistentialQuantification #-}
@@ -192,4 +198,3 @@ instance (Monoid t, MonadOrville conn m) =>
   getOrvilleEnv = lift getOrvilleEnv
   localOrvilleEnv f  = mapTrackedOrville (localOrvilleEnv f)
   startTransactionSQL = lift startTransactionSQL
-

--- a/stack-gh-pages-haddock.sh
+++ b/stack-gh-pages-haddock.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Based on https://github.com/yamadapc/stack-gh-pages
+set -e
+
+stack haddock --haddock-hyperlink-source --no-haddock-deps
+
+version_number=`cat orville.cabal | grep "version:" | cut -d : -f 2 | cut -w -f 2 | head -n 1`
+docs=`stack path --local-doc-root`/orville-$version_number
+
+git stash
+git branch -D gh-pages
+git checkout --orphan gh-pages
+
+rm -rf *
+cp -r $docs/* .
+git add .
+git commit -m "Automated Haddock commit"
+git push -f -u origin gh-pages
+git checkout master


### PR DESCRIPTION
The change is _actually_ quite small, despite what the files changed looks like. 

- Adds a *very* basic Haddock module description block for each module
- Also adds a script to assist the automated generation of haddocks and a `gh-pages` branch containing said haddock

Notably, this does *not* document anything inside the modules other than what was already there or is picked up automatically (like type signatures).

I have not created the gh-pages branch for the main repo, but have for my fork. That way they could be reviewed before I just put them up under the company name. `Core` is a good example, I think https://telser.github.io/orville/Database-Orville-Core.html