### PR TITLE
Makes a first pass at new FieldDefinition construction

### DIFF
--- a/src/Database/Orville/Core.hs
+++ b/src/Database/Orville/Core.hs
@@ -41,6 +41,20 @@ module Database.Orville.Core
   , Now(..)
   , ColumnType(..)
   , FieldDefinition
+  , textField
+  , fixedTextField
+  , dayField
+  , utcTimeField
+  , int32Field
+  , int64Field
+  , doubleField
+  , boolField
+  , automaticIdField
+  , searchVectorField
+  , nullableField
+  , withFlag
+  , withName
+  , withConversion
   , SomeField(..)
   , withPrefix
   , fieldName
@@ -57,8 +71,6 @@ module Database.Orville.Core
   , ToSql
   , getField
   , getComponent
-  , withFlag
-  , withName
   , SchemaItem(..)
   , SchemaDefinition
   , Record

--- a/src/Database/Orville/Core.hs
+++ b/src/Database/Orville/Core.hs
@@ -16,6 +16,15 @@ module Database.Orville.Core
   , sqlConvertible
   , sqlConversionVia
   , maybeSqlConversionVia
+  , nullableConversion
+  , textConversion
+  , dayConversion
+  , utcTimeConversion
+  , intConversion
+  , int32Conversion
+  , int64Conversion
+  , doubleConversion
+  , boolConversion
   , TableParams(..)
   , RelationalMap
   , mapAttr

--- a/src/Database/Orville/Internal/FieldDefinition.hs
+++ b/src/Database/Orville/Internal/FieldDefinition.hs
@@ -5,10 +5,65 @@ License   : MIT
 -}
 module Database.Orville.Internal.FieldDefinition where
 
+import Data.Int (Int32, Int64)
+import Data.Text (Text)
+import Data.Time (Day, UTCTime)
 import Database.HDBC
 
 import Database.Orville.Internal.SqlConversion
 import Database.Orville.Internal.Types
+
+textField :: String -> Int -> FieldDefinition Text
+textField name len = (name, VarText len, [], textConversion)
+
+fixedTextField :: String -> Int -> FieldDefinition Text
+fixedTextField name len = (name, Text len, [], textConversion)
+
+dayField :: String -> FieldDefinition Day
+dayField = fieldOfType Date dayConversion
+
+utcTimeField :: String -> FieldDefinition UTCTime
+utcTimeField = fieldOfType Timestamp utcTimeConversion
+
+int32Field :: String -> FieldDefinition Int32
+int32Field = fieldOfType Integer int32Conversion
+
+int64Field :: String -> FieldDefinition Int64
+int64Field = fieldOfType BigInteger int64Conversion
+
+doubleField :: String -> FieldDefinition Double
+doubleField = fieldOfType Double doubleConversion
+
+boolField :: String -> FieldDefinition Bool
+boolField = fieldOfType Boolean boolConversion
+
+automaticIdField :: String -> FieldDefinition Int
+automaticIdField = fieldOfType AutomaticId intConversion
+
+searchVectorField :: String -> FieldDefinition Text
+searchVectorField = fieldOfType TextSearchVector textConversion
+
+nullableField :: FieldDefinition a -> FieldDefinition (Maybe a)
+nullableField field = field `withFlag` Null `withConversion` nullableConversion
+
+foreignKeyField ::
+     String
+  -> TableDefinition entity key
+  -> FieldDefinition key
+  -> FieldDefinition key
+foreignKeyField name refTable refField =
+  ( name
+  , foreignFieldType (fieldType refField)
+  , [References refTable refField]
+  , fieldConversion refField)
+  where
+    foreignFieldType AutomaticId = ForeignId
+    foreignFieldType typ = typ
+
+-- This is an internal field for building the basic field types
+-- above. It should not be exposed outside Orville
+fieldOfType :: ColumnType -> SqlConversion a -> String -> FieldDefinition a
+fieldOfType columnType conversion name = (name, columnType, [], conversion)
 
 isPrimaryKey :: ColumnFlag -> Bool
 isPrimaryKey PrimaryKey = True

--- a/src/Database/Orville/Internal/SqlConversion.hs
+++ b/src/Database/Orville/Internal/SqlConversion.hs
@@ -9,10 +9,21 @@ module Database.Orville.Internal.SqlConversion
   , convertToSql
   , convertFromSql
   , nullableConversion
+  , textConversion
+  , dayConversion
+  , utcTimeConversion
+  , intConversion
+  , int32Conversion
+  , int64Conversion
+  , doubleConversion
+  , boolConversion
   ) where
 
 import Control.Monad ((<=<))
 import Data.Convertible
+import Data.Int (Int32, Int64)
+import Data.Text (Text)
+import Data.Time (Day, UTCTime)
 
 import Database.HDBC
 
@@ -23,6 +34,30 @@ data SqlConversion a = SqlConversion
 
 sqlConversion :: (a -> SqlValue) -> (SqlValue -> Maybe a) -> SqlConversion a
 sqlConversion = SqlConversion
+
+textConversion :: SqlConversion Text
+textConversion = sqlConvertible
+
+dayConversion :: SqlConversion Day
+dayConversion = sqlConvertible
+
+utcTimeConversion :: SqlConversion UTCTime
+utcTimeConversion = sqlConvertible
+
+intConversion :: SqlConversion Int
+intConversion = sqlConvertible
+
+int32Conversion :: SqlConversion Int32
+int32Conversion = sqlConvertible
+
+int64Conversion :: SqlConversion Int64
+int64Conversion = sqlConvertible
+
+doubleConversion :: SqlConversion Double
+doubleConversion = sqlConvertible
+
+boolConversion :: SqlConversion Bool
+boolConversion = sqlConvertible
 
 nullableConversion :: SqlConversion a -> SqlConversion (Maybe a)
 nullableConversion aConversion = sqlConversion maybeToSql maybeFromSql

--- a/test/CrudTest.hs
+++ b/test/CrudTest.hs
@@ -5,6 +5,7 @@ module CrudTest where
 import Control.Monad (void)
 import Data.Convertible (convert)
 import Data.Pool (Pool, createPool, destroyAllResources)
+import qualified Data.Text as Text
 import qualified Database.HDBC as HDBC
 import qualified Database.HDBC.PostgreSQL as Postgres
 import System.Environment (getEnv)
@@ -65,11 +66,17 @@ test_crud =
 
 bpsVirus :: Virus ()
 bpsVirus =
-  Virus {virusId = (), virusName = VirusName "Bovine popular stomachitis"}
+  Virus
+    { virusId = ()
+    , virusName = VirusName (Text.pack "Bovine popular stomachitis")
+    }
 
 brnVirus :: Virus ()
 brnVirus =
-  Virus {virusId = (), virusName = VirusName "Black raspberry necrosis"}
+  Virus
+    { virusId = ()
+    , virusName = VirusName (Text.pack "Black raspberry necrosis")
+    }
 
 resetToBlankSchema :: O.SchemaDefinition -> O.Orville ()
 resetToBlankSchema schemaDef = do

--- a/test/Example/Data/Virus.hs
+++ b/test/Example/Data/Virus.hs
@@ -4,6 +4,8 @@ module Example.Data.Virus
   , VirusName(..)
   ) where
 
+import Data.Text (Text)
+
 data Virus key = Virus
   { virusId :: key
   , virusName :: VirusName
@@ -14,5 +16,5 @@ newtype VirusId = VirusId
   } deriving (Show, Eq)
 
 newtype VirusName = VirusName
-  { unVirusName :: String
+  { unVirusName :: Text
   } deriving (Show, Eq)

--- a/test/Example/Schema/Virus.hs
+++ b/test/Example/Schema/Virus.hs
@@ -27,14 +27,10 @@ virusTable =
 
 virusIdField :: O.FieldDefinition VirusId
 virusIdField =
-  ( "id"
-  , O.AutomaticId
-  , [O.PrimaryKey]
-  , O.sqlConversionVia unVirusId VirusId O.sqlConvertible)
+  O.automaticIdField "id" `O.withFlag` O.PrimaryKey `O.withConversion`
+  O.sqlConversionVia unVirusId VirusId
 
 virusNameField :: O.FieldDefinition VirusName
 virusNameField =
-  ( "name"
-  , O.VarText 255
-  , []
-  , O.sqlConversionVia unVirusName VirusName O.sqlConvertible)
+  O.textField "name" 255 `O.withConversion`
+  O.sqlConversionVia unVirusName VirusName


### PR DESCRIPTION
This adds a set of helpers for creating FieldDefinitions with the
correct ColumnType values to match common Haskell types. This is more
step away from using convertible because using these predefined field
types together with `withConversion` will allow users to convert their
custom types to/from other normal Haskell types rather than needing to
define Convertible instances for their types with SqlValue.

You can see a very simple usage example in `Example/Schema/Virus.hs`,
though not complicated enough to exhibit all scenarios.