### PR TITLE
Wrap stack install in bash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -185,9 +185,9 @@ before_install:
 - |
   if [ `uname` = "Darwin" ]
   then
-    travis_retry curl --insecure -L https://www.stackage.org/stack/osx-x86_64 | tar xz --strip-components=1 --include '*/stack' -C ~/.local/bin
+    travis_retry bash -c 'curl --insecure -L https://www.stackage.org/stack/osx-x86_64 | tar xz --strip-components=1 --include \'*/stack\' -C ~/.local/bin'
   else
-    travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+    travis_retry bash -c 'curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin \'*/stack\''
   fi
 
   # Use the more reliable S3 mirror of Hackage

--- a/.travis.yml
+++ b/.travis.yml
@@ -185,9 +185,9 @@ before_install:
 - |
   if [ `uname` = "Darwin" ]
   then
-    travis_retry bash -c 'curl --insecure -L https://www.stackage.org/stack/osx-x86_64 | tar xz --strip-components=1 --include "*/stack" -C ~/.local/bin'
+    travis_retry sh -c 'curl --insecure -L https://www.stackage.org/stack/osx-x86_64 | tar xz --strip-components=1 --include "*/stack" -C ~/.local/bin'
   else
-    travis_retry bash -c 'curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin "*/stack"'
+    travis_retry sh -c 'curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin "*/stack"'
   fi
 
   # Use the more reliable S3 mirror of Hackage

--- a/.travis.yml
+++ b/.travis.yml
@@ -185,9 +185,9 @@ before_install:
 - |
   if [ `uname` = "Darwin" ]
   then
-    travis_retry bash -c 'curl --insecure -L https://www.stackage.org/stack/osx-x86_64 | tar xz --strip-components=1 --include \'*/stack\' -C ~/.local/bin'
+    travis_retry bash -c 'curl --insecure -L https://www.stackage.org/stack/osx-x86_64 | tar xz --strip-components=1 --include "*/stack" -C ~/.local/bin'
   else
-    travis_retry bash -c 'curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin \'*/stack\''
+    travis_retry bash -c 'curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin "*/stack"'
   fi
 
   # Use the more reliable S3 mirror of Hackage


### PR DESCRIPTION
I beleive the issues we are seeing with travis builds failing with the
error "The program 'stack' is currently not installed." is due to
travis_retry not actually retrying the install when it fails.

Localy running
```

source ./travis_retry
travis_retry echo "should cause a failure" | tar xz --wildcards --strip-components=1
```
where ./travis_retry is https://github.com/travis-ci/travis-build/blob/master/lib/travis/build/bash/travis_retry.bash
results in no retrys but running
```

source ./travis_retry
travis_retry bash -c 'echo "should cause a failure" | tar xz --wildcards --strip-components=1'
```
results in retrys.

I'm assuming that the call to `curl -L https://www.stackage.org/stack/linux-x86_64`
is not erroring but returning some error page which then fails when
being interpreted by tar.

I'm merging this one into my open PR so the build gets fixed.