### PR TITLE
Add support for making raw WHERE conditions

### DIFF
--- a/src/Database/Orville/Core.hs
+++ b/src/Database/Orville/Core.hs
@@ -101,6 +101,7 @@ module Database.Orville.Core
   , whereLikeInsensitive
   , whereNotIn
   , whereQualified
+  , whereRaw
   , isNull
   , isNotNull
   , (.==)


### PR DESCRIPTION
The idea behind this PR is to leverage the current capability of Orville to generate most `WHERE` conditions, but still allow custom-written where clauses when needed, such as those that contain subqueries.