### PR TITLE
[ch12596] [WIP] A second cut at triggers respecting transactions. Not to be merged

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -58,6 +58,7 @@ library:
     - Database.Orville.PostgresSQL
     - Database.Orville.Raw
     - Database.Orville.Select
+    - Database.Orville.Trigger
 tests:
   spec:
     main: Driver.hs

--- a/src/Database/Orville/Trigger.hs
+++ b/src/Database/Orville/Trigger.hs
@@ -1,0 +1,243 @@
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Database.Orville.Trigger
+  ( insertTriggered
+  , InsertTrigger(insertTriggers)
+  , updateTriggered
+  , UpdateTrigger(updateTriggers)
+  , deleteTriggered
+  , DeleteTrigger(deleteTriggers)
+  , MonadTrigger(runTriggers)
+  , OrvilleTriggerT
+  , RecordedTriggers(..)
+  , runOrvilleTriggerT
+  , askTriggers
+  , clearTriggers
+  ) where
+
+import Control.Monad.Base (MonadBase)
+import Control.Monad.Catch (MonadCatch, MonadThrow)
+import Control.Monad.IO.Class (MonadIO(liftIO))
+import Control.Monad.Reader (ReaderT, ask, mapReaderT, runReaderT)
+import Control.Monad.Trans (MonadTrans(lift))
+import Control.Monad.Trans.Control
+  ( MonadBaseControl(..)
+  , MonadTransControl(..)
+  , defaultLiftBaseWith
+  , defaultRestoreM
+  )
+import Data.IORef
+  ( IORef
+  , atomicModifyIORef'
+  , atomicWriteIORef
+  , newIORef
+  , readIORef
+  )
+import Data.Pool (Pool)
+import qualified Database.HDBC as HDBC
+import qualified Database.Orville as O
+
+class MonadTrigger trigger m | m -> trigger where
+  runTriggers :: [trigger] -> m ()
+
+class InsertTrigger trigger readEntity where
+  insertTriggers :: readEntity -> [trigger]
+
+class UpdateTrigger trigger readEntity writeEntity where
+  updateTriggers :: readEntity -> writeEntity -> [trigger]
+
+class DeleteTrigger trigger readEntity where
+  deleteTriggers :: readEntity -> [trigger]
+
+insertTriggered ::
+     ( MonadThrow m
+     , O.MonadOrville conn m
+     , MonadTrigger trigger m
+     , InsertTrigger trigger readEntity
+     )
+  => O.TableDefinition readEntity writeEntity key
+  -> writeEntity
+  -> m readEntity
+insertTriggered tableDef writeEntity = do
+  readEntity <- O.insertRecord tableDef writeEntity
+  runTriggers $ insertTriggers readEntity
+  pure readEntity
+
+updateTriggered ::
+     ( MonadThrow m
+     , O.MonadOrville conn m
+     , MonadTrigger trigger m
+     , UpdateTrigger trigger readEntity writeEntity
+     )
+  => O.TableDefinition readEntity writeEntity key
+  -> readEntity
+  -> writeEntity
+  -> m ()
+updateTriggered tableDef oldEntity newEntity = do
+  O.updateRecord tableDef (O.tableGetKey tableDef oldEntity) newEntity
+  runTriggers $ updateTriggers oldEntity newEntity
+
+deleteTriggered ::
+     ( MonadThrow m
+     , O.MonadOrville conn m
+     , MonadTrigger trigger m
+     , DeleteTrigger trigger readEntity
+     )
+  => O.TableDefinition readEntity writeEntity key
+  -> readEntity
+  -> m ()
+deleteTriggered tableDef readEntity = do
+  O.deleteRecord tableDef (O.tableGetKey tableDef readEntity)
+  runTriggers $ deleteTriggers readEntity
+
+type RecordedTriggersRef trigger = IORef (RecordedTriggers trigger)
+
+data RecordedTriggers trigger = RecordedTriggers
+  { committedTriggers :: [trigger]
+  , uncommittedTriggers :: Maybe [trigger]
+  }
+
+emptyTriggerData :: RecordedTriggers trigger
+emptyTriggerData = RecordedTriggers mempty mempty
+
+atomicModifyIORef'_ :: IORef a -> (a -> a) -> IO ()
+atomicModifyIORef'_ ref f = atomicModifyIORef' ref (\a -> (f a, ()))
+
+recordTriggers :: RecordedTriggersRef trigger -> [trigger] -> IO ()
+recordTriggers ref triggers =
+  atomicModifyIORef'_ ref $ \recorded ->
+    case uncommittedTriggers recorded of
+      Just uncommitted ->
+        recorded {uncommittedTriggers = Just (uncommitted ++ triggers)}
+      Nothing ->
+        recorded {committedTriggers = committedTriggers recorded ++ triggers}
+
+startTriggerTxn :: RecordedTriggersRef trigger -> IO ()
+startTriggerTxn ref =
+  atomicModifyIORef'_ ref $ \recorded ->
+    case uncommittedTriggers recorded of
+      Just _ -> recorded
+      Nothing -> recorded {uncommittedTriggers = Just []}
+
+commitTriggerTxn :: RecordedTriggersRef trigger -> IO ()
+commitTriggerTxn ref =
+  atomicModifyIORef'_ ref $ \recorded ->
+    case uncommittedTriggers recorded of
+      Just uncommitted ->
+        recorded
+          { uncommittedTriggers = Nothing
+          , committedTriggers = committedTriggers recorded ++ uncommitted
+          }
+      Nothing -> recorded
+
+rollbackTriggerTxn :: RecordedTriggersRef trigger -> IO ()
+rollbackTriggerTxn ref =
+  atomicModifyIORef'_ ref $ \recorded ->
+    recorded {uncommittedTriggers = Nothing}
+
+newtype OrvilleTriggerT trigger conn m a = OrvilleTriggerT
+  { unTriggerT :: ReaderT (RecordedTriggersRef trigger) (O.OrvilleT conn m) a
+  } deriving ( Functor
+             , Applicative
+             , Monad
+             , MonadIO
+             , MonadBase b
+             , MonadThrow
+             , MonadCatch
+             )
+
+instance MonadTrans (OrvilleTriggerT trigger conn) where
+  lift = OrvilleTriggerT . lift . lift
+
+--
+-- Because OrvilleTriggerT is a stack of two transformers, the default MonadTransControl functions
+-- don't work here, so we have to implement them manually.
+--
+instance MonadTransControl (OrvilleTriggerT trigger conn) where
+  type StT (OrvilleTriggerT trigger conn) a = StT (ReaderT (RecordedTriggersRef trigger)) (StT (O.OrvilleT conn) a)
+  liftWith f =
+    OrvilleTriggerT $
+    liftWith $ \runReader ->
+      liftWith $ \runOrville -> f (runOrville . runReader . unTriggerT)
+  restoreT = OrvilleTriggerT . restoreT . restoreT
+
+instance MonadBaseControl b m =>
+         MonadBaseControl b (OrvilleTriggerT trigger conn m) where
+  type StM (OrvilleTriggerT trigger conn m) a = StM (ReaderT (RecordedTriggersRef trigger) m) a
+  liftBaseWith = defaultLiftBaseWith
+  restoreM = defaultRestoreM
+
+instance (Monad m, MonadIO m, HDBC.IConnection conn, MonadBaseControl IO m) =>
+         O.MonadOrville conn (OrvilleTriggerT trigger conn m) where
+  getOrvilleEnv = OrvilleTriggerT $ lift O.getOrvilleEnv
+  localOrvilleEnv f =
+    OrvilleTriggerT . mapReaderT (O.localOrvilleEnv f) . unTriggerT
+
+instance MonadIO m =>
+         MonadTrigger trigger (OrvilleTriggerT trigger conn m) where
+  runTriggers triggers =
+    OrvilleTriggerT $ do
+      recordedTriggers <- ask
+      liftIO $ recordTriggers recordedTriggers triggers
+
+{-
+   `askTriggers` retrieves triggers that have been recorded thus far. If you
+   do not want to see the triggers returned again from future calls, you should
+   use `clearTriggers` as well.
+ -}
+askTriggers ::
+     MonadIO m => OrvilleTriggerT trigger conn m (RecordedTriggers trigger)
+askTriggers =
+  OrvilleTriggerT $ do
+    recordedTriggers <- ask
+    liftIO $ readIORef recordedTriggers
+
+{-
+   `clearTriggers` clears out the trigger list. This is useful if you have
+   processed the trigger list and don't want to see those triggers again.
+ -}
+clearTriggers :: MonadIO m => OrvilleTriggerT trigger conn m ()
+clearTriggers =
+  OrvilleTriggerT $ do
+    recordedTriggers <- ask
+    liftIO $ atomicWriteIORef recordedTriggers emptyTriggerData
+
+{-
+   `runOrvilleTriggerT` runs an Orville actions that has triggering behavior and
+   returns the triggers that were committed. Note there there will never be any
+   *uncommitted* triggers at the end because any `withTransaction` block must
+   by contained *within* the action passed  to `runOrvilleTriggerT`. If you
+   layer `OrvilleTriggerT` on top of a Monad `m` that *also* allows for database
+   connection activity, god rest your soul.
+
+   Note that if an exception occurs in `m` and is not caught within the action passed
+   to `runOrvilleTriggerT`, you will lose any triggers that may have happened up to
+   the point of the action, including those related to database operations that were
+   successfully committed. If you wish to respond to those triggers, you need to perform
+   some Exception handling inside the action given to `runOrvilleTriggerT` and use
+   `askTriggers` to retrieve the triggers inside the exception handler.
+ -}
+runOrvilleTriggerT ::
+     (MonadIO m, MonadBaseControl IO m)
+  => OrvilleTriggerT trigger conn m a
+  -> Pool conn
+  -> m (a, [trigger])
+runOrvilleTriggerT triggerT pool = do
+  ref <- liftIO $ newIORef emptyTriggerData
+  let orvilleT = runReaderT (unTriggerT triggerT) ref
+      orvilleEnv =
+        O.addTransactionCallBack (trackTransactions ref) (O.newOrvilleEnv pool)
+  a <- O.runOrville orvilleT orvilleEnv
+  triggers <- committedTriggers <$> liftIO (readIORef ref)
+  pure (a, triggers)
+
+trackTransactions :: RecordedTriggersRef trigger -> O.TransactionEvent -> IO ()
+trackTransactions recorded event =
+  case event of
+    O.TransactionStart -> startTriggerTxn recorded
+    O.TransactionCommit -> commitTriggerTxn recorded
+    O.TransactionRollback -> rollbackTriggerTxn recorded

--- a/test/AppManagedEntity/Data/Virus.hs
+++ b/test/AppManagedEntity/Data/Virus.hs
@@ -4,6 +4,7 @@ module AppManagedEntity.Data.Virus
   , VirusName(..)
   , bpsVirusName
   , brnVirusName
+  , bpsVirus
   ) where
 
 import Data.Int (Int64)
@@ -28,3 +29,6 @@ bpsVirusName = VirusName (Text.pack "Bovine popular stomachitis")
 
 brnVirusName :: VirusName
 brnVirusName = VirusName (Text.pack "Black raspberry necrosis")
+
+bpsVirus :: Virus
+bpsVirus = Virus {virusId = VirusId 1, virusName = bpsVirusName}

--- a/test/TransactionTest.hs
+++ b/test/TransactionTest.hs
@@ -10,14 +10,10 @@ import Test.Tasty.HUnit (assertEqual, testCase)
 
 import qualified Database.Orville as O
 
-import AppManagedEntity.Data.Virus (Virus(..), VirusId(..), bpsVirusName)
-
+import AppManagedEntity.Data.Virus (Virus(..), bpsVirus)
 import AppManagedEntity.Schema (schema, virusTable)
 
 import qualified TestDB as TestDB
-
-bpsVirus :: Virus
-bpsVirus = Virus {virusId = VirusId 1, virusName = bpsVirusName}
 
 data FakeError =
   FakeError

--- a/test/TriggerTest.hs
+++ b/test/TriggerTest.hs
@@ -1,0 +1,163 @@
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module TriggerTest where
+
+import Control.Exception (Exception)
+import Control.Monad (void)
+import Control.Monad.Base (MonadBase)
+import Control.Monad.Catch (MonadCatch, MonadThrow, catch, throwM)
+import Control.Monad.IO.Class (MonadIO(liftIO))
+import Control.Monad.Trans.Control (MonadBaseControl(..))
+import qualified Data.Text as Text
+import Data.Typeable (Typeable)
+import qualified Database.HDBC.PostgreSQL as Postgres
+
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertEqual, testCase)
+
+import qualified Database.Orville as O
+import qualified Database.Orville.Trigger as OT
+
+import AppManagedEntity.Data.Virus (Virus(..), VirusName(..), bpsVirus)
+import AppManagedEntity.Schema (schema, virusTable)
+
+import qualified TestDB as TestDB
+
+test_trigger :: TestTree
+test_trigger =
+  TestDB.withOrvilleRun $ \run ->
+    testGroup
+      "Trigger Test"
+      [ testCase "Without Transaction" $ do
+          let oldVirus = bpsVirus
+              newVirus =
+                bpsVirus {virusName = VirusName (Text.pack "New Name")}
+          run $ do
+            TestDB.reset schema
+            runTriggerTest $ do
+              void $ OT.insertTriggered virusTable oldVirus
+              assertTriggersCommitted
+                "Expected Insert Triggers to be fired"
+                [Inserted oldVirus]
+              TriggerTestMonad OT.clearTriggers
+              void $ OT.updateTriggered virusTable oldVirus newVirus
+              assertTriggersCommitted
+                "Expected Update Triggers to be fired"
+                [Updated oldVirus newVirus]
+              TriggerTestMonad OT.clearTriggers
+              void $ OT.deleteTriggered virusTable newVirus
+              assertTriggersCommitted
+                "Expected Delete Triggers to be fired"
+                [Deleted newVirus]
+      , testCase "With Successful Transaction" $ do
+          let oldVirus = bpsVirus
+              newVirus =
+                bpsVirus {virusName = VirusName (Text.pack "New Name")}
+          run $ do
+            TestDB.reset schema
+            runTriggerTest $ do
+              O.withTransaction $ do
+                void $ OT.insertTriggered virusTable oldVirus
+                void $ OT.updateTriggered virusTable oldVirus newVirus
+                void $ OT.deleteTriggered virusTable newVirus
+                assertTriggersCommitted
+                  "Expected No Triggers to be fired inside transaction"
+                  []
+              assertTriggersCommitted
+                "Expected All Triggers to be fired update transaction commit"
+                [ Inserted oldVirus
+                , Updated oldVirus newVirus
+                , Deleted newVirus
+                ]
+      , testCase "With Aborted Transaction" $ do
+          let oldVirus = bpsVirus
+              newVirus =
+                bpsVirus {virusName = VirusName (Text.pack "New Name")}
+          run $ do
+            TestDB.reset schema
+            runTriggerTest $ do
+              O.withTransaction
+                (do void $ OT.insertTriggered virusTable oldVirus
+                    void $ OT.updateTriggered virusTable oldVirus newVirus
+                    void $ OT.deleteTriggered virusTable newVirus
+                    throwM AbortTransaction) `catch`
+                (\AbortTransaction -> pure ())
+              assertTriggersCommitted
+                "Expected No Triggers to be fired update transaction rollback"
+                []
+      , testCase "With Triggers around Aborted Transaction" $ do
+          let oldVirus = bpsVirus
+              newVirus =
+                bpsVirus {virusName = VirusName (Text.pack "New Name")}
+          run $ do
+            TestDB.reset schema
+            runTriggerTest $ do
+              void $ OT.insertTriggered virusTable oldVirus
+              O.withTransaction
+                (do void $ OT.updateTriggered virusTable oldVirus newVirus
+                    throwM AbortTransaction) `catch`
+                (\AbortTransaction -> pure ())
+              void $ OT.deleteTriggered virusTable newVirus
+              assertTriggersCommitted
+                "Expected triggers from inside transaction to have been rolled back"
+                [Inserted oldVirus, Deleted newVirus]
+      ]
+
+data TestTrigger
+  = Inserted Virus
+  | Updated Virus
+            Virus
+  | Deleted Virus
+  deriving (Eq, Show)
+
+instance OT.InsertTrigger TestTrigger Virus where
+  insertTriggers virus = [Inserted virus]
+
+instance OT.UpdateTrigger TestTrigger Virus Virus where
+  updateTriggers old new = [Updated old new]
+
+instance OT.DeleteTrigger TestTrigger Virus where
+  deleteTriggers virus = [Deleted virus]
+
+newtype TriggerTestMonad a = TriggerTestMonad
+  { unTriggerTest :: OT.OrvilleTriggerT TestTrigger Postgres.Connection IO a
+  } deriving ( Functor
+             , Applicative
+             , Monad
+             , MonadIO
+             , MonadBase IO
+             , MonadThrow
+             , MonadCatch
+             , O.MonadOrville Postgres.Connection
+             , OT.MonadTrigger TestTrigger
+             )
+
+--
+-- Note that this tosses out the orville env that is in the TestDB.TestMonad instance
+-- and just steals its conncetion pool to use with runOrvilleTriggerT. This is ok for the
+-- tests here, but in the real world would result in the TriggerTestMonad using a different
+-- database connection that the surrounding TestMonad.TestMonad was using.
+--
+runTriggerTest :: TriggerTestMonad () -> TestDB.TestMonad ()
+runTriggerTest (TriggerTestMonad trigger) = do
+  orvilleEnv <- O.getOrvilleEnv
+  void $ liftIO $ OT.runOrvilleTriggerT trigger (O.ormEnvPool orvilleEnv)
+
+assertTriggersCommitted :: String -> [TestTrigger] -> TriggerTestMonad ()
+assertTriggersCommitted description expected = do
+  actual <- OT.committedTriggers <$> TriggerTestMonad OT.askTriggers
+  liftIO $ assertEqual description expected actual
+
+instance MonadBaseControl IO TriggerTestMonad where
+  type StM TriggerTestMonad a = StM TestDB.TestMonad a
+  liftBaseWith f =
+    TriggerTestMonad $
+    liftBaseWith $ \runInBase -> f (\(TriggerTestMonad m) -> runInBase m)
+  restoreM stm = TriggerTestMonad (restoreM stm)
+
+data AbortTransaction =
+  AbortTransaction
+  deriving (Eq, Show, Typeable)
+
+instance Exception AbortTransaction


### PR DESCRIPTION
This reduces the scope of the TriggerT transformer (now OrvilleTriggerT) from the previous
PR in two important ways:

1) It includes the OrvilleT directly, rather than allowing TriggerT to be layered on top of
   any old MonadOrville implementation. This allows runOrvilleTriggerT to have control over
   when the OrvilleEnv is instantiated to avoid runOrvilleTriggerT being called with a transaction
   already in progress.

2) It only allows for keeping track of a list of triggers as data to be processed at a later
   time, rather than executing monadic trigger actions in line. This removed the need for any
   runInBase nonsense because all the action performed by runOrvilleTriggerT can be easily
   monomorphised to IO

This in no way reduced the scope of the `MonadTrigger` class itself, only the scope of the
default implementation. If a specific application wanted different behavior, it could implement
a custom `MonadTrigger` implementation and still use the provided insert/update/delete functions
for sending the triggers.

This PR does *not* address using an appropriate data structure for efficient appending and
iteration of triggers. I will addresss such issues once I am happy with the Monadic structures
involved in the computation.