### PR TITLE
liminalisht/qualifiedtablefromsql

### DIFF
--- a/src/Database/Orville/Core.hs
+++ b/src/Database/Orville/Core.hs
@@ -11,7 +11,6 @@ module Database.Orville.Core
   , mkTableDefinition
   , tableKeyToSql
   , tableKeyFromSql
-  , qualifiedTableFromSql
   , SqlConversion
   , sqlConversion
   , sqlConvertible

--- a/src/Database/Orville/Core.hs
+++ b/src/Database/Orville/Core.hs
@@ -227,7 +227,9 @@ findRecordsBy ::
   -> SelectOptions
   -> Orville (Map.Map fieldValue [readEntity])
 findRecordsBy tableDef field opts = do
-  let builder = (,) <$> fieldFromSql field <*> tableFromSql tableDef
+  let
+      tblNm = tableName tableDef
+      builder = (,) <$> fieldFromSql tblNm field <*> tableFromSql tableDef
       query = selectQuery builder (fromClauseTable tableDef) opts
   Map.groupBy' id <$> runSelect query
 

--- a/src/Database/Orville/Core.hs
+++ b/src/Database/Orville/Core.hs
@@ -11,6 +11,7 @@ module Database.Orville.Core
   , mkTableDefinition
   , tableKeyToSql
   , tableKeyFromSql
+  , qualifiedTableFromSql
   , SqlConversion
   , sqlConversion
   , sqlConvertible

--- a/src/Database/Orville/Expr.hs
+++ b/src/Database/Orville/Expr.hs
@@ -14,7 +14,7 @@ module Database.Orville.Expr
   , NameForm
   , unescapedName
   , SelectExpr
-  , SelectForm(..)
+  , SelectForm
   , selectColumn
   , qualified
   , aliased

--- a/src/Database/Orville/Internal/Expr/SelectExpr.hs
+++ b/src/Database/Orville/Internal/Expr/SelectExpr.hs
@@ -30,13 +30,11 @@ selectColumn :: NameForm -> SelectForm
 selectColumn form = SelectForm form Nothing
 
 selectFormOutput :: SelectForm -> NameForm
-selectFormOutput form =
-  case selectFormAlias form of
-    Just alias -> alias
-    Nothing ->
-      case selectFormColumn form of
-        (NameForm Nothing _) -> selectFormColumn form
-        (NameForm (Just table) name) -> (NameForm Nothing (table ++ "." ++ name))
+selectFormOutput form = case selectFormAlias form of
+  Just alias -> alias
+  Nothing -> case selectFormColumn form of
+    (NameForm Nothing _) -> selectFormColumn form
+    (NameForm (Just table) name) -> (NameForm Nothing (table ++ "." ++ name))
 
 aliased :: SelectForm -> NameForm -> SelectForm
 aliased sf name = sf {selectFormAlias = Just name}

--- a/src/Database/Orville/Internal/QueryCache.hs
+++ b/src/Database/Orville/Internal/QueryCache.hs
@@ -67,7 +67,7 @@ selectCachedRows tableDef opts =
   unsafeLift $
   runSelect $ selectQueryRows selects (fromClauseTable tableDef) opts
   where
-    selects = expr . selectColumn . fromString <$> tableColumnNames tableDef
+    selects = expr . selectColumn . (`qualified` (tableName tableDef)) . fromString <$> tableColumnNames tableDef
     key = mconcat [queryKey tableDef, queryKey opts]
 
 selectCached ::

--- a/src/Database/Orville/Internal/QueryCache.hs
+++ b/src/Database/Orville/Internal/QueryCache.hs
@@ -68,10 +68,8 @@ selectCachedRows tableDef opts =
   runSelect $ selectQueryRows selects (fromClauseTable tableDef) opts
   where
     selectQualifiedColumn = selectColumn . (`qualified` (tableName tableDef))
-    qualifiedSelects =
+    selects =
       expr . selectQualifiedColumn . fromString <$> tableColumnNames tableDef
-    unqualifiedSelects = expr . selectColumn . fromString <$> tableColumnNames tableDef
-    selects = qualifiedSelects <> unqualifiedSelects
     key = mconcat [queryKey tableDef, queryKey opts]
 
 selectCached ::

--- a/src/Database/Orville/Internal/QueryCache.hs
+++ b/src/Database/Orville/Internal/QueryCache.hs
@@ -67,7 +67,9 @@ selectCachedRows tableDef opts =
   unsafeLift $
   runSelect $ selectQueryRows selects (fromClauseTable tableDef) opts
   where
-    selects = expr . selectColumn . (`qualified` (tableName tableDef)) . fromString <$> tableColumnNames tableDef
+    selectQualifiedColumn = selectColumn . (`qualified` (tableName tableDef))
+    selects =
+      expr . selectQualifiedColumn . fromString <$> tableColumnNames tableDef
     key = mconcat [queryKey tableDef, queryKey opts]
 
 selectCached ::

--- a/src/Database/Orville/Internal/QueryCache.hs
+++ b/src/Database/Orville/Internal/QueryCache.hs
@@ -68,8 +68,10 @@ selectCachedRows tableDef opts =
   runSelect $ selectQueryRows selects (fromClauseTable tableDef) opts
   where
     selectQualifiedColumn = selectColumn . (`qualified` (tableName tableDef))
-    selects =
+    qualifiedSelects =
       expr . selectQualifiedColumn . fromString <$> tableColumnNames tableDef
+    unqualifiedSelects = expr . selectColumn . fromString <$> tableColumnNames tableDef
+    selects = qualifiedSelects <> unqualifiedSelects
     key = mconcat [queryKey tableDef, queryKey opts]
 
 selectCached ::

--- a/src/Database/Orville/Internal/QueryCache.hs
+++ b/src/Database/Orville/Internal/QueryCache.hs
@@ -114,7 +114,9 @@ findRecordsByCached ::
   -> SelectOptions
   -> QueryCached m (Map.Map fieldValue [readEntity])
 findRecordsByCached tableDef field opts = do
-  let builder = (,) <$> fieldFromSql field <*> tableFromSql tableDef
+  let
+      tblName = tableName tableDef
+      builder = (,) <$> fieldFromSql tblName field <*> tableFromSql tableDef
   rows <- selectCachedRows tableDef opts
   Map.groupBy' id <$> unsafeLift (decodeSqlRows builder rows)
 

--- a/src/Database/Orville/Internal/RelationalMap.hs
+++ b/src/Database/Orville/Internal/RelationalMap.hs
@@ -182,7 +182,8 @@ mkFromSql tblName (RM_Nest _ rm) = mkFromSql tblName rm
 mkFromSql tblName (RM_ReadOnly rm) = mkFromSql tblName rm
 mkFromSql tblName (RM_MaybeTag rm) = mkFromSql tblName rm
 mkFromSql       _ (RM_Pure b) = pure b
-mkFromSql tblName (RM_Apply rmF rmC) = mkFromSql tblName rmF <*> mkFromSql tblName rmC
+mkFromSql tblName (RM_Apply rmF rmC) =
+  mkFromSql tblName rmF <*> mkFromSql tblName rmC
 mkFromSql tblName (RM_Partial rm) = do
   joinFromSqlError (wrapError <$> mkFromSql tblName rm)
   where

--- a/src/Database/Orville/Internal/Types.hs
+++ b/src/Database/Orville/Internal/Types.hs
@@ -229,14 +229,6 @@ tableKeysToSql ::
      TableDefinition fullEntity writeEntity key -> [key] -> [SqlValue]
 tableKeysToSql tableDef = map (tableKeyToSql tableDef)
 
-qualifiedTableFromSql ::
-     TableDefinition fullEntity writeEntity key -> FromSql fullEntity
-qualifiedTableFromSql tableDef = fromSQL { fromSqlSelects = qualifiedSelects }
-  where
-    fromSQL = tableFromSql tableDef
-    qualifiedSelects =
-      fmap (`qualified` (NameForm $ tableName tableDef)) $ fromSqlSelects fromSQL
-
 instance QueryKeyable (TableDefinition fullEntity writeEntity key) where
   queryKey = QKTable . tableName
 

--- a/src/Database/Orville/Internal/Types.hs
+++ b/src/Database/Orville/Internal/Types.hs
@@ -230,10 +230,12 @@ tableKeysToSql ::
 tableKeysToSql tableDef = map (tableKeyToSql tableDef)
 
 qualifiedTableFromSql ::
-     TableDefinition fullEntity writeEntity key -> FromSql a -> FromSql a
-qualifiedTableFromSql table fromSQL = fromSQL { fromSqlSelects = qualifiedSelects }
+     TableDefinition fullEntity writeEntity key -> FromSql fullEntity
+qualifiedTableFromSql tableDef = fromSQL { fromSqlSelects = qualifiedSelects }
   where
-    qualifiedSelects = fmap (`qualified` (NameForm $ tableName table)) $ fromSqlSelects fromSQL
+    fromSQL = tableFromSql tableDef
+    qualifiedSelects =
+      fmap (`qualified` (NameForm $ tableName tableDef)) $ fromSqlSelects fromSQL
 
 instance QueryKeyable (TableDefinition fullEntity writeEntity key) where
   queryKey = QKTable . tableName

--- a/src/Database/Orville/Internal/Types.hs
+++ b/src/Database/Orville/Internal/Types.hs
@@ -229,6 +229,12 @@ tableKeysToSql ::
      TableDefinition fullEntity writeEntity key -> [key] -> [SqlValue]
 tableKeysToSql tableDef = map (tableKeyToSql tableDef)
 
+qualifiedTableFromSql ::
+     TableDefinition fullEntity writeEntity key -> FromSql a -> FromSql a
+qualifiedTableFromSql table fromSQL = fromSQL { fromSqlSelects = qualifiedSelects }
+  where
+    qualifiedSelects = fmap (`qualified` (NameForm $ tableName table)) $ fromSqlSelects fromSQL
+
 instance QueryKeyable (TableDefinition fullEntity writeEntity key) where
   queryKey = QKTable . tableName
 

--- a/test/ErrorsTest.hs
+++ b/test/ErrorsTest.hs
@@ -53,4 +53,7 @@ badVirusNameField = virusNameField `O.withConversion` const O.intConversion
 
 badVirusFromSql :: O.FromSql BadVirus
 badVirusFromSql =
-  BadVirus <$> O.fieldFromSql virusIdField <*> O.fieldFromSql badVirusNameField
+  BadVirus <$> O.fieldFromSql tblName virusIdField
+           <*> O.fieldFromSql tblName badVirusNameField
+  where
+    tblName = O.tableName virusTable


### PR DESCRIPTION
This PR adds a function to return a `FromSql fullEntity` given a `TableDefinition fullEntity writeEntity key` in such a way that the selections are qualified by the table's name.

An example use case is where we want to join on tables that have column names that conflict. We'd like (in such a case) to reuse the fromsql derived from the table, but we can't b/c we get an ambilguous reference error unless qualified.
```
"SqlError {seState = \"42702\", seNativeError = 7, seErrorMsg = \"execute: PGRES_FATAL_ERROR: ERROR:  column reference \\\"id\\\" is ambiguous\\nLINE 1: SELECT \\\"id\\\", \\\"supplier_order_id\\\"..."
```

With this function, we can reuse that `FromSql` qualified by the table's name as so:
```
f = runSelect $ selectQuery fromSql fromClause selectOptions
  where
    fromSql    = qualifiedTableFromSql someTable
    fromClause = fromClauseRaw $
      " FROM some_table \
      \ LEFT JOIN some_other_table   \
      \ ON some_table.supplier_order_id = some_other_table.supplier_order_id "
    selectOptions   = where_ whereConditions
    whereConditions = whereAnd
      [ whereQualified someTable $ ...
      , whereQualified someOtherTable $ ...
      ]
```

