### PR TITLE
[ch12596] Moves the startTransactionSQL callback into OrvilleEnv

### DIFF
--- a/src/Database/Orville/Core.hs
+++ b/src/Database/Orville/Core.hs
@@ -37,6 +37,7 @@ module Database.Orville.Core
   , readOnlyField
   , OrvilleEnv
   , newOrvilleEnv
+  , setStartTransactionSQL
   , ormEnvPool
   , Orville
   , OrvilleT

--- a/src/Database/Orville/Core.hs
+++ b/src/Database/Orville/Core.hs
@@ -39,7 +39,9 @@ module Database.Orville.Core
   , newOrvilleEnv
   , setStartTransactionSQL
   , aroundRunningQuery
+  , addTransactionCallBack
   , ormEnvPool
+  , TransactionEvent(..)
   , Orville
   , OrvilleT
   , unOrvilleT

--- a/src/Database/Orville/Core.hs
+++ b/src/Database/Orville/Core.hs
@@ -38,6 +38,7 @@ module Database.Orville.Core
   , OrvilleEnv
   , newOrvilleEnv
   , setStartTransactionSQL
+  , aroundRunningQuery
   , ormEnvPool
   , Orville
   , OrvilleT

--- a/src/Database/Orville/Internal/Execute.hs
+++ b/src/Database/Orville/Internal/Execute.hs
@@ -12,7 +12,8 @@ import Database.Orville.Internal.Monad
 
 executingSql :: MonadOrville conn m => QueryType -> String -> IO a -> m a
 executingSql queryType sql action = do
-  runningQuery queryType sql $ liftIO $ catchSqlErr sql action
+  runningQuery <- ormEnvRunningQuery <$> getOrvilleEnv
+  liftIO $ runningQuery queryType sql (catchSqlErr sql action)
 
 catchSqlErr :: String -> IO a -> IO a
 catchSqlErr sql action =

--- a/test/TestDB.hs
+++ b/test/TestDB.hs
@@ -6,7 +6,7 @@ module TestDB where
 
 import Control.Monad (void)
 import Control.Monad.Base (MonadBase)
-import Control.Monad.Catch (MonadThrow)
+import Control.Monad.Catch (MonadCatch, MonadThrow)
 import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Trans (lift)
 import Control.Monad.Trans.Control (MonadBaseControl(..), StM)
@@ -29,7 +29,14 @@ type QueryWriterT = WriterT [(O.QueryType, String)]
 
 newtype TestMonad a = TestMonad
   { runTestMonad :: QueryWriterT (O.OrvilleT Postgres.Connection IO) a
-  } deriving (Functor, Applicative, Monad, MonadIO, MonadBase IO, MonadThrow)
+  } deriving ( Functor
+             , Applicative
+             , Monad
+             , MonadIO
+             , MonadBase IO
+             , MonadThrow
+             , MonadCatch
+             )
 
 queryTrace ::
      (O.QueryType -> Bool) -> TestMonad a -> TestMonad [(O.QueryType, String)]

--- a/test/TransactionTest.hs
+++ b/test/TransactionTest.hs
@@ -1,0 +1,62 @@
+module TransactionTest where
+
+import Control.Exception (Exception)
+import Control.Monad (void)
+import Control.Monad.Catch (throwM, try)
+import Data.Typeable (Typeable)
+
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertEqual, testCase)
+
+import qualified Database.Orville as O
+
+import AppManagedEntity.Data.Virus (Virus(..), VirusId(..), bpsVirusName)
+
+import AppManagedEntity.Schema (schema, virusTable)
+
+import qualified TestDB as TestDB
+
+bpsVirus :: Virus
+bpsVirus = Virus {virusId = VirusId 1, virusName = bpsVirusName}
+
+data FakeError =
+  FakeError
+  deriving (Eq, Show, Typeable)
+
+instance Exception FakeError
+
+test_transaction :: TestTree
+test_transaction =
+  TestDB.withOrvilleRun $ \run ->
+    testGroup
+      "Transaction Test"
+      [ testCase "Commit" $ do
+          run (TestDB.reset schema)
+          result <-
+            run $ do
+              void $ O.withTransaction (O.insertRecord virusTable bpsVirus)
+              O.findRecord virusTable (virusId bpsVirus)
+          assertEqual
+            "Unable to find virus that was inserted. Maybe transaction did not commit?"
+            (Just bpsVirus)
+            result
+      , testCase "Rollback" $ do
+          run (TestDB.reset schema)
+          (transactionResult, findResult) <-
+            run $ do
+              transactionResult <-
+                try $
+                O.withTransaction $ do
+                  void $ O.insertRecord virusTable bpsVirus
+                  void $ throwM FakeError
+              findResult <- O.findRecord virusTable (virusId bpsVirus)
+              pure (transactionResult, findResult)
+          assertEqual
+            "Found virus that should not have been committed!"
+            Nothing
+            findResult
+          assertEqual
+            "Transaction result was not an error!"
+            (Left FakeError)
+            transactionResult
+      ]

--- a/test/TransactionTest.hs
+++ b/test/TransactionTest.hs
@@ -2,7 +2,7 @@ module TransactionTest where
 
 import Control.Exception (Exception)
 import Control.Monad (void)
-import Control.Monad.Catch (throwM, try)
+import Control.Monad.Catch (catch, throwM, try)
 import Data.Typeable (Typeable)
 
 import Test.Tasty (TestTree, testGroup)
@@ -59,4 +59,34 @@ test_transaction =
             "Transaction result was not an error!"
             (Left FakeError)
             transactionResult
+      , testCase "TransactionStart Event" $ do
+          events <-
+            run $
+            TestDB.withTransactionEvents $ \getEvents -> do
+              O.withTransaction $ getEvents
+          assertEqual
+            "Expected (only) TransactionStart to have been triggered inside transaction block"
+            [O.TransactionStart]
+            events
+      , testCase "TransactionCommit Event" $ do
+          events <-
+            run $
+            TestDB.withTransactionEvents $ \getEvents -> do
+              O.withTransaction (pure ())
+              getEvents
+          assertEqual
+            "Expected TransactionStart and TransactionCommit to have been triggered after successful transaction block"
+            [O.TransactionStart, O.TransactionCommit]
+            events
+      , testCase "TransactionRollback Event" $ do
+          events <-
+            run $
+            TestDB.withTransactionEvents $ \getEvents -> do
+              O.withTransaction (throwM FakeError) `catch`
+                (\FakeError -> pure ())
+              getEvents
+          assertEqual
+            "Expected TransactionStart and TransactionRollback to have been triggered after aborted transaction block"
+            [O.TransactionStart, O.TransactionRollback]
+            events
       ]


### PR DESCRIPTION
This simplifies the typeclass and opens the door to more sophisticated
callbacks being registered in the OrvilleEnv datatype rather than flooding
the typeclass with many methods.

It's possible this is the beginning of a "Driver"-like framework, but it's
unclear. Mostly I want to see if this is workable from an end-user standpoint.