### PR TITLE
Adds ghc-8.6.5 to tests and marks it as default in docker-compose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,10 @@ matrix:
     compiler: ": #GHC 8.6.4"
     addons: {apt: {packages: [cabal-install-2.4,ghc-8.6.4,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
 
+  - env: BUILD=cabal GHCVER=8.6.5 CABALVER=2.4 HAPPYVER=1.19.5 ALEXVER=3.1.7
+    compiler: ": #GHC 8.6.5"
+    addons: {apt: {packages: [cabal-install-2.4,ghc-8.6.5,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+
   - env: BUILD=cabal GHCVER=head CABALVER=head HAPPYVER=1.19.5 ALEXVER=3.1.7
     compiler: ": #GHC HEAD"
     addons: {apt: {packages: [cabal-install-head,ghc-head,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
@@ -126,6 +130,10 @@ matrix:
 
   - env: BUILD=stack ARGS="--stack-yaml stack-lts-13.12.yml"
     compiler: ": #stack 8.6.4 (lts-13)"
+    addons: {apt: {packages: [libgmp-dev]}}
+
+  - env: BUILD=stack ARGS="--stack-yaml stack-lts-13.20.yml"
+    compiler: ": #stack 8.6.5 (lts-13)"
     addons: {apt: {packages: [libgmp-dev]}}
 
   - env: BUILD=stack ARGS="--stack-yaml stack-lts-13.0.yml --resolver nightly"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       TEST_CONN_STRING: "host=testdb user=orville_test"
     command:
       - ./test-loop
-      - stack-lts-13.12.yml
+      - stack-lts-13.20.yml
     # A TTY is required for the test-loop script to use
     # stack test. stdin_open would be sufficient, but
     # allocating a tty provides colorful test output :)

--- a/stack-lts-13.20.yml
+++ b/stack-lts-13.20.yml
@@ -1,0 +1,6 @@
+resolver: lts-13.20
+packages:
+  - .
+extra-deps:
+  - HDBC-postgresql-2.3.2.5
+


### PR DESCRIPTION
Using 8.6.5 in production, thought it might be good to have it in the test matrix. If we'd rather leave 8.6.4 as the default (or any other version for that matter), I'll gladly make that change.