### PR TITLE
RFC: Initial port of sqltype

### DIFF
--- a/orville-postgresql-libpq/orville-postgresql-libpq.cabal
+++ b/orville-postgresql-libpq/orville-postgresql-libpq.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 22a6b8d1ff133715412fe0c1824cc328239d91dd02f224f40c6d277fbcef1bdc
+-- hash: 764b2916ff3cee43c61e16ca12b3d7f83230b6c18e2c8ca5fed5ab7505323169
 
 name:           orville-postgresql-libpq
 version:        0.9.0.0
@@ -34,7 +34,8 @@ library
       src
   ghc-options: -Wall -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
   build-depends:
-      base >=4.8 && <5
+      attoparsec
+    , base >=4.8 && <5
     , bytestring
     , postgresql-libpq >=0.9.4.2 && <0.10
     , resource-pool

--- a/orville-postgresql-libpq/orville-postgresql-libpq.cabal
+++ b/orville-postgresql-libpq/orville-postgresql-libpq.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: e8c97a996a496f045221621eefb08d42f0e046f5352e175d51576ee91ec631b2
+-- hash: 22a6b8d1ff133715412fe0c1824cc328239d91dd02f224f40c6d277fbcef1bdc
 
 name:           orville-postgresql-libpq
 version:        0.9.0.0
@@ -25,8 +25,10 @@ source-repository head
 
 library
   exposed-modules:
-      Database.Orville.PostgreSQL.Connection
+      Database.Orville.PostgreSQL
   other-modules:
+      Database.Orville.PostgreSQL.Connection
+      Database.Orville.PostgreSQL.Internal.SqlType
       Paths_orville_postgresql_libpq
   hs-source-dirs:
       src
@@ -37,5 +39,4 @@ library
     , postgresql-libpq >=0.9.4.2 && <0.10
     , resource-pool
     , time >=1.5
-    , unliftio
   default-language: Haskell2010

--- a/orville-postgresql-libpq/package.yaml
+++ b/orville-postgresql-libpq/package.yaml
@@ -16,6 +16,7 @@ ghc-options:
   - -fwarn-incomplete-record-updates
 dependencies:
   - base >=4.8 && <5
+  - attoparsec
   - bytestring
   - postgresql-libpq >= 0.9.4.2 && <0.10
   - resource-pool

--- a/orville-postgresql-libpq/package.yaml
+++ b/orville-postgresql-libpq/package.yaml
@@ -20,9 +20,8 @@ dependencies:
   - postgresql-libpq >= 0.9.4.2 && <0.10
   - resource-pool
   - time >=1.5
-  - unliftio
 
 library:
   source-dirs: src
   exposed-modules:
-    - Database.Orville.PostgreSQL.Connection
+    - Database.Orville.PostgreSQL

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL.hs
@@ -1,0 +1,31 @@
+{-|
+Module    : Database.Orville.PostgreSQL.Raw
+Copyright : Flipstone Technology Partners 2020
+License   : MIT
+-}
+
+module Database.Orville.PostgreSQL
+  ( createConnectionPool
+  , SqlType ( SqlType
+            , sqlTypeDDL
+            , sqlTypeReferenceDDL
+            , sqlTypeNullable
+            , sqlTypeId
+            , sqlTypeSqlSize
+            , sqlTypeToSql
+            , sqlTypeFromSql
+            )
+  )
+where
+
+import Database.Orville.PostgreSQL.Connection (createConnectionPool)
+import Database.Orville.PostgreSQL.Internal.SqlType (SqlType ( SqlType
+                                                             , sqlTypeDDL
+                                                             , sqlTypeReferenceDDL
+                                                             , sqlTypeNullable
+                                                             , sqlTypeId
+                                                             , sqlTypeSqlSize
+                                                             , sqlTypeToSql
+                                                             , sqlTypeFromSql
+                                                             )
+                                                    )

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL.hs
@@ -15,6 +15,7 @@ module Database.Orville.PostgreSQL
             , sqlTypeToSql
             , sqlTypeFromSql
             )
+  , integer
   )
 where
 
@@ -28,4 +29,5 @@ import Database.Orville.PostgreSQL.Internal.SqlType (SqlType ( SqlType
                                                              , sqlTypeToSql
                                                              , sqlTypeFromSql
                                                              )
+                                                    , integer
                                                     )

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL.hs
@@ -16,8 +16,7 @@ module Database.Orville.PostgreSQL
             , sqlTypeFromSql
             )
   , integer
-  )
-where
+  ) where
 
 import Database.Orville.PostgreSQL.Connection (createConnectionPool)
 import Database.Orville.PostgreSQL.Internal.SqlType (SqlType ( SqlType

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Connection.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Connection.hs
@@ -12,10 +12,10 @@ import Control.Concurrent (threadWaitRead, threadWaitWrite)
 import Control.Concurrent.MVar (MVar, newMVar, tryTakeMVar)
 import Control.Exception(Exception, mask, throwIO)
 import Control.Monad (void)
-import qualified Database.PostgreSQL.LibPQ as LibPQ
 import Data.ByteString (ByteString)
 import Data.Pool (Pool, createPool)
 import Data.Time (NominalDiffTime)
+import qualified Database.PostgreSQL.LibPQ as LibPQ
 
 {-|
  'createConnectionPool' allocates a pool of connections to a PosgreSQL

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/SqlType.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/SqlType.hs
@@ -1,0 +1,51 @@
+{-|
+Module    : Database.Orville.PostgreSQL.SqlType
+Copyright : Flipstone Technology Partners 2016-2020
+License   : MIT
+-}
+
+module Database.Orville.PostgreSQL.Internal.SqlType
+  (SqlType ( SqlType
+           , sqlTypeDDL
+           , sqlTypeReferenceDDL
+           , sqlTypeNullable
+           , sqlTypeId
+           , sqlTypeSqlSize
+           , sqlTypeToSql
+           , sqlTypeFromSql
+           )
+  )
+where
+
+import Data.ByteString (ByteString)
+import qualified Database.PostgreSQL.LibPQ as LibPQ
+
+{-|
+  SqlType defines the mapping of a Haskell type (`a`) to a SQL column type in the
+  database. This includes both how to convert the type to and from the raw values
+  read from the database as well as the schema information required to create
+  and migrate columns using the type.
+  -}
+data SqlType a = SqlType
+  { sqlTypeDDL :: String
+    -- ^ The raw SQL DDL to use when creating/migrating columns of this type
+    -- (not including any NULL or NOT NULL declarations)
+  , sqlTypeReferenceDDL :: Maybe String
+    -- ^ The raw SQL DDL to use when creating/migrating columns with foreign
+    -- keys to this type. This is used foreignRefType to build a new SqlType
+    -- when making foreign key fields
+  , sqlTypeNullable :: Bool
+    -- ^ Indicates whether columns should be marked NULL or NOT NULL in the
+    -- database schema. If this is 'True', then 'sqlTypeFromSql' should
+    -- provide a handling of 'SqlNull' that returns an 'a', not 'Nothing'.
+  , sqlTypeId :: LibPQ.Oid
+  , sqlTypeSqlSize :: Maybe Int
+  , sqlTypeToSql :: a -> ByteString
+    -- ^ A function for converting Haskell values of this type into values to
+    -- be stored in the database.
+  , sqlTypeFromSql :: ByteString -> Maybe a
+    -- ^ A function for converting values of this are stored in the database
+    -- into Haskell values. This function should return 'Nothing' to indicate
+    -- an error if the conversion is impossible. Otherwise it should return
+    -- 'Just' the corresponding 'a' value.
+  }

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/SqlType.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/SqlType.hs
@@ -15,8 +15,7 @@ module Database.Orville.PostgreSQL.Internal.SqlType
            , sqlTypeFromSql
            )
   , integer
-  )
-where
+  ) where
 
 import Data.Attoparsec.ByteString (parseOnly)
 import Data.Attoparsec.ByteString.Char8 (signed, decimal)


### PR DESCRIPTION
I would really love feedback on this before getting much further. As it stands this is a pretty basic translation of `SqlType` but there are a few things to think about for driving forward:

1. Do we want the functions for conversion to take/return `ByteString`?
   The underlying LibPQ stuff all works on `ByteString`s so at some point we'll have to be there but we could..
   a) Use a type alias to at least give some hint to users that this is the PostgreSQL representation of things
   b) Use a newtype wrapper to force _some_ thought around working with these.
   c) Use the plain `ByteString` which is arguably the least amount of work when creating a `SqlType`
2. Do we want the reading of a value from PostgreSQL to return `Maybe a`?
    I did it this way because that is how Orville operates with `HDBC` today, but maybe it would be better to have some way to report errors back out?
3. This code uses `attoparsec` to do the ByteString to Int32 conversion (which we could extend/reuse easily to other Integral types). Note that end users would not be forced to directly interact with `attoparsec` and when writing custom `SqlType`s could use whatever they wanted. Still, how do we feel about this as a dependency? Any suggestions on using something else? 
