### PR TITLE
Give OrvilleTriggerT a MonadError instance.

### DIFF
--- a/src/Database/Orville/Trigger.hs
+++ b/src/Database/Orville/Trigger.hs
@@ -23,6 +23,7 @@ module Database.Orville.Trigger
 
 import Control.Monad.Base (MonadBase)
 import Control.Monad.Catch (MonadCatch, MonadThrow)
+import Control.Monad.Except (MonadError(..))
 import Control.Monad.IO.Class (MonadIO(liftIO))
 import Control.Monad.Reader (ReaderT, ask, mapReaderT, runReaderT)
 import Control.Monad.Trans (MonadTrans(lift))
@@ -169,6 +170,11 @@ newtype OrvilleTriggerT trigger conn m a = OrvilleTriggerT
 
 instance MonadTrans (OrvilleTriggerT trigger conn) where
   lift = OrvilleTriggerT . lift . lift
+
+instance (MonadError e m) => MonadError e (OrvilleTriggerT trigger conn m) where
+  throwError = lift . throwError
+  catchError action handler =
+    OrvilleTriggerT ((unTriggerT action) `catchError` (unTriggerT . handler))
 
 --
 -- Because OrvilleTriggerT is a stack of two transformers, the default MonadTransControl functions


### PR DESCRIPTION
This PR gives `OrvilleTriggerT` a `MonadError` instance.