### PR TITLE
[ch12596] [WIP] A first cut at triggers respecting transactions. Not to be merged

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -58,6 +58,7 @@ library:
     - Database.Orville.PostgresSQL
     - Database.Orville.Raw
     - Database.Orville.Select
+    - Database.Orville.Trigger
 tests:
   spec:
     main: Driver.hs

--- a/src/Database/Orville/Trigger.hs
+++ b/src/Database/Orville/Trigger.hs
@@ -1,0 +1,158 @@
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Database.Orville.Trigger
+  ( insertTriggered
+  , InsertTrigger(insertTriggers)
+  , updateTriggered
+  , UpdateTrigger(updateTriggers)
+  , deleteTriggered
+  , DeleteTrigger(deleteTriggers)
+  , MonadTrigger(runTriggers)
+  , TriggerT
+  , runTriggerT
+  ) where
+
+import Control.Monad (void)
+import Control.Monad.Base (MonadBase)
+import Control.Monad.Catch (MonadCatch, MonadThrow)
+import Control.Monad.IO.Class (MonadIO(liftIO))
+import Control.Monad.Reader (ReaderT, ask, mapReaderT, runReaderT)
+import Control.Monad.Trans (MonadTrans(lift))
+import Control.Monad.Trans.Control (MonadBaseControl(..))
+import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef, writeIORef)
+import qualified Database.Orville as O
+
+class InsertTrigger trigger readEntity where
+  insertTriggers :: readEntity -> [trigger]
+
+class UpdateTrigger trigger readEntity writeEntity where
+  updateTriggers :: readEntity -> writeEntity -> [trigger]
+
+class DeleteTrigger trigger readEntity where
+  deleteTriggers :: readEntity -> [trigger]
+
+class MonadTrigger trigger m | m -> trigger where
+  runTriggers :: [trigger] -> m ()
+
+insertTriggered ::
+     ( MonadThrow m
+     , O.MonadOrville conn m
+     , MonadTrigger trigger m
+     , InsertTrigger trigger readEntity
+     )
+  => O.TableDefinition readEntity writeEntity key
+  -> writeEntity
+  -> m readEntity
+insertTriggered tableDef writeEntity = do
+  readEntity <- O.insertRecord tableDef writeEntity
+  runTriggers $ insertTriggers readEntity
+  pure readEntity
+
+updateTriggered ::
+     ( MonadThrow m
+     , O.MonadOrville conn m
+     , MonadTrigger trigger m
+     , UpdateTrigger trigger readEntity writeEntity
+     )
+  => O.TableDefinition readEntity writeEntity key
+  -> readEntity
+  -> writeEntity
+  -> m ()
+updateTriggered tableDef oldEntity newEntity = do
+  O.updateRecord tableDef (O.tableGetKey tableDef oldEntity) newEntity
+  runTriggers $ updateTriggers oldEntity newEntity
+
+deleteTriggered ::
+     ( MonadThrow m
+     , O.MonadOrville conn m
+     , MonadTrigger trigger m
+     , DeleteTrigger trigger readEntity
+     )
+  => O.TableDefinition readEntity writeEntity key
+  -> readEntity
+  -> m ()
+deleteTriggered tableDef readEntity = do
+  O.deleteRecord tableDef (O.tableGetKey tableDef readEntity)
+  runTriggers $ deleteTriggers readEntity
+
+data TriggerTEnv trigger m = TriggerTEnv
+  { triggerTEnvAction :: TriggerAction trigger m
+  , triggerTEnvTxnTriggers :: IORef (Maybe [trigger])
+  }
+
+type TriggerAction trigger m = [trigger] -> m ()
+
+newtype TriggerT trigger m a = TriggerT
+  { unTriggerT :: ReaderT (TriggerTEnv trigger m) m a
+  } deriving ( Functor
+             , Applicative
+             , Monad
+             , MonadIO
+             , MonadBase b
+             , MonadThrow
+             , MonadCatch
+             )
+
+instance MonadTrans (TriggerT trigger) where
+  lift = TriggerT . lift
+
+--
+-- This does not follow the usual pattern of defining a MonadTransControl instance for TriggerT
+-- because the Reader environment references the type `m`. This makes it impossible for TriggerT
+-- to provide an implementation of `liftWith` because to do so requires producing a run function of
+-- type `forall n b. Monad n => (TriggerT trigger) n b -> n b`. TriggerT can only provide such
+-- a function for the type `m` that is referenced in the ReaderT context, not `forall n.` as it
+-- demanded by the signature of `liftWith`.
+--
+instance MonadBaseControl b m => MonadBaseControl b (TriggerT trigger m) where
+  type StM (TriggerT trigger m) a = StM (ReaderT (TriggerAction trigger m) m) a
+  liftBaseWith action =
+    TriggerT $ liftBaseWith $ \runInBase -> action (runInBase . unTriggerT)
+  restoreM = TriggerT . restoreM
+
+instance O.MonadOrville conn m =>
+         O.MonadOrville conn (TriggerT trigger m) where
+  getOrvilleEnv = lift O.getOrvilleEnv
+  localOrvilleEnv f = TriggerT . mapReaderT (O.localOrvilleEnv f) . unTriggerT
+
+instance MonadIO m => MonadTrigger trigger (TriggerT trigger m) where
+  runTriggers triggers =
+    TriggerT $ do
+      triggerTEnv <- ask
+      txnTriggers <- liftIO $ readIORef $ triggerTEnvTxnTriggers triggerTEnv
+      case txnTriggers of
+        Nothing -> lift $ triggerTEnvAction triggerTEnv triggers
+        Just previousTriggers ->
+          liftIO $
+          writeIORef
+            (triggerTEnvTxnTriggers triggerTEnv)
+            (Just (previousTriggers ++ triggers))
+
+runTriggerT ::
+     O.MonadOrville conn m
+  => TriggerT trigger m a
+  -> TriggerAction trigger m
+  -> m a
+runTriggerT triggerT triggerAction = do
+  txnTriggersRef <- liftIO $ newIORef Nothing -- There may be a transaction already open when runTriggerT is called!!!
+  runInIO <- liftBaseWith (\run -> pure (void . run)) -- Note this runInIO discards the monadic state returned by run!!!!
+  let env = TriggerTEnv triggerAction txnTriggersRef
+  O.localOrvilleEnv (O.addTransactionCallBack $ trackTransactions env runInIO) $
+    runReaderT (unTriggerT triggerT) env
+
+trackTransactions ::
+     TriggerTEnv trigger m -> (m () -> IO ()) -> O.TransactionEvent -> IO ()
+trackTransactions env runInIO event =
+  case event of
+    O.TransactionStart -> writeIORef (triggerTEnvTxnTriggers env) (Just [])
+    O.TransactionCommit -> do
+      triggers <-
+        atomicModifyIORef' (triggerTEnvTxnTriggers env) $ \triggers ->
+          (Nothing, triggers)
+      case triggers of
+        Nothing -> pure ()
+        Just t -> runInIO $ triggerTEnvAction env t
+    O.TransactionRollback -> writeIORef (triggerTEnvTxnTriggers env) Nothing

--- a/test/AppManagedEntity/Data/Virus.hs
+++ b/test/AppManagedEntity/Data/Virus.hs
@@ -4,6 +4,7 @@ module AppManagedEntity.Data.Virus
   , VirusName(..)
   , bpsVirusName
   , brnVirusName
+  , bpsVirus
   ) where
 
 import Data.Int (Int64)
@@ -28,3 +29,6 @@ bpsVirusName = VirusName (Text.pack "Bovine popular stomachitis")
 
 brnVirusName :: VirusName
 brnVirusName = VirusName (Text.pack "Black raspberry necrosis")
+
+bpsVirus :: Virus
+bpsVirus = Virus {virusId = VirusId 1, virusName = bpsVirusName}

--- a/test/TransactionTest.hs
+++ b/test/TransactionTest.hs
@@ -10,14 +10,10 @@ import Test.Tasty.HUnit (assertEqual, testCase)
 
 import qualified Database.Orville as O
 
-import AppManagedEntity.Data.Virus (Virus(..), VirusId(..), bpsVirusName)
-
+import AppManagedEntity.Data.Virus (Virus(..), bpsVirus)
 import AppManagedEntity.Schema (schema, virusTable)
 
 import qualified TestDB as TestDB
-
-bpsVirus :: Virus
-bpsVirus = Virus {virusId = VirusId 1, virusName = bpsVirusName}
 
 data FakeError =
   FakeError

--- a/test/TriggerTest.hs
+++ b/test/TriggerTest.hs
@@ -1,0 +1,165 @@
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module TriggerTest where
+
+import Control.Exception (Exception)
+import Control.Monad (void)
+import Control.Monad.Base (MonadBase)
+import Control.Monad.Catch (MonadCatch, MonadThrow, catch, throwM)
+import Control.Monad.IO.Class (MonadIO(liftIO))
+import Control.Monad.Reader (ReaderT, ask, runReaderT)
+import Control.Monad.Trans (lift)
+import Control.Monad.Trans.Control (MonadBaseControl(..))
+import Data.IORef (IORef, modifyIORef', newIORef, readIORef, writeIORef)
+import qualified Data.Text as Text
+import Data.Typeable (Typeable)
+import qualified Database.HDBC.PostgreSQL as Postgres
+
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertEqual, testCase)
+
+import qualified Database.Orville as O
+import qualified Database.Orville.Trigger as OT
+
+import AppManagedEntity.Data.Virus (Virus(..), VirusName(..), bpsVirus)
+import AppManagedEntity.Schema (schema, virusTable)
+
+import qualified TestDB as TestDB
+
+test_trigger :: TestTree
+test_trigger =
+  TestDB.withOrvilleRun $ \run ->
+    testGroup
+      "Trigger Test"
+      [ testCase "Without Transaction" $ do
+          let oldVirus = bpsVirus
+              newVirus =
+                bpsVirus {virusName = VirusName (Text.pack "New Name")}
+          run $ do
+            TestDB.reset schema
+            runTriggerTest $ do
+              void $ OT.insertTriggered virusTable oldVirus
+              assertTriggersReceived
+                "Expected Insert Triggers to be fired"
+                [Inserted oldVirus]
+              clearTriggers
+              void $ OT.updateTriggered virusTable oldVirus newVirus
+              assertTriggersReceived
+                "Expected Update Triggers to be fired"
+                [Updated oldVirus newVirus]
+              clearTriggers
+              void $ OT.deleteTriggered virusTable newVirus
+              assertTriggersReceived
+                "Expected Delete Triggers to be fired"
+                [Deleted newVirus]
+      , testCase "With Successful Transaction" $ do
+          let oldVirus = bpsVirus
+              newVirus =
+                bpsVirus {virusName = VirusName (Text.pack "New Name")}
+          run $ do
+            TestDB.reset schema
+            runTriggerTest $ do
+              O.withTransaction $ do
+                void $ OT.insertTriggered virusTable oldVirus
+                void $ OT.updateTriggered virusTable oldVirus newVirus
+                void $ OT.deleteTriggered virusTable newVirus
+                assertTriggersReceived
+                  "Expected No Triggers to be fired inside transaction"
+                  []
+              assertTriggersReceived
+                "Expected All Triggers to be fired update transaction commit"
+                [ Inserted oldVirus
+                , Updated oldVirus newVirus
+                , Deleted newVirus
+                ]
+      , testCase "With Aborted Transaction" $ do
+          let oldVirus = bpsVirus
+              newVirus =
+                bpsVirus {virusName = VirusName (Text.pack "New Name")}
+          run $ do
+            TestDB.reset schema
+            runTriggerTest $ do
+              O.withTransaction
+                (do void $ OT.insertTriggered virusTable oldVirus
+                    void $ OT.updateTriggered virusTable oldVirus newVirus
+                    void $ OT.deleteTriggered virusTable newVirus
+                    assertTriggersReceived
+                      "Expected No Triggers to be fired inside transaction"
+                      []
+                    throwM AbortTransaction) `catch`
+                (\AbortTransaction -> pure ())
+              assertTriggersReceived
+                "Expected No Triggers to be fired update transaction rollback"
+                []
+      ]
+
+data TestTrigger
+  = Inserted Virus
+  | Updated Virus
+            Virus
+  | Deleted Virus
+  deriving (Eq, Show)
+
+instance OT.InsertTrigger TestTrigger Virus where
+  insertTriggers virus = [Inserted virus]
+
+instance OT.UpdateTrigger TestTrigger Virus Virus where
+  updateTriggers old new = [Updated old new]
+
+instance OT.DeleteTrigger TestTrigger Virus where
+  deleteTriggers virus = [Deleted virus]
+
+newtype TriggerTestMonad a =
+  TriggerTestMonad (OT.TriggerT TestTrigger (ReaderT (IORef [TestTrigger]) TestDB.TestMonad) a)
+  deriving ( Functor
+           , Applicative
+           , Monad
+           , MonadIO
+           , MonadBase IO
+           , MonadThrow
+           , MonadCatch
+           , O.MonadOrville Postgres.Connection
+           , OT.MonadTrigger TestTrigger
+           )
+
+runTriggerTest :: TriggerTestMonad a -> TestDB.TestMonad a
+runTriggerTest (TriggerTestMonad trigger) = do
+  triggersRef <- liftIO $ newIORef []
+  runReaderT (OT.runTriggerT trigger appendTriggers) triggersRef
+
+appendTriggers ::
+     [TestTrigger] -> ReaderT (IORef [TestTrigger]) TestDB.TestMonad ()
+appendTriggers triggers = do
+  triggersRef <- ask
+  liftIO $ modifyIORef' triggersRef (++ triggers)
+
+askTriggers :: TriggerTestMonad [TestTrigger]
+askTriggers =
+  TriggerTestMonad $ do
+    triggersRef <- lift ask
+    liftIO $ readIORef triggersRef
+
+clearTriggers :: TriggerTestMonad ()
+clearTriggers =
+  TriggerTestMonad $ do
+    triggersRef <- lift ask
+    liftIO $ writeIORef triggersRef []
+
+assertTriggersReceived :: String -> [TestTrigger] -> TriggerTestMonad ()
+assertTriggersReceived description expected = do
+  actual <- askTriggers
+  liftIO $ assertEqual description expected actual
+
+instance MonadBaseControl IO TriggerTestMonad where
+  type StM TriggerTestMonad a = StM TestDB.TestMonad a
+  liftBaseWith f =
+    TriggerTestMonad $
+    liftBaseWith $ \runInBase -> f (\(TriggerTestMonad m) -> runInBase m)
+  restoreM stm = TriggerTestMonad (restoreM stm)
+
+data AbortTransaction =
+  AbortTransaction
+  deriving (Eq, Show, Typeable)
+
+instance Exception AbortTransaction


### PR DESCRIPTION
This successfully implements a crude TriggerT monad transformer that supports using
triggered versions of the insert/update/delete functions. Aside from the flippant
use of IORefs (rather than carefully considered selection of a concurrency primitive),
there are a couple of other issues with this implementation:

* Any monadic state modifications made by the trigger callback *during a transaction commit*
  are thrown away, due to the fact that the transaction callbacks are monomorphised to IO.
  This will need to be re-visited

* It is possible to use `runTriggerT` to layer on triggering *in the middle* of another
  *untriggered* Orville computation. This is nice flexbility, but if the outer computation
  has a transaction open, the inner triggered computation does not currently know this,
  nor would it ever see the commit of the transaction inside the scope of its own computation.
  It may be that this is fundamentally unsound, or possibly requires extreme weirdness to
  make work (e.g. saving the triggers and running them later outside the triggered computation
  context when the commit happens????)

If you have time, please take a look and provide any thoughts or feedback you might have.