### PR TITLE
Export FieldDefinition record fields

### DIFF
--- a/src/Database/Orville/Core.hs
+++ b/src/Database/Orville/Core.hs
@@ -71,6 +71,8 @@ module Database.Orville.Core
   , SomeField(..)
   , withPrefix
   , fieldName
+  , fieldType
+  , fieldFlags
   , IndexDefinition(..)
   , uniqueIndex
   , simpleIndex


### PR DESCRIPTION
Adds the `fieldType` and `fieldFlags` functions as exports in `Database.Orville.Core`.