### PR TITLE
Add support for SELECT DISTINCT

### DIFF
--- a/sample-project/Main.hs
+++ b/sample-project/Main.hs
@@ -156,7 +156,7 @@ selectFirstTest = do
 
 selectAllTest :: O.OrvilleT Postgres.Connection IO [Student StudentId]
 selectAllTest = do
-  let options = O.SelectOptions mempty mempty mempty mempty mempty
+  let options = O.SelectOptions mempty mempty mempty mempty mempty mempty
   O.selectAll studentTable options
 
 findRecordTest :: O.OrvilleT Postgres.Connection IO (Maybe (Student StudentId))

--- a/src/Database/Orville/Core.hs
+++ b/src/Database/Orville/Core.hs
@@ -113,7 +113,7 @@ module Database.Orville.Core
   , (.<=)
   , SelectOptions(..)
   , where_
-  , whereDistinct
+  , distinct
   , order
   , limit
   , offset

--- a/src/Database/Orville/Core.hs
+++ b/src/Database/Orville/Core.hs
@@ -113,6 +113,7 @@ module Database.Orville.Core
   , (.<=)
   , SelectOptions(..)
   , where_
+  , whereDistinct
   , order
   , limit
   , offset

--- a/src/Database/Orville/Internal/Select.hs
+++ b/src/Database/Orville/Internal/Select.hs
@@ -30,7 +30,7 @@ selectQueryColumns selectExprs builder fromClause opts =
       List.intercalate ", " $ map (rawExprToSql . generateSql) selectExprs
     querySql =
       List.concat
-        [ "SELECT "
+        [ selectClause opts
         , columns
         , " "
         , fromClauseToSql fromClause

--- a/src/Database/Orville/Internal/SelectOptions.hs
+++ b/src/Database/Orville/Internal/SelectOptions.hs
@@ -112,11 +112,11 @@ selectOffsetClause opts =
     Nothing -> ""
     Just _ -> "OFFSET ?"
 
+distinct :: SelectOptions
+distinct = SelectOptions (First $ Just True) mempty mempty mempty mempty mempty
+
 where_ :: WhereCondition -> SelectOptions
 where_ clause = SelectOptions mempty [clause] mempty mempty mempty mempty
-
-whereDistinct :: WhereCondition -> SelectOptions
-whereDistinct clause = SelectOptions (First $ Just True) [clause] mempty mempty mempty mempty
 
 order :: ToOrderBy a => a -> SortDirection -> SelectOptions
 order orderable dir =

--- a/src/Database/Orville/Internal/SelectOptions.hs
+++ b/src/Database/Orville/Internal/SelectOptions.hs
@@ -21,7 +21,8 @@ import Database.Orville.Internal.Types ()
 import Database.Orville.Internal.Where
 
 data SelectOptions = SelectOptions
-  { selectOptWhere :: [WhereCondition]
+  { selectDistinct :: First Bool
+  , selectOptWhere :: [WhereCondition]
   , selectOptOrder :: [OrderByClause]
   , selectOptLimit :: First Int
   , selectOptOffset :: First Int
@@ -35,9 +36,10 @@ selectOptOffsetSql :: SelectOptions -> Maybe SqlValue
 selectOptOffsetSql = fmap convert . getFirst . selectOptOffset
 
 instance Monoid SelectOptions where
-  mempty = SelectOptions mempty mempty mempty mempty mempty
+  mempty = SelectOptions mempty mempty mempty mempty mempty mempty
   mappend opt opt' =
     SelectOptions
+      (selectDistinct opt <> selectDistinct opt')
       (selectOptWhere opt <> selectOptWhere opt')
       (selectOptOrder opt <> selectOptOrder opt')
       (selectOptLimit opt <> selectOptLimit opt')
@@ -53,6 +55,12 @@ instance QueryKeyable SelectOptions where
       , qkOp "LIMIT" $ selectOptLimitSql opt
       , qkOp "OFFSET" $ selectOptOffsetSql opt
       ]
+
+selectClause :: SelectOptions -> String
+selectClause opts =
+  case selectDistinct opts of
+    First (Just True)  -> "SELECT DISTINCT "
+    _ -> "SELECT "
 
 selectOptClause :: SelectOptions -> String
 selectOptClause opts =
@@ -105,18 +113,21 @@ selectOffsetClause opts =
     Just _ -> "OFFSET ?"
 
 where_ :: WhereCondition -> SelectOptions
-where_ clause = SelectOptions [clause] mempty mempty mempty mempty
+where_ clause = SelectOptions mempty [clause] mempty mempty mempty mempty
+
+whereDistinct :: WhereCondition -> SelectOptions
+whereDistinct clause = SelectOptions (First $ Just True) [clause] mempty mempty mempty mempty
 
 order :: ToOrderBy a => a -> SortDirection -> SelectOptions
 order orderable dir =
-  SelectOptions mempty [toOrderBy orderable dir] mempty mempty mempty
+  SelectOptions mempty mempty [toOrderBy orderable dir] mempty mempty mempty
 
 limit :: Int -> SelectOptions
-limit n = SelectOptions mempty mempty (First $ Just n) mempty mempty
+limit n = SelectOptions mempty mempty mempty (First $ Just n) mempty mempty
 
 offset :: Int -> SelectOptions
-offset n = SelectOptions mempty mempty mempty (First $ Just n) mempty
+offset n = SelectOptions mempty mempty mempty mempty (First $ Just n) mempty
 
 groupBy :: ToGroupBy a => a -> SelectOptions
 groupBy groupable =
-  SelectOptions mempty mempty mempty mempty [toGroupBy groupable]
+  SelectOptions mempty mempty mempty mempty mempty [toGroupBy groupable]

--- a/test/WhereConditionTest.hs
+++ b/test/WhereConditionTest.hs
@@ -23,9 +23,7 @@ test_where_condition =
           run (TestDB.reset schema)
           void $ run (O.insertRecord orderTable foobarOrder)
           void $ run (O.insertRecord orderTable anotherFoobarOrder)
-          let opts =
-                O.whereDistinct $
-                (orderNameField .== orderName foobarOrder)
+          let opts = O.distinct
           result <- run (S.runSelect $ orderNameSelect opts)
           assertEqual
             "Order returned didn't match expected result"

--- a/test/WhereConditionTest.hs
+++ b/test/WhereConditionTest.hs
@@ -19,7 +19,19 @@ test_where_condition =
   TestDB.withOrvilleRun $ \run ->
     testGroup
       "Where condition queries"
-      [ testCase "Where like" $ do
+      [ testCase "Where distinct" $ do
+          run (TestDB.reset schema)
+          void $ run (O.insertRecord orderTable foobarOrder)
+          void $ run (O.insertRecord orderTable anotherFoobarOrder)
+          let opts =
+                O.whereDistinct $
+                (orderNameField .== orderName foobarOrder)
+          result <- run (S.runSelect $ orderNameSelect opts)
+          assertEqual
+            "Order returned didn't match expected result"
+            [orderName foobarOrder]
+            result
+      , testCase "Where like" $ do
           run (TestDB.reset schema)
           void $ run (O.insertRecord orderTable foobarOrder)
           void $ run (O.insertRecord orderTable orderNamedAlice)
@@ -138,6 +150,14 @@ foobarOrder =
     , orderName = OrderName "foobar"
     }
 
+anotherFoobarOrder :: Order
+anotherFoobarOrder =
+  Order
+    { orderId = OrderId 3
+    , customerFkId = CustomerId 2
+    , orderName = OrderName "foobar"
+    }
+
 orderNamedAlice :: Order
 orderNamedAlice =
   Order
@@ -145,6 +165,15 @@ orderNamedAlice =
     , customerFkId = CustomerId 2
     , orderName = OrderName "Alice"
     }
+
+orderNameSelect :: O.SelectOptions -> S.Select OrderName
+orderNameSelect = S.selectQuery buildOrderName orderNameFrom
+
+buildOrderName :: O.FromSql OrderName
+buildOrderName = OrderName <$> O.col (S.selectField orderNameField)
+
+orderNameFrom :: S.FromClause
+orderNameFrom = S.fromClauseTable orderTable
 
 -- Customer definitions
 customerTable :: O.TableDefinition Customer Customer CustomerId


### PR DESCRIPTION
Adds support for `SELECT DISTINCT` queries. A distinct query can be done by using `whereDistinct` or by modifying `SelectOptions`.