### PR TITLE
liminalisht/semigroupifdefsbase

### DIFF
--- a/src/Database/Orville/Internal/Expr/Expr.hs
+++ b/src/Database/Orville/Internal/Expr/Expr.hs
@@ -3,6 +3,8 @@ Module    : Database.Orville.Internal.Expr.Expr
 Copyright : Flipstone Technology Partners 2016-2018
 License   : MIT
 -}
+{-#LANGUAGE CPP#-}
+
 module Database.Orville.Internal.Expr.Expr where
 
 import Data.String
@@ -22,6 +24,11 @@ rawExprToSql = go ""
     go rest (RawExprString s) = s ++ rest
     go rest (RawExprAppend r1 r2) = go (go rest r2) r1
     go rest (RawExprConcat exprs) = foldr (flip go) rest exprs
+
+#if __GLASGOW_HASKELL__ >= 841
+instance Semigroup RawExpr where
+  (<>) = RawExprAppend
+#endif
 
 instance Monoid RawExpr where
   mempty = RawExprString ""

--- a/src/Database/Orville/Internal/Expr/Expr.hs
+++ b/src/Database/Orville/Internal/Expr/Expr.hs
@@ -25,7 +25,7 @@ rawExprToSql = go ""
     go rest (RawExprAppend r1 r2) = go (go rest r2) r1
     go rest (RawExprConcat exprs) = foldr (flip go) rest exprs
 
-#if __GLASGOW_HASKELL__ >= 841
+#if MIN_VERSION_base(4,11,0)
 instance Semigroup RawExpr where
   (<>) = RawExprAppend
 #endif

--- a/src/Database/Orville/Internal/QueryKey.hs
+++ b/src/Database/Orville/Internal/QueryKey.hs
@@ -21,7 +21,7 @@ data QueryKey
   | QKEmpty
   deriving (Eq, Ord)
 
-#if __GLASGOW_HASKELL__ >= 841
+#if MIN_VERSION_base(4,11,0)
 instance Semigroup QueryKey where
   (<>) = appendQueryKeys
 #endif

--- a/src/Database/Orville/Internal/QueryKey.hs
+++ b/src/Database/Orville/Internal/QueryKey.hs
@@ -3,6 +3,8 @@ Module    : Database.Orville.Internal.QueryKey
 Copyright : Flipstone Technology Partners 2016-2018
 License   : MIT
 -}
+{-#LANGUAGE CPP#-}
+
 module Database.Orville.Internal.QueryKey where
 
 import Data.Monoid
@@ -19,10 +21,18 @@ data QueryKey
   | QKEmpty
   deriving (Eq, Ord)
 
+#if __GLASGOW_HASKELL__ >= 841
+instance Semigroup QueryKey where
+  (<>) = appendQueryKeys
+#endif
+
 instance Monoid QueryKey where
   mempty = QKEmpty
-  mappend a b = QKList [a, b]
+  mappend = appendQueryKeys
   mconcat = QKList
+
+appendQueryKeys :: QueryKey -> QueryKey -> QueryKey
+appendQueryKeys a b = QKList [a, b]
 
 class QueryKeyable a where
   queryKey :: a -> QueryKey

--- a/src/Database/Orville/Internal/SelectOptions.hs
+++ b/src/Database/Orville/Internal/SelectOptions.hs
@@ -3,6 +3,7 @@ Module    : Database.Orville.Internal.SelectOptions
 Copyright : Flipstone Technology Partners 2016-2018
 License   : MIT
 -}
+{-# LANGUAGE CPP#-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Database.Orville.Internal.SelectOptions where
@@ -35,16 +36,24 @@ selectOptLimitSql = fmap convert . getFirst . selectOptLimit
 selectOptOffsetSql :: SelectOptions -> Maybe SqlValue
 selectOptOffsetSql = fmap convert . getFirst . selectOptOffset
 
+#if __GLASGOW_HASKELL__ >= 841
+instance Semigroup SelectOptions where
+  (<>) = appendSelectOptions
+#endif
+
 instance Monoid SelectOptions where
   mempty = SelectOptions mempty mempty mempty mempty mempty mempty
-  mappend opt opt' =
-    SelectOptions
-      (selectDistinct opt <> selectDistinct opt')
-      (selectOptWhere opt <> selectOptWhere opt')
-      (selectOptOrder opt <> selectOptOrder opt')
-      (selectOptLimit opt <> selectOptLimit opt')
-      (selectOptOffset opt <> selectOptOffset opt')
-      (selectOptGroup opt <> selectOptGroup opt')
+  mappend = appendSelectOptions
+
+appendSelectOptions :: SelectOptions -> SelectOptions -> SelectOptions
+appendSelectOptions opt opt' =
+  SelectOptions
+    (selectDistinct  opt <> selectDistinct  opt')
+    (selectOptWhere  opt <> selectOptWhere  opt')
+    (selectOptOrder  opt <> selectOptOrder  opt')
+    (selectOptLimit  opt <> selectOptLimit  opt')
+    (selectOptOffset opt <> selectOptOffset opt')
+    (selectOptGroup  opt <> selectOptGroup  opt')
 
 instance QueryKeyable SelectOptions where
   queryKey opt =

--- a/src/Database/Orville/Internal/SelectOptions.hs
+++ b/src/Database/Orville/Internal/SelectOptions.hs
@@ -36,7 +36,7 @@ selectOptLimitSql = fmap convert . getFirst . selectOptLimit
 selectOptOffsetSql :: SelectOptions -> Maybe SqlValue
 selectOptOffsetSql = fmap convert . getFirst . selectOptOffset
 
-#if __GLASGOW_HASKELL__ >= 841
+#if MIN_VERSION_base(4,11,0)
 instance Semigroup SelectOptions where
   (<>) = appendSelectOptions
 #endif


### PR DESCRIPTION
This PR addresses the change in GHC `8.4.1` wherein `Semigroup` is now a superclass of `Monoid`.

If a version of `base` >= 4.11.0 is used, then a `Semigroup` instance is supplied for all datatypes implementing `Monoid`.  

Specifically, the `CPP` language extension and `#if` statements are used to check the version of `base` (which is tightly coupled with the version of GHC).

Note: an initial attempt to check the version of GHC (instead of the version of `base`) using `__GLASGOW_HASKELL__` did not work.