### PR TITLE
Allows use of abitrary haskell types as primary keys

### DIFF
--- a/src/Database/Orville/Internal/ConstraintDefinition.hs
+++ b/src/Database/Orville/Internal/ConstraintDefinition.hs
@@ -16,15 +16,17 @@ import Database.Orville.Internal.Types
 uniqueConstraint ::
      String
   -> TableDefinition entity key
-  -> [FieldDefinition]
+  -> [SomeField]
   -> ConstraintDefinition
 uniqueConstraint name tableDef fields =
   ConstraintDefinition
     { constraintName = name
     , constraintTable = tableName tableDef
     , constraintBody =
-        "UNIQUE (" ++ intercalate "," (map escapedFieldName fields) ++ ")"
+        "UNIQUE (" ++ intercalate "," (map someEscapedFieldName fields) ++ ")"
     }
+  where
+    someEscapedFieldName (SomeField f) = escapedFieldName f
 
 dropConstraint :: TableDefinition entity key -> String -> SchemaItem
 dropConstraint tableDef = DropConstraint (tableName tableDef)

--- a/src/Database/Orville/Internal/ConstraintDefinition.hs
+++ b/src/Database/Orville/Internal/ConstraintDefinition.hs
@@ -15,7 +15,7 @@ import Database.Orville.Internal.Types
 
 uniqueConstraint ::
      String
-  -> TableDefinition entity
+  -> TableDefinition entity key
   -> [FieldDefinition]
   -> ConstraintDefinition
 uniqueConstraint name tableDef fields =
@@ -26,5 +26,5 @@ uniqueConstraint name tableDef fields =
         "UNIQUE (" ++ intercalate "," (map escapedFieldName fields) ++ ")"
     }
 
-dropConstraint :: TableDefinition entity -> String -> SchemaItem
+dropConstraint :: TableDefinition entity key -> String -> SchemaItem
 dropConstraint tableDef = DropConstraint (tableName tableDef)

--- a/src/Database/Orville/Internal/FieldUpdate.hs
+++ b/src/Database/Orville/Internal/FieldUpdate.hs
@@ -7,17 +7,17 @@ License   : MIT
 
 module Database.Orville.Internal.FieldUpdate where
 
-import Data.Convertible
-import Database.HDBC
-
 import Database.Orville.Internal.FieldDefinition
 import Database.Orville.Internal.Types
 
-fieldUpdate :: Convertible a SqlValue => FieldDefinition -> a -> FieldUpdate
-fieldUpdate def = FieldUpdate def . convert
+fieldUpdate :: FieldDefinition a -> a -> FieldUpdate
+fieldUpdate fieldDef a =
+  FieldUpdate (SomeField fieldDef) (fieldToSqlValue fieldDef a)
 
-(.:=) :: Convertible a SqlValue => FieldDefinition -> a -> FieldUpdate
+(.:=) :: FieldDefinition a -> a -> FieldUpdate
 (.:=) = fieldUpdate
 
 fieldUpdateName :: FieldUpdate -> String
-fieldUpdateName = fieldName . fieldUpdateField
+fieldUpdateName = someFieldName . fieldUpdateField
+  where
+    someFieldName (SomeField f) = fieldName f

--- a/src/Database/Orville/Internal/FromClause.hs
+++ b/src/Database/Orville/Internal/FromClause.hs
@@ -17,7 +17,7 @@ fromClauseRaw = FromClause
 fromClauseTableName :: String -> FromClause
 fromClauseTableName name = fromClauseRaw ("FROM " ++ escapedName name)
 
-fromClauseTable :: TableDefinition entity -> FromClause
+fromClauseTable :: TableDefinition entity key -> FromClause
 fromClauseTable = fromClauseTableName . tableName
 
 fromClauseToSql :: FromClause -> String

--- a/src/Database/Orville/Internal/GroupBy.hs
+++ b/src/Database/Orville/Internal/GroupBy.hs
@@ -29,7 +29,7 @@ groupingValues (GroupByClause _ values) = values
 class ToGroupBy a where
   toGroupBy :: a -> GroupByClause
 
-instance ToGroupBy FieldDefinition where
+instance ToGroupBy (FieldDefinition a) where
   toGroupBy fieldDef = GroupByClause (fieldName fieldDef) []
 
 instance ToGroupBy (String, [SqlValue]) where

--- a/src/Database/Orville/Internal/IndexDefinition.hs
+++ b/src/Database/Orville/Internal/IndexDefinition.hs
@@ -14,7 +14,10 @@ import Database.Orville.Internal.FieldDefinition
 import Database.Orville.Internal.Types
 
 uniqueIndex ::
-     String -> TableDefinition entity -> [FieldDefinition] -> IndexDefinition
+     String
+  -> TableDefinition entity key
+  -> [FieldDefinition]
+  -> IndexDefinition
 uniqueIndex name tableDef fields =
   IndexDefinition
     { indexName = name
@@ -24,7 +27,10 @@ uniqueIndex name tableDef fields =
     }
 
 simpleIndex ::
-     String -> TableDefinition entity -> [FieldDefinition] -> IndexDefinition
+     String
+  -> TableDefinition entity key
+  -> [FieldDefinition]
+  -> IndexDefinition
 simpleIndex name tableDef fields =
   IndexDefinition
     { indexName = name

--- a/src/Database/Orville/Internal/IndexDefinition.hs
+++ b/src/Database/Orville/Internal/IndexDefinition.hs
@@ -14,10 +14,7 @@ import Database.Orville.Internal.FieldDefinition
 import Database.Orville.Internal.Types
 
 uniqueIndex ::
-     String
-  -> TableDefinition entity key
-  -> [FieldDefinition]
-  -> IndexDefinition
+     String -> TableDefinition entity key -> [SomeField] -> IndexDefinition
 uniqueIndex name tableDef fields =
   IndexDefinition
     { indexName = name
@@ -27,10 +24,7 @@ uniqueIndex name tableDef fields =
     }
 
 simpleIndex ::
-     String
-  -> TableDefinition entity key
-  -> [FieldDefinition]
-  -> IndexDefinition
+     String -> TableDefinition entity key -> [SomeField] -> IndexDefinition
 simpleIndex name tableDef fields =
   IndexDefinition
     { indexName = name
@@ -39,6 +33,7 @@ simpleIndex name tableDef fields =
     , indexBody = indexFieldsBody fields
     }
 
-indexFieldsBody :: [FieldDefinition] -> String
-indexFieldsBody fields =
-  "(" ++ intercalate "," (map escapedFieldName fields) ++ ")"
+indexFieldsBody :: [SomeField] -> String
+indexFieldsBody fields = "(" ++ intercalate "," (map name fields) ++ ")"
+  where
+    name (SomeField field) = escapedFieldName field

--- a/src/Database/Orville/Internal/OrderBy.hs
+++ b/src/Database/Orville/Internal/OrderBy.hs
@@ -43,7 +43,7 @@ sortingValues (OrderByClause _ values _) = values
 class ToOrderBy a where
   toOrderBy :: a -> SortDirection -> OrderByClause
 
-instance ToOrderBy FieldDefinition where
+instance ToOrderBy (FieldDefinition a) where
   toOrderBy fieldDef = OrderByClause (fieldName fieldDef) []
 
 instance ToOrderBy (String, [SqlValue]) where

--- a/src/Database/Orville/Internal/Select.hs
+++ b/src/Database/Orville/Internal/Select.hs
@@ -43,7 +43,7 @@ selectQuery builder =
   selectQueryColumns (expr <$> fromSqlSelects builder) builder
 
 selectQueryTable ::
-     TableDefinition entity -> SelectOptions -> Select (entity Record)
+     TableDefinition entity key -> SelectOptions -> Select (entity key)
 selectQueryTable tbl = selectQuery (tableFromSql tbl) (fromClauseTable tbl)
 
 selectQueryRows ::

--- a/src/Database/Orville/Internal/Select.hs
+++ b/src/Database/Orville/Internal/Select.hs
@@ -70,5 +70,5 @@ rowFromSql =
     , runFromSql = Right <$> ask
     }
 
-selectField :: FieldDefinition -> SelectForm
+selectField :: FieldDefinition a -> SelectForm
 selectField field = selectColumn (NameForm (fieldName field))

--- a/src/Database/Orville/Internal/SqlConversion.hs
+++ b/src/Database/Orville/Internal/SqlConversion.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+module Database.Orville.Internal.SqlConversion
+  ( SqlConversion
+  , sqlConversion
+  , sqlConversionVia
+  , sqlConvertible
+  , convertToSql
+  , convertFromSql
+  , nullableConversion
+  ) where
+
+import Control.Monad ((<=<))
+import Data.Convertible
+
+import Database.HDBC
+
+data SqlConversion a = SqlConversion
+  { convertToSql :: a -> SqlValue
+  , convertFromSql :: SqlValue -> Maybe a
+  }
+
+sqlConversion :: (a -> SqlValue) -> (SqlValue -> Maybe a) -> SqlConversion a
+sqlConversion = SqlConversion
+
+nullableConversion :: SqlConversion a -> SqlConversion (Maybe a)
+nullableConversion aConversion = sqlConversion maybeToSql maybeFromSql
+  where
+    maybeToSql = maybe SqlNull (convertToSql aConversion)
+    maybeFromSql SqlNull = Just Nothing
+    maybeFromSql sql = Just <$> convertFromSql aConversion sql
+
+sqlConversionVia ::
+     (b -> a) -> (a -> Maybe b) -> SqlConversion a -> SqlConversion b
+sqlConversionVia bToA aToB aConversion =
+  sqlConversion
+    (convertToSql aConversion . bToA)
+    (aToB <=< convertFromSql aConversion)
+
+sqlConvertible ::
+     (Convertible a SqlValue, Convertible SqlValue a) => SqlConversion a
+sqlConvertible = sqlConversion convert safeConvertFromSql
+  where
+    safeConvertFromSql sql =
+      case safeConvert sql of
+        Right a -> Just a
+        Left _ -> Nothing

--- a/src/Database/Orville/Internal/TableDefinition.hs
+++ b/src/Database/Orville/Internal/TableDefinition.hs
@@ -10,14 +10,14 @@ import qualified Data.List as List
 import Database.Orville.Internal.FieldDefinition
 import Database.Orville.Internal.Types
 
-tableColumnNames :: TableDefinition entity -> [String]
+tableColumnNames :: TableDefinition entity key -> [String]
 tableColumnNames = map fieldName . tableFields
 
-insertableColumnNames :: TableDefinition entity -> [String]
+insertableColumnNames :: TableDefinition entity key -> [String]
 insertableColumnNames =
   map fieldName . filter (not . isUninsertedField) . tableFields
 
-tablePrimaryKey :: TableDefinition entity -> FieldDefinition
+tablePrimaryKey :: TableDefinition entity key -> FieldDefinition
 tablePrimaryKey tableDef =
   case List.find isPrimaryKeyField (tableFields tableDef) of
     Just field -> field

--- a/src/Database/Orville/Internal/TableDefinition.hs
+++ b/src/Database/Orville/Internal/TableDefinition.hs
@@ -5,20 +5,17 @@ License   : MIT
 -}
 module Database.Orville.Internal.TableDefinition where
 
-import qualified Data.List as List
-
 import Database.Orville.Internal.FieldDefinition
 import Database.Orville.Internal.Types
 
 tableColumnNames :: TableDefinition entity key -> [String]
-tableColumnNames = map fieldName . tableFields
+tableColumnNames = map someFieldName . tableFields
+  where
+    someFieldName (SomeField f) = fieldName f
 
 insertableColumnNames :: TableDefinition entity key -> [String]
 insertableColumnNames =
-  map fieldName . filter (not . isUninsertedField) . tableFields
-
-tablePrimaryKey :: TableDefinition entity key -> FieldDefinition
-tablePrimaryKey tableDef =
-  case List.find isPrimaryKeyField (tableFields tableDef) of
-    Just field -> field
-    Nothing -> error $ "No primary key defined for " ++ tableName tableDef
+  map someFieldName . filter (not . isSomeUninsertedField) . tableFields
+  where
+    isSomeUninsertedField (SomeField f) = isUninsertedField f
+    someFieldName (SomeField f) = fieldName f


### PR DESCRIPTION
This requires adding a type parameter to TableDefinition to capture the
primary key type, as well as conversion functions related to it.

Note that this is probably not actually all the useful with Poppers
unless a similar change is made to FieldDefinition to track the Haskell
type associated with the fields. I'll add that as another commit here.