### PR TITLE
Extracts HasOrvilleContext typeclass from MonadOrville.

### DIFF
--- a/src/Database/Orville/Core.hs
+++ b/src/Database/Orville/Core.hs
@@ -45,7 +45,8 @@ module Database.Orville.Core
   , OrvilleT
   , unOrvilleT
   , SqlValue
-  , MonadOrville(..)
+  , HasOrvilleContext(..)
+  , MonadOrville
   , runOrville
   , mapOrvilleT
   , MonadOrvilleControl(..)

--- a/src/Database/Orville/Internal/Monad.hs
+++ b/src/Database/Orville/Internal/Monad.hs
@@ -187,10 +187,10 @@ class IConnection conn =>
       liftFinally = defaultLiftFinally wrapMyMonad unWrapMyMonad
    @
 
-   If you are using transformers in your monad stack other beyond 'ReaderT',
-   they probably don't provide 'MonadOrvilleControl' instances (e.g. third
-   party libraries). In this case, see 'Database.Orville.MonadUnliftIO' for
-   more help. If you're still stuck (because your library doesn't support
+   If you are using transformers in your monad stack beyond 'ReaderT', they
+   probably don't provide 'MonadOrvilleControl' instances (e.g. third party
+   libraries). In this case, see 'Database.Orville.MonadUnliftIO' for more
+   help. If you're still stuck (because your library doesn't support
    'MonadTransControl'), try 'Database.Orville.MonadBaseControl' instead. If
    you're *still* stuck after that, please file an issue on Github at
    https://github.com/flipstone/orville so we can can help out!

--- a/src/Database/Orville/Internal/Trigger.hs
+++ b/src/Database/Orville/Internal/Trigger.hs
@@ -157,13 +157,8 @@ instance (MonadError e m) =>
   catchError action handler =
     OrvilleTriggerT ((unTriggerT action) `catchError` (unTriggerT . handler))
 
-instance ( Monad m
-         , MonadIO m
-         , HDBC.IConnection conn
-         , O.MonadOrvilleControl m
-         , MonadThrow m
-         ) =>
-         O.MonadOrville conn (OrvilleTriggerT trigger conn m) where
+instance (Monad m, HDBC.IConnection conn) =>
+         O.HasOrvilleContext conn (OrvilleTriggerT trigger conn m) where
   getOrvilleEnv = OrvilleTriggerT $ lift O.getOrvilleEnv
   localOrvilleEnv f =
     OrvilleTriggerT . mapReaderT (O.localOrvilleEnv f) . unTriggerT
@@ -179,6 +174,14 @@ instance (Monad m, O.MonadOrvilleControl m) =>
          O.MonadOrvilleControl (OrvilleTriggerT trigger conn m) where
   liftWithConnection = O.defaultLiftWithConnection OrvilleTriggerT unTriggerT
   liftFinally = O.defaultLiftFinally OrvilleTriggerT unTriggerT
+
+instance ( Monad m
+         , MonadThrow m
+         , MonadIO m
+         , HDBC.IConnection conn
+         , O.MonadOrvilleControl m
+         ) =>
+         O.MonadOrville conn (OrvilleTriggerT trigger conn m)
 
 {-
    `askTriggers` retrieves triggers that have been recorded thus far. If you

--- a/test/MonadBaseControlTest.hs
+++ b/test/MonadBaseControlTest.hs
@@ -53,9 +53,17 @@ newtype EndUserMonad a = EndUserMonad
              , Monad
              , MIO.MonadIO
              , MB.MonadBase IO
-             , O.MonadOrville Postgres.Connection
+             , O.HasOrvilleContext Postgres.Connection
              , MonadThrow
              )
+
+{-|
+   This cannot be derived because 'ThirdPartyMonad' does not implement
+   'MonadOrvilleControl'. Declaring an empty instance is trivial, however, and
+   avoids having to provide an orphan instance of 'MonadOrvilleControl' for
+   'ThirdPartyMonad'.
+  -}
+instance O.MonadOrville Postgres.Connection EndUserMonad
 
 {-|
    If the user is using 'MonadBaseControl', then it would be up to them to
@@ -78,17 +86,6 @@ instance MTC.MonadBaseControl IO EndUserMonad where
    they are using 'MonadBaseControl' as their lifting strategy.
   -}
 instance O.MonadOrvilleControl EndUserMonad where
-  liftWithConnection = OMBC.liftWithConnectionViaBaseControl
-  liftFinally = OMBC.liftFinallyViaBaseControl
-
-{-|
-   The organization of the Orville typeclasses currently requires this orphan
-   instance to be provided by the user for third-party monad's they are using.
-   Although it is trivial and relatively innocent, we would prefer to avoid
-   requiring orphan instances when using Orville or even introducing new users
-   to the concept.
-  -}
-instance O.MonadOrvilleControl ThirdPartyMonad where
   liftWithConnection = OMBC.liftWithConnectionViaBaseControl
   liftFinally = OMBC.liftFinallyViaBaseControl
 

--- a/test/TestDB.hs
+++ b/test/TestDB.hs
@@ -38,6 +38,7 @@ newtype TestMonad a = TestMonad
              , MonadBase IO
              , MonadThrow
              , MonadCatch
+             , O.HasOrvilleContext Postgres.Connection
              , O.MonadOrville Postgres.Connection
              )
 

--- a/test/TriggerTest.hs
+++ b/test/TriggerTest.hs
@@ -126,6 +126,7 @@ newtype TriggerTestMonad a = TriggerTestMonad
              , MonadIO
              , MonadThrow
              , MonadCatch
+             , O.HasOrvilleContext Postgres.Connection
              , O.MonadOrville Postgres.Connection
              , OT.MonadTrigger TestTrigger
              )

--- a/test/UnliftIOTest.hs
+++ b/test/UnliftIOTest.hs
@@ -39,9 +39,17 @@ newtype EndUserMonad a = EndUserMonad
              , Applicative
              , Monad
              , UL.MonadIO
-             , O.MonadOrville Postgres.Connection
+             , O.HasOrvilleContext Postgres.Connection
              , MonadThrow
              )
+
+{-|
+   This cannot be derived because 'ThirdPartyMonad' does not implement
+   'MonadOrvilleControl'. Declaring an empty instance is trivial, however, and
+   avoids having to provide an orphan instance of 'MonadOrvilleControl' for
+   'ThirdPartyMonad'.
+  -}
+instance O.MonadOrville Postgres.Connection EndUserMonad
 
 {-|
    If the user is using 'MonadUnliftIO', then it would be up to them to provide
@@ -62,17 +70,6 @@ instance UL.MonadUnliftIO EndUserMonad where
    quick start tutorial.
   -}
 instance O.MonadOrvilleControl EndUserMonad where
-  liftWithConnection = OULIO.liftWithConnectionViaUnliftIO
-  liftFinally = OULIO.liftFinallyViaUnliftIO
-
-{-|
-   The organization of the Orville typeclasses currently requires this orphan
-   instance to be provided by the user for third-party monad's they are using.
-   Although it is trivial and relatively innocent, we would prefer to avoid
-   requiring orphan instances when using Orville or even introducing new users
-   to the concept.
-  -}
-instance O.MonadOrvilleControl ThirdPartyMonad where
   liftWithConnection = OULIO.liftWithConnectionViaUnliftIO
   liftFinally = OULIO.liftFinallyViaUnliftIO
 


### PR DESCRIPTION
Originally I was hoping to simply invert the MonadOrvilleControl ->
MonadOrville relationship so that the the functions for managing context were
in the superclass and control functions in the subclass. That failed, however,
because then no MonadOrvilleControl instance can exist for IO, because IO lacks
any Orville context to manage.

Instead, I ended up extracting the context management functions to
HasOrvilleContext and changing MonadOrville to an empty typeclass that has
superclass contraints for all the classes that Orville functions need. This
allows the context management functions and the control lifting functions to be
implemented by different layers of the monad stack, and by different lifting
strategies. In the end, only the top layer of the monad stack is required to
actually implement *both*, by providing a MonadOrville instance.

In practice, this means that there are *three* typeclasses that a user needs to
be aware of, which is someone annoying. However, `HasOrvilleContext` should
almost always be derivable and `MonadOrville` instances are trivial, so I think
this cost is a reasonable tradeoff to provide the flexibility to use either
`MonadUnliftIO` or `MonadBaseControl` (or another solution) as required. For
release, we will just need to make sure we have enough documentation and
tutorials in place to satisfy users.