### PR TITLE
Makes the stack nightly build an allowed failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -162,13 +162,13 @@ matrix:
   #   compiler: ": #stack 8.0.2 osx"
   #   os: osx
 
-  - env: BUILD=stack ARGS="--stack-yaml stack-lts-12.13.yml --resolver nightly" DB=postgresql
+  - env: BUILD=stack ARGS="--stack-yaml stack-lts-13.0.yml --resolver nightly" DB=postgresql
     compiler: ": #stack nightly osx"
     os: osx
 
   allow_failures:
   - env: BUILD=cabal GHCVER=head CABALVER=head HAPPYVER=1.19.5 ALEXVER=3.1.7 DB=postgresql
-  - env: BUILD=stack ARGS="--stack-yaml stack-lts-12.13.yml --resolver nightly" DB=postgresql
+  - env: BUILD=stack ARGS="--stack-yaml stack-lts-13.0.yml --resolver nightly" DB=postgresql
   - os: osx
 
 before_install:

--- a/orville-postgresql/cabal.config
+++ b/orville-postgresql/cabal.config
@@ -1,0 +1,1 @@
+constraints: HDBC-postgresql < 2.3.2.7


### PR DESCRIPTION
Either it never was before, or it was and we updated the definition so
that it no longer matched the allowed failures. In any case, this fixes
it.