### PR TITLE
Adds support for ghc-8.6.3 and lts-13.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,11 @@ matrix:
 
   - env: BUILD=cabal GHCVER=8.4.4 CABALVER=2.2 HAPPYVER=1.19.5 ALEXVER=3.1.7
     compiler: ": #GHC 8.4.4"
-    addons: {apt: {packages: [cabal-install-2.2,ghc-8.4.4,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}   
+    addons: {apt: {packages: [cabal-install-2.2,ghc-8.4.4,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+
+  - env: BUILD=cabal GHCVER=8.6.3 CABALVER=2.4 HAPPYVER=1.19.5 ALEXVER=3.1.7
+    compiler: ": #GHC 8.6.3"
+    addons: {apt: {packages: [cabal-install-2.4,ghc-8.6.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
 
   - env: BUILD=cabal GHCVER=head CABALVER=head HAPPYVER=1.19.5 ALEXVER=3.1.7
     compiler: ": #GHC HEAD"
@@ -112,12 +116,11 @@ matrix:
     compiler: ": #stack 8.4.4 (lts-12)"
     addons: {apt: {packages: [libgmp-dev]}}
 
-  # conduit dependency keeps this from working right now, so disabling
-  #- env: BUILD=stack ARGS="--resolver lts-12"
-  #  compiler: ": #stack 8.4.4 (lts-12)"
-  #  addons: {apt: {packages: [libgmp-dev]}}
+  - env: BUILD=stack ARGS="--stack-yaml stack-lts-13.3.yml"
+    compiler: ": #stack 8.6.3 (lts-13)"
+    addons: {apt: {packages: [libgmp-dev]}}
 
-  - env: BUILD=stack ARGS="--stack-yaml stack-lts-12.20.yml --resolver nightly"
+  - env: BUILD=stack ARGS="--stack-yaml stack-lts-13.3.yml --resolver nightly"
     compiler: ": #stack nightly"
     addons: {apt: {packages: [libgmp-dev]}}
 
@@ -224,4 +227,3 @@ script:
       ;;
   esac
   set +ex
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       TEST_CONN_STRING: "host=testdb user=orville_test"
     command:
       - ./test-loop
-      - stack-lts-12.20.yml
+      - stack-lts-13.3.yml
     # A TTY is required for the test-loop script to use
     # stack test. stdin_open would be sufficient, but
     # allocating a tty provides colorful test output :)

--- a/src/Database/Orville/Internal/Monad.hs
+++ b/src/Database/Orville/Internal/Monad.hs
@@ -3,6 +3,7 @@ Module    : Database.Orville.Internal.Monad
 Copyright : Flipstone Technology Partners 2016-2018
 License   : MIT
 -}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE RankNTypes #-}
@@ -18,6 +19,10 @@ import Control.Monad.Reader (ReaderT(..), ask, local, mapReaderT, runReaderT)
 import Control.Monad.State (StateT, mapStateT)
 import Data.Pool
 import Database.HDBC hiding (withTransaction)
+
+#if MIN_VERSION_base(4,11,0)
+import Control.Monad.Fail (MonadFail)
+#endif
 
 data ConnectionEnv conn = ConnectionEnv
   { ormTransactionOpen :: Bool
@@ -111,6 +116,9 @@ newtype OrvilleT conn m a = OrvilleT
              , MonadThrow
              , MonadCatch
              , MonadMask
+#if MIN_VERSION_base (4,11,0)
+             , MonadFail
+#endif
              )
 
 mapOrvilleT ::
@@ -219,6 +227,9 @@ class ( Monad m
       , HasOrvilleContext conn m
       , MonadThrow m
       , MonadOrvilleControl m
+#if MIN_VERSION_base(4,11,0)
+      , MonadFail m
+#endif
       ) =>
       MonadOrville conn m
 
@@ -303,6 +314,9 @@ instance ( Monad m
          , MonadIO m
          , IConnection conn
          , MonadOrvilleControl m
+#if MIN_VERSION_base (4,11,0)
+         , MonadFail m
+#endif
          ) =>
          MonadOrville conn (OrvilleT conn m)
 

--- a/src/Database/Orville/Internal/Trigger.hs
+++ b/src/Database/Orville/Internal/Trigger.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -24,6 +25,10 @@ import Data.Monoid ((<>))
 import Data.Pool (Pool)
 import qualified Database.HDBC as HDBC
 import qualified Database.Orville as O
+
+#if MIN_VERSION_base(4,11,0)
+import Control.Monad.Fail (MonadFail)
+#endif
 
 class MonadTrigger trigger m | m -> trigger where
   runTriggers :: [trigger] -> m ()
@@ -146,6 +151,9 @@ newtype OrvilleTriggerT trigger conn m a = OrvilleTriggerT
              , MonadThrow
              , MonadCatch
              , MonadMask
+#if MIN_VERSION_base (4,11,0)
+             , MonadFail
+#endif
              )
 
 instance MonadTrans (OrvilleTriggerT trigger conn) where
@@ -180,6 +188,9 @@ instance ( Monad m
          , MonadIO m
          , HDBC.IConnection conn
          , O.MonadOrvilleControl m
+#if MIN_VERSION_base (4,11,0)
+         , MonadFail m
+#endif
          ) =>
          O.MonadOrville conn (OrvilleTriggerT trigger conn m)
 

--- a/stack-lts-13.3.yml
+++ b/stack-lts-13.3.yml
@@ -1,0 +1,6 @@
+resolver: lts-13.3
+packages:
+  - .
+extra-deps:
+  - HDBC-postgresql-2.3.2.5
+

--- a/test/MonadBaseControlTest.hs
+++ b/test/MonadBaseControlTest.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -16,6 +17,10 @@ import Test.Tasty.HUnit (testCase)
 
 import qualified TestDB as TestDB
 
+#if MIN_VERSION_base(4,11,0)
+import Control.Monad.Fail (MonadFail)
+#endif
+
 {-|
    'ThirdPartyMonad' is a stand in for a Monad (or Monad Transformer) that an
    Orville user might by using from another library that doesn't know anything
@@ -30,6 +35,9 @@ newtype ThirdPartyMonad a = ThirdPartyMonad
              , MIO.MonadIO
              , MB.MonadBase IO
              , MonadThrow
+#if MIN_VERSION_base(4,11,0)
+             , MonadFail
+#endif
              )
 
 instance MTC.MonadBaseControl IO ThirdPartyMonad where
@@ -55,6 +63,9 @@ newtype EndUserMonad a = EndUserMonad
              , MB.MonadBase IO
              , O.HasOrvilleContext Postgres.Connection
              , MonadThrow
+#if MIN_VERSION_base(4,11,0)
+             , MonadFail
+#endif
              )
 
 {-|

--- a/test/TestDB.hs
+++ b/test/TestDB.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -24,6 +25,11 @@ import qualified Database.Orville.MonadBaseControl as OMBC
 import qualified Database.Orville.MonadUnliftIO ()
 import qualified Database.Orville.Raw as ORaw
 
+#if MIN_VERSION_base(4,11,0)
+import Control.Monad.Fail (MonadFail)
+#endif
+
+
 type TestPool = Pool Postgres.Connection
 
 data Trace = Trace
@@ -42,6 +48,9 @@ newtype TestMonad a = TestMonad
              , MonadCatch
              , O.HasOrvilleContext Postgres.Connection
              , O.MonadOrville Postgres.Connection
+#if MIN_VERSION_base(4,11,0)
+             , MonadFail
+#endif
              )
 
 queryTrace ::

--- a/test/TriggerTest.hs
+++ b/test/TriggerTest.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -21,6 +22,10 @@ import AppManagedEntity.Data.Virus (Virus(..), VirusName(..), bpsVirus)
 import AppManagedEntity.Schema (schema, virusTable)
 
 import qualified TestDB as TestDB
+
+#if MIN_VERSION_base(4,11,0)
+import Control.Monad.Fail (MonadFail)
+#endif
 
 test_trigger :: TestTree
 test_trigger =
@@ -129,6 +134,9 @@ newtype TriggerTestMonad a = TriggerTestMonad
              , O.HasOrvilleContext Postgres.Connection
              , O.MonadOrville Postgres.Connection
              , OT.MonadTrigger TestTrigger
+#if MIN_VERSION_base(4,11,0)
+             , MonadFail
+#endif
              )
 
 --

--- a/test/UnliftIOTest.hs
+++ b/test/UnliftIOTest.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module UnliftIOTest where
 
 import Control.Monad.Catch (MonadThrow)
@@ -10,6 +11,10 @@ import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCase)
 
 import qualified TestDB as TestDB
+
+#if MIN_VERSION_base(4,11,0)
+import Control.Monad.Fail (MonadFail)
+#endif
 
 {-|
    'ThirdPartyMonad' is a stand in for a Monad (or Monad Transformer) that an
@@ -25,6 +30,9 @@ newtype ThirdPartyMonad a = ThirdPartyMonad
              , UL.MonadIO
              , UL.MonadUnliftIO
              , MonadThrow
+#if MIN_VERSION_base(4,11,0)
+             , MonadFail
+#endif
              )
 
 {-|
@@ -41,6 +49,10 @@ newtype EndUserMonad a = EndUserMonad
              , UL.MonadIO
              , O.HasOrvilleContext Postgres.Connection
              , MonadThrow
+#if MIN_VERSION_base(4,11,0)
+             , MonadFail
+#endif
+
              )
 
 {-|


### PR DESCRIPTION
GHC 8.6 continues the MFP(edit: MonadFail Proposal), giving more errors around the requirement of a `MonadFail` instance. To support it and past versions I added conditional compilation on the `base` package which is what handles the inclusion of `MonadFail` (via the `Control.Monad.Fail` module). Also added a lts-13.3 configuration file and ghc 8.6.3 to the travis config.