### PR TITLE
Add ability to generate where SQL clauses with qualified field names

### DIFF
--- a/src/Database/Orville/Core.hs
+++ b/src/Database/Orville/Core.hs
@@ -98,6 +98,7 @@ module Database.Orville.Core
   , whereOr
   , whereIn
   , whereNotIn
+  , whereQualified
   , isNull
   , isNotNull
   , (.==)

--- a/src/Database/Orville/Core.hs
+++ b/src/Database/Orville/Core.hs
@@ -101,6 +101,7 @@ module Database.Orville.Core
   , whereQualified
   , isNull
   , isNotNull
+  , whereConditionSql
   , (.==)
   , (.<>)
   , (.<-)

--- a/src/Database/Orville/Core.hs
+++ b/src/Database/Orville/Core.hs
@@ -101,7 +101,6 @@ module Database.Orville.Core
   , whereQualified
   , isNull
   , isNotNull
-  , whereConditionSql
   , (.==)
   , (.<>)
   , (.<-)

--- a/src/Database/Orville/Internal/Where.hs
+++ b/src/Database/Orville/Internal/Where.hs
@@ -16,7 +16,6 @@ module Database.Orville.Internal.Where
 , (.<=)
 , (.<-)
 , (%==)
-, whereConditionSql
 , whereConditionValues
 , whereAnd
 , whereOr

--- a/src/Database/Orville/Internal/Where.hs
+++ b/src/Database/Orville/Internal/Where.hs
@@ -107,17 +107,17 @@ whereConditionSql cond = internalWhereConditionSql Nothing cond
 
 internalWhereConditionSql :: Maybe (TableDefinition a b c) -> WhereCondition -> String
 internalWhereConditionSql tableDef (BinOp op fieldDef _) =
-  getQualifiedFieldName tableDef fieldDef ++ " " ++ op ++ " ?"
+  qualifiedFieldName tableDef fieldDef ++ " " ++ op ++ " ?"
 internalWhereConditionSql tableDef (IsNull fieldDef) =
-  getQualifiedFieldName tableDef fieldDef ++ " IS NULL"
+  qualifiedFieldName tableDef fieldDef ++ " IS NULL"
 internalWhereConditionSql tableDef (IsNotNull fieldDef) =
-  getQualifiedFieldName tableDef fieldDef ++ " IS NOT NULL"
+  qualifiedFieldName tableDef fieldDef ++ " IS NOT NULL"
 internalWhereConditionSql tableDef (In fieldDef values) =
-  getQualifiedFieldName tableDef fieldDef ++ " IN (" ++ quesses ++ ")"
+  qualifiedFieldName tableDef fieldDef ++ " IN (" ++ quesses ++ ")"
   where
     quesses = List.intercalate "," (map (const "?") values)
 internalWhereConditionSql tableDef (NotIn fieldDef values) =
-  getQualifiedFieldName tableDef fieldDef ++ " NOT IN (" ++ quesses ++ ")"
+  qualifiedFieldName tableDef fieldDef ++ " NOT IN (" ++ quesses ++ ")"
   where
     quesses = List.intercalate "," (map (const "?") values)
 internalWhereConditionSql _ AlwaysFalse = "TRUE = FALSE"
@@ -131,8 +131,8 @@ internalWhereConditionSql tableDef (And conds) = List.intercalate " AND " condsS
     condSql c = "(" ++ internalWhereConditionSql tableDef c ++ ")"
 internalWhereConditionSql _ (Qualified tableDef cond) = internalWhereConditionSql (Just tableDef) cond
 
-getQualifiedFieldName :: Maybe (TableDefinition a b c) -> FieldDefinition d -> String
-getQualifiedFieldName maybeTableDef fieldDef =
+qualifiedFieldName :: Maybe (TableDefinition a b c) -> FieldDefinition d -> String
+qualifiedFieldName maybeTableDef fieldDef =
   case maybeTableDef of
     Just tableDef -> tableName tableDef ++ "." ++ fieldName fieldDef
     Nothing -> fieldName fieldDef

--- a/src/Database/Orville/Internal/Where.hs
+++ b/src/Database/Orville/Internal/Where.hs
@@ -7,7 +7,7 @@ License   : MIT
 {-# LANGUAGE ExistentialQuantification #-}
 
 module Database.Orville.Internal.Where
-( WhereCondition
+( WhereCondition(..)
 , (.==)
 , (.<>)
 , (.>)
@@ -22,6 +22,7 @@ module Database.Orville.Internal.Where
 , whereOr
 , whereIn
 , whereNotIn
+, whereQualified
 , isNull
 , isNotNull
 , whereClause
@@ -159,6 +160,9 @@ whereIn fieldDef values = In fieldDef (map (fieldToSqlValue fieldDef) values)
 whereNotIn :: FieldDefinition a -> [a] -> WhereCondition
 whereNotIn fieldDef values =
   NotIn fieldDef (map (fieldToSqlValue fieldDef) values)
+
+whereQualified :: TableDefinition a b c -> WhereCondition -> WhereCondition
+whereQualified tableDef cond = Qualified tableDef cond
 
 isNull :: FieldDefinition a -> WhereCondition
 isNull fieldDef = IsNull fieldDef

--- a/src/Database/Orville/Internal/Where.hs
+++ b/src/Database/Orville/Internal/Where.hs
@@ -43,7 +43,7 @@ data WhereCondition
   | Or [WhereCondition]
   | And [WhereCondition]
   | AlwaysFalse
-  | Qualified String WhereCondition
+  | forall a b c. Qualified (TableDefinition a b c) WhereCondition
 
 instance QueryKeyable WhereCondition where
   queryKey (BinOp op field value) = qkOp2 op field value
@@ -103,9 +103,8 @@ whereConditionSql (And conds) = List.intercalate " AND " condsSql
   where
     condsSql = map condSql conds
     condSql c = "(" ++ whereConditionSql c ++ ")"
-
-whereConditionSql (Qualified tableNameStr cond) =
-  tableNameStr ++ "." ++ whereConditionSql cond
+whereConditionSql (Qualified tableDef cond) =
+  tableName tableDef ++ "." ++ whereConditionSql cond
 
 whereConditionValues :: WhereCondition -> [SqlValue]
 whereConditionValues (BinOp _ _ value) = [value]

--- a/test/QualifiedTest.hs
+++ b/test/QualifiedTest.hs
@@ -1,0 +1,20 @@
+module QualifiedTest where
+
+import qualified Database.Orville as O
+
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertEqual, testCase)
+
+import AppManagedEntity.Schema.Virus (virusTable, virusNameField)
+
+test_qualified_name :: TestTree
+test_qualified_name =
+    testGroup
+      "QualifiedTest"
+      [ testCase "Qualified Names" $
+          let whereCondition = O.isNull virusNameField
+              qualified = O.whereQualified virusTable whereCondition
+              actual = O.whereConditionSql qualified
+              expected = "virus.name IS NULL"
+          in assertEqual "Expected names to match" expected actual
+      ]

--- a/test/QualifiedTest.hs
+++ b/test/QualifiedTest.hs
@@ -1,20 +1,169 @@
+{-# LANGUAGE OverloadedStrings #-}
 module QualifiedTest where
 
+import qualified Data.Text as T
 import qualified Database.Orville as O
+import qualified Database.Orville.Select as S
+import qualified TestDB as TestDB
 
+import Control.Monad (void)
+import Data.Int (Int64)
+import Database.Orville ((.==))
+import Database.Orville.Expr (qualified, aliased)
 import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.HUnit (assertEqual, testCase)
-
-import AppManagedEntity.Schema.Virus (virusTable, virusNameField)
+import Test.Tasty.HUnit (assertEqual, assertFailure, testCase)
 
 test_qualified_name :: TestTree
 test_qualified_name =
+  TestDB.withOrvilleRun $ \run ->
     testGroup
       "QualifiedTest"
-      [ testCase "Qualified Names" $
-          let whereCondition = O.isNull virusNameField
-              qualified = O.whereQualified virusTable whereCondition
-              actual = O.whereConditionSql qualified
-              expected = "virus.name IS NULL"
-          in assertEqual "Expected names to match" expected actual
+      [ testCase "Qualified Names" $ do
+          run (TestDB.reset schema)
+          void $ run (O.insertRecord orderTable foobarOrder)
+          void $ run (O.insertRecord orderTable badOrder)
+          void $ run (O.insertRecord customerTable aliceCustomer)
+          void $ run (O.insertRecord customerTable bobCustomer)
+
+          let opts = O.where_
+                   $ O.whereQualified customerTable
+                   $ (customerNameField .== (CustomerName "Alice"))
+          result <- run (S.runSelect $ completeOrderSelect opts)
+
+          case length result of
+            0 -> assertFailure "Expected CompleteOrder, but no records returned"
+            1 -> assertEqual
+                "Order returned didn't match expected result"
+                "Alice"
+                (customer $ result !! 0)
+            _ -> assertFailure "Expected one record, but got many records"
       ]
+
+data CompleteOrder = CompleteOrder
+  { order    :: T.Text
+  , customer :: T.Text
+  }
+
+completeOrderSelect :: O.SelectOptions -> S.Select CompleteOrder
+completeOrderSelect = S.selectQuery buildCompleteOrder orderCustomerFrom
+
+buildCompleteOrder :: O.FromSql CompleteOrder
+buildCompleteOrder = CompleteOrder
+  <$> O.col (S.selectField orderNameField `qualified` "order" `aliased` "order_name")
+  <*> O.col (S.selectField customerNameField `qualified` "customer" `aliased` "customer_name")
+
+orderCustomerFrom :: S.FromClause
+orderCustomerFrom = S.fromClauseRaw
+  "FROM \"order\" INNER JOIN \"customer\" ON \"order\".\"customer_id\" = \"customer\".\"id\""
+
+schema :: O.SchemaDefinition
+schema = [O.Table orderTable, O.Table customerTable]
+
+-- Order definitions
+orderTable :: O.TableDefinition Order Order OrderId
+orderTable =
+  O.mkTableDefinition $
+  O.TableParams
+    { O.tblName = "order"
+    , O.tblPrimaryKey = orderIdField
+    , O.tblMapper = Order
+               <$> O.attrField orderId orderIdField
+               <*> O.attrField customerFkId customerFkIdField
+               <*> O.attrField orderName orderNameField
+    , O.tblGetKey = orderId
+    , O.tblSafeToDelete = []
+    , O.tblComments = O.noComments
+    }
+
+orderIdField :: O.FieldDefinition OrderId
+orderIdField =
+  O.int64Field "id" `O.withFlag` O.PrimaryKey `O.withConversion`
+  O.sqlConversionVia unOrderId OrderId
+
+customerFkIdField :: O.FieldDefinition CustomerId
+customerFkIdField =
+  O.int64Field "customer_id" `O.withConversion`
+  O.sqlConversionVia unCustomerId CustomerId
+
+orderNameField :: O.FieldDefinition OrderName
+orderNameField =
+  O.textField "name" 255 `O.withConversion`
+  O.sqlConversionVia unOrderName OrderName
+
+data Order = Order
+  { orderId :: OrderId
+  , customerFkId :: CustomerId
+  , orderName :: OrderName
+  } deriving (Show, Eq)
+
+newtype OrderId = OrderId
+  { unOrderId :: Int64
+  } deriving (Show, Eq)
+
+newtype OrderName = OrderName
+  { unOrderName :: T.Text
+  } deriving (Show, Eq)
+
+foobarOrder :: Order
+foobarOrder = Order
+  { orderId = OrderId 1
+  , customerFkId = CustomerId 1
+  , orderName = OrderName "foobar"
+  }
+
+badOrder :: Order
+badOrder = Order
+  { orderId = OrderId 2
+  , customerFkId = CustomerId 2
+  , orderName = OrderName "Alice"
+  }
+
+-- Customer definitions
+customerTable :: O.TableDefinition Customer Customer CustomerId
+customerTable =
+  O.mkTableDefinition $
+  O.TableParams
+    { O.tblName = "customer"
+    , O.tblPrimaryKey = customerIdField
+    , O.tblMapper = Customer
+               <$> O.attrField customerId customerIdField
+               <*> O.attrField customerName customerNameField
+    , O.tblGetKey = customerId
+    , O.tblSafeToDelete = []
+    , O.tblComments = O.noComments
+    }
+
+customerIdField :: O.FieldDefinition CustomerId
+customerIdField =
+  O.int64Field "id" `O.withFlag` O.PrimaryKey `O.withConversion`
+  O.sqlConversionVia unCustomerId CustomerId
+
+customerNameField :: O.FieldDefinition CustomerName
+customerNameField =
+  O.textField "name" 255 `O.withConversion`
+  O.sqlConversionVia unCustomerName CustomerName
+
+data Customer = Customer
+  { customerId :: CustomerId
+  , customerName :: CustomerName
+  } deriving (Show, Eq)
+
+newtype CustomerId = CustomerId
+  { unCustomerId :: Int64
+  } deriving (Show, Eq)
+
+newtype CustomerName = CustomerName
+  { unCustomerName :: T.Text
+  } deriving (Show, Eq)
+
+aliceCustomer :: Customer
+aliceCustomer = Customer
+  { customerId = CustomerId 1
+  , customerName = CustomerName "Alice"
+  }
+
+bobCustomer :: Customer
+bobCustomer = Customer
+  { customerId = CustomerId 2
+  , customerName = CustomerName "Bob"
+  }


### PR DESCRIPTION
Add the ability to get the generated `where` SQL clauses for qualified field names.

Right now, Orville lacks a lot of features. However, it is still desirable to replace some hard-coded SQL strings with automatically-generated ones. This allows a user to slowly replace SQL strings in the application as Orville becomes more feature complete.