### PR TITLE
Exports fieldToSqlValue

### DIFF
--- a/src/Database/Orville/Core.hs
+++ b/src/Database/Orville/Core.hs
@@ -65,6 +65,7 @@ module Database.Orville.Core
   , withName
   , withConversion
   , fieldFromSql
+  , fieldToSqlValue
   , SomeField(..)
   , withPrefix
   , fieldName


### PR DESCRIPTION
This PR exports `fieldToSqlValue` to convert haskell values into `SqlValue`s for use with `selectSql` in `Databse.Orville.Raw`