### PR TITLE
 [ch12596] Adds TransactionEvent broadcasting

### DIFF
--- a/src/Database/Orville/Core.hs
+++ b/src/Database/Orville/Core.hs
@@ -39,7 +39,9 @@ module Database.Orville.Core
   , newOrvilleEnv
   , setStartTransactionSQL
   , aroundRunningQuery
+  , addTransactionCallBack
   , ormEnvPool
+  , TransactionEvent(..)
   , Orville
   , OrvilleT
   , unOrvilleT

--- a/test/TransactionTest.hs
+++ b/test/TransactionTest.hs
@@ -2,7 +2,7 @@ module TransactionTest where
 
 import Control.Exception (Exception)
 import Control.Monad (void)
-import Control.Monad.Catch (throwM, try)
+import Control.Monad.Catch (catch, throwM, try)
 import Data.Typeable (Typeable)
 
 import Test.Tasty (TestTree, testGroup)
@@ -59,4 +59,34 @@ test_transaction =
             "Transaction result was not an error!"
             (Left FakeError)
             transactionResult
+      , testCase "TransactionStart Event" $ do
+          events <-
+            run $
+            TestDB.withTransactionEvents $ \getEvents -> do
+              O.withTransaction $ getEvents
+          assertEqual
+            "Expected (only) TransactionStart to have been triggered inside transaction block"
+            [O.TransactionStart]
+            events
+      , testCase "TransactionCommit Event" $ do
+          events <-
+            run $
+            TestDB.withTransactionEvents $ \getEvents -> do
+              O.withTransaction (pure ())
+              getEvents
+          assertEqual
+            "Expected TransactionStart and TransactionCommit to have been triggered after successful transaction block"
+            [O.TransactionStart, O.TransactionCommit]
+            events
+      , testCase "TransactionRollback Event" $ do
+          events <-
+            run $
+            TestDB.withTransactionEvents $ \getEvents -> do
+              O.withTransaction (throwM FakeError) `catch`
+                (\FakeError -> pure ())
+              getEvents
+          assertEqual
+            "Expected TransactionStart and TransactionRollback to have been triggered after aborted transaction block"
+            [O.TransactionStart, O.TransactionRollback]
+            events
       ]


### PR DESCRIPTION
This adds a callback to allow Orville to let interested parties know
when transactions start,commit, and rollback. The callbacks are
monomorphized to IO for simplicity and clarity. The presumption is
that if you are a sophisticated enough user to be interested in these
callbacks that you will understand the value of dealing with any
necessary unlifting yourself rather than having Orville tie you to a
specific unlifting implementation.

This does, however, eliminate the possibility of using a stateful
monad (Writer, State) if your goal is simply to record a list of the
transaction events that happen. Instead you have to use an IORef (or
similar) construct that you can access from the IO monad.