### PR TITLE
Adds generateMigrationPlan

### DIFF
--- a/src/Database/Orville/Core.hs
+++ b/src/Database/Orville/Core.hs
@@ -132,6 +132,11 @@ module Database.Orville.Core
   , OrderByClause(..)
   , SortDirection(..)
   , migrateSchema
+  , MigrationError(..)
+  , generateMigrationPlan
+  , MigrationPlan
+  , MigrationItem(..)
+  , migrationPlanItems
   , selectAll
   , selectFirst
   , deleteRecord
@@ -143,7 +148,6 @@ module Database.Orville.Core
   , insertRecordMany
   , updateFields
   , updateRecord
-  , MigrationError(..)
   ) where
 
 import Control.Monad.Except
@@ -166,6 +170,8 @@ import Database.Orville.Internal.FromSql
 import Database.Orville.Internal.GroupBy ()
 import Database.Orville.Internal.IndexDefinition
 import Database.Orville.Internal.MigrateSchema
+import Database.Orville.Internal.MigrationError
+import Database.Orville.Internal.MigrationPlan
 import Database.Orville.Internal.Monad
 import Database.Orville.Internal.OrderBy
 import Database.Orville.Internal.RelationalMap

--- a/src/Database/Orville/Internal/MigrateConstraint.hs
+++ b/src/Database/Orville/Internal/MigrateConstraint.hs
@@ -6,47 +6,39 @@ License   : MIT
 {-# LANGUAGE RecordWildCards #-}
 
 module Database.Orville.Internal.MigrateConstraint
-  ( createConstraint
-  , dropConstraint
-  , getConstraints
+  ( createConstraintPlan
+  , dropConstraintPlan
   ) where
 
 import Control.Monad
-import Data.Convertible
 import Data.List
-import Database.HDBC
 
-import Database.Orville.Internal.Execute
-import Database.Orville.Internal.Monad
+import Database.Orville.Internal.MigrationPlan
+import Database.Orville.Internal.SchemaState
 import Database.Orville.Internal.Types
 
-createConstraint :: MonadOrville conn m => conn -> ConstraintDefinition -> m ()
-createConstraint conn (ConstraintDefinition {..}) = do
-  let ddl =
-        intercalate
-          " "
-          [ "ALTER TABLE"
-          , "\"" ++ constraintTable ++ "\""
-          , "ADD CONSTRAINT"
-          , "\"" ++ constraintName ++ "\""
-          , constraintBody
-          ]
-  executingSql DDLQuery ddl $ void $ run conn ddl []
+createConstraintPlan ::
+     ConstraintDefinition -> SchemaState -> Maybe MigrationPlan
+createConstraintPlan constraintDef schemaState = do
+  guard
+    (not $
+     schemaStateConstraintExists (constraintName constraintDef) schemaState)
+  pure $
+    migrationDDLForItem
+      (Constraint constraintDef)
+      (intercalate
+         " "
+         [ "ALTER TABLE"
+         , "\"" ++ constraintTable constraintDef ++ "\""
+         , "ADD CONSTRAINT"
+         , "\"" ++ constraintName constraintDef ++ "\""
+         , constraintBody constraintDef
+         ])
 
-dropConstraint :: MonadOrville conn m => conn -> String -> String -> m ()
-dropConstraint conn tableName constraintName = do
-  let ddl =
-        "ALTER TABLE " ++ tableName ++ " DROP CONSTRAINT " ++ constraintName
-  executingSql DDLQuery ddl $ void $ run conn ddl []
-
-getConstraints :: IConnection conn => conn -> IO [String]
-getConstraints conn = do
-  query <-
-    prepare
-      conn
-      "SELECT conname \
-                        \FROM pg_constraint \
-                        \JOIN pg_namespace ON pg_namespace.oid = pg_constraint.connamespace \
-                        \WHERE nspname = current_schema()"
-  void $ execute query []
-  map (convert . head) <$> fetchAllRows' query
+dropConstraintPlan :: String -> String -> SchemaState -> Maybe MigrationPlan
+dropConstraintPlan tableName constraintName schemaState = do
+  guard (schemaStateConstraintExists constraintName schemaState)
+  pure $
+    migrationDDLForItem
+      (DropConstraint tableName constraintName)
+      ("ALTER TABLE " ++ tableName ++ " DROP CONSTRAINT " ++ constraintName)

--- a/src/Database/Orville/Internal/MigrateIndex.hs
+++ b/src/Database/Orville/Internal/MigrateIndex.hs
@@ -6,47 +6,37 @@ License   : MIT
 {-# LANGUAGE RecordWildCards #-}
 
 module Database.Orville.Internal.MigrateIndex
-  ( createIndex
-  , dropIndex
-  , getIndexes
+  ( createIndexPlan
+  , dropIndexPlan
   ) where
 
 import Control.Monad
-import Data.Convertible
 import Data.List
-import Database.HDBC
 
-import Database.Orville.Internal.Execute
-import Database.Orville.Internal.Monad
+import Database.Orville.Internal.MigrationPlan
+import Database.Orville.Internal.SchemaState
 import Database.Orville.Internal.Types
 
-createIndex :: MonadOrville conn m => conn -> IndexDefinition -> m ()
-createIndex conn (IndexDefinition {..}) = do
-  let ddl =
-        intercalate
-          " "
-          [ "CREATE"
-          , if indexUnique
-              then "UNIQUE"
-              else ""
-          , "INDEX"
-          , indexName
-          , "ON"
-          , "\"" ++ indexTable ++ "\""
-          , indexBody
-          ]
-  executingSql DDLQuery ddl $ void $ run conn ddl []
+createIndexPlan :: IndexDefinition -> SchemaState -> Maybe MigrationPlan
+createIndexPlan indexDef schemaState = do
+  guard (not $ schemaStateIndexExists (indexName indexDef) schemaState)
+  pure $
+    migrationDDLForItem
+      (Index indexDef)
+      (intercalate
+         " "
+         [ "CREATE"
+         , if indexUnique indexDef
+             then "UNIQUE"
+             else ""
+         , "INDEX"
+         , indexName indexDef
+         , "ON"
+         , "\"" ++ indexTable indexDef ++ "\""
+         , indexBody indexDef
+         ])
 
-dropIndex :: MonadOrville conn m => conn -> String -> m ()
-dropIndex conn name = do
-  let ddl = "DROP INDEX " ++ name
-  executingSql DDLQuery ddl $ void $ run conn ddl []
-
-getIndexes :: IConnection conn => conn -> IO [String]
-getIndexes conn = do
-  query <-
-    prepare
-      conn
-      "SELECT indexname FROM pg_indexes WHERE schemaname = current_schema();"
-  void $ execute query []
-  map (convert . head) <$> fetchAllRows' query
+dropIndexPlan :: String -> SchemaState -> Maybe MigrationPlan
+dropIndexPlan name schemaState = do
+  guard (schemaStateIndexExists name schemaState)
+  pure $ migrationDDLForItem (DropIndex name) ("DROP INDEX " ++ name)

--- a/src/Database/Orville/Internal/MigrationError.hs
+++ b/src/Database/Orville/Internal/MigrationError.hs
@@ -1,0 +1,67 @@
+module Database.Orville.Internal.MigrationError
+  ( MigrationError(..)
+  ) where
+
+import Control.Exception (Exception, SomeException, displayException)
+import qualified Data.List as List
+import Data.Typeable (Typeable)
+
+import Database.Orville.Internal.Types
+
+data MigrationError
+  = MigrationLockExcessiveRetryError String
+  | MigrationExecutionError SchemaItem
+                            SomeException
+  deriving (Typeable)
+
+instance Exception MigrationError
+
+--
+-- This Show instance is not great, in fact it's horribly inconsistent. I'm leaving it like
+-- this for now to avoid be derailed.
+--
+instance Show MigrationError where
+  show err =
+    case err of
+      MigrationLockExcessiveRetryError msg ->
+        "MigrationLockExcessiveRetryError " ++ show msg
+      MigrationExecutionError (Table tableDef) someException ->
+        formatTableMigrationException tableDef someException
+      MigrationExecutionError schemaItem someException ->
+        concat ["MigrationError ", show schemaItem, show someException]
+
+formatTableMigrationException ::
+     TableDefinition readEntity writeEntity key -> SomeException -> String
+formatTableMigrationException tableDef exception = message
+  where
+    message =
+      "There was an error migrating table " ++
+      name ++
+      ".\n\
+                  \The error is:\n\
+                  \\n\
+                  \ " ++
+      displayException exception ++
+      "\\n\
+                  \\n\
+                  \\n\
+                  \Here are the developer comments regarding the table:\n\
+                  \\n\
+                  \ " ++
+      comments ++
+      "\
+                  \\n"
+    name = tableName tableDef
+    comments = formatTableComments " " tableDef
+
+formatTableComments ::
+     String -> TableDefinition readEntity writeEntity key -> String
+formatTableComments indent tableDef =
+  List.intercalate ("\n" ++ indent) commentLines
+  where
+    commentLines = map formatTableComment comments
+    comments = runComments (tableComments tableDef)
+
+formatTableComment :: TableComment -> String
+formatTableComment c =
+  List.intercalate " - " [tcWhat c, show (tcWhen c), tcWho c]

--- a/src/Database/Orville/Internal/MigrationPlan.hs
+++ b/src/Database/Orville/Internal/MigrationPlan.hs
@@ -1,0 +1,54 @@
+{-|
+Module    : Database.Orville.Internal.MigrationPlan
+Copyright : Flipstone Technology Partners 2016-2018
+License   : MIT
+-}
+{-# LANGUAGE CPP #-}
+
+module Database.Orville.Internal.MigrationPlan
+  ( MigrationPlan
+  , MigrationItem(..)
+  , DDL
+  , migrationDDLForItem
+  , migrationPlanItems
+  ) where
+
+import qualified Data.DList as DList
+
+import Database.Orville.Internal.Types (SchemaItem)
+
+type DDL = String
+
+data MigrationItem = MigrationItem
+  { migrationItemSchemaItem :: SchemaItem
+  , migrationItemDDL :: DDL
+  }
+
+data MigrationPlan =
+  MigrationPlan MigrationItem
+                (DList.DList MigrationItem)
+
+migrationDDLForItem :: SchemaItem -> DDL -> MigrationPlan
+migrationDDLForItem schemaItem ddl =
+  MigrationPlan (MigrationItem schemaItem ddl) DList.empty
+
+append :: MigrationPlan -> MigrationPlan -> MigrationPlan
+append (MigrationPlan itemA restA) (MigrationPlan itemB restB) =
+  MigrationPlan itemA $ DList.append restA $ DList.cons itemB restB
+
+migrationPlanItems :: MigrationPlan -> [MigrationItem]
+migrationPlanItems (MigrationPlan item rest) =
+  DList.toList $ DList.cons item rest
+#if MIN_VERSION_base(4,11,0)
+instance Semigroup RawExpr where
+  (<>) = append
+#else
+instance Monoid MigrationPlan
+-- MigrationPlan doesn't support mempty, so don't provide a Monoid instance for
+-- base versions that have migrated to Semigroup.
+                                                  where
+  mempty =
+    error
+      "mempty for MigrationPlan used, but MigrationPlan cannot be empty! MigrationPlan only support Monoid prior to base 4.11.0"
+  mappend = append
+#endif

--- a/src/Database/Orville/Internal/SchemaState.hs
+++ b/src/Database/Orville/Internal/SchemaState.hs
@@ -1,0 +1,74 @@
+module Database.Orville.Internal.SchemaState
+  ( SchemaState
+  , schemaStateTableColumns
+  , schemaStateTableExists
+  , schemaStateIndexExists
+  , schemaStateConstraintExists
+  , loadSchemaState
+  ) where
+
+import Control.Monad (forM, void)
+import Data.Convertible (convert)
+import qualified Database.HDBC as HDBC
+
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+
+type TableName = String
+
+type IndexName = String
+
+type ConstraintName = String
+
+type Columns = [(String, HDBC.SqlColDesc)]
+
+data SchemaState = SchemaState
+  { schemaStateTables :: Map.Map TableName Columns
+  , schemaStateIndexes :: Set.Set IndexName
+  , schemaStateConstraints :: Set.Set ConstraintName
+  }
+
+schemaStateTableColumns :: TableName -> SchemaState -> Maybe Columns
+schemaStateTableColumns name = Map.lookup name . schemaStateTables
+
+schemaStateTableExists :: TableName -> SchemaState -> Bool
+schemaStateTableExists name = Map.member name . schemaStateTables
+
+schemaStateIndexExists :: IndexName -> SchemaState -> Bool
+schemaStateIndexExists name = Set.member name . schemaStateIndexes
+
+schemaStateConstraintExists :: ConstraintName -> SchemaState -> Bool
+schemaStateConstraintExists name = Set.member name . schemaStateConstraints
+
+loadSchemaState :: HDBC.IConnection conn => conn -> IO SchemaState
+loadSchemaState conn = do
+  SchemaState <$> getTables conn <*> getIndexes conn <*> getConstraints conn
+
+getTables :: HDBC.IConnection conn => conn -> IO (Map.Map TableName Columns)
+getTables conn = do
+  tables <- HDBC.getTables conn
+  fmap Map.fromList $
+    forM tables $ \table -> do
+      columns <- HDBC.describeTable conn table
+      pure (table, columns)
+
+getIndexes :: HDBC.IConnection conn => conn -> IO (Set.Set IndexName)
+getIndexes conn = do
+  query <-
+    HDBC.prepare
+      conn
+      "SELECT indexname FROM pg_indexes WHERE schemaname = current_schema();"
+  void $ HDBC.execute query []
+  Set.fromList <$> map (convert . head) <$> HDBC.fetchAllRows' query
+
+getConstraints :: HDBC.IConnection conn => conn -> IO (Set.Set ConstraintName)
+getConstraints conn = do
+  query <-
+    HDBC.prepare
+      conn
+      "SELECT conname \
+                        \FROM pg_constraint \
+                        \JOIN pg_namespace ON pg_namespace.oid = pg_constraint.connamespace \
+                        \WHERE nspname = current_schema()"
+  void $ HDBC.execute query []
+  Set.fromList <$> map (convert . head) <$> HDBC.fetchAllRows' query

--- a/test/MigrateTest.hs
+++ b/test/MigrateTest.hs
@@ -1,9 +1,11 @@
 module MigrateTest where
 
+import qualified Data.List as List
+
 import qualified Database.Orville as O
 
 import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.HUnit (assertBool, assertEqual, testCase)
+import Test.Tasty.HUnit (assertBool, assertFailure, testCase)
 
 import ParameterizedEntity.Schema (schema)
 import qualified TestDB as TestDB
@@ -15,16 +17,22 @@ test_migrate =
       "Migrate Test"
       [ testCase "Migration is idempotent" $ do
           run (TestDB.reset [])
-          firstTrace <- run (TestDB.queryTrace isDDL (O.migrateSchema schema))
+          trace <- run (TestDB.queryTrace isDDL (O.migrateSchema schema))
           assertBool
             "Expected first migration trace not to be empty, but it was!"
-            (not (null firstTrace))
-          secondTrace <- run (TestDB.queryTrace isDDL (O.migrateSchema schema))
-          assertEqual
-            "Expected second migration trace to be empty"
-            []
-            secondTrace
+            (not (null trace))
+          plan <- run (O.generateMigrationPlan schema)
+          case plan of
+            Nothing -> pure ()
+            Just somethingToDo ->
+              assertFailure $
+              "Expected migration plan to be Nothing when database is already migrated, but ddl was:\n" ++
+              showDDL somethingToDo
       ]
 
 isDDL :: O.QueryType -> Bool
 isDDL qt = qt == O.DDLQuery
+
+showDDL :: O.MigrationPlan -> String
+showDDL =
+  List.intercalate "\n\n" . map O.migrationItemDDL . O.migrationPlanItems


### PR DESCRIPTION
generateMigrationPlan allows users to build and view the plan that Orville will use to migrate
a database schema without the plan being executed. This can be used simply to preview changes
at the repl during development, or to verify that the database you are connected to matches
your Haskell data definitions without attempting to modify it (e.g. you are accessing a read-only
database).