### PR TITLE
Add and expose unboundedTextField

### DIFF
--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Core.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Core.hs
@@ -15,6 +15,7 @@ module Database.Orville.PostgreSQL.Core
   , bigserial
   , text
   , varText
+  , unboundedText
   , integer
   , bigInteger
   , double
@@ -60,6 +61,7 @@ module Database.Orville.PostgreSQL.Core
   , fieldOfType
   , textField
   , fixedTextField
+  , unboundedTextField
   , dayField
   , utcTimeField
   , int32Field

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/FieldDefinition.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/FieldDefinition.hs
@@ -20,6 +20,9 @@ textField name len = FieldDefinition name (varText len) []
 fixedTextField :: String -> Int -> FieldDefinition Text
 fixedTextField name len = FieldDefinition name (text len) []
 
+unboundedTextField :: String -> FieldDefinition Text
+unboundedTextField = fieldOfType unboundedText
+
 dayField :: String -> FieldDefinition Day
 dayField = fieldOfType date
 


### PR DESCRIPTION
This exposes `unboundedText` in Database.Orville.PostgreSQL.Core and
uses it in a new field definition helper `unboundedTextField`.