### PR TITLE
Add whereRaw to Where module

### DIFF
--- a/src/Database/Orville/Core.hs
+++ b/src/Database/Orville/Core.hs
@@ -101,6 +101,7 @@ module Database.Orville.Core
   , whereLikeInsensitive
   , whereNotIn
   , whereQualified
+  , whereRaw
   , isNull
   , isNotNull
   , (.==)

--- a/src/Database/Orville/Internal/Where.hs
+++ b/src/Database/Orville/Internal/Where.hs
@@ -205,8 +205,8 @@ whereNotIn fieldDef values =
 whereQualified :: TableDefinition a b c -> WhereCondition -> WhereCondition
 whereQualified tableDef cond = Qualified tableDef cond
 
-whereRaw :: String -> WhereCondition
-whereRaw = WhereConditionExpr . rawSqlExpr
+whereRaw :: String -> [SqlValue] -> WhereCondition
+whereRaw str values = WhereConditionExpr . expr $ E.whereRaw str values
 
 isNull :: FieldDefinition a -> WhereCondition
 isNull = WhereConditionExpr . expr . E.whereNull . fieldToNameForm

--- a/test/WhereConditionTest.hs
+++ b/test/WhereConditionTest.hs
@@ -9,6 +9,7 @@ import qualified TestDB as TestDB
 
 import Control.Monad (void)
 import Data.Int (Int64)
+import Database.HDBC (toSql)
 import Database.Orville ((.==))
 import Database.Orville.Expr (aliased, qualified)
 import Test.Tasty (TestTree, testGroup)
@@ -76,7 +77,7 @@ test_where_condition =
           void $ run (O.insertRecord customerTable bobCustomer)
           let opts =
                 O.where_ $
-                O.whereRaw $ "customer.name = 'Alice'"
+                O.whereRaw "customer.name = ?" [toSql ("Alice" :: String)]
           result <- run (S.runSelect $ completeOrderSelect opts)
           assertEqual
             "Order returned didn't match expected result"

--- a/test/WhereConditionTest.hs
+++ b/test/WhereConditionTest.hs
@@ -68,6 +68,20 @@ test_where_condition =
             "Order returned didn't match expected result"
             [CompleteOrder {order = "foobar", customer = "Alice"}]
             result
+      , testCase "Raw where" $ do
+          run (TestDB.reset schema)
+          void $ run (O.insertRecord orderTable foobarOrder)
+          void $ run (O.insertRecord orderTable orderNamedAlice)
+          void $ run (O.insertRecord customerTable aliceCustomer)
+          void $ run (O.insertRecord customerTable bobCustomer)
+          let opts =
+                O.where_ $
+                O.whereRaw $ "customer.name = 'Alice'"
+          result <- run (S.runSelect $ completeOrderSelect opts)
+          assertEqual
+            "Order returned didn't match expected result"
+            [CompleteOrder {order = "foobar", customer = "Alice"}]
+            result
       ]
 
 data CompleteOrder = CompleteOrder


### PR DESCRIPTION
Adds the `whereRaw` function to the the `Database.Orville.Internal.Where` module. This will allow a user of the `Where` API to create where conditions using raw strings.

In order to make this work, `WhereConditionForm` has been renamed to `WhereConditionExpr` and now contains a `WhereExpr` instead of a `WhereForm`.