### PR TITLE
Give RelationalMap a Profunctor instance.

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -30,6 +30,7 @@ dependencies:
   - HDBC >=2.4
   - HDBC-postgresql >=2.3
   - mtl >=2.2
+  - profunctors >= 5.2.1
   - resource-pool >=0.2
   - text
   - time >=1.5

--- a/src/Database/Orville/Internal/RelationalMap.hs
+++ b/src/Database/Orville/Internal/RelationalMap.hs
@@ -25,7 +25,7 @@ module Database.Orville.Internal.RelationalMap
 import Control.Monad (join, when)
 import Control.Monad.Reader (ask)
 import Control.Monad.State (modify)
-import Data.Profunctor(Profunctor(..))
+import Data.Profunctor(Profunctor(lmap, rmap))
 
 import Database.Orville.Internal.FieldDefinition
 import Database.Orville.Internal.FromSql

--- a/src/Database/Orville/Internal/RelationalMap.hs
+++ b/src/Database/Orville/Internal/RelationalMap.hs
@@ -25,6 +25,7 @@ module Database.Orville.Internal.RelationalMap
 import Control.Monad (join, when)
 import Control.Monad.Reader (ask)
 import Control.Monad.State (modify)
+import Data.Profunctor(Profunctor(..))
 
 import Database.Orville.Internal.FieldDefinition
 import Database.Orville.Internal.FromSql
@@ -112,6 +113,10 @@ instance Functor (RelationalMap a) where
 instance Applicative (RelationalMap a) where
   pure = RM_Pure
   (<*>) = RM_Apply
+
+instance Profunctor RelationalMap where
+  rmap = fmap
+  lmap = mapAttr
 
 mapAttr :: (a -> b) -> RelationalMap b c -> RelationalMap a c
 mapAttr = RM_Nest


### PR DESCRIPTION
This PR gives `RelationalMap` a `Profunctor` instance. `dimap f g` is arguably clearer than `O.mapAttr f . fmap g` for those who understand what a `Profunctor` is.