### PR TITLE
Updates to text fields for Oracle.

### DIFF
--- a/orville-oracle/orville-oracle.cabal
+++ b/orville-oracle/orville-oracle.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.31.1.
+-- This file has been generated from package.yaml by hpack version 0.31.2.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: e02833eaee54681c4746cfd8dc3657460749260491a08784ec99462945be060e
+-- hash: e5688586cd486f347728db6466e2c62da2db7c83d57d531c89a9e352f196c366
 
 name:           orville-oracle
 version:        0.8.3.0
@@ -15,7 +15,7 @@ author:         Flipstone Technology Partners
 maintainer:     development@flipstone.com
 license:        MIT
 license-file:   LICENSE
-tested-with:    GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4
+tested-with:    GHC == 8.6.5
 build-type:     Simple
 extra-source-files:
     README.md
@@ -40,6 +40,7 @@ library
       Database.Orville.Oracle.Trigger
   other-modules:
       Data.Map.Helpers
+      Data.String.Helpers
       Database.Orville.Oracle.Internal.ConstraintDefinition
       Database.Orville.Oracle.Internal.Execute
       Database.Orville.Oracle.Internal.Expr

--- a/orville-oracle/package.yaml
+++ b/orville-oracle/package.yaml
@@ -7,7 +7,7 @@ author: Flipstone Technology Partners
 maintainer: development@flipstone.com
 license: MIT
 git: git@github.com:flipstone/orville.git
-tested-with: GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4
+tested-with: GHC == 8.6.5
 extra-source-files:
   - README.md
 default-extensions:
@@ -22,7 +22,6 @@ dependencies:
   - base >=4.8 && <5
   - bytestring
   - conduit >=1.2 && <1.4
-
   - containers >=0.5
   - convertible >=1.1
   - dlist >=0.7

--- a/orville-oracle/sample-project/Example/Schema/Student.hs
+++ b/orville-oracle/sample-project/Example/Schema/Student.hs
@@ -38,17 +38,17 @@ majorTable =
 
 majorIdField :: O.FieldDefinition MajorId
 majorIdField =
-  O.int32Field "id" `O.withFlag` O.PrimaryKey `O.withConversion`
+  O.int32Field "ID" `O.withFlag` O.PrimaryKey `O.withConversion`
   O.convertSqlType majorIdInt MajorId
 
 majorNameField :: O.FieldDefinition MajorName
 majorNameField =
-  O.textField "name" 255 `O.withConversion`
+  O.textField "NAME" 255 `O.withConversion`
   O.convertSqlType majorNameText MajorName
 
 majorCollegeField :: O.FieldDefinition MajorCollege
 majorCollegeField =
-  O.textField "college" 255 `O.withConversion`
+  O.textField "COLLEGE" 255 `O.withConversion`
   O.convertSqlType collegeMajorToText textToCollegeMajor
 
 studentTable :: O.TableDefinition (Student StudentId) (Student ()) StudentId

--- a/orville-oracle/src/Data/String/Helpers.hs
+++ b/orville-oracle/src/Data/String/Helpers.hs
@@ -1,0 +1,15 @@
+{-|
+Module    : Data.String.Helpers
+Copyright : Flipstone Technology Partners 2019
+License   : MIT
+-}
+
+{-| Helpers for dealing with String/Text particularly escaping
+-}
+module Data.String.Helpers
+  ( escapeString
+  )
+where
+
+escapeString :: String -> String
+escapeString str = "\"" <> str <> "\""

--- a/orville-oracle/src/Database/Orville/Oracle/Core.hs
+++ b/orville-oracle/src/Database/Orville/Oracle/Core.hs
@@ -12,7 +12,7 @@ module Database.Orville.Oracle.Core
   , tableKeyFromSql
   , SqlType(..)
   , text
-  , varText
+  , autoPadAndStripText
   , integer
   , bigInteger
   , double
@@ -57,7 +57,7 @@ module Database.Orville.Oracle.Core
   , FieldDefinition
   , fieldOfType
   , textField
-  , fixedTextField
+  , autoPadAndStripTextField
   , dayField
   , localTimeField
   , utcTimeField

--- a/orville-oracle/src/Database/Orville/Oracle/Core.hs
+++ b/orville-oracle/src/Database/Orville/Oracle/Core.hs
@@ -12,7 +12,6 @@ module Database.Orville.Oracle.Core
   , tableKeyFromSql
   , SqlType(..)
   , text
-  , autoPadAndStripText
   , integer
   , bigInteger
   , double
@@ -57,7 +56,6 @@ module Database.Orville.Oracle.Core
   , FieldDefinition
   , fieldOfType
   , textField
-  , autoPadAndStripTextField
   , dayField
   , localTimeField
   , utcTimeField

--- a/orville-oracle/src/Database/Orville/Oracle/Internal/Expr/NameExpr.hs
+++ b/orville-oracle/src/Database/Orville/Oracle/Internal/Expr/NameExpr.hs
@@ -7,10 +7,9 @@ License   : MIT
 
 module Database.Orville.Oracle.Internal.Expr.NameExpr where
 
-import Data.String
+import Data.String(IsString(fromString))
 
 import Database.Orville.Oracle.Internal.MappendCompat ((<>))
-
 import Database.Orville.Oracle.Internal.Expr.Expr
 import Database.Orville.Oracle.Internal.QueryKey
 

--- a/orville-oracle/src/Database/Orville/Oracle/Internal/FieldDefinition.hs
+++ b/orville-oracle/src/Database/Orville/Oracle/Internal/FieldDefinition.hs
@@ -27,10 +27,14 @@ doubleNumberField :: String -> FieldDefinition Double
 doubleNumberField = fieldOfType doubleNumber
 
 textField :: String -> Int -> FieldDefinition Text
-textField name len = FieldDefinition name (varText len) []
+textField name len = FieldDefinition name (text len) []
 
-fixedTextField :: String -> Int -> FieldDefinition Text
-fixedTextField name len = FieldDefinition name (text len) []
+{-|
+  'autoPadAndStripTextField' defines a fixed-length text field and will be padded
+  with spaces on the left entering the database and such spaces stripped on the way out.
+-}
+autoPadAndStripTextField :: String -> Int -> FieldDefinition Text
+autoPadAndStripTextField name len = FieldDefinition name (autoPadAndStripText len) []
 
 dayField :: String -> FieldDefinition Day
 dayField = fieldOfType date

--- a/orville-oracle/src/Database/Orville/Oracle/Internal/FieldDefinition.hs
+++ b/orville-oracle/src/Database/Orville/Oracle/Internal/FieldDefinition.hs
@@ -29,13 +29,6 @@ doubleNumberField = fieldOfType doubleNumber
 textField :: String -> Int -> FieldDefinition Text
 textField name len = FieldDefinition name (text len) []
 
-{-|
-  'autoPadAndStripTextField' defines a fixed-length text field and will be padded
-  with spaces on the left entering the database and such spaces stripped on the way out.
--}
-autoPadAndStripTextField :: String -> Int -> FieldDefinition Text
-autoPadAndStripTextField name len = FieldDefinition name (autoPadAndStripText len) []
-
 dayField :: String -> FieldDefinition Day
 dayField = fieldOfType date
 

--- a/orville-oracle/src/Database/Orville/Oracle/Internal/FromClause.hs
+++ b/orville-oracle/src/Database/Orville/Oracle/Internal/FromClause.hs
@@ -5,7 +5,6 @@ License   : MIT
 -}
 module Database.Orville.Oracle.Internal.FromClause where
 
-import Database.Orville.Oracle.Internal.Sql
 import Database.Orville.Oracle.Internal.Types
 
 newtype FromClause =

--- a/orville-oracle/src/Database/Orville/Oracle/Internal/Sql.hs
+++ b/orville-oracle/src/Database/Orville/Oracle/Internal/Sql.hs
@@ -7,6 +7,8 @@ module Database.Orville.Oracle.Internal.Sql where
 
 import qualified Data.List as List
 
+import Data.String.Helpers(escapeString)
+
 mkInsertClause :: String -> [String] -> String
 mkInsertClause tblName columnNames =
   "INSERT INTO " ++
@@ -17,15 +19,13 @@ mkInsertClause tblName columnNames =
 
 mkUpdateClause :: String -> [String] -> String
 mkUpdateClause tblName columnNames =
-  "UPDATE " ++ escapedName tblName ++ " SET " ++ placeholders
+  "UPDATE " <> escapeString tblName <> " SET " <> placeholders
   where
     placeholders = List.intercalate "," $ map columnUpdateSql columnNames
-    columnUpdateSql column = column ++ " = ?"
+    columnUpdateSql column = column <> " = ?"
 
 mkDeleteClause :: String -> String
-mkDeleteClause tblName = "DELETE FROM " ++ escapedName tblName
+mkDeleteClause tblName = "DELETE FROM " <> escapeString tblName
 
-escapedName :: String -> String
-escapedName name = concat ["\"", name, "\""]
 -- If you came here looking for mkSelectClause, check out
 -- Database.Orville.Oracle.Internal.Select


### PR DESCRIPTION
On text(read: CHAR(n)) columns, Oracle will right pad inserted values with spaces.
This manifested an issue when doing direct comparisons, such as in WHERE clauses, that
values did not compare in the expected behavior.

This changes the textField behavior to pad values on the way into the database
and strip whitespace on the way out.

Other minor change is moving an escaping helper to another module for reuse (when we finally add it back).
And an update to the sample project to reflect column names being capitalized in Oracle.

Other notes/Gotchas:
  - Orville does not have support for the Oracle types: VARCHAR2 or NVARCHAR2 so this has not been tested against those.
  - The behavior of the textField now means that data purposely ending with some number of spaces will not retain
    those spaces on the way out of the database, but potentially many more would have been added in the previous behavior.
  - Perhaps add "rawTextField" to allow users of Orville to handle the whitespace issue in application code, if needed?

Things still broken/needing attention:
  - The test suite needs to be completely reworked with instructions on using the available Oracle 12c docker image.
  - Several functions still do not work including:
    - `migrateSchema` (causes db thread to spin indefinitely)
    - `selectFirst` (uses incompatible sql)
    - `insertRecord` ("Function sequence error")