### PR TITLE
Pin HDBC-postgresql version in cabal.config

### DIFF
--- a/cabal.config
+++ b/cabal.config
@@ -1,0 +1,1 @@
+constraints: HDBC-postgresql ==2.3.2.4


### PR DESCRIPTION
A cabal.config file has been added that pins
HDC-postgresql to the same version that we have
pinned in stack.yaml.

This is currently necessary, because the newest
version of the library is broken due to improper
constraints. (The newest version doesn't correctly
build with old versions of cabal and GHC anymore,
so HDC-postgresql should update their versions
accordingly.)