### PR TITLE
Changes types to use app assigned primary key values

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -35,6 +35,7 @@ dependencies:
   - time >=1.5
   - transformers >=0.4
   - transformers-base >=0.4
+  - uuid >=1.3.11
 library:
   source-dirs: src
   exposed-modules:

--- a/src/Database/Orville/Core.hs
+++ b/src/Database/Orville/Core.hs
@@ -25,6 +25,7 @@ module Database.Orville.Core
   , int64Conversion
   , doubleConversion
   , boolConversion
+  , uuidConversion
   , TableParams(..)
   , RelationalMap
   , mapAttr
@@ -59,6 +60,7 @@ module Database.Orville.Core
   , doubleField
   , boolField
   , searchVectorField
+  , uuidField
   , nullableField
   , withFlag
   , withName

--- a/src/Database/Orville/Internal/FieldDefinition.hs
+++ b/src/Database/Orville/Internal/FieldDefinition.hs
@@ -8,6 +8,7 @@ module Database.Orville.Internal.FieldDefinition where
 import Data.Int (Int32, Int64)
 import Data.Text (Text)
 import Data.Time (Day, UTCTime)
+import Data.UUID (UUID)
 import Database.HDBC
 
 import Database.Orville.Internal.SqlConversion
@@ -36,6 +37,9 @@ doubleField = fieldOfType Double doubleConversion
 
 boolField :: String -> FieldDefinition Bool
 boolField = fieldOfType Boolean boolConversion
+
+uuidField :: String -> FieldDefinition UUID
+uuidField = fieldOfType UUID uuidConversion
 
 searchVectorField :: String -> FieldDefinition Text
 searchVectorField = fieldOfType TextSearchVector textConversion

--- a/src/Database/Orville/Internal/FieldDefinition.hs
+++ b/src/Database/Orville/Internal/FieldDefinition.hs
@@ -37,9 +37,6 @@ doubleField = fieldOfType Double doubleConversion
 boolField :: String -> FieldDefinition Bool
 boolField = fieldOfType Boolean boolConversion
 
-automaticIdField :: String -> FieldDefinition Int
-automaticIdField = fieldOfType AutomaticId intConversion
-
 searchVectorField :: String -> FieldDefinition Text
 searchVectorField = fieldOfType TextSearchVector textConversion
 
@@ -53,12 +50,9 @@ foreignKeyField ::
   -> FieldDefinition key
 foreignKeyField name refTable refField =
   ( name
-  , foreignFieldType (fieldType refField)
+  , fieldType refField
   , [References refTable refField]
   , fieldConversion refField)
-  where
-    foreignFieldType AutomaticId = ForeignId
-    foreignFieldType typ = typ
 
 -- This is an internal field for building the basic field types
 -- above. It should not be exposed outside Orville
@@ -72,10 +66,6 @@ isPrimaryKey _ = False
 isNullFlag :: ColumnFlag -> Bool
 isNullFlag Null = True
 isNullFlag _ = False
-
-isUninserted :: ColumnFlag -> Bool
-isUninserted PrimaryKey = True
-isUninserted _ = False
 
 fieldName :: FieldDefinition a -> String
 fieldName (name, _, _, _) = name
@@ -103,9 +93,6 @@ withConversion ::
   -> FieldDefinition b
 withConversion (name, typ, flags, aConversion) mapConversion =
   (name, typ, flags, mapConversion aConversion)
-
-isUninsertedField :: FieldDefinition a -> Bool
-isUninsertedField (_, _, flags, _) = any isUninserted flags
 
 withPrefix :: FieldDefinition a -> String -> FieldDefinition a
 withPrefix f@(name, _, _, _) prefix = f `withName` (prefix ++ "_" ++ name)

--- a/src/Database/Orville/Internal/MigrateTable.hs
+++ b/src/Database/Orville/Internal/MigrateTable.hs
@@ -117,6 +117,7 @@ mkTypeDDL (VarText len) = "VARCHAR(" ++ show len ++ ")"
 mkTypeDDL (Date) = "DATE"
 mkTypeDDL (Timestamp) = "TIMESTAMP with time zone"
 mkTypeDDL TextSearchVector = "TSVECTOR"
+mkTypeDDL UUID = "UUID"
 
 mkFieldDDL :: FieldDefinition a -> String
 mkFieldDDL (name, columnType, flags, _) =
@@ -137,6 +138,7 @@ mkCreateTableDDL tableDef =
     mkSomeFieldDDL (SomeField f) = mkFieldDDL f
 
 columnTypeSqlId :: ColumnType -> SqlTypeId
+columnTypeSqlId UUID = SqlUnknownT "2950"
 columnTypeSqlId Integer = SqlBigIntT
 columnTypeSqlId Boolean = SqlBitT
 columnTypeSqlId BigInteger = SqlBigIntT
@@ -148,6 +150,7 @@ columnTypeSqlId Timestamp = SqlTimestampWithZoneT
 columnTypeSqlId TextSearchVector = SqlUnknownT "3614"
 
 columnTypeSqlSize :: ColumnType -> Maybe Int
+columnTypeSqlSize UUID = Just 16
 columnTypeSqlSize Integer = Just 4
 columnTypeSqlSize BigInteger = Just 8
 columnTypeSqlSize Double = Just 8

--- a/src/Database/Orville/Internal/MigrateTable.hs
+++ b/src/Database/Orville/Internal/MigrateTable.hs
@@ -108,8 +108,6 @@ mkFlagDDL (References table field) =
 mkFlagDDL (ColumnDescription _) = Nothing
 
 mkTypeDDL :: ColumnType -> String
-mkTypeDDL AutomaticId = "SERIAL"
-mkTypeDDL ForeignId = "INTEGER"
 mkTypeDDL Integer = "INTEGER"
 mkTypeDDL BigInteger = "BIGINT"
 mkTypeDDL Double = "DOUBLE PRECISION"
@@ -139,8 +137,6 @@ mkCreateTableDDL tableDef =
     mkSomeFieldDDL (SomeField f) = mkFieldDDL f
 
 columnTypeSqlId :: ColumnType -> SqlTypeId
-columnTypeSqlId AutomaticId = SqlBigIntT
-columnTypeSqlId ForeignId = SqlBigIntT
 columnTypeSqlId Integer = SqlBigIntT
 columnTypeSqlId Boolean = SqlBitT
 columnTypeSqlId BigInteger = SqlBigIntT
@@ -152,8 +148,6 @@ columnTypeSqlId Timestamp = SqlTimestampWithZoneT
 columnTypeSqlId TextSearchVector = SqlUnknownT "3614"
 
 columnTypeSqlSize :: ColumnType -> Maybe Int
-columnTypeSqlSize AutomaticId = Just 4
-columnTypeSqlSize ForeignId = Just 4
 columnTypeSqlSize Integer = Just 4
 columnTypeSqlSize BigInteger = Just 8
 columnTypeSqlSize Double = Just 8

--- a/src/Database/Orville/Internal/QueryCache.hs
+++ b/src/Database/Orville/Internal/QueryCache.hs
@@ -74,7 +74,7 @@ selectCached ::
      (MonadThrow m, MonadOrville conn m)
   => TableDefinition entity key
   -> SelectOptions
-  -> QueryCached m [entity key]
+  -> QueryCached m [entity]
 selectCached tableDef opts = do
   rows <- selectCachedRows tableDef opts
   unsafeLift $ decodeSqlRows (tableFromSql tableDef) rows
@@ -83,7 +83,7 @@ selectFirstCached ::
      (MonadThrow m, MonadOrville conn m)
   => TableDefinition entity key
   -> SelectOptions
-  -> QueryCached m (Maybe (entity key))
+  -> QueryCached m (Maybe entity)
 selectFirstCached tableDef opts =
   listToMaybe <$> selectCached tableDef (limit 1 <> opts)
 
@@ -91,7 +91,7 @@ findRecordsCached ::
      (MonadThrow m, MonadOrville conn m, Ord key)
   => TableDefinition entity key
   -> [key]
-  -> QueryCached m (Map.Map key (entity key))
+  -> QueryCached m (Map.Map key entity)
 findRecordsCached tableDef keys = do
   let keyField = tablePrimaryKey tableDef
       mkEntry record = (tableGetKey tableDef record, record)
@@ -102,7 +102,7 @@ findRecordCached ::
      (MonadThrow m, MonadOrville conn m)
   => TableDefinition entity key
   -> key
-  -> QueryCached m (Maybe (entity key))
+  -> QueryCached m (Maybe entity)
 findRecordCached tableDef key =
   let keyField = tablePrimaryKey tableDef
    in selectFirstCached tableDef (where_ $ keyField .== key)
@@ -112,7 +112,7 @@ findRecordsByCached ::
   => TableDefinition entity key
   -> FieldDefinition fieldValue
   -> SelectOptions
-  -> QueryCached m (Map.Map fieldValue [entity key])
+  -> QueryCached m (Map.Map fieldValue [entity])
 findRecordsByCached tableDef field opts = do
   let builder = (,) <$> fieldFromSql field <*> tableFromSql tableDef
   rows <- selectCachedRows tableDef opts

--- a/src/Database/Orville/Internal/RelationalMap.hs
+++ b/src/Database/Orville/Internal/RelationalMap.hs
@@ -21,7 +21,7 @@ module Database.Orville.Internal.RelationalMap
   , readOnlyMap
   ) where
 
-import Control.Monad (join, when)
+import Control.Monad (join)
 import Control.Monad.Reader (ask)
 import Control.Monad.State (modify)
 
@@ -183,10 +183,9 @@ mkFromSql (RM_Partial rm) = do
     wrapError = either (Left . RowDataError) Right
 
 mkToSql :: RelationalMap a b -> ToSql a ()
-mkToSql (RM_Field field) =
-  when (not $ isUninsertedField field) $ do
-    value <- ask
-    modify (fieldToSqlValue field value :)
+mkToSql (RM_Field field) = do
+  value <- ask
+  modify (fieldToSqlValue field value :)
 mkToSql (RM_Nest f rm) = getComponent f (mkToSql rm)
 mkToSql (RM_Apply rmF rmC) = mkToSql rmF >> mkToSql rmC
 mkToSql (RM_Partial rm) = mkToSql rm

--- a/src/Database/Orville/Internal/RelationalMap.hs
+++ b/src/Database/Orville/Internal/RelationalMap.hs
@@ -41,7 +41,7 @@ import Database.Orville.Internal.Types
 data TableParams entity key = TableParams
   { tblName :: String
       -- ^ The name of the table in the database
-  , tblMapper :: RelationalMap (entity key) (entity key)
+  , tblMapper :: RelationalMap entity entity
       -- ^ The relational mapping that defines how the Haskell entity type
       -- is converted both to and from sql. The fields utilized in the mapping
       -- are used to automatically build the list of 'FieldDefinitions' that
@@ -51,9 +51,9 @@ data TableParams entity key = TableParams
       -- (Orville will never delete a column without being told it is safe)
   , tblPrimaryKey :: FieldDefinition key
       -- ^ A FieldDefinition for the primary key.
-  , tblSetKey :: forall anyKey1 anyKey2. anyKey2 -> entity anyKey1 -> entity anyKey2
+  , tblSetKey :: key -> entity -> entity
       -- ^ A function to set the key on the entity
-  , tblGetKey :: forall anyKey. entity anyKey -> anyKey
+  , tblGetKey :: entity -> key
       -- ^ A function to get the key on the entity
   , tblComments :: TableComments ()
       -- ^ Any comments that might be interesting for developers to see. These
@@ -82,11 +82,11 @@ data TableParams entity key = TableParams
  @
  -}
 mkTableDefinition :: TableParams entity key -> TableDefinition entity key
-mkTableDefinition p@(TableParams {..}) =
+mkTableDefinition (TableParams {..}) =
   TableDefinition
     { tableFields = fields tblMapper
     , tableFromSql = mkFromSql tblMapper
-    , tableToSql = getComponent (unsafeSquashPrimaryKey p) (mkToSql tblMapper)
+    , tableToSql = mkToSql tblMapper
     , tablePrimaryKey = tblPrimaryKey
     , tableName = tblName
     , tableSafeToDelete = tblSafeToDelete
@@ -94,11 +94,6 @@ mkTableDefinition p@(TableParams {..}) =
     , tableGetKey = tblGetKey
     , tableComments = tblComments
     }
-
-unsafeSquashPrimaryKey ::
-     TableParams entity key -> entity anyKey1 -> forall anyKey2. entity anyKey2
-unsafeSquashPrimaryKey params =
-  tblSetKey params (error "Primary key field was used!")
 
 data RelationalMap a b where
   RM_Field :: FieldDefinition a -> RelationalMap a a

--- a/src/Database/Orville/Internal/Select.hs
+++ b/src/Database/Orville/Internal/Select.hs
@@ -43,7 +43,7 @@ selectQuery builder =
   selectQueryColumns (expr <$> fromSqlSelects builder) builder
 
 selectQueryTable ::
-     TableDefinition entity key -> SelectOptions -> Select (entity key)
+     TableDefinition entity key -> SelectOptions -> Select entity
 selectQueryTable tbl = selectQuery (tableFromSql tbl) (fromClauseTable tbl)
 
 selectQueryRows ::

--- a/src/Database/Orville/Internal/SqlConversion.hs
+++ b/src/Database/Orville/Internal/SqlConversion.hs
@@ -17,6 +17,7 @@ module Database.Orville.Internal.SqlConversion
   , int64Conversion
   , doubleConversion
   , boolConversion
+  , uuidConversion
   ) where
 
 import Control.Monad ((<=<))
@@ -24,6 +25,8 @@ import Data.Convertible
 import Data.Int (Int32, Int64)
 import Data.Text (Text)
 import Data.Time (Day, UTCTime)
+import Data.UUID (UUID)
+import qualified Data.UUID as UUID
 
 import Database.HDBC
 
@@ -58,6 +61,10 @@ doubleConversion = sqlConvertible
 
 boolConversion :: SqlConversion Bool
 boolConversion = sqlConvertible
+
+uuidConversion :: SqlConversion UUID
+uuidConversion =
+  maybeSqlConversionVia (UUID.toText) (UUID.fromText) textConversion
 
 nullableConversion :: SqlConversion a -> SqlConversion (Maybe a)
 nullableConversion aConversion = sqlConversion maybeToSql maybeFromSql

--- a/src/Database/Orville/Internal/TableDefinition.hs
+++ b/src/Database/Orville/Internal/TableDefinition.hs
@@ -12,10 +12,3 @@ tableColumnNames :: TableDefinition entity key -> [String]
 tableColumnNames = map someFieldName . tableFields
   where
     someFieldName (SomeField f) = fieldName f
-
-insertableColumnNames :: TableDefinition entity key -> [String]
-insertableColumnNames =
-  map someFieldName . filter (not . isSomeUninsertedField) . tableFields
-  where
-    isSomeUninsertedField (SomeField f) = isUninsertedField f
-    someFieldName (SomeField f) = fieldName f

--- a/src/Database/Orville/Internal/Types.hs
+++ b/src/Database/Orville/Internal/Types.hs
@@ -35,9 +35,7 @@ type UpdatedAt = Time.UTCTime
 type OccurredAt = Time.UTCTime
 
 data ColumnType
-  = AutomaticId
-  | ForeignId
-  | Text Int
+  = Text Int
   | VarText Int
   | Date
   | Timestamp

--- a/src/Database/Orville/Internal/Types.hs
+++ b/src/Database/Orville/Internal/Types.hs
@@ -44,6 +44,7 @@ data ColumnType
   | TextSearchVector
   | Double
   | Boolean
+  | UUID
 
 data ColumnFlag
   = PrimaryKey

--- a/src/Database/Orville/Internal/Types.hs
+++ b/src/Database/Orville/Internal/Types.hs
@@ -196,13 +196,13 @@ data TableDefinition entity key = TableDefinition
   , tablePrimaryKey :: FieldDefinition key
       -- ^ The statically typed field definition that is the primary key. Currently
       -- this field must still by listed in `tableFields`
-  , tableFromSql :: FromSql (entity key)
+  , tableFromSql :: FromSql entity
       -- ^ A definition of how to convert the haskell type from a sql row
-  , tableToSql :: forall anyKey. ToSql (entity anyKey) ()
+  , tableToSql :: ToSql entity ()
       -- ^ A definition of how to convert the haskell type to a sql row
-  , tableSetKey :: forall anyKey1 anyKey2. anyKey2 -> entity anyKey1 -> entity anyKey2
+  , tableSetKey :: key -> entity -> entity
       -- ^ A function to set the key on the entity
-  , tableGetKey :: forall anyKey. entity anyKey -> anyKey
+  , tableGetKey :: entity -> key
       -- ^ A function to get the key on the entity
   , tableComments :: TableComments ()
       -- ^ Any comments that might be interesting for developers to see. These

--- a/src/Database/Orville/Popper.hs
+++ b/src/Database/Orville/Popper.hs
@@ -82,22 +82,19 @@ certainly' msgPopper bPopper =
   (msgPopper &&& bPopper) >>>
   liftPop (\(err, maybeB) -> maybe (PoppedError err) PoppedValue maybeB)
 
-popRecord :: TableDefinition entity key -> key -> Popper a (Maybe (entity key))
+popRecord :: TableDefinition entity key -> key -> Popper a (Maybe entity)
 popRecord tableDef key = popQuery (findRecord tableDef key)
 
-popRecord' :: TableDefinition entity key -> key -> Popper a (entity key)
+popRecord' :: TableDefinition entity key -> key -> Popper a entity
 popRecord' td key = popRecord td key >>> certainly err
   where
     err = MissingRecord td (tablePrimaryKey td) key
 
 popFirst ::
-     TableDefinition entity key
-  -> SelectOptions
-  -> Popper a (Maybe (entity key))
+     TableDefinition entity key -> SelectOptions -> Popper a (Maybe entity)
 popFirst tableDef opts = popQuery (selectFirst tableDef opts)
 
-popTable ::
-     TableDefinition entity key -> SelectOptions -> Popper a ([entity key])
+popTable :: TableDefinition entity key -> SelectOptions -> Popper a [entity]
 popTable tableDef opts = popQuery (selectAll tableDef opts)
 
 popMaybe :: Popper a b -> Popper (Maybe a) (Maybe b)
@@ -107,21 +104,21 @@ hasMany ::
      Ord fieldValue
   => TableDefinition entity key
   -> FieldDefinition fieldValue
-  -> Popper fieldValue [entity key]
+  -> Popper fieldValue [entity]
 hasMany tableDef fieldDef = PopRecordManyBy tableDef fieldDef mempty
 
 hasOneIn ::
      Ord fieldValue
   => TableDefinition entity key
   -> FieldDefinition fieldValue
-  -> Popper [fieldValue] (Map.Map fieldValue (entity key))
+  -> Popper [fieldValue] (Map.Map fieldValue entity)
 hasOneIn tableDef fieldDef = PopRecordsBy tableDef fieldDef mempty
 
 hasManyIn ::
      Ord fieldValue
   => TableDefinition entity key
   -> FieldDefinition fieldValue
-  -> Popper [fieldValue] (Map.Map fieldValue [entity key])
+  -> Popper [fieldValue] (Map.Map fieldValue [entity])
 hasManyIn tableDef fieldDef = PopRecordsManyBy tableDef fieldDef mempty
 
 hasManyWhere ::
@@ -129,7 +126,7 @@ hasManyWhere ::
   => TableDefinition entity key
   -> FieldDefinition fieldValue
   -> SelectOptions
-  -> Popper fieldValue [entity key]
+  -> Popper fieldValue [entity]
 hasManyWhere = PopRecordManyBy
 
 hasManyInWhere ::
@@ -137,14 +134,14 @@ hasManyInWhere ::
   => TableDefinition entity key
   -> FieldDefinition fieldValue
   -> SelectOptions
-  -> Popper [fieldValue] (Map.Map fieldValue [entity key])
+  -> Popper [fieldValue] (Map.Map fieldValue [entity])
 hasManyInWhere = PopRecordsManyBy
 
 hasOne ::
      Ord fieldValue
   => TableDefinition entity key
   -> FieldDefinition fieldValue
-  -> Popper fieldValue (Maybe (entity key))
+  -> Popper fieldValue (Maybe entity)
 hasOne tableDef fieldDef = hasOneWhere tableDef fieldDef mempty
 
 hasOneWhere ::
@@ -152,14 +149,14 @@ hasOneWhere ::
   => TableDefinition entity key
   -> FieldDefinition fieldValue
   -> SelectOptions
-  -> Popper fieldValue (Maybe (entity key))
+  -> Popper fieldValue (Maybe entity)
 hasOneWhere = PopRecordBy
 
 hasOne' ::
      Ord fieldValue
   => TableDefinition entity key
   -> FieldDefinition fieldValue
-  -> Popper fieldValue (entity key)
+  -> Popper fieldValue entity
 hasOne' tableDef fieldDef =
   certainly' (popMissingRecord tableDef fieldDef) (hasOne tableDef fieldDef)
 
@@ -314,35 +311,35 @@ instance Applicative Popped where
 data Popper a b where
   PopQuery :: Orville b -> Popper a b
   PopRecord
-    :: Ord key => TableDefinition entity key -> Popper key (Maybe (entity key))
+    :: Ord key => TableDefinition entity key -> Popper key (Maybe entity)
   PopRecords
     :: Ord key
     => TableDefinition entity key
-    -> Popper [key] (Map.Map key (entity key))
+    -> Popper [key] (Map.Map key entity)
   PopRecordBy
     :: Ord fieldValue
     => TableDefinition entity key
     -> FieldDefinition fieldValue
     -> SelectOptions
-    -> Popper fieldValue (Maybe (entity key))
+    -> Popper fieldValue (Maybe entity)
   PopRecordManyBy
     :: Ord fieldValue
     => TableDefinition entity key
     -> FieldDefinition fieldValue
     -> SelectOptions
-    -> Popper fieldValue [entity key]
+    -> Popper fieldValue [entity]
   PopRecordsBy
     :: Ord fieldValue
     => TableDefinition entity key
     -> FieldDefinition fieldValue
     -> SelectOptions
-    -> Popper [fieldValue] (Map.Map fieldValue (entity key))
+    -> Popper [fieldValue] (Map.Map fieldValue entity)
   PopRecordsManyBy
     :: Ord fieldValue
     => TableDefinition entity key
     -> FieldDefinition fieldValue
     -> SelectOptions
-    -> Popper [fieldValue] (Map.Map fieldValue [entity key])
+    -> Popper [fieldValue] (Map.Map fieldValue [entity])
   PopId :: Popper a a
   PopPure :: b -> Popper a b
   PopLift :: (a -> Popped b) -> Popper a b

--- a/src/Database/Orville/Tracked.hs
+++ b/src/Database/Orville/Tracked.hs
@@ -45,7 +45,7 @@ data Sign = forall key entity. (Typeable entity, Typeable key) =>
                                Sign
   { signType :: SignType
   , signTable :: TableDefinition entity key
-  , signEntity :: entity key
+  , signEntity :: entity
   }
 
 signTableAs ::
@@ -55,21 +55,17 @@ signTableAs ::
   -> Maybe (TableDefinition entity key)
 signTableAs _ (Sign _ tableDef _) = cast tableDef
 
-signEntityAs ::
-     (Typeable entity, Typeable key)
-  => p (entity key)
-  -> Sign
-  -> Maybe (entity key)
+signEntityAs :: Typeable entity => p entity -> Sign -> Maybe entity
 signEntityAs _ (Sign _ _ entity) = cast entity
 
 signEntityFrom ::
      (Typeable entity, Typeable key)
   => TableDefinition entity key
   -> Sign
-  -> Maybe (entity key)
+  -> Maybe entity
 signEntityFrom _ (Sign _ _ entity) = cast entity
 
-signEntityGet :: Typeable entity => (entity Record -> a) -> Sign -> Maybe a
+signEntityGet :: Typeable entity => (entity -> a) -> Sign -> Maybe a
 signEntityGet f sign = f <$> signEntityAs proxy sign
   where
     proxy = Nothing
@@ -136,8 +132,8 @@ untracked = TrackedOrville . lift
 insertRecordTracked ::
      (MonadTrackedOrville conn m, Typeable entity, Typeable key)
   => TableDefinition entity key
-  -> entity ()
-  -> m (entity key)
+  -> entity
+  -> m entity
 insertRecordTracked tableDef entity = do
   record <- insertRecord tableDef entity
   track $ Sign Inserted tableDef record
@@ -147,8 +143,8 @@ updateRecordTracked ::
      (MonadTrackedOrville conn m, Typeable entity, Typeable key)
   => TableDefinition entity key
   -> key
-  -> entity anyKey
-  -> m (entity key)
+  -> entity
+  -> m entity
 updateRecordTracked tableDef key record = do
   updated <- updateRecord tableDef key record
   track $ Sign Updated tableDef updated
@@ -157,7 +153,7 @@ updateRecordTracked tableDef key record = do
 deleteRecordTracked ::
      (MonadTrackedOrville conn m, Typeable entity, Typeable key)
   => TableDefinition entity key
-  -> entity key
+  -> entity
   -> m ()
 deleteRecordTracked tableDef record = do
   deleteRecord tableDef record

--- a/src/Database/Orville/Tracked.hs
+++ b/src/Database/Orville/Tracked.hs
@@ -41,7 +41,7 @@ data SignType
   | Deleted
   deriving (Eq, Show, Enum)
 
-data Sign = forall key entity. (Typeable entity, Typeable key) =>
+data Sign = forall entity key. (Typeable entity, Typeable key) =>
                                Sign
   { signType :: SignType
   , signTable :: TableDefinition entity key
@@ -133,22 +133,20 @@ insertRecordTracked ::
      (MonadTrackedOrville conn m, Typeable entity, Typeable key)
   => TableDefinition entity key
   -> entity
-  -> m entity
+  -> m ()
 insertRecordTracked tableDef entity = do
-  record <- insertRecord tableDef entity
-  track $ Sign Inserted tableDef record
-  pure record
+  insertRecord tableDef entity
+  track $ Sign Inserted tableDef entity
 
 updateRecordTracked ::
      (MonadTrackedOrville conn m, Typeable entity, Typeable key)
   => TableDefinition entity key
   -> key
   -> entity
-  -> m entity
-updateRecordTracked tableDef key record = do
-  updated <- updateRecord tableDef key record
-  track $ Sign Updated tableDef updated
-  pure updated
+  -> m ()
+updateRecordTracked tableDef key entity = do
+  updateRecord tableDef key entity
+  track $ Sign Updated tableDef entity
 
 deleteRecordTracked ::
      (MonadTrackedOrville conn m, Typeable entity, Typeable key)

--- a/test/CrudTest.hs
+++ b/test/CrudTest.hs
@@ -16,7 +16,7 @@ import qualified Database.Orville.Raw as ORaw
 import Test.Tasty (TestTree, testGroup, withResource)
 import Test.Tasty.HUnit (assertEqual, testCase)
 
-import Example.Data.Virus (Virus(..), VirusName(..))
+import Example.Data.Virus (Virus(..), VirusId(..), VirusName(..))
 import Example.Schema (schema, virusTable)
 
 type TestPool = Pool Postgres.Connection
@@ -64,17 +64,17 @@ test_crud =
             foundDeletedVirus
       ]
 
-bpsVirus :: Virus ()
+bpsVirus :: Virus
 bpsVirus =
   Virus
-    { virusId = ()
+    { virusId = VirusId 1
     , virusName = VirusName (Text.pack "Bovine popular stomachitis")
     }
 
-brnVirus :: Virus ()
+brnVirus :: Virus
 brnVirus =
   Virus
-    { virusId = ()
+    { virusId = VirusId 2
     , virusName = VirusName (Text.pack "Black raspberry necrosis")
     }
 

--- a/test/CrudTest.hs
+++ b/test/CrudTest.hs
@@ -1,33 +1,24 @@
-{-# LANGUAGE RankNTypes #-}
-
 module CrudTest where
 
-import Control.Monad (void)
-import Data.Convertible (convert)
-import Data.Pool (Pool, createPool, destroyAllResources)
 import qualified Data.Text as Text
-import qualified Database.HDBC as HDBC
-import qualified Database.HDBC.PostgreSQL as Postgres
-import System.Environment (getEnv)
 
 import qualified Database.Orville as O
-import qualified Database.Orville.Raw as ORaw
 
-import Test.Tasty (TestTree, testGroup, withResource)
+import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (assertEqual, testCase)
 
-import Example.Data.Virus (Virus(..), VirusId(..), VirusName(..))
+import Example.Data.Virus (Virus(..), VirusName(..), newVirus)
 import Example.Schema (schema, virusTable)
-
-type TestPool = Pool Postgres.Connection
+import qualified TestDB as TestDB
 
 test_crud :: TestTree
 test_crud =
-  withOrvilleRun $ \run ->
+  TestDB.withOrvilleRun $ \run ->
     testGroup
       "CRUD Test"
       [ testCase "Insert and find" $ do
-          run (resetToBlankSchema schema)
+          bpsVirus <- newVirus bovinePopularStomachitis
+          run (TestDB.reset schema)
           run (O.insertRecord virusTable bpsVirus)
           foundVirus <- run $ O.findRecord virusTable (virusId bpsVirus)
           assertEqual
@@ -36,7 +27,9 @@ test_crud =
             foundVirus
         --
       , testCase "Update" $ do
-          run (resetToBlankSchema schema)
+          bpsVirus <- newVirus bovinePopularStomachitis
+          brnVirus <- newVirus blackRaspberryNecrosis
+          run (TestDB.reset schema)
           run (O.insertRecord virusTable bpsVirus)
           run $ O.updateRecord virusTable (virusId bpsVirus) brnVirus
           newlyFoundVirus <- run (O.findRecord virusTable (virusId brnVirus))
@@ -46,7 +39,8 @@ test_crud =
             newlyFoundVirus
         --
       , testCase "Delete" $ do
-          run (resetToBlankSchema schema)
+          bpsVirus <- newVirus bovinePopularStomachitis
+          run (TestDB.reset schema)
           foundDeletedVirus <-
             run $ do
               O.insertRecord virusTable bpsVirus
@@ -58,44 +52,8 @@ test_crud =
             foundDeletedVirus
       ]
 
-bpsVirus :: Virus
-bpsVirus =
-  Virus
-    { virusId = VirusId 1
-    , virusName = VirusName (Text.pack "Bovine popular stomachitis")
-    }
+bovinePopularStomachitis :: VirusName
+bovinePopularStomachitis = VirusName (Text.pack "Bovine popular stomachitis")
 
-brnVirus :: Virus
-brnVirus =
-  Virus
-    { virusId = VirusId 2
-    , virusName = VirusName (Text.pack "Black raspberry necrosis")
-    }
-
-resetToBlankSchema :: O.SchemaDefinition -> O.Orville ()
-resetToBlankSchema schemaDef = do
-  results <- ORaw.selectSqlRows "SELECT current_user" []
-  case results of
-    [[("current_user", currentUser)]]
-    -- I would like to use placeholders here, but postgres gives my a
-    -- sql syntax error when I do :(
-     -> void $ ORaw.updateSql ("DROP OWNED BY " ++ convert currentUser) []
-    _ ->
-      error $ "Expected single 'current_user' result row, got " ++ show results
-  O.migrateSchema schemaDef
-
-withOrvilleRun :: ((forall a. O.Orville a -> IO a) -> TestTree) -> TestTree
-withOrvilleRun mkOrvilleTree = withDb (\pool -> mkOrvilleTree (run pool))
-  where
-    run :: IO TestPool -> forall a. O.Orville a -> IO a
-    run getPool action = do
-      pool <- getPool
-      O.runOrville action (O.newOrvilleEnv pool)
-
-withDb :: (IO TestPool -> TestTree) -> TestTree
-withDb = withResource acquirePool destroyAllResources
-
-acquirePool :: IO TestPool
-acquirePool = do
-  connString <- getEnv "TEST_CONN_STRING"
-  createPool (Postgres.connectPostgreSQL' connString) HDBC.disconnect 1 60 1
+blackRaspberryNecrosis :: VirusName
+blackRaspberryNecrosis = VirusName (Text.pack "Black raspberry necrosis")

--- a/test/CrudTest.hs
+++ b/test/CrudTest.hs
@@ -28,36 +28,30 @@ test_crud =
       "CRUD Test"
       [ testCase "Insert and find" $ do
           run (resetToBlankSchema schema)
-          insertedVirus <- run (O.insertRecord virusTable bpsVirus)
-          foundVirus <- run $ O.findRecord virusTable (virusId insertedVirus)
+          run (O.insertRecord virusTable bpsVirus)
+          foundVirus <- run $ O.findRecord virusTable (virusId bpsVirus)
           assertEqual
             "Virus found in database didn't match the originally inserted values"
-            (Just insertedVirus)
+            (Just bpsVirus)
             foundVirus
         --
       , testCase "Update" $ do
           run (resetToBlankSchema schema)
-          insertedVirus <- run (O.insertRecord virusTable bpsVirus)
-          updatedVirus <-
-            run $ O.updateRecord virusTable (virusId insertedVirus) brnVirus
-          newlyFoundVirus <-
-            run $ O.findRecord virusTable (virusId insertedVirus)
-          assertEqual
-            "Virus returned from update didn't match the values passed in for update"
-            (virusName brnVirus)
-            (virusName updatedVirus)
+          run (O.insertRecord virusTable bpsVirus)
+          run $ O.updateRecord virusTable (virusId bpsVirus) brnVirus
+          newlyFoundVirus <- run (O.findRecord virusTable (virusId brnVirus))
           assertEqual
             "Virus found in database didn't match the values returned by from update"
-            (Just updatedVirus)
+            (Just brnVirus)
             newlyFoundVirus
         --
       , testCase "Delete" $ do
           run (resetToBlankSchema schema)
           foundDeletedVirus <-
             run $ do
-              insertedVirus <- O.insertRecord virusTable bpsVirus
-              O.deleteRecord virusTable insertedVirus
-              O.findRecord virusTable (virusId insertedVirus)
+              O.insertRecord virusTable bpsVirus
+              O.deleteRecord virusTable bpsVirus
+              O.findRecord virusTable (virusId bpsVirus)
           assertEqual
             "Virus was found in the database, but it should have been deleted"
             Nothing

--- a/test/Example/Data/Virus.hs
+++ b/test/Example/Data/Virus.hs
@@ -2,19 +2,34 @@ module Example.Data.Virus
   ( Virus(..)
   , VirusId(..)
   , VirusName(..)
+  , newVirus
+  , newVirusId
   ) where
 
-import Data.Int (Int32)
+import Control.Applicative (liftA2)
 import Data.Text (Text)
+import Data.UUID (UUID)
+import Data.UUID.V4 as UUIDv4
 
 data Virus = Virus
   { virusId :: VirusId
   , virusName :: VirusName
   } deriving (Show, Eq)
 
+newVirus :: VirusName -> IO Virus
+newVirus name = liftA2 Virus newVirusId (pure name)
+
 newtype VirusId = VirusId
-  { unVirusId :: Int32
+  { unVirusId :: UUID
   } deriving (Show, Eq)
+
+-- This uses V4 UUIDS because they can be reliably generated.
+-- Applications should *probably* be using V1 UUIDs. We should
+-- determine how best to provide a convenient helper for generating
+-- those as the UUID library returns a Nothing if you generate
+-- them too quickly.
+newVirusId :: IO VirusId
+newVirusId = fmap VirusId UUIDv4.nextRandom
 
 newtype VirusName = VirusName
   { unVirusName :: Text

--- a/test/Example/Data/Virus.hs
+++ b/test/Example/Data/Virus.hs
@@ -4,6 +4,7 @@ module Example.Data.Virus
   , VirusName(..)
   ) where
 
+import Data.Int (Int32)
 import Data.Text (Text)
 
 data Virus = Virus
@@ -12,7 +13,7 @@ data Virus = Virus
   } deriving (Show, Eq)
 
 newtype VirusId = VirusId
-  { unVirusId :: Int
+  { unVirusId :: Int32
   } deriving (Show, Eq)
 
 newtype VirusName = VirusName

--- a/test/Example/Data/Virus.hs
+++ b/test/Example/Data/Virus.hs
@@ -6,8 +6,8 @@ module Example.Data.Virus
 
 import Data.Text (Text)
 
-data Virus key = Virus
-  { virusId :: key
+data Virus = Virus
+  { virusId :: VirusId
   , virusName :: VirusName
   } deriving (Show, Eq)
 

--- a/test/Example/Schema/Virus.hs
+++ b/test/Example/Schema/Virus.hs
@@ -27,7 +27,7 @@ virusTable =
 
 virusIdField :: O.FieldDefinition VirusId
 virusIdField =
-  O.automaticIdField "id" `O.withFlag` O.PrimaryKey `O.withConversion`
+  O.int32Field "id" `O.withFlag` O.PrimaryKey `O.withConversion`
   O.sqlConversionVia unVirusId VirusId
 
 virusNameField :: O.FieldDefinition VirusName

--- a/test/Example/Schema/Virus.hs
+++ b/test/Example/Schema/Virus.hs
@@ -27,7 +27,7 @@ virusTable =
 
 virusIdField :: O.FieldDefinition VirusId
 virusIdField =
-  O.int32Field "id" `O.withFlag` O.PrimaryKey `O.withConversion`
+  O.uuidField "id" `O.withFlag` O.PrimaryKey `O.withConversion`
   O.sqlConversionVia unVirusId VirusId
 
 virusNameField :: O.FieldDefinition VirusName

--- a/test/MigrateTest.hs
+++ b/test/MigrateTest.hs
@@ -1,0 +1,30 @@
+module MigrateTest where
+
+import qualified Database.Orville as O
+
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertBool, assertEqual, testCase)
+
+import Example.Schema (schema)
+import qualified TestDB as TestDB
+
+test_migrate :: TestTree
+test_migrate =
+  TestDB.withOrvilleRun $ \run ->
+    testGroup
+      "Migrate Test"
+      [ testCase "Migration is idempotent" $ do
+          run (TestDB.reset [])
+          firstTrace <- run (TestDB.queryTrace isDDL (O.migrateSchema schema))
+          assertBool
+            "Expected first migration trace not to be empty, but it was!"
+            (not (null firstTrace))
+          secondTrace <- run (TestDB.queryTrace isDDL (O.migrateSchema schema))
+          assertEqual
+            "Expected second migration trace to be empty"
+            []
+            secondTrace
+      ]
+
+isDDL :: O.QueryType -> Bool
+isDDL qt = qt == O.DDLQuery

--- a/test/TestDB.hs
+++ b/test/TestDB.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module TestDB where
+
+import Control.Monad (void)
+import Control.Monad.Base (MonadBase)
+import Control.Monad.Catch (MonadThrow)
+import Control.Monad.IO.Class (MonadIO)
+import Control.Monad.Trans (lift)
+import Control.Monad.Trans.Control (MonadBaseControl(..), StM)
+import Control.Monad.Writer (WriterT)
+import qualified Control.Monad.Writer as Writer
+import Data.Convertible (convert)
+import Data.Pool (Pool, createPool, destroyAllResources)
+import qualified Database.HDBC as HDBC
+import qualified Database.HDBC.PostgreSQL as Postgres
+import System.Environment (getEnv)
+
+import Test.Tasty (TestTree, withResource)
+
+import qualified Database.Orville as O
+import qualified Database.Orville.Raw as ORaw
+
+type TestPool = Pool Postgres.Connection
+
+type QueryWriterT = WriterT [(O.QueryType, String)]
+
+newtype TestMonad a = TestMonad
+  { runTestMonad :: QueryWriterT (O.OrvilleT Postgres.Connection IO) a
+  } deriving (Functor, Applicative, Monad, MonadIO, MonadBase IO, MonadThrow)
+
+queryTrace ::
+     (O.QueryType -> Bool) -> TestMonad a -> TestMonad [(O.QueryType, String)]
+queryTrace queryPred (TestMonad writer) = do
+  (_, fullTrace) <- TestMonad (Writer.listen writer)
+  pure (filter (queryPred . fst) fullTrace)
+
+instance MonadBaseControl IO TestMonad where
+  type StM TestMonad a = StM (QueryWriterT (O.OrvilleT Postgres.Connection IO)) a
+  liftBaseWith f =
+    TestMonad $ liftBaseWith $ \runInBase -> f (\(TestMonad m) -> runInBase m)
+  restoreM stm = TestMonad (restoreM stm)
+
+instance O.MonadOrville Postgres.Connection TestMonad where
+  getOrvilleEnv = TestMonad (lift O.getOrvilleEnv)
+  localOrvilleEnv f (TestMonad m) =
+    TestMonad (Writer.mapWriterT (O.localOrvilleEnv f) m)
+  runningQuery typ sql action = do
+    TestMonad (Writer.tell [(typ, sql)])
+    action
+
+reset :: O.SchemaDefinition -> O.Orville ()
+reset schemaDef = do
+  results <- ORaw.selectSqlRows "SELECT current_user" []
+  case results of
+    [[("current_user", currentUser)]]
+    -- I would like to use placeholders here, but postgres gives my a
+    -- sql syntax error when I do :(
+     -> void $ ORaw.updateSql ("DROP OWNED BY " ++ convert currentUser) []
+    _ ->
+      error $ "Expected single 'current_user' result row, got " ++ show results
+  O.migrateSchema schemaDef
+
+withOrvilleRun :: ((forall a. TestMonad a -> IO a) -> TestTree) -> TestTree
+withOrvilleRun mkTree = withDb (\pool -> mkTree (run pool))
+  where
+    run :: IO TestPool -> forall a. TestMonad a -> IO a
+    run getPool action = do
+      pool <- getPool
+      fmap
+        fst
+        (O.runOrville
+           (Writer.runWriterT (runTestMonad action))
+           (O.newOrvilleEnv pool))
+
+withDb :: (IO TestPool -> TestTree) -> TestTree
+withDb = withResource acquirePool destroyAllResources
+
+acquirePool :: IO TestPool
+acquirePool = do
+  connString <- getEnv "TEST_CONN_STRING"
+  createPool (Postgres.connectPostgreSQL' connString) HDBC.disconnect 1 60 1


### PR DESCRIPTION
This essentially only changes the types involved in things so that
Orville doesn't apply the `entity` type variable to other variables.
Instead `entity` should be a fully applied concrete type.

Overall this makes the type signatures of functions simpler to read.
Occassionaly we have lost some clarity on how the `entity` and `key`
types are related. Only the presence of a `TableDefinition` in the
function signature enforces this relationship now.

We also lose any sense in the type system of "saved entities" vs
"unsaved entities". Where the type of `insertRecord` previously gave a
hint that entity given should not yet be saved now there is no such
hint.

This commit does not provide any facilities to help applications
generate approriate primary key values. More experimentation surrounding
that to follow.