### PR TITLE
Adds support for lts-11/12 (including conduit-1.3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,12 +104,20 @@ matrix:
     compiler: ": #stack 8.2.2 (lts-10)"
     addons: {apt: {packages: [libgmp-dev]}}
 
+  - env: BUILD=stack ARGS="--stack-yaml stack-lts-11.22.yml"
+    compiler: ": #stack 8.2.2 (lts-11)"
+    addons: {apt: {packages: [libgmp-dev]}}
+
+  - env: BUILD=stack ARGS="--stack-yaml stack-lts-12.20.yml"
+    compiler: ": #stack 8.4.4 (lts-12)"
+    addons: {apt: {packages: [libgmp-dev]}}
+
   # conduit dependency keeps this from working right now, so disabling
   #- env: BUILD=stack ARGS="--resolver lts-12"
   #  compiler: ": #stack 8.4.4 (lts-12)"
   #  addons: {apt: {packages: [libgmp-dev]}}
 
-  - env: BUILD=stack ARGS="--stack-yaml stack-lts-10.10.yml --resolver nightly"
+  - env: BUILD=stack ARGS="--stack-yaml stack-lts-12.20.yml --resolver nightly"
     compiler: ": #stack nightly"
     addons: {apt: {packages: [libgmp-dev]}}
 
@@ -131,13 +139,13 @@ matrix:
   #   compiler: ": #stack 8.0.2 osx"
   #   os: osx
 
-  - env: BUILD=stack ARGS="--stack-yaml stack-lts-10.10.yml --resolver nightly"
+  - env: BUILD=stack ARGS="--stack-yaml stack-lts-12.20.yml --resolver nightly"
     compiler: ": #stack nightly osx"
     os: osx
 
   allow_failures:
   - env: BUILD=cabal GHCVER=head CABALVER=head HAPPYVER=1.19.5 ALEXVER=3.1.7
-  - env: BUILD=stack ARGS="--stack-yaml stack-lts-10.10.yml --resolver nightly"
+  - env: BUILD=stack ARGS="--stack-yaml stack-lts-12.20.yml --resolver nightly"
   - os: osx
 
 before_install:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       TEST_CONN_STRING: "host=testdb user=orville_test"
     command:
       - ./test-loop
-      - stack-lts-10.10.yml
+      - stack-lts-12.20.yml
     # A TTY is required for the test-loop script to use
     # stack test. stdin_open would be sufficient, but
     # allocating a tty provides colorful test output :)

--- a/orville.cabal
+++ b/orville.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: aac4e11fd334ef1bed06baf6d3200c0b50cfb974602a09751fec28951c6ea9e3
+-- hash: d7790f3e7dea3b40e1132734b194a00886028a10d6ccd3049ccf85c116a8c566
 
 name:           orville
 version:        0.8.3.0
@@ -34,6 +34,7 @@ library
       Database.Orville.Popper
       Database.Orville.PostgresSQL
       Database.Orville.Raw
+      Database.Orville.ResourceT
       Database.Orville.Select
       Database.Orville.Trigger
   other-modules:
@@ -51,6 +52,7 @@ library
       Database.Orville.Internal.FromSql
       Database.Orville.Internal.GroupBy
       Database.Orville.Internal.IndexDefinition
+      Database.Orville.Internal.MappendCompat
       Database.Orville.Internal.MigrateConstraint
       Database.Orville.Internal.MigrateIndex
       Database.Orville.Internal.MigrateSchema
@@ -81,7 +83,7 @@ library
     , HDBC-postgresql >=2.3
     , base >=4.8 && <5
     , bytestring
-    , conduit >=1.2.4 && <1.3
+    , conduit >=1.2 && <1.4
     , containers >=0.5
     , convertible >=1.1
     , dlist >=0.7
@@ -91,6 +93,7 @@ library
     , mtl >=2.2
     , profunctors >=5.2
     , resource-pool >=0.2
+    , resourcet >=1.1
     , text
     , time >=1.5
     , transformers >=0.4
@@ -115,7 +118,7 @@ executable orville-sample-exe
     , HDBC-postgresql >=2.3
     , base >=4.8 && <5
     , bytestring
-    , conduit >=1.2.4 && <1.3
+    , conduit >=1.2 && <1.4
     , containers >=0.5
     , convertible >=1.1
     , dlist >=0.7
@@ -126,6 +129,7 @@ executable orville-sample-exe
     , orville
     , profunctors >=5.2
     , resource-pool >=0.2
+    , resourcet >=1.1
     , text
     , time >=1.5
     , transformers >=0.4
@@ -141,6 +145,7 @@ test-suite spec
       AppManagedEntity.Data.Virus
       AppManagedEntity.Schema
       AppManagedEntity.Schema.Virus
+      ConduitTest
       EntityWrapper.CrudTest
       EntityWrapper.Data.Entity
       EntityWrapper.Data.Virus
@@ -169,7 +174,7 @@ test-suite spec
     , HDBC-postgresql >=2.3
     , base >=4.8 && <5
     , bytestring
-    , conduit >=1.2.4 && <1.3
+    , conduit >=1.2 && <1.4
     , containers >=0.5
     , convertible >=1.1
     , dlist >=0.7
@@ -180,6 +185,7 @@ test-suite spec
     , orville
     , profunctors >=5.2
     , resource-pool
+    , resourcet >=1.1
     , tasty
     , tasty-discover
     , tasty-hunit

--- a/package.yaml
+++ b/package.yaml
@@ -21,7 +21,8 @@ ghc-options:
 dependencies:
   - base >=4.8 && <5
   - bytestring
-  - conduit >=1.2.4 && <1.3
+  - conduit >=1.2 && <1.4
+
   - containers >=0.5
   - convertible >=1.1
   - dlist >=0.7
@@ -33,6 +34,7 @@ dependencies:
   - mtl >=2.2
   - profunctors >= 5.2
   - resource-pool >=0.2
+  - resourcet >= 1.1
   - text
   - time >=1.5
   - transformers >=0.4
@@ -62,6 +64,7 @@ library:
     - Database.Orville.Popper
     - Database.Orville.PostgresSQL
     - Database.Orville.Raw
+    - Database.Orville.ResourceT
     - Database.Orville.Select
     - Database.Orville.Trigger
 tests:

--- a/src/Database/Orville/Conduit.hs
+++ b/src/Database/Orville/Conduit.hs
@@ -3,10 +3,88 @@ Module    : Database.Orville.Conduit
 Copyright : Flipstone Technology Partners 2016-2018
 License   : MIT
 -}
+{-# LANGUAGE CPP #-}
+
 module Database.Orville.Conduit
   ( selectConduit
   ) where
 
+{-
+  !!! WARNING !!!
+
+  Basically this entire file is forked using conditional compilation on the
+  version of conduit that is being used. Only 'feedRows' is shared below, and
+  even that needs a different type signature. If you're changing this file,
+  you should probably take the time to run some earlier LTS versions to double
+  check that conduit support works correctly with different library versions.
+-}
+
+#if MIN_VERSION_conduit(1,3,0)
+import Conduit
+  ( Acquire
+  , ReleaseType(..)
+  , allocateAcquire
+  , mkAcquire
+  , mkAcquireType
+  )
+
+import Control.Monad (void)
+import Control.Monad.Catch
+import Control.Monad.Trans
+import Control.Monad.Trans.Resource (MonadResource, release)
+import Data.Conduit
+import Data.Pool
+import Database.HDBC hiding (withTransaction)
+
+import Database.Orville.Internal.Monad
+import Database.Orville.Internal.Select
+import Database.Orville.Internal.Types
+
+{-|
+   'selectConduit' provides a way to stream the results of a 'Select' query
+   from the database one by one using the conduit library. You can 'fuse' the
+   conduit built by this function with your own conduit pipeline to handle rows
+   individually in whatever fashion you need (e.g. turning them into rows of
+   CSV). This is useful if you want to be able to process many rows one by one
+   without loading them all into memory at once. You can aggregate the results
+   however you require as part of the conduit processing and then use
+   'runConduit' (or 'runConduitRes') from the conduit library to execute the
+   processing pipeline. Alternatively, your web server ('wai', 'servant', etc)
+   may provide support for converting a conduit into a streaming HTTP response.
+  -}
+selectConduit ::
+     (Monad m, MonadOrville conn m, MonadCatch m, MonadResource m)
+  => Select row
+  -> ConduitT () row m ()
+selectConduit select = do
+  pool <- ormEnvPool <$> lift getOrvilleEnv
+  (releaseKey, query) <-
+    allocateAcquire (acquireStatement pool (selectSql select))
+  void $ liftIO $ execute query $ selectValues select
+  result <- feedRows (selectBuilder select) query
+  -- Note this doesn't use finally to release this, but it will be released
+  -- automatically at the end of runResourceT. finally cannot be used here
+  -- because Conduit doesn't offer MonadMask. Alternatively we could use
+  -- withAllocate here, but that would require an UNLiftIO instance
+  release releaseKey
+  pure result
+
+acquireConnection :: Pool conn -> Acquire conn
+acquireConnection pool =
+  fst <$> mkAcquireType (takeResource pool) releaseConnection
+  where
+    releaseConnection (conn, local) releaseType =
+      case releaseType of
+        ReleaseEarly -> putResource local conn
+        ReleaseNormal -> putResource local conn
+        ReleaseException -> destroyResource pool local conn
+
+acquireStatement ::
+     IConnection conn => Pool conn -> String -> Acquire Statement
+acquireStatement pool sql = do
+  conn <- acquireConnection pool
+  mkAcquire (prepare conn sql) finish
+#else
 import qualified Control.Exception as E
 import Control.Monad
 import Control.Monad.Catch
@@ -70,8 +148,14 @@ selectConduit select = do
   result <- go `onException` runCleanup
   runFinish
   pure $ result
+#endif
 
-feedRows :: (Monad m, MonadIO m) => FromSql row -> Statement -> Source m row
+feedRows ::
+#if MIN_VERSION_conduit(1,3,0)
+     (Monad m, MonadIO m) => FromSql row -> Statement -> ConduitT () row m ()
+#else
+     (Monad m, MonadIO m) => FromSql row -> Statement -> Source m row
+#endif
 feedRows builder query = do
   row <- liftIO $ fetchRowAL query
   case runFromSql builder <$> row of

--- a/src/Database/Orville/Core.hs
+++ b/src/Database/Orville/Core.hs
@@ -161,8 +161,9 @@ import Data.Convertible
 import qualified Data.List as List
 import qualified Data.Map.Strict as Map
 import Data.Maybe (listToMaybe)
-import Data.Monoid
 import Database.HDBC hiding (withTransaction)
+
+import Database.Orville.Internal.MappendCompat ((<>))
 
 import qualified Data.Map.Helpers as Map
 import Database.Orville.Internal.ConstraintDefinition

--- a/src/Database/Orville/Internal/Expr/NameExpr.hs
+++ b/src/Database/Orville/Internal/Expr/NameExpr.hs
@@ -7,27 +7,22 @@ License   : MIT
 
 module Database.Orville.Internal.Expr.NameExpr where
 
-import Data.Monoid
 import Data.String
+
+import Database.Orville.Internal.MappendCompat ((<>))
 
 import Database.Orville.Internal.Expr.Expr
 import Database.Orville.Internal.QueryKey
 
 type NameExpr = Expr NameForm
 
-data NameForm =
-  NameForm
-    { nameFormTable :: Maybe String
-    , nameFormName :: String
-    }
-  deriving (Eq, Ord)
+data NameForm = NameForm
+  { nameFormTable :: Maybe String
+  , nameFormName :: String
+  } deriving (Eq, Ord)
 
 instance IsString NameForm where
-  fromString str =
-    NameForm
-      { nameFormTable = Nothing
-      , nameFormName = str
-      }
+  fromString str = NameForm {nameFormTable = Nothing, nameFormName = str}
 
 instance QualifySql NameForm where
   qualified form table = form {nameFormTable = Just table}
@@ -36,8 +31,7 @@ instance QueryKeyable NameForm where
   queryKey = QKField . unescapedName
 
 instance GenerateSql NameForm where
-  generateSql (NameForm Nothing name) =
-    "\"" <> rawSql name <> "\""
+  generateSql (NameForm Nothing name) = "\"" <> rawSql name <> "\""
   generateSql (NameForm (Just table) name) =
     "\"" <> rawSql table <> "\".\"" <> rawSql name <> "\""
 

--- a/src/Database/Orville/Internal/Expr/SelectExpr.hs
+++ b/src/Database/Orville/Internal/Expr/SelectExpr.hs
@@ -9,7 +9,8 @@ License   : MIT
 module Database.Orville.Internal.Expr.SelectExpr where
 
 import Data.Maybe
-import Data.Monoid
+
+import Database.Orville.Internal.MappendCompat ((<>))
 
 import Database.Orville.Internal.Expr.Expr
 import Database.Orville.Internal.Expr.NameExpr
@@ -32,12 +33,11 @@ aliased sf name = sf {selectFormAlias = Just name}
 
 instance QualifySql SelectForm where
   qualified form table =
-    form { selectFormColumn = (selectFormColumn form) `qualified` table }
+    form {selectFormColumn = (selectFormColumn form) `qualified` table}
 
 instance GenerateSql SelectForm where
   generateSql (SelectForm {..}) =
-    generateSql selectFormColumn <>
-    asOutput selectFormAlias
+    generateSql selectFormColumn <> asOutput selectFormAlias
 
 asOutput :: Maybe NameForm -> RawExpr
 asOutput Nothing = mempty

--- a/src/Database/Orville/Internal/MappendCompat.hs
+++ b/src/Database/Orville/Internal/MappendCompat.hs
@@ -1,0 +1,14 @@
+{-|
+Module    : Database.Orville.Internal.Expr.NameExpr
+Copyright : Flipstone Technology Partners 2016-2018
+License   : MIT
+-}
+{-# LANGUAGE CPP #-}
+
+module Database.Orville.Internal.MappendCompat
+  ( (<>)
+  ) where
+#if MIN_VERSION_base(4,11,0)
+#else
+import Data.Monoid ((<>))
+#endif

--- a/src/Database/Orville/Internal/MigrateSchema.hs
+++ b/src/Database/Orville/Internal/MigrateSchema.hs
@@ -16,9 +16,10 @@ import Control.Monad
 import Control.Monad.Catch
 import Control.Monad.IO.Class
 import Data.Int
-import Data.Monoid
 import Data.String
 import Database.HDBC hiding (withTransaction)
+
+import Database.Orville.Internal.MappendCompat ((<>))
 
 import Database.Orville.Internal.Execute
 import Database.Orville.Internal.Expr

--- a/src/Database/Orville/Internal/QueryCache.hs
+++ b/src/Database/Orville/Internal/QueryCache.hs
@@ -22,8 +22,10 @@ import Control.Monad.Trans.State
 import qualified Data.Map as Map
 import qualified Data.Map.Helpers as Map
 import Data.Maybe
-import Data.Monoid
+
 import Data.String (fromString)
+
+import Database.Orville.Internal.MappendCompat ((<>))
 
 import Database.Orville.Internal.Expr
 import Database.Orville.Internal.FromSql

--- a/src/Database/Orville/Internal/QueryKey.hs
+++ b/src/Database/Orville/Internal/QueryKey.hs
@@ -3,11 +3,12 @@ Module    : Database.Orville.Internal.QueryKey
 Copyright : Flipstone Technology Partners 2016-2018
 License   : MIT
 -}
-{-#LANGUAGE CPP#-}
+{-# LANGUAGE CPP #-}
 
 module Database.Orville.Internal.QueryKey where
 
-import Data.Monoid
+import Database.Orville.Internal.MappendCompat ((<>))
+
 import Data.Time.LocalTime
 import Database.HDBC
 
@@ -20,12 +21,10 @@ data QueryKey
   | QKList [QueryKey]
   | QKEmpty
   deriving (Eq, Ord)
-
 #if MIN_VERSION_base(4,11,0)
 instance Semigroup QueryKey where
   (<>) = appendQueryKeys
 #endif
-
 instance Monoid QueryKey where
   mempty = QKEmpty
   mappend = appendQueryKeys

--- a/src/Database/Orville/ResourceT.hs
+++ b/src/Database/Orville/ResourceT.hs
@@ -1,0 +1,70 @@
+{-|
+Module    : Database.Orville.Internal.Monad
+Copyright : Flipstone Technology Partners 2016-2018
+License   : MIT
+
+'Database.Orville.ResourceT' provides 'ResourceT' instance of the Orville typeclasses for situations
+where you might need it. In particular, if you are using the conduit library, you
+may want to wrap 'ResourceT' around your normal monad stack, in which case you'll need
+the 'MonadOrville' instance provided here to use 'selectConduit'.
+
+These instances are not included in the default exports for Orville because the required
+either a 'MonadUnliftIO' or 'MonadBaseControl' instance of the monad underlying 'ResourceT',
+depending on the version of 'ResourceT' you are using. For resource-1.1.10 and above you
+must provide 'MonadUnliftIO' instance. For versions prior to 1.1.10 you must provide a
+'MonadBaseControl' instance.
+
+This is required by 'MonadOrville' requires an instance to 'MonadBaseControl' to be defined.
+The instance provided here can only use one lifting strategy, one we choose 'MonadUnliftIO'
+wherever possible (both by our own opinion and because later versions of 'ResourceT' have
+removed 'MonadBaseControl' support). 'MonadBaseControl' is used for versions of 'ResourceT'
+before 'ResourceT' supported 'MonadUnliftIO'.
+-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Database.Orville.ResourceT
+  (
+  ) where
+
+import Control.Monad.Trans (lift)
+import Control.Monad.Trans.Resource (ResourceT, transResourceT)
+import qualified Database.Orville as O
+--
+#if MIN_VERSION_resourcet(1,1,10)
+import Control.Monad.IO.Unlift (MonadUnliftIO)
+import qualified Database.Orville.MonadUnliftIO as OULIO
+#else
+import Control.Monad.Trans.Control (MonadBaseControl)
+import qualified Database.Orville.MonadBaseControl as OMBC
+#endif
+--
+instance (Monad m, O.HasOrvilleContext conn m) =>
+         O.HasOrvilleContext conn (ResourceT m) where
+  getOrvilleEnv = lift O.getOrvilleEnv
+  localOrvilleEnv modEnv = transResourceT (O.localOrvilleEnv modEnv)
+--
+#if MIN_VERSION_resourcet(1,1,10)
+--
+instance (O.MonadOrvilleControl m, MonadUnliftIO m) =>
+         O.MonadOrvilleControl (ResourceT m) where
+  liftWithConnection = OULIO.liftWithConnectionViaUnliftIO
+  liftFinally = OULIO.liftFinallyViaUnliftIO
+
+instance (MonadUnliftIO m, O.MonadOrville conn m) =>
+         O.MonadOrville conn (ResourceT m)
+--
+#else
+--
+instance (O.MonadOrvilleControl m, MonadBaseControl IO m) =>
+         O.MonadOrvilleControl (ResourceT m) where
+  liftWithConnection = OMBC.liftWithConnectionViaBaseControl
+  liftFinally = OMBC.liftFinallyViaBaseControl
+
+instance (MonadBaseControl IO m, O.MonadOrville conn m) =>
+         O.MonadOrville conn (ResourceT m)
+--
+#endif
+
+--

--- a/stack-lts-11.22.yml
+++ b/stack-lts-11.22.yml
@@ -1,0 +1,6 @@
+resolver: lts-11.22
+packages:
+  - .
+extra-deps:
+  - HDBC-postgresql-2.3.2.5
+

--- a/stack-lts-12.20.yml
+++ b/stack-lts-12.20.yml
@@ -1,0 +1,6 @@
+resolver: lts-12.20
+packages:
+  - .
+extra-deps:
+  - HDBC-postgresql-2.3.2.5
+

--- a/test/AppManagedEntity/Data/Virus.hs
+++ b/test/AppManagedEntity/Data/Virus.hs
@@ -8,12 +8,13 @@ module AppManagedEntity.Data.Virus
   , brnDiscoveredAt
   , brnVirusName
   , bpsVirus
+  , brnVirus
   ) where
 
 import Data.Int (Int64)
 import Data.Text (Text)
-import qualified Data.Time as Time
 import qualified Data.Text as Text
+import qualified Data.Time as Time
 
 data Virus = Virus
   { virusId :: VirusId
@@ -50,7 +51,15 @@ brnDiscoveredAt =
 bpsVirus :: Virus
 bpsVirus =
   Virus
-  { virusId = VirusId 1
-  , virusName = bpsVirusName
-  , virusDiscoveredAt = bpsDiscoveredAt
-  }
+    { virusId = VirusId 1
+    , virusName = bpsVirusName
+    , virusDiscoveredAt = bpsDiscoveredAt
+    }
+
+brnVirus :: Virus
+brnVirus =
+  Virus
+    { virusId = VirusId 2
+    , virusName = brnVirusName
+    , virusDiscoveredAt = brnDiscoveredAt
+    }

--- a/test/ConduitTest.hs
+++ b/test/ConduitTest.hs
@@ -1,0 +1,42 @@
+module ConduitTest where
+
+import Control.Monad.Trans.Resource (runResourceT)
+import Data.Conduit (fuse, runConduit)
+import Data.Conduit.List (consume)
+
+import qualified Database.Orville as O
+import qualified Database.Orville.Conduit as OC
+import Database.Orville.ResourceT ()
+import qualified Database.Orville.Select as OS
+
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertEqual, testCase)
+
+import qualified TestDB as TestDB
+
+import AppManagedEntity.Data.Virus (bpsVirus, brnVirus)
+import AppManagedEntity.Schema (schema, virusIdField, virusTable)
+
+test_conduit :: TestTree
+test_conduit =
+  testGroup
+    "ConduitTest"
+    [ TestDB.withOrvilleRun $ \run -> do
+        testCase "selectConduit can read all result rows" $ do
+          actual <-
+            run $ do
+              TestDB.reset schema
+              O.insertRecordMany virusTable [bpsVirus, brnVirus]
+              runResourceT $
+                runConduit $
+                fuse
+                  (OC.selectConduit
+                     (OS.selectQueryTable
+                        virusTable
+                        (O.order virusIdField O.Ascending)))
+                  consume
+          assertEqual
+            "Expected all viruses to be loaded by conduit"
+            [bpsVirus, brnVirus]
+            actual
+    ]


### PR DESCRIPTION
This addresses both semigroup related issues and breaking changes in the
conduit library. For the time being I have left the old conduit code in place
and adding conditional compilation to maintain compatibility with older lts
versions. If this becomes cumbersome to maintain, we may decide to drop support
for older lts versions before the 0.9 release, but if it turns out to be
trivial we might as well keep it.