### PR TITLE
Minimizes lts minor versions. Stepping down on either 12 or 7 results in not building.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,39 +88,39 @@ matrix:
   # The Stack builds. We can pass in arbitrary Stack arguments via the ARGS
   # variable, such as using --stack-yaml to point to a different file.
 
-  - env: BUILD=stack ARGS="--stack-yaml stack-lts-6.35.yml"
+  - env: BUILD=stack ARGS="--stack-yaml stack-lts-6.0.yml"
     compiler: ": #stack 7.10.3 (lts-6)"
     addons: {apt: {packages: [libgmp-dev]}}
 
-  - env: BUILD=stack ARGS="--stack-yaml stack-lts-7.24.yml"
+  - env: BUILD=stack ARGS="--stack-yaml stack-lts-7.22.yml"
     compiler: ": #stack 8.0.1 (lts-7)"
     addons: {apt: {packages: [libgmp-dev]}}
 
-  - env: BUILD=stack ARGS="--stack-yaml stack-lts-8.24.yml"
+  - env: BUILD=stack ARGS="--stack-yaml stack-lts-8.0.yml"
     compiler: ": #stack 8.0.2 (lts-8)"
     addons: {apt: {packages: [libgmp-dev]}}
 
-  - env: BUILD=stack ARGS="--stack-yaml stack-lts-9.21.yml"
+  - env: BUILD=stack ARGS="--stack-yaml stack-lts-9.0.yml"
     compiler: ": #stack 8.0.2 (lts-9)"
     addons: {apt: {packages: [libgmp-dev]}}
 
-  - env: BUILD=stack ARGS="--stack-yaml stack-lts-10.10.yml"
+  - env: BUILD=stack ARGS="--stack-yaml stack-lts-10.0.yml"
     compiler: ": #stack 8.2.2 (lts-10)"
     addons: {apt: {packages: [libgmp-dev]}}
 
-  - env: BUILD=stack ARGS="--stack-yaml stack-lts-11.22.yml"
+  - env: BUILD=stack ARGS="--stack-yaml stack-lts-11.0.yml"
     compiler: ": #stack 8.2.2 (lts-11)"
     addons: {apt: {packages: [libgmp-dev]}}
 
-  - env: BUILD=stack ARGS="--stack-yaml stack-lts-12.20.yml"
+  - env: BUILD=stack ARGS="--stack-yaml stack-lts-12.13.yml"
     compiler: ": #stack 8.4.4 (lts-12)"
     addons: {apt: {packages: [libgmp-dev]}}
 
-  - env: BUILD=stack ARGS="--stack-yaml stack-lts-13.3.yml"
+  - env: BUILD=stack ARGS="--stack-yaml stack-lts-13.0.yml"
     compiler: ": #stack 8.6.3 (lts-13)"
     addons: {apt: {packages: [libgmp-dev]}}
 
-  - env: BUILD=stack ARGS="--stack-yaml stack-lts-13.3.yml --resolver nightly"
+  - env: BUILD=stack ARGS="--stack-yaml stack-lts-13.0.yml --resolver nightly"
     compiler: ": #stack nightly"
     addons: {apt: {packages: [libgmp-dev]}}
 
@@ -142,13 +142,13 @@ matrix:
   #   compiler: ": #stack 8.0.2 osx"
   #   os: osx
 
-  - env: BUILD=stack ARGS="--stack-yaml stack-lts-12.20.yml --resolver nightly"
+  - env: BUILD=stack ARGS="--stack-yaml stack-lts-12.13.yml --resolver nightly"
     compiler: ": #stack nightly osx"
     os: osx
 
   allow_failures:
   - env: BUILD=cabal GHCVER=head CABALVER=head HAPPYVER=1.19.5 ALEXVER=3.1.7
-  - env: BUILD=stack ARGS="--stack-yaml stack-lts-12.20.yml --resolver nightly"
+  - env: BUILD=stack ARGS="--stack-yaml stack-lts-12.13.yml --resolver nightly"
   - os: osx
 
 before_install:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       TEST_CONN_STRING: "host=testdb user=orville_test"
     command:
       - ./test-loop
-      - stack-lts-13.3.yml
+      - stack-lts-13.0.yml
     # A TTY is required for the test-loop script to use
     # stack test. stdin_open would be sufficient, but
     # allocating a tty provides colorful test output :)

--- a/stack-lts-10.0.yml
+++ b/stack-lts-10.0.yml
@@ -1,4 +1,4 @@
-resolver: lts-11.22
+resolver: lts-10.0
 packages:
   - .
 extra-deps:

--- a/stack-lts-11.0.yml
+++ b/stack-lts-11.0.yml
@@ -1,7 +1,6 @@
-resolver: lts-7.24
+resolver: lts-11.0
 packages:
   - .
 extra-deps:
   - HDBC-postgresql-2.3.2.5
-  - unliftio-core-0.1.2.0
 

--- a/stack-lts-12.13.yml
+++ b/stack-lts-12.13.yml
@@ -1,4 +1,4 @@
-resolver: lts-10.10
+resolver: lts-12.13
 packages:
   - .
 extra-deps:

--- a/stack-lts-13.0.yml
+++ b/stack-lts-13.0.yml
@@ -1,4 +1,4 @@
-resolver: lts-9.21
+resolver: lts-13.0
 packages:
   - .
 extra-deps:

--- a/stack-lts-6.0.yml
+++ b/stack-lts-6.0.yml
@@ -1,4 +1,4 @@
-resolver: lts-6.35
+resolver: lts-6.0
 packages:
   - .
 extra-deps:

--- a/stack-lts-7.22.yml
+++ b/stack-lts-7.22.yml
@@ -1,6 +1,7 @@
-resolver: lts-13.3
+resolver: lts-7.22
 packages:
   - .
 extra-deps:
   - HDBC-postgresql-2.3.2.5
+  - unliftio-core-0.1.2.0
 

--- a/stack-lts-8.0.yml
+++ b/stack-lts-8.0.yml
@@ -1,4 +1,4 @@
-resolver: lts-8.24
+resolver: lts-8.0
 packages:
   - .
 extra-deps:

--- a/stack-lts-9.0.yml
+++ b/stack-lts-9.0.yml
@@ -1,4 +1,4 @@
-resolver: lts-12.20
+resolver: lts-9.0
 packages:
   - .
 extra-deps:


### PR DESCRIPTION
Note that github seems to think the lts-11 file became the lts-13 file and vice versa... Not sure why.