### PR TITLE
Update MonadUnliftIO implementations for version 0.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -185,9 +185,9 @@ before_install:
 - |
   if [ `uname` = "Darwin" ]
   then
-    travis_retry curl --insecure -L https://www.stackage.org/stack/osx-x86_64 | tar xz --strip-components=1 --include '*/stack' -C ~/.local/bin
+    travis_retry bash -c 'curl --insecure -L https://www.stackage.org/stack/osx-x86_64 | tar xz --strip-components=1 --include \'*/stack\' -C ~/.local/bin'
   else
-    travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+    travis_retry bash -c 'curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin \'*/stack\''
   fi
 
   # Use the more reliable S3 mirror of Hackage

--- a/.travis.yml
+++ b/.travis.yml
@@ -185,9 +185,9 @@ before_install:
 - |
   if [ `uname` = "Darwin" ]
   then
-    travis_retry bash -c 'curl --insecure -L https://www.stackage.org/stack/osx-x86_64 | tar xz --strip-components=1 --include "*/stack" -C ~/.local/bin'
+    travis_retry sh -c 'curl --insecure -L https://www.stackage.org/stack/osx-x86_64 | tar xz --strip-components=1 --include "*/stack" -C ~/.local/bin'
   else
-    travis_retry bash -c 'curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin "*/stack"'
+    travis_retry sh -c 'curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin "*/stack"'
   fi
 
   # Use the more reliable S3 mirror of Hackage

--- a/.travis.yml
+++ b/.travis.yml
@@ -185,9 +185,9 @@ before_install:
 - |
   if [ `uname` = "Darwin" ]
   then
-    travis_retry bash -c 'curl --insecure -L https://www.stackage.org/stack/osx-x86_64 | tar xz --strip-components=1 --include \'*/stack\' -C ~/.local/bin'
+    travis_retry bash -c 'curl --insecure -L https://www.stackage.org/stack/osx-x86_64 | tar xz --strip-components=1 --include "*/stack" -C ~/.local/bin'
   else
-    travis_retry bash -c 'curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin \'*/stack\''
+    travis_retry bash -c 'curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin "*/stack"'
   fi
 
   # Use the more reliable S3 mirror of Hackage

--- a/orville-oracle/test/TestDB.hs
+++ b/orville-oracle/test/TestDB.hs
@@ -101,10 +101,17 @@ instance MonadBaseControl IO TestMonad where
 -- This instance is used by `ConduitTest` because runConduit requires the underlying
 -- monad to be `MonadUnliftIO` since conduit 1.3
 instance UL.MonadUnliftIO TestMonad where
+#if MIN_VERSION_unliftio_core(0,2,0)
+  withRunInIO inner =
+    TestMonad $ do
+      UL.withRunInIO $ \run ->
+        inner (run . runTestMonad)
+#else
   askUnliftIO =
     TestMonad $ do
       unlio <- UL.askUnliftIO
       pure $ UL.UnliftIO (UL.unliftIO unlio . runTestMonad)
+#endif
 
 instance O.MonadOrvilleControl TestMonad where
   liftWithConnection = OMBC.liftWithConnectionViaBaseControl

--- a/orville-oracle/test/UnliftIOTest.hs
+++ b/orville-oracle/test/UnliftIOTest.hs
@@ -70,10 +70,17 @@ instance O.MonadOrville ODBC.Connection EndUserMonad
    as broad as possibly, so we can't use that helper here.
   -}
 instance UL.MonadUnliftIO EndUserMonad where
+#if MIN_VERSION_unliftio_core(0,2,0)
+  withRunInIO inner =
+    EndUserMonad $ do
+      UL.withRunInIO $ \run ->
+        inner (run . runEndUserMonad)
+#else
   askUnliftIO =
     EndUserMonad $ do
       unlio <- UL.askUnliftIO
       pure $ UL.UnliftIO (UL.unliftIO unlio . runEndUserMonad)
+#endif
 
 {-|
    This is the 'MonadOrvilleControl' instance that a user would need to built if

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/MonadUnliftIO.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/MonadUnliftIO.hs
@@ -16,6 +16,7 @@ following 'MonadOrvilleControl' instance:
 
 This module also provides a 'MonadUnliftIO' instance for 'OrvilleT' and 'OrvilleTrigger'.
 |-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE RankNTypes #-}
 
 module Database.Orville.PostgreSQL.MonadUnliftIO
@@ -59,14 +60,28 @@ liftFinallyViaUnliftIO ioFinally action cleanup = do
   UL.liftIO $ ioFinally (UL.unliftIO unlio action) (UL.unliftIO unlio cleanup)
 
 instance UL.MonadUnliftIO m => UL.MonadUnliftIO (O.OrvilleT conn m) where
+#if MIN_VERSION_unliftio_core(0,2,0)
+  withRunInIO inner =
+    InternalMonad.OrvilleT $ do
+      UL.withRunInIO $ \run ->
+        inner (run . InternalMonad.unOrvilleT)
+#else
   askUnliftIO =
     InternalMonad.OrvilleT $ do
       unlio <- UL.askUnliftIO
       pure $ UL.UnliftIO (UL.unliftIO unlio . InternalMonad.unOrvilleT)
+#endif
 
 instance UL.MonadUnliftIO m =>
          UL.MonadUnliftIO (OT.OrvilleTriggerT trigger conn m) where
+#if MIN_VERSION_unliftio_core(0,2,0)
+  withRunInIO inner =
+    InternalTrigger.OrvilleTriggerT $ do
+      UL.withRunInIO $ \run ->
+        inner (run . InternalTrigger.unTriggerT)
+#else
   askUnliftIO =
     InternalTrigger.OrvilleTriggerT $ do
       unlio <- UL.askUnliftIO
       pure $ UL.UnliftIO (UL.unliftIO unlio . InternalTrigger.unTriggerT)
+#endif

--- a/orville-postgresql/test/TestDB.hs
+++ b/orville-postgresql/test/TestDB.hs
@@ -101,10 +101,17 @@ instance MonadBaseControl IO TestMonad where
 -- This instance is used by `ConduitTest` because runConduit requires the underlying
 -- monad to be `MonadUnliftIO` since conduit 1.3
 instance UL.MonadUnliftIO TestMonad where
+#if MIN_VERSION_unliftio_core(0,2,0)
+  withRunInIO inner =
+    TestMonad $ do
+      UL.withRunInIO $ \run ->
+        inner (run . runTestMonad)
+#else
   askUnliftIO =
     TestMonad $ do
       unlio <- UL.askUnliftIO
       pure $ UL.UnliftIO (UL.unliftIO unlio . runTestMonad)
+#endif
 
 instance O.MonadOrvilleControl TestMonad where
   liftWithConnection = OMBC.liftWithConnectionViaBaseControl

--- a/orville-postgresql/test/UnliftIOTest.hs
+++ b/orville-postgresql/test/UnliftIOTest.hs
@@ -70,10 +70,17 @@ instance O.MonadOrville Postgres.Connection EndUserMonad
    as broad as possibly, so we can't use that helper here.
   -}
 instance UL.MonadUnliftIO EndUserMonad where
+#if MIN_VERSION_unliftio_core(0,2,0)
+  withRunInIO inner =
+    EndUserMonad $ do
+      UL.withRunInIO $ \run ->
+        inner (run . runEndUserMonad)
+#else
   askUnliftIO =
     EndUserMonad $ do
       unlio <- UL.askUnliftIO
       pure $ UL.UnliftIO (UL.unliftIO unlio . runEndUserMonad)
+#endif
 
 {-|
    This is the 'MonadOrvilleControl' instance that a user would need to built if


### PR DESCRIPTION
Version 0.2.0 of unliftio-core removes `askUnliftIO` from the typeclass
in favor of `withRunInIO`. I've added a CPP check on the version of
unliftio-core to implement the right function for the right version.

I've also tested adding a restriction to unliftio-core for <0.2 which
also works. Please let me know if you would prefer that.