### PR TITLE
Use current schema instead of public

### DIFF
--- a/src/Database/Orville/Internal/MigrateConstraint.hs
+++ b/src/Database/Orville/Internal/MigrateConstraint.hs
@@ -47,6 +47,6 @@ getConstraints conn = do
       "SELECT conname \
                         \FROM pg_constraint \
                         \JOIN pg_namespace ON pg_namespace.oid = pg_constraint.connamespace \
-                        \WHERE nspname = 'public'"
+                        \WHERE nspname = current_schema()"
   void $ execute query []
   map (convert . head) <$> fetchAllRows' query

--- a/src/Database/Orville/Internal/MigrateIndex.hs
+++ b/src/Database/Orville/Internal/MigrateIndex.hs
@@ -47,6 +47,6 @@ getIndexes conn = do
   query <-
     prepare
       conn
-      "SELECT indexname FROM pg_indexes WHERE schemaname = 'public';"
+      "SELECT indexname FROM pg_indexes WHERE schemaname = current_schema();"
   void $ execute query []
   map (convert . head) <$> fetchAllRows' query


### PR DESCRIPTION
By default, postgres creates new indexes under the schema given by `current_schema()`, but Orville checks for the existence of an index in the `public` schema. This PR fixes this discrepancy by making the check use `current_schema()`.