### PR TITLE
Fixes infinite loop bug when popMany is used on pure

### DIFF
--- a/src/Database/Orville/Popper.hs
+++ b/src/Database/Orville/Popper.hs
@@ -234,8 +234,15 @@ popMany (PopPrim (PrimRecordsBy tableDef fieldDef opts)) =
     isKey keys key _ = key `elem` keys
 popMany PopId = PopId
 popMany (PopAbort err) = (PopAbort err)
-popMany (PopPure a) = PopPure (repeat a) -- lists here should be treated as
-                     -- ZipLists, so 'repeat' is 'pure'
+popMany (PopPure a)
+  -- Important: Even though lists are ZipLists in the context of popMany, it is
+  -- important that the popMany version of pure actual examines its input and
+  -- produces the correct number of outputs. Using `repeat` here can produce
+  -- a list of infinite results for a finite input list, which can then ultimately
+  -- create an infinite loop when zipped without non-finite lists. Instead of
+  -- using `repeat` here we use `map` to product *exactly a many as* as there are
+  -- input values.
+ = PopLift (PoppedValue . map (const a))
 popMany (PopLift f) =
   PopLift $ \inputs ->
     let poppeds = map f inputs

--- a/test/PopperTest.hs
+++ b/test/PopperTest.hs
@@ -52,6 +52,18 @@ test_popper =
                   QC.counterexample
                     ("Actual: " ++ show actual)
                     (expected == actual)
+    , TestDB.withOrvilleRun $ \run ->
+        testProperty "popMany pure doesn't cause infinite loop" $ \count -> do
+          let roots1Pooper =
+                P.popMany (pure (RootId 1) >>> P.hasOne rootTable rootIdField)
+              inputs = replicate count ()
+              expected = replicate count Nothing
+          QC.ioProperty $ do
+            actual <-
+              run $ do
+                TestDB.reset testSchema
+                P.popThrow roots1Pooper inputs
+            pure (expected == actual)
     ]
 
 -- mkTreeRecords projects a Tree into the Root, Branch and Leaf entities


### PR DESCRIPTION
The old handing of popMany for the PopPure case allow an infinite
list of results to be produced even when the list of inputs was
finite. This could result in an infinite loop when that infinite list
is used as the input to further operations (either within the scope
of the popper, or after the popper has finished and returned an
infinite list).