### PR TITLE
Add whereLike

### DIFF
--- a/src/Database/Orville/Core.hs
+++ b/src/Database/Orville/Core.hs
@@ -97,6 +97,7 @@ module Database.Orville.Core
   , whereAnd
   , whereOr
   , whereIn
+  , whereLike
   , whereNotIn
   , whereQualified
   , isNull

--- a/src/Database/Orville/Internal/Where.hs
+++ b/src/Database/Orville/Internal/Where.hs
@@ -170,7 +170,7 @@ whereIn :: FieldDefinition a -> [a] -> WhereCondition
 whereIn fieldDef values = In fieldDef (map (fieldToSqlValue fieldDef) values)
 
 whereLike :: FieldDefinition a -> String -> WhereCondition
-whereLike fieldDef raw = Like fieldDef (SqlString raw)
+whereLike fieldDef raw = Like fieldDef (toSql raw)
 
 whereNotIn :: FieldDefinition a -> [a] -> WhereCondition
 whereNotIn fieldDef values =

--- a/src/Database/Orville/Internal/Where.hs
+++ b/src/Database/Orville/Internal/Where.hs
@@ -20,6 +20,7 @@ module Database.Orville.Internal.Where
   , whereAnd
   , whereOr
   , whereIn
+  , whereLike
   , whereNotIn
   , whereQualified
   , isNull
@@ -58,6 +59,8 @@ data WhereCondition
   | forall a. IsNotNull (FieldDefinition a)
   | forall a. In (FieldDefinition a)
                  [SqlValue]
+  | forall a. Like (FieldDefinition a)
+                   String
   | forall a. NotIn (FieldDefinition a)
                     [SqlValue]
   | Or [WhereCondition]
@@ -71,6 +74,7 @@ instance QueryKeyable WhereCondition where
   queryKey (IsNull field) = qkOp "IS NULL" field
   queryKey (IsNotNull field) = qkOp "NOT IS NULL" field
   queryKey (In field values) = qkOp2 "IN" field values
+  queryKey (Like field raw) = qkOp ("LIKE LOWER('" ++ raw ++ "')") field
   queryKey (NotIn field values) = qkOp2 "NOT IN" field values
   queryKey (Or conds) = qkOp "OR" conds
   queryKey (And conds) = qkOp "And" conds
@@ -117,6 +121,8 @@ internalWhereConditionSql tableDef (In fieldDef values) =
   qualifiedFieldName tableDef fieldDef ++ " IN (" ++ quesses ++ ")"
   where
     quesses = List.intercalate "," (map (const "?") values)
+internalWhereConditionSql tableDef (Like fieldDef raw) =
+  "LOWER(" ++ (qualifiedFieldName tableDef fieldDef) ++ ") LIKE LOWER('" ++ raw ++ "')"
 internalWhereConditionSql tableDef (NotIn fieldDef values) =
   qualifiedFieldName tableDef fieldDef ++ " NOT IN (" ++ quesses ++ ")"
   where
@@ -147,6 +153,7 @@ whereConditionValues (BinOp _ _ value) = [value]
 whereConditionValues (IsNull _) = []
 whereConditionValues (IsNotNull _) = []
 whereConditionValues (In _ values) = values
+whereConditionValues (Like _ _) = []
 whereConditionValues (NotIn _ values) = values
 whereConditionValues AlwaysFalse = []
 whereConditionValues (Or conds) = concatMap whereConditionValues conds
@@ -161,6 +168,9 @@ whereOr = Or
 
 whereIn :: FieldDefinition a -> [a] -> WhereCondition
 whereIn fieldDef values = In fieldDef (map (fieldToSqlValue fieldDef) values)
+
+whereLike :: FieldDefinition a -> String -> WhereCondition
+whereLike fieldDef raw = Like fieldDef raw
 
 whereNotIn :: FieldDefinition a -> [a] -> WhereCondition
 whereNotIn fieldDef values =

--- a/test/QualifiedTest.hs
+++ b/test/QualifiedTest.hs
@@ -9,7 +9,6 @@ import qualified TestDB as TestDB
 
 import Control.Monad (void)
 import Data.Int (Int64)
-import Database.Orville ((.==))
 import Database.Orville.Expr (aliased, qualified)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (assertEqual, assertFailure, testCase)

--- a/test/QualifiedTest.hs
+++ b/test/QualifiedTest.hs
@@ -28,7 +28,7 @@ test_qualified_name =
           let opts =
                 O.where_ $
                 O.whereQualified customerTable $
-                (customerNameField .== (CustomerName "Alice"))
+                (O.whereLike customerNameField "%LI%")
           result <- run (S.runSelect $ completeOrderSelect opts)
           case length result of
             0 ->

--- a/test/QualifiedTest.hs
+++ b/test/QualifiedTest.hs
@@ -27,7 +27,7 @@ test_qualified_name =
           let opts =
                 O.where_ $
                 O.whereQualified customerTable $
-                O.whereLike customerNameField "%LI%"
+                O.whereLike customerNameField "%li%"
           result <- run (S.runSelect $ completeOrderSelect opts)
           assertEqual
             "Order returned didn't match expected result"


### PR DESCRIPTION
Add support for `LIKE` queries.

`whereLike` expects the field to be compared against and the raw sql string to compare with. This allows users to put `%` or `_` anywhere they please. It also automatically calls `LOWER` for both arguments to `LIKE`, since I expect that to be desirable.