### PR TITLE
Initial WhereExpr

### DIFF
--- a/src/Database/Orville/Internal/Expr/NameExpr.hs
+++ b/src/Database/Orville/Internal/Expr/NameExpr.hs
@@ -11,6 +11,7 @@ import Data.Monoid
 import Data.String
 
 import Database.Orville.Internal.Expr.Expr
+import Database.Orville.Internal.QueryKey
 
 type NameExpr = Expr NameForm
 
@@ -30,6 +31,9 @@ instance IsString NameForm where
 
 instance QualifySql NameForm where
   qualified form table = form {nameFormTable = Just table}
+
+instance QueryKeyable NameForm where
+  queryKey = QKField . nameFormName
 
 instance GenerateSql NameForm where
   generateSql (NameForm Nothing name) =

--- a/src/Database/Orville/Internal/Expr/NameExpr.hs
+++ b/src/Database/Orville/Internal/Expr/NameExpr.hs
@@ -33,7 +33,7 @@ instance QualifySql NameForm where
   qualified form table = form {nameFormTable = Just table}
 
 instance QueryKeyable NameForm where
-  queryKey = QKField . nameFormName
+  queryKey = QKField . unescapedName
 
 instance GenerateSql NameForm where
   generateSql (NameForm Nothing name) =

--- a/src/Database/Orville/Internal/Expr/WhereExpr.hs
+++ b/src/Database/Orville/Internal/Expr/WhereExpr.hs
@@ -65,7 +65,7 @@ whereBinOp op field a = WhereBinOp op nameForm sqlValue
     sqlValue = (fieldToSqlValue field a)
 
 whereValues :: [WhereForm] -> [SqlValue]
-whereValues = List.concatMap whereValues'
+whereValues = List.concatMap whereValuesInternal
 
-whereValues' :: WhereForm -> [SqlValue]
-whereValues' (WhereBinOp _ _ value) = [value]
+whereValuesInternal :: WhereForm -> [SqlValue]
+whereValuesInternal (WhereBinOp _ _ value) = [value]

--- a/src/Database/Orville/Internal/Expr/WhereExpr.hs
+++ b/src/Database/Orville/Internal/Expr/WhereExpr.hs
@@ -1,0 +1,71 @@
+module Database.Orville.Internal.Expr.WhereExpr
+( WhereExpr
+, WhereForm
+, (.==)
+, (.<>)
+, (.>)
+, (.>=)
+, (.<)
+, (.<=)
+, (%==)
+, whereValues
+) where
+
+import qualified Data.List as List
+import Data.Monoid
+import Database.HDBC
+
+import Database.Orville.Internal.Expr.Expr
+import Database.Orville.Internal.Expr.NameExpr
+import Database.Orville.Internal.FieldDefinition
+import Database.Orville.Internal.QueryKey
+import Database.Orville.Internal.Types
+
+type WhereExpr = Expr WhereForm
+
+data WhereForm
+  = WhereBinOp String NameForm SqlValue
+
+instance QualifySql WhereForm where
+  qualified (WhereBinOp op name value) table =
+    WhereBinOp op (name `qualified` table) value
+
+instance QueryKeyable WhereForm where
+  queryKey (WhereBinOp op field value) = qkOp2 op field value
+
+instance GenerateSql WhereForm where
+  generateSql (WhereBinOp op name _) =
+    (generateSql name) <> rawSql (" " <> op <> " ?")
+
+(.==) :: FieldDefinition a -> a -> WhereForm
+field .== a = whereBinOp "=" field a
+
+(.<>) :: FieldDefinition a -> a -> WhereForm
+field .<> a = whereBinOp "<>" field a
+
+(.>) :: FieldDefinition a -> a -> WhereForm
+field .> a = whereBinOp ">" field a
+
+(.>=) :: FieldDefinition a -> a -> WhereForm
+field .>= a = whereBinOp ">=" field a
+
+(.<) :: FieldDefinition a -> a -> WhereForm
+field .< a = whereBinOp "<" field a
+
+(.<=) :: FieldDefinition a -> a -> WhereForm
+field .<= a = whereBinOp "<=" field a
+
+(%==) :: FieldDefinition a -> a -> WhereForm
+field %== a = whereBinOp "@@" field a
+
+whereBinOp :: String -> FieldDefinition a -> a -> WhereForm
+whereBinOp op field a = WhereBinOp op nameForm sqlValue
+  where
+    nameForm = fieldToNameForm field
+    sqlValue = (fieldToSqlValue field a)
+
+whereValues :: [WhereForm] -> [SqlValue]
+whereValues = List.concatMap whereValues'
+
+whereValues' :: WhereForm -> [SqlValue]
+whereValues' (WhereBinOp _ _ value) = [value]

--- a/src/Database/Orville/Internal/Expr/WhereExpr.hs
+++ b/src/Database/Orville/Internal/Expr/WhereExpr.hs
@@ -17,9 +17,7 @@ import Database.HDBC
 
 import Database.Orville.Internal.Expr.Expr
 import Database.Orville.Internal.Expr.NameExpr
-import Database.Orville.Internal.FieldDefinition
 import Database.Orville.Internal.QueryKey
-import Database.Orville.Internal.Types
 
 type WhereExpr = Expr WhereForm
 
@@ -37,32 +35,26 @@ instance GenerateSql WhereForm where
   generateSql (WhereBinOp op name _) =
     (generateSql name) <> rawSql (" " <> op <> " ?")
 
-(.==) :: FieldDefinition a -> a -> WhereForm
-field .== a = whereBinOp "=" field a
+(.==) :: NameForm -> SqlValue -> WhereForm
+name .== value = WhereBinOp "=" name value
 
-(.<>) :: FieldDefinition a -> a -> WhereForm
-field .<> a = whereBinOp "<>" field a
+(.<>) :: NameForm -> SqlValue -> WhereForm
+name .<> value = WhereBinOp "<>" name value
 
-(.>) :: FieldDefinition a -> a -> WhereForm
-field .> a = whereBinOp ">" field a
+(.>) :: NameForm -> SqlValue -> WhereForm
+name .> value = WhereBinOp ">" name value
 
-(.>=) :: FieldDefinition a -> a -> WhereForm
-field .>= a = whereBinOp ">=" field a
+(.>=) :: NameForm -> SqlValue -> WhereForm
+name .>= value = WhereBinOp ">=" name value
 
-(.<) :: FieldDefinition a -> a -> WhereForm
-field .< a = whereBinOp "<" field a
+(.<) :: NameForm -> SqlValue -> WhereForm
+name .< value = WhereBinOp "<" name value
 
-(.<=) :: FieldDefinition a -> a -> WhereForm
-field .<= a = whereBinOp "<=" field a
+(.<=) :: NameForm -> SqlValue -> WhereForm
+name .<= value = WhereBinOp "<=" name value
 
-(%==) :: FieldDefinition a -> a -> WhereForm
-field %== a = whereBinOp "@@" field a
-
-whereBinOp :: String -> FieldDefinition a -> a -> WhereForm
-whereBinOp op field a = WhereBinOp op nameForm sqlValue
-  where
-    nameForm = fieldToNameForm field
-    sqlValue = (fieldToSqlValue field a)
+(%==) :: NameForm -> SqlValue -> WhereForm
+name %== value = WhereBinOp "@@" name value
 
 whereValues :: [WhereForm] -> [SqlValue]
 whereValues = List.concatMap whereValuesInternal

--- a/src/Database/Orville/Internal/FieldDefinition.hs
+++ b/src/Database/Orville/Internal/FieldDefinition.hs
@@ -10,6 +10,7 @@ import Data.Text (Text)
 import Data.Time (Day, UTCTime)
 import Database.HDBC
 
+import Database.Orville.Internal.Expr.NameExpr (NameForm(..))
 import Database.Orville.Internal.SqlConversion
 import Database.Orville.Internal.Types
 
@@ -112,6 +113,9 @@ withPrefix f@(name, _, _, _) prefix = f `withName` (prefix ++ "_" ++ name)
 
 fieldConversion :: FieldDefinition a -> SqlConversion a
 fieldConversion (_, _, _, conversion) = conversion
+
+fieldToNameForm :: FieldDefinition a -> NameForm
+fieldToNameForm field = NameForm Nothing (fieldName field)
 
 fieldToSqlValue :: FieldDefinition a -> a -> SqlValue
 fieldToSqlValue = convertToSql . fieldConversion

--- a/src/Database/Orville/Internal/Select.hs
+++ b/src/Database/Orville/Internal/Select.hs
@@ -10,7 +10,7 @@ import qualified Data.List as List
 import Database.HDBC
 
 import Database.Orville.Internal.Expr
-import Database.Orville.Internal.FieldDefinition (fieldName)
+import Database.Orville.Internal.FieldDefinition (fieldToNameForm)
 import Database.Orville.Internal.FromClause
 import Database.Orville.Internal.SelectOptions
 import Database.Orville.Internal.Types
@@ -73,4 +73,4 @@ rowFromSql =
     }
 
 selectField :: FieldDefinition a -> SelectForm
-selectField field = selectColumn (NameForm Nothing (fieldName field))
+selectField field = selectColumn (fieldToNameForm field)

--- a/src/Database/Orville/Internal/Where.hs
+++ b/src/Database/Orville/Internal/Where.hs
@@ -86,29 +86,50 @@ instance QueryKeyable WhereCondition where
   queryKey (Qualified _ cond) = queryKey cond
 
 (.==) :: FieldDefinition a -> a -> WhereCondition
-fieldDef .== a = WhereConditionForm (fieldDef E..== a)
+fieldDef .== a = WhereConditionForm $ nameForm E..== sqlValue
+  where
+    nameForm = fieldToNameForm fieldDef
+    sqlValue = fieldToSqlValue fieldDef a
 
 (.<>) :: FieldDefinition a -> a -> WhereCondition
-fieldDef .<> a = WhereConditionForm (fieldDef E..<> a)
+fieldDef .<> a = WhereConditionForm $ nameForm E..<> sqlValue
+  where
+    nameForm = fieldToNameForm fieldDef
+    sqlValue = fieldToSqlValue fieldDef a
 
 (.>) :: FieldDefinition a -> a -> WhereCondition
-fieldDef .> a = WhereConditionForm (fieldDef E..> a)
+fieldDef .> a = WhereConditionForm $ nameForm E..> sqlValue
+  where
+    nameForm = fieldToNameForm fieldDef
+    sqlValue = fieldToSqlValue fieldDef a
 
 (.>=) :: FieldDefinition a -> a -> WhereCondition
-fieldDef .>= a = WhereConditionForm (fieldDef E..>= a)
+fieldDef .>= a = WhereConditionForm $ nameForm E..>= sqlValue
+  where
+    nameForm = fieldToNameForm fieldDef
+    sqlValue = fieldToSqlValue fieldDef a
 
 (.<) :: FieldDefinition a -> a -> WhereCondition
-fieldDef .< a = WhereConditionForm (fieldDef E..< a)
+fieldDef .< a = WhereConditionForm $ nameForm E..< sqlValue
+  where
+    nameForm = fieldToNameForm fieldDef
+    sqlValue = fieldToSqlValue fieldDef a
 
 (.<=) :: FieldDefinition a -> a -> WhereCondition
-fieldDef .<= a = WhereConditionForm (fieldDef E..<= a)
+fieldDef .<= a = WhereConditionForm $ nameForm E..<= sqlValue
+  where
+    nameForm = fieldToNameForm fieldDef
+    sqlValue = fieldToSqlValue fieldDef a
 
 (.<-) :: FieldDefinition a -> [a] -> WhereCondition
 _ .<- [] = AlwaysFalse
 fieldDef .<- as = In fieldDef (List.nub $ map (fieldToSqlValue fieldDef) as)
 
 (%==) :: FieldDefinition a -> a -> WhereCondition
-fieldDef %== a = WhereConditionForm (fieldDef E.%== a)
+fieldDef %== a = WhereConditionForm $ nameForm E.%== sqlValue
+  where
+    nameForm = fieldToNameForm fieldDef
+    sqlValue = fieldToSqlValue fieldDef a
 
 whereConditionSql :: WhereCondition -> String
 whereConditionSql cond = internalWhereConditionSql Nothing cond


### PR DESCRIPTION
Adds the initial `WhereExpr` type.

This PR is one part of a potential series of PRs to slowly replace the functionality in `WhereCondition` with `WhereExpr`.

This PR only implements the binary operators. If this PR is approved, then I will do the same incrementally to the rest of the `WhereCondition` sumtypes.

The original API is preserved in this PR. It should be noted that if someone qualifies a `WhereForm` and then uses `Qualified` on the resulting `WhereCondition`, the `WhereCondition` qualification will take precedence over the `WhereForm` one. This is done in favor of making sure the original API still works until it is completely replaced by `WhereExpr`.