### PR TITLE
liminalisht/timefix

### DIFF
--- a/src/Database/Orville/Internal/SqlType.hs
+++ b/src/Database/Orville/Internal/SqlType.hs
@@ -358,7 +358,8 @@ utcTimeToSql = HDBC.SqlUTCTime
 utcTimeFromSql :: HDBC.SqlValue -> Maybe Time.UTCTime
 utcTimeFromSql sql =
   case sql of
-    HDBC.SqlUTCTime t -> Just t
+    HDBC.SqlUTCTime   t -> Just t
+    HDBC.SqlZonedTime t -> Just (Time.zonedTimeToUTC t)
     _ -> Nothing
 
 toBoundedInteger :: (Bounded num, Integral num) => Integer -> Maybe num


### PR DESCRIPTION
This PR adds a crucial fix to the way sql values of type `timestamp with time zone` are parsed into `UTCTime`.

You are likely to get this sort of error when trying to read a row with a column of type `timestamp with time zone`: 

```
RowDataError \"Error decoding data from column active_at value\""
```

This code change seems to fix the issue.