### PR TITLE
Unshackles MonadOrville from MonadBaseControl

### DIFF
--- a/orville.cabal
+++ b/orville.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 3de2b6dba09a60fdd3600acf5c58f7e486547add5240a828e74b0a55b4d661d6
+-- hash: 358f1434af15d0e40e0659a31f7c6ba29711accdfa5ce40c1892107f615c60e3
 
 name:           orville
 version:        0.8.3.0
@@ -28,6 +28,7 @@ library
       Database.Orville.Conduit
       Database.Orville.Core
       Database.Orville.Expr
+      Database.Orville.MonadBaseControl
       Database.Orville.Popper
       Database.Orville.PostgresSQL
       Database.Orville.Raw

--- a/package.yaml
+++ b/package.yaml
@@ -55,6 +55,7 @@ library:
     - Database.Orville.Conduit
     - Database.Orville.Core
     - Database.Orville.Expr
+    - Database.Orville.MonadBaseControl
     - Database.Orville.Popper
     - Database.Orville.PostgresSQL
     - Database.Orville.Raw

--- a/src/Database/Orville/Core.hs
+++ b/src/Database/Orville/Core.hs
@@ -48,6 +48,9 @@ module Database.Orville.Core
   , MonadOrville(..)
   , runOrville
   , mapOrvilleT
+  , MonadOrvilleControl(..)
+  , defaultLiftWithConnection
+  , defaultLiftFinally
   , QueryType(..)
   , withTransaction
   , ColumnFlag(..)

--- a/src/Database/Orville/MonadBaseControl.hs
+++ b/src/Database/Orville/MonadBaseControl.hs
@@ -95,7 +95,7 @@ instance (MTC.MonadBaseControl IO m, O.MonadOrville conn m) =>
 {-|
    Because we recommend using 'MonadUnliftIO' rather than 'MonadTransControl',
    we do not provide 'MonadTransControl' instance for 'OrvilleT' by default
-   along wit the definition. If you do need to use 'MonadTransControl',
+   along with the definition. If you do need to use 'MonadTransControl',
    however, this is the canonical instance for 'OrvilleT'.
   |-}
 instance MTC.MonadTransControl (O.OrvilleT conn) where
@@ -106,7 +106,7 @@ instance MTC.MonadTransControl (O.OrvilleT conn) where
 {-|
    Because we recommend using 'MonadUnliftIO' rather than 'MonadBaseControl',
    we do not provide 'MonadBaseControl' instance for 'OrvilleT' by default
-   along wit the definition. If you do need to use 'MonadBaseControl',
+   along with the definition. If you do need to use 'MonadBaseControl',
    however, this is the canonical instance for 'OrvilleT'.
   |-}
 instance MTC.MonadBaseControl b m =>

--- a/src/Database/Orville/MonadBaseControl.hs
+++ b/src/Database/Orville/MonadBaseControl.hs
@@ -1,0 +1,116 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE TypeFamilies #-}
+
+{-|
+   'Database.Orville.MonadBaseControl' provides functions and instances for
+   using 'MonadOrville' and 'OrvilleT' for situations where you need to use
+   'MonadBaseControl'. If you do not know if you need 'MonadBaseControl', then
+   you probably don't need to use this module. If you are thinking about
+   using 'MonadBaseControl' instead of 'MonadUnliftIO', we recommend
+   reading Michael Snoyman's excellent "A Tale of Two Brackets"
+   (https://www.fpcomplete.com/blog/2017/06/tale-of-two-brackets) if you
+   have not already done so.
+
+   If you're still here after reading above, this module provides
+   the functions you need to implement 'MonadOrvilleControl' for your
+   Monad stack using its 'MonadBaseControl' instance. The most common way
+   to do this is simply to add the following 'MonadOrvilleControl' instance:
+
+   @
+    instance MonadOrvilleControl MyMonad where
+      liftWithConnection = liftWithConnectionViaBaseControl
+      liftFinally = liftFinallyViaBaseControl
+   @
+
+   This module also provides a 'MonadOrvilleControl' for 'StateT' as well as
+   'MonadBaseControl' and 'MonadTransControl' instances for 'OrvilleT'.
+ |-}
+module Database.Orville.MonadBaseControl
+  ( liftWithConnectionViaBaseControl
+  , liftFinallyViaBaseControl
+  ) where
+
+import Control.Monad.Reader (ReaderT)
+import Control.Monad.State (StateT(StateT, runStateT))
+import Control.Monad.Trans (lift)
+import qualified Control.Monad.Trans.Control as MTC
+
+import qualified Database.Orville as O
+import qualified Database.Orville.Internal.Monad as Internal
+
+{-|
+   liftWithConnectionViaBaseControl can be use as the implementation of
+   'liftWithConnection' for 'MonadOrvilleControl' when the 'Monad'
+   implements 'MonadBaseControl'.
+ |-}
+liftWithConnectionViaBaseControl ::
+     MTC.MonadBaseControl IO m
+  => (forall b. (conn -> IO b) -> IO b)
+  -> (conn -> m a)
+  -> m a
+liftWithConnectionViaBaseControl ioWithConn action =
+  MTC.control $ \runInIO -> ioWithConn (runInIO . action)
+
+{-|
+   liftFinallyViaBaseControl can be use as the implementation of
+   'liftFinally for 'MonadOrvilleControl' when the 'Monad'
+   implements 'MonadBaseControl'.
+ |-}
+liftFinallyViaBaseControl ::
+     MTC.MonadBaseControl IO m
+  => (forall c d. IO c -> IO d -> IO c)
+  -> m a
+  -> m b
+  -> m a
+liftFinallyViaBaseControl ioFinally action cleanup =
+  MTC.control $ \runInIO -> ioFinally (runInIO action) (runInIO cleanup)
+
+{-|
+   Because lifting control operations into 'StateT' is fraught with peril, a
+   'MonadOrvilleControl' instance for 'StateT' is provided here and implemented
+   via 'MonadBaseControl' rather than together with the 'MonadOrvilleControl'
+   definition. We do not recommend using stateful Monad transformer layers in
+   Monad stacks based on IO. For anyone that must, this is the canonical
+   instance for 'StateT'
+  |-}
+instance MTC.MonadBaseControl IO m => O.MonadOrvilleControl (StateT a m) where
+  liftWithConnection = liftWithConnectionViaBaseControl
+  liftFinally = liftFinallyViaBaseControl
+
+{-|
+   Because 'MonadOrvilleControl' is a superclass of 'MonadOrville', the
+   'MonadOrville' instace of 'StateT' is provided here instead with the
+   definition of 'MonadOrville'. See the commentary on the other instance
+   for an admonition to not use it :)
+  |-}
+instance (MTC.MonadBaseControl IO m, O.MonadOrville conn m) =>
+         O.MonadOrville conn (StateT a m) where
+  getOrvilleEnv = lift O.getOrvilleEnv
+  localOrvilleEnv modEnv action =
+    StateT $ \val -> O.localOrvilleEnv modEnv (runStateT action val)
+
+{-|
+   Because we recommend using 'MonadUnliftIO' rather than 'MonadTransControl',
+   we do not provide 'MonadTransControl' instance for 'OrvilleT' by default
+   along wit the definition. If you do need to use 'MonadTransControl',
+   however, this is the canonical instance for 'OrvilleT'.
+  |-}
+instance MTC.MonadTransControl (O.OrvilleT conn) where
+  type StT (O.OrvilleT conn) a = MTC.StT (ReaderT (O.OrvilleEnv conn)) a
+  liftWith = MTC.defaultLiftWith Internal.OrvilleT Internal.unOrvilleT
+  restoreT = MTC.defaultRestoreT Internal.OrvilleT
+
+{-|
+   Because we recommend using 'MonadUnliftIO' rather than 'MonadBaseControl',
+   we do not provide 'MonadBaseControl' instance for 'OrvilleT' by default
+   along wit the definition. If you do need to use 'MonadBaseControl',
+   however, this is the canonical instance for 'OrvilleT'.
+  |-}
+instance MTC.MonadBaseControl b m =>
+         MTC.MonadBaseControl b (O.OrvilleT conn m) where
+  type StM (O.OrvilleT conn m) a = MTC.ComposeSt (O.OrvilleT conn) m a
+  liftBaseWith = MTC.defaultLiftBaseWith
+  restoreM = MTC.defaultRestoreM

--- a/src/Database/Orville/Raw.hs
+++ b/src/Database/Orville/Raw.hs
@@ -13,7 +13,7 @@ module Database.Orville.Raw
   , withTransaction
   ) where
 
-import Control.Exception.Lifted (finally)
+import Control.Exception (finally)
 import Control.Monad
 import Control.Monad.IO.Class
 import Data.IORef
@@ -74,4 +74,4 @@ withTransaction action =
                 when (not finished) $ do
                   rollback conn
                   txnCallback TransactionRollback
-        doAction `finally` rollbackUncommitted
+        liftFinally finally doAction rollbackUncommitted


### PR DESCRIPTION
This replaces the MonadBaseControl superclass constraint for MonadOrville
with a constraint for a new MonadOrvilleControl typeclass instead.
MonadOrvilleControl defines the specific control lifting functions that
Orville needs rather than requiring the full power of either MonadBaseControl
or MonadUnliftIO.

An unexpected outcome of this was that much of the testing infrastructure was
able to abandon MonadBaseControl immediately, without replacing it with
MonadUnliftIO at all. This is mainly due to the fact that Orville provides a
ReaderT instance for MonadOrvilleControl that doesn't rely on any extrenal
libraries. This only works because the tests only use ReaderT in their Monad
stacks. In the real world, users will have other transformers (e.g. for
web frameworks) that will need help providing instances of MonadOrvilleControl.
We can build a library of helper functions in Orville for implementing
MonadOrvilleControl based on commonly used libraries, both general purpose
and even web-framework specific (in their own libraries).

The existing MonadBaseControl dependencies in the library entirely moved to
Database.Orville.MonadBaseControl which is not exported from Core. Instaed,
users can import this module explicitly if they know that they need to use
MonadBaseControl.

Also note: `hindent` has mangled some comment formatting a bit. I'm planning
to move away from `hindent` (as as result of this and other frustrations). I could
not find a good solution to fix any of the comment format weirdness.