### PR TITLE
Show the value that could not be decoded

### DIFF
--- a/src/Database/Orville/Internal/FromSql.hs
+++ b/src/Database/Orville/Internal/FromSql.hs
@@ -43,7 +43,7 @@ fieldFromSql field =
           Left $
           RowDataError $
           concat
-            ["Error decoding data from column ", fieldName field, " value"]
+            ["Error decoding ", show sql, " from column ", fieldName field, " value"]
 
 class ColumnSpecifier col where
   selectForm :: col -> SelectForm


### PR DESCRIPTION
When throwing a `RowDataError`, Orville does not include what the value that could not be decoded was.

This makes the error useless when trying to understand why something broke in a production environment, especially when a database query doesn't reveal any immediately obvious solutions. Including the value that could not be decoded can make similar situations easier to debug.