### PR TITLE
[ch12596] Moves runningQuery callback into OrvilleEnv

### DIFF
--- a/src/Database/Orville/Core.hs
+++ b/src/Database/Orville/Core.hs
@@ -39,7 +39,9 @@ module Database.Orville.Core
   , newOrvilleEnv
   , setStartTransactionSQL
   , aroundRunningQuery
+  , addTransactionCallBack
   , ormEnvPool
+  , TransactionEvent(..)
   , Orville
   , OrvilleT
   , unOrvilleT

--- a/src/Database/Orville/Core.hs
+++ b/src/Database/Orville/Core.hs
@@ -38,6 +38,7 @@ module Database.Orville.Core
   , OrvilleEnv
   , newOrvilleEnv
   , setStartTransactionSQL
+  , aroundRunningQuery
   , ormEnvPool
   , Orville
   , OrvilleT

--- a/src/Database/Orville/Internal/Execute.hs
+++ b/src/Database/Orville/Internal/Execute.hs
@@ -12,7 +12,8 @@ import Database.Orville.Internal.Monad
 
 executingSql :: MonadOrville conn m => QueryType -> String -> IO a -> m a
 executingSql queryType sql action = do
-  runningQuery queryType sql $ liftIO $ catchSqlErr sql action
+  runningQuery <- ormEnvRunningQuery <$> getOrvilleEnv
+  liftIO $ runningQuery queryType sql (catchSqlErr sql action)
 
 catchSqlErr :: String -> IO a -> IO a
 catchSqlErr sql action =

--- a/test/TransactionTest.hs
+++ b/test/TransactionTest.hs
@@ -2,7 +2,7 @@ module TransactionTest where
 
 import Control.Exception (Exception)
 import Control.Monad (void)
-import Control.Monad.Catch (throwM, try)
+import Control.Monad.Catch (catch, throwM, try)
 import Data.Typeable (Typeable)
 
 import Test.Tasty (TestTree, testGroup)
@@ -59,4 +59,34 @@ test_transaction =
             "Transaction result was not an error!"
             (Left FakeError)
             transactionResult
+      , testCase "TransactionStart Event" $ do
+          events <-
+            run $
+            TestDB.withTransactionEvents $ \getEvents -> do
+              O.withTransaction $ getEvents
+          assertEqual
+            "Expected (only) TransactionStart to have been triggered inside transaction block"
+            [O.TransactionStart]
+            events
+      , testCase "TransactionCommit Event" $ do
+          events <-
+            run $
+            TestDB.withTransactionEvents $ \getEvents -> do
+              O.withTransaction (pure ())
+              getEvents
+          assertEqual
+            "Expected TransactionStart and TransactionCommit to have been triggered after successful transaction block"
+            [O.TransactionStart, O.TransactionCommit]
+            events
+      , testCase "TransactionRollback Event" $ do
+          events <-
+            run $
+            TestDB.withTransactionEvents $ \getEvents -> do
+              O.withTransaction (throwM FakeError) `catch`
+                (\FakeError -> pure ())
+              getEvents
+          assertEqual
+            "Expected TransactionStart and TransactionRollback to have been triggered after aborted transaction block"
+            [O.TransactionStart, O.TransactionRollback]
+            events
       ]


### PR DESCRIPTION
test/TestDB.hs provides an instructive example of the impact of
this change to users of the tracing feature. On the one hand I
think the user code is more straightforward overall, with the
tracing concern now being concentrated in just a couple of
functions. On the other hand, the tracing concern has been
completely eliminated from the type signatures, so the type
system cannot be used to make guarantees about it.