### PR TITLE
Adds support for MonadUnliftIO

### DIFF
--- a/orville.cabal
+++ b/orville.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: c5fd7779b4d320abcf36b279057892f7585c711e87e5008c3edf3c09d21eafd7
+-- hash: 62042f25d9401cb71f84fe356b1e1a883494786af00ac6c0faae07323f16a9e4
 
 name:           orville
 version:        0.8.3.0
@@ -29,6 +29,7 @@ library
       Database.Orville.Core
       Database.Orville.Expr
       Database.Orville.MonadBaseControl
+      Database.Orville.MonadUnliftIO
       Database.Orville.Popper
       Database.Orville.PostgresSQL
       Database.Orville.Raw
@@ -93,6 +94,7 @@ library
     , time >=1.5
     , transformers >=0.4
     , transformers-base >=0.4
+    , unliftio-core >=0.1
   default-language: Haskell2010
 
 executable orville-sample-exe
@@ -127,6 +129,7 @@ executable orville-sample-exe
     , time >=1.5
     , transformers >=0.4
     , transformers-base >=0.4
+    , unliftio-core >=0.1
   default-language: Haskell2010
 
 test-suite spec
@@ -152,6 +155,7 @@ test-suite spec
       TestDB
       TransactionTest
       TriggerTest
+      UnliftIOTest
       WhereConditionTest
       Paths_orville
   hs-source-dirs:
@@ -182,4 +186,5 @@ test-suite spec
     , time >=1.5
     , transformers >=0.4
     , transformers-base >=0.4
+    , unliftio-core >=0.1
   default-language: Haskell2010

--- a/orville.cabal
+++ b/orville.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 62042f25d9401cb71f84fe356b1e1a883494786af00ac6c0faae07323f16a9e4
+-- hash: 2887e13eb28b2250509d3b06828be61801f3a68888aee11e5967d10545ecd865
 
 name:           orville
 version:        0.8.3.0
@@ -147,6 +147,7 @@ test-suite spec
       EntityWrapper.Schema.Virus
       ErrorsTest
       MigrateTest
+      MonadBaseControlTest
       ParameterizedEntity.CrudTest
       ParameterizedEntity.Data.Virus
       ParameterizedEntity.Schema

--- a/package.yaml
+++ b/package.yaml
@@ -36,6 +36,7 @@ dependencies:
   - time >=1.5
   - transformers >=0.4
   - transformers-base >=0.4
+  - unliftio-core >= 0.1
 
 executables:
   orville-sample-exe:
@@ -56,6 +57,7 @@ library:
     - Database.Orville.Core
     - Database.Orville.Expr
     - Database.Orville.MonadBaseControl
+    - Database.Orville.MonadUnliftIO
     - Database.Orville.Popper
     - Database.Orville.PostgresSQL
     - Database.Orville.Raw

--- a/src/Database/Orville/MonadBaseControl.hs
+++ b/src/Database/Orville/MonadBaseControl.hs
@@ -26,8 +26,9 @@
    @
 
    This module also provides a 'MonadOrvilleControl' for 'StateT' as well as
-   'MonadBaseControl' and 'MonadTransControl' instances for 'OrvilleT'.
- |-}
+   'MonadBaseControl' and 'MonadTransControl' instances for 'OrvilleT' and
+   'OrvilleTriggerT'.
+  |-}
 module Database.Orville.MonadBaseControl
   ( liftWithConnectionViaBaseControl
   , liftFinallyViaBaseControl

--- a/src/Database/Orville/MonadUnliftIO.hs
+++ b/src/Database/Orville/MonadUnliftIO.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE RankNTypes #-}
+
+{-|
+   'Database.Orville.MonadUnliftIO provides functions and instances for using
+   'MonadOrville' and 'OrvilleT' for Monad transformer stacks that are using
+   'MonadUnliftIO'.  The most common way to do this is simply to add the
+   following 'MonadOrvilleControl' instance:
+
+   @
+    instance MonadOrvilleControl MyMonad where
+      liftWithConnection = liftWithConnectionViaUnliftIO
+      liftFinally = liftFinallyViaUnliftIO
+   @
+
+   This module also provides a 'MonadUnliftIO' instance for 'OrvilleT' and 'OrvilleTrigger'.
+ |-}
+module Database.Orville.MonadUnliftIO
+  ( liftWithConnectionViaUnliftIO
+  , liftFinallyViaUnliftIO
+  ) where
+
+import qualified Control.Monad.IO.Unlift as UL
+
+import qualified Database.Orville as O
+import qualified Database.Orville.Internal.Monad as InternalMonad
+import qualified Database.Orville.Internal.Trigger as InternalTrigger
+import qualified Database.Orville.Trigger as OT
+
+{-|
+   liftWithConnectionViaUnliftIO can be use as the implementation of
+   'liftWithConnection' for 'MonadOrvilleControl' when the 'Monad'
+   implements 'MonadUnliftIO'.
+ |-}
+liftWithConnectionViaUnliftIO ::
+     UL.MonadUnliftIO m
+  => (forall a. (conn -> IO a) -> IO a)
+  -> (conn -> m b)
+  -> m b
+liftWithConnectionViaUnliftIO ioWithConn action =
+  UL.withRunInIO $ \runInIO -> ioWithConn (runInIO . action)
+
+{-|
+   liftFinallyViaUnliftIO can be use as the implementation of
+   'liftFinally' for 'MonadOrvilleControl' when the 'Monad'
+   implements 'MonadUnliftIO'.
+ |-}
+liftFinallyViaUnliftIO ::
+     UL.MonadUnliftIO m
+  => (forall a b. IO a -> IO b -> IO a)
+  -> m c
+  -> m d
+  -> m c
+liftFinallyViaUnliftIO ioFinally action cleanup = do
+  unlio <- UL.askUnliftIO
+  UL.liftIO $ ioFinally (UL.unliftIO unlio action) (UL.unliftIO unlio cleanup)
+
+instance UL.MonadUnliftIO m => UL.MonadUnliftIO (O.OrvilleT conn m) where
+  askUnliftIO =
+    InternalMonad.OrvilleT $ do
+      unlio <- UL.askUnliftIO
+      pure $ UL.UnliftIO (UL.unliftIO unlio . InternalMonad.unOrvilleT)
+
+instance UL.MonadUnliftIO m =>
+         UL.MonadUnliftIO (OT.OrvilleTriggerT trigger conn m) where
+  askUnliftIO =
+    InternalTrigger.OrvilleTriggerT $ do
+      unlio <- UL.askUnliftIO
+      pure $ UL.UnliftIO (UL.unliftIO unlio . InternalTrigger.unTriggerT)

--- a/test/MonadBaseControlTest.hs
+++ b/test/MonadBaseControlTest.hs
@@ -1,0 +1,107 @@
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module MonadBaseControlTest where
+
+import qualified Control.Monad.Base as MB
+import Control.Monad.Catch (MonadThrow)
+import qualified Control.Monad.IO.Class as MIO
+import qualified Control.Monad.Trans.Control as MTC
+import qualified Database.HDBC.PostgreSQL as Postgres
+import qualified Database.Orville as O
+import qualified Database.Orville.MonadBaseControl as OMBC
+
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase)
+
+import qualified TestDB as TestDB
+
+{-|
+   'ThirdPartyMonad' is a stand in for a Monad (or Monad Transformer) that an
+   Orville user might by using from another library that doesn't know anything
+   about the Orville Monad stack. We would like to make using such third
+   parties painless as possible.
+  -}
+newtype ThirdPartyMonad a = ThirdPartyMonad
+  { runThirdPartyMonad :: IO a
+  } deriving ( Functor
+             , Applicative
+             , Monad
+             , MIO.MonadIO
+             , MB.MonadBase IO
+             , MonadThrow
+             )
+
+instance MTC.MonadBaseControl IO ThirdPartyMonad where
+  type StM ThirdPartyMonad a = MTC.StM IO a
+  liftBaseWith withRunInBase =
+    ThirdPartyMonad $
+    MTC.liftBaseWith $ \runInBase ->
+      withRunInBase (runInBase . runThirdPartyMonad)
+  restoreM = ThirdPartyMonad . MTC.restoreM
+
+{-|
+   'EndUserMonad' is a stand in for the Monad stack that an Orville user might
+   build using a third party monad from another library. We would like to make
+   it easy to build the typeclass instances that Orville requires as easy as
+   possible for new users.
+  -}
+newtype EndUserMonad a = EndUserMonad
+  { runEndUserMonad :: O.OrvilleT Postgres.Connection ThirdPartyMonad a
+  } deriving ( Functor
+             , Applicative
+             , Monad
+             , MIO.MonadIO
+             , MB.MonadBase IO
+             , O.MonadOrville Postgres.Connection
+             , MonadThrow
+             )
+
+{-|
+   If the user is using 'MonadBaseControl', then it would be up to them to
+   provide this instance for their own Monad. It is perhaps worth noting that
+   the 'defaultLiftBaseWith' and 'defaultRestoreM' from 'MonadBaseControl' are
+   not particularly helpful here, because the rely on having an instance of
+   'MonadTransControl', but newtype wrappers used to cap-off Monad stacks are
+   not transformers, so they can provide such an instance.
+  -}
+instance MTC.MonadBaseControl IO EndUserMonad where
+  type StM EndUserMonad a = MTC.StM (O.OrvilleT Postgres.Connection ThirdPartyMonad) a
+  liftBaseWith withRunInBase =
+    EndUserMonad $
+    MTC.liftBaseWith $ \runInBase ->
+      withRunInBase (runInBase . runEndUserMonad)
+  restoreM = EndUserMonad . MTC.restoreM
+
+{-|
+   This is the 'MonadOrvilleControl' instance that a user would need to built if
+   they are using 'MonadBaseControl' as their lifting strategy.
+  -}
+instance O.MonadOrvilleControl EndUserMonad where
+  liftWithConnection = OMBC.liftWithConnectionViaBaseControl
+  liftFinally = OMBC.liftFinallyViaBaseControl
+
+{-|
+   The organization of the Orville typeclasses currently requires this orphan
+   instance to be provided by the user for third-party monad's they are using.
+   Although it is trivial and relatively innocent, we would prefer to avoid
+   requiring orphan instances when using Orville or even introducing new users
+   to the concept.
+  -}
+instance O.MonadOrvilleControl ThirdPartyMonad where
+  liftWithConnection = OMBC.liftWithConnectionViaBaseControl
+  liftFinally = OMBC.liftFinallyViaBaseControl
+
+orvilleAction :: EndUserMonad ()
+orvilleAction = TestDB.reset []
+
+test_migrate :: TestTree
+test_migrate =
+  TestDB.withDb $ \getPool ->
+    testGroup
+      "MonadBaseControl"
+      [ testCase "works" $ do
+          pool <- getPool
+          runThirdPartyMonad $
+            O.runOrville (runEndUserMonad orvilleAction) (O.newOrvilleEnv pool)
+      ]

--- a/test/UnliftIOTest.hs
+++ b/test/UnliftIOTest.hs
@@ -1,0 +1,91 @@
+module UnliftIOTest where
+
+import Control.Monad.Catch (MonadThrow)
+import qualified Control.Monad.IO.Unlift as UL
+import qualified Database.HDBC.PostgreSQL as Postgres
+import qualified Database.Orville as O
+import qualified Database.Orville.MonadUnliftIO as OULIO
+
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase)
+
+import qualified TestDB as TestDB
+
+{-|
+   'ThirdPartyMonad' is a stand in for a Monad (or Monad Transformer) that an
+   Orville user might by using from another library that doesn't know anything
+   about the Orville Monad stack. We would like to make using such third
+   parties painless as possible.
+  -}
+newtype ThirdPartyMonad a = ThirdPartyMonad
+  { runThirdPartyMonad :: IO a
+  } deriving ( Functor
+             , Applicative
+             , Monad
+             , UL.MonadIO
+             , UL.MonadUnliftIO
+             , MonadThrow
+             )
+
+{-|
+   'EndUserMonad' is a stand in for the Monad stack that an Orville user might
+   build using a third party monad from another library. We would like to make
+   it easy to build the typeclass instances that Orville requires as easy as
+   possible for new users.
+  -}
+newtype EndUserMonad a = EndUserMonad
+  { runEndUserMonad :: O.OrvilleT Postgres.Connection ThirdPartyMonad a
+  } deriving ( Functor
+             , Applicative
+             , Monad
+             , UL.MonadIO
+             , O.MonadOrville Postgres.Connection
+             , MonadThrow
+             )
+
+{-|
+   If the user is using 'MonadUnliftIO', then it would be up to them to provide
+   this instance for their own Monad. Later versions of UnliftIO provide a helper
+   function for implementing this, but we would like to keep the dependency bounds
+   as broad as possibly, so we can't use that helper here.
+  -}
+instance UL.MonadUnliftIO EndUserMonad where
+  askUnliftIO =
+    EndUserMonad $ do
+      unlio <- UL.askUnliftIO
+      pure $ UL.UnliftIO (UL.unliftIO unlio . runEndUserMonad)
+
+{-|
+   This is the 'MonadOrvilleControl' instance that a user would need to built if
+   they are using 'MonadUnliftIO' as their lifting strategy. We would like this to
+   be trivial enough that we could easily provide it in the documentation of a
+   quick start tutorial.
+  -}
+instance O.MonadOrvilleControl EndUserMonad where
+  liftWithConnection = OULIO.liftWithConnectionViaUnliftIO
+  liftFinally = OULIO.liftFinallyViaUnliftIO
+
+{-|
+   The organization of the Orville typeclasses currently requires this orphan
+   instance to be provided by the user for third-party monad's they are using.
+   Although it is trivial and relatively innocent, we would prefer to avoid
+   requiring orphan instances when using Orville or even introducing new users
+   to the concept.
+  -}
+instance O.MonadOrvilleControl ThirdPartyMonad where
+  liftWithConnection = OULIO.liftWithConnectionViaUnliftIO
+  liftFinally = OULIO.liftFinallyViaUnliftIO
+
+orvilleAction :: EndUserMonad ()
+orvilleAction = TestDB.reset []
+
+test_migrate :: TestTree
+test_migrate =
+  TestDB.withDb $ \getPool ->
+    testGroup
+      "UnliftIO"
+      [ testCase "works" $ do
+          pool <- getPool
+          runThirdPartyMonad $
+            O.runOrville (runEndUserMonad orvilleAction) (O.newOrvilleEnv pool)
+      ]


### PR DESCRIPTION
Rather than making this explicitly the default in the library by
exporting the UnliftIO oriented functions from the Core module, I
opted instead to built it as a peer to MonadBaseControl. This does
not represent a change in thinking that we should direct new users to
use UnliftIO as a default approach, merely that we should convey that
opinion through means other that module organization in the library.
For instance, doing it through both comments in the API documentation
and directing users to UnliftIO rather than MonadBaseControl in any
tutorial docs we write in the future.