### PR TITLE
Updates Oracle insertRecord to not give back the data just inserted.

### DIFF
--- a/orville-oracle/README.md
+++ b/orville-oracle/README.md
@@ -1,4 +1,34 @@
 
-# Orville
+# Orville Oracle
 
 [![Build Status](https://secure.travis-ci.org/flipstone/orville.svg)](http://travis-ci.org/flipstone/orville)
+
+A port of Orville to work with Oracle database.
+This is very much a work in progress and many features either do not work or remain untested.
+
+## Features/Functions known to work
+   - `selectAll`
+   - various forms of where clauses including:
+     - `whereAnd`
+     - `where_`
+     - `whereOr`
+   - `updateSql`
+   - `insertRecord`*
+   - certain column types including:
+     - `textField`
+     - `numberIntField`
+     - `numberDoubleField`
+
+   * Note that `insertRecord` had been modified and does not have the same api as `orville-postgresql`
+
+## Features known to not work
+   - `selectFirst`
+
+## Differences from `orville-postgresql`
+   - `insertRecord` has been modified and does not return the newly inserted data.
+   - `textField`
+   - `numberIntField` refers to the Oracle NUMBER column type specified to be an integer
+   - `numberDoubleField` refers to the Oracle NUMBER column type specified to be a double
+
+## Untested
+   Features not listed above may not have been tested and thus may fail in odd and confusing ways

--- a/orville-oracle/sample-project/Main.hs
+++ b/orville-oracle/sample-project/Main.hs
@@ -40,8 +40,9 @@ main = do
   _ <- O.runOrville initialInsertMajors env
   _ <- O.runOrville initialInsertStudents env
   catch
-    ((O.runOrville insertStudentFail env) >>=
-     T.putStrLn . studentNameText . studentName)
+    (pure ())
+    -- ((O.runOrville insertStudentFail env) >>=
+    --  T.putStrLn . studentNameText . studentName)
     (\e -> do
        let err = show (e :: SomeException)
        putStrLn
@@ -60,16 +61,16 @@ main = do
   resultSelectAll <- O.runOrville selectAllTest env
   putStrLn "\nSelect all result: "
   mapM_ (T.putStrLn . studentNameText . studentName) resultSelectAll
-  deletedStudent <- O.runOrville deleteTest env
-  putStrLn $
-    "\nInserted and deleted: " ++
-    unpack (studentNameText $ studentName deletedStudent) ++
-    ", ID: " ++ show (studentIdInt $ studentId deletedStudent)
-  deletedMajor <- O.runOrville deleteMajorSuccess env
-  putStrLn $
-    "\nInserted and deleted: " ++
-    unpack (majorNameText $ majorName deletedMajor) ++
-    ", ID: " ++ show (majorIdInt $ majorId deletedMajor)
+  -- deletedStudent <- O.runOrville deleteTest env
+  -- putStrLn $
+  --   "\nInserted and deleted: " ++
+  --   unpack (studentNameText $ studentName deletedStudent) ++
+  --   ", ID: " ++ show (studentIdInt $ studentId deletedStudent)
+  -- deletedMajor <- O.runOrville deleteMajorSuccess env
+  -- putStrLn $
+  --   "\nInserted and deleted: " ++
+  --   unpack (majorNameText $ majorName deletedMajor) ++
+  --   ", ID: " ++ show (majorIdInt $ majorId deletedMajor)
   numDeletedMajors <- O.runOrville deleteWhereMajorSuccess env
   putStrLn $
     "\nNumber of records deleted from major table: " ++ (show numDeletedMajors)
@@ -126,7 +127,7 @@ printTuple (major, studentList) = do
   mapM_ (T.putStrLn . studentNameText . studentName) studentList
 
 -- demonstrates insertRecord function
-initialInsertMajors :: O.OrvilleT ODBC.Connection IO (Major MajorId)
+initialInsertMajors :: O.OrvilleT ODBC.Connection IO Integer -- (Major MajorId)
 initialInsertMajors = do
   resetToBlankSchema studentSchema
   _ <- O.insertRecord majorTable business
@@ -142,7 +143,7 @@ initialInsertStudents = do
   O.insertRecordMany studentTable student_list
 
 -- insert invalid (student has Major Id that is not in major table)
-insertStudentFail :: O.OrvilleT ODBC.Connection IO (Student StudentId)
+insertStudentFail :: O.OrvilleT ODBC.Connection IO Integer-- (Student StudentId)
 insertStudentFail = do
   O.insertRecord studentTable testStudent
 
@@ -161,17 +162,17 @@ findRecordTest :: O.OrvilleT ODBC.Connection IO (Maybe (Student StudentId))
 findRecordTest = do
   O.findRecord studentTable (StudentId 1)
 
-deleteTest :: O.OrvilleT ODBC.Connection IO (Student StudentId)
-deleteTest = do
-  insertedStudent <- O.insertRecord studentTable allan
-  O.deleteRecord studentTable (studentId insertedStudent)
-  pure insertedStudent
+-- deleteTest :: O.OrvilleT ODBC.Connection IO (Student StudentId)
+-- deleteTest = do
+--   insertedStudent <- O.insertRecord studentTable allan
+--   O.deleteRecord studentTable (studentId insertedStudent)
+--   pure insertedStudent
 
-deleteMajorSuccess :: O.OrvilleT ODBC.Connection IO (Major MajorId)
-deleteMajorSuccess = do
-  insertedMajor <- O.insertRecord majorTable testMajor
-  O.deleteRecord majorTable (majorId insertedMajor)
-  pure insertedMajor
+-- deleteMajorSuccess :: O.OrvilleT ODBC.Connection IO (Major MajorId)
+-- deleteMajorSuccess = do
+--   insertedMajor <- O.insertRecord majorTable testMajor
+--   O.deleteRecord majorTable (majorId insertedMajor)
+--   pure insertedMajor
 
 deleteWhereMajorSuccess :: O.OrvilleT ODBC.Connection IO (Integer)
 deleteWhereMajorSuccess = do

--- a/orville-oracle/src/Database/Orville/Oracle/Core.hs
+++ b/orville-oracle/src/Database/Orville/Oracle/Core.hs
@@ -297,7 +297,6 @@ insertRecord tableDef newRecord = do
           (tableName tableDef)
           (tableAssignableColumnNames tableDef)
       vals = runToSql (tableToSql tableDef) newRecord
-  liftIO $ putStrLn insertSql
   numRows <-
     withConnection $ \conn -> do
       executingSql InsertQuery insertSql $ do

--- a/orville-oracle/src/Database/Orville/Oracle/Internal/Trigger.hs
+++ b/orville-oracle/src/Database/Orville/Oracle/Internal/Trigger.hs
@@ -42,19 +42,19 @@ class UpdateTrigger trigger readEntity writeEntity where
 class DeleteTrigger trigger readEntity where
   deleteTriggers :: readEntity -> [trigger]
 
-insertTriggered ::
-     ( MonadThrow m
-     , O.MonadOrville conn m
-     , MonadTrigger trigger m
-     , InsertTrigger trigger readEntity
-     )
-  => O.TableDefinition readEntity writeEntity key
-  -> writeEntity
-  -> m readEntity
-insertTriggered tableDef writeEntity = do
-  readEntity <- O.insertRecord tableDef writeEntity
-  runTriggers $ insertTriggers readEntity
-  pure readEntity
+-- insertTriggered ::
+--      ( MonadThrow m
+--      , O.MonadOrville conn m
+--      , MonadTrigger trigger m
+--      , InsertTrigger trigger readEntity
+--      )
+--   => O.TableDefinition readEntity writeEntity key
+--   -> writeEntity
+--   -> m readEntity
+-- insertTriggered tableDef writeEntity = do
+--   readEntity <- O.insertRecord tableDef writeEntity
+--   runTriggers $ insertTriggers readEntity
+--   pure readEntity
 
 updateTriggered ::
      ( MonadThrow m

--- a/orville-oracle/src/Database/Orville/Oracle/Trigger.hs
+++ b/orville-oracle/src/Database/Orville/Oracle/Trigger.hs
@@ -1,6 +1,6 @@
 module Database.Orville.Oracle.Trigger
-  ( insertTriggered
-  , InsertTrigger(insertTriggers)
+  ( -- insertTriggered
+  InsertTrigger(insertTriggers)
   , updateTriggered
   , UpdateTrigger(updateTriggers)
   , deleteTriggered


### PR DESCRIPTION
This is due to a difference in how Oracle handles RETURNING. Notably, they use a
RETURNING INTO clause which is the area that needs further investigation.

Also includes in the README notes about functionality that has been tested/known to work,
as well as things that are known to not work.

Lastly, impacted areas in the sample-project remain commented out with the hopes that they are
 brought back shortly.