### PR TITLE
liminalisht/fixcopypasta

### DIFF
--- a/src/Database/Orville/Internal/MigrationPlan.hs
+++ b/src/Database/Orville/Internal/MigrationPlan.hs
@@ -39,16 +39,17 @@ append (MigrationPlan itemA restA) (MigrationPlan itemB restB) =
 migrationPlanItems :: MigrationPlan -> [MigrationItem]
 migrationPlanItems (MigrationPlan item rest) =
   DList.toList $ DList.cons item rest
+
 #if MIN_VERSION_base(4,11,0)
-instance Semigroup RawExpr where
+instance Semigroup MigrationPlan where
   (<>) = append
 #else
 instance Monoid MigrationPlan
--- MigrationPlan doesn't support mempty, so don't provide a Monoid instance for
--- base versions that have migrated to Semigroup.
-                                                  where
-  mempty =
-    error
-      "mempty for MigrationPlan used, but MigrationPlan cannot be empty! MigrationPlan only support Monoid prior to base 4.11.0"
-  mappend = append
+  -- MigrationPlan doesn't support mempty, so don't provide a Monoid instance for
+  -- base versions that have migrated to Semigroup.
+  where
+    mempty =
+      error
+        "mempty for MigrationPlan used, but MigrationPlan cannot be empty! MigrationPlan only support Monoid prior to base 4.11.0"
+    mappend = append
 #endif


### PR DESCRIPTION
This PR fixes an issue introduced in sha 4239ac3a37495dea4927c446d28dab11f2326a27 which causes `orville` not to compile against target versions of GHC >= 8.4.1.

If you attempt to refer to this sha (or a later sha) in a project that uses, say, GHC 8.4.4, when  it attempted to compile orville, you'd get an error like this:

```
Not in scope: type constructor or class ‘RawExpr’
       |
    43 | instance Semigroup RawExpr where
```

I've confirmed that you can indeed compile `orville` on 8.4.4 with the fix below.