### PR TITLE
Quote column names in order by clauses

### DIFF
--- a/orville-oracle/src/Database/Orville/Oracle/Internal/OrderBy.hs
+++ b/orville-oracle/src/Database/Orville/Oracle/Internal/OrderBy.hs
@@ -9,6 +9,7 @@ module Database.Orville.Oracle.Internal.OrderBy where
 
 import Database.HDBC
 
+import Database.Orville.Oracle.Internal.Expr
 import Database.Orville.Oracle.Internal.QueryKey
 import Database.Orville.Oracle.Internal.Types
 
@@ -43,7 +44,7 @@ class ToOrderBy a where
   toOrderBy :: a -> SortDirection -> OrderByClause
 
 instance ToOrderBy (FieldDefinition a) where
-  toOrderBy fieldDef = OrderByClause (fieldName fieldDef) []
+  toOrderBy fieldDef = OrderByClause (rawExprToSql . generateSql . NameForm Nothing $ fieldName fieldDef) []
 
 instance ToOrderBy (String, [SqlValue]) where
   toOrderBy (sql, values) = OrderByClause sql values

--- a/orville-oracle/src/Database/Orville/Oracle/Internal/Sql.hs
+++ b/orville-oracle/src/Database/Orville/Oracle/Internal/Sql.hs
@@ -16,7 +16,7 @@ mkInsertClause tblName columnNames =
   tblName ++ " (" ++ columns ++ ") VALUES (" ++ placeholders ++ ")"
   where
     escapedColumnNames = rawExprToSql . generateSql . NameForm Nothing <$> columnNames
-    columns = List.intercalate "," excapedColumnNames
+    columns = List.intercalate "," escapedColumnNames
     placeholders = List.intercalate "," $ map (const "?") columnNames
 
 mkUpdateClause :: String -> [String] -> String

--- a/orville-postgresql/orville-postgresql.cabal
+++ b/orville-postgresql/orville-postgresql.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 6d370ce2609a1afe4541e3107c76ccb3e4220f15b7c6dc391a5ad37541762d73
+-- hash: e1bd1160c7d4a30389711c2985b88bf253ec618f282d7f423d140084c58e058e
 
 name:           orville-postgresql
 version:        0.8.3.0
@@ -148,7 +148,6 @@ test-suite spec
       AppManagedEntity.Schema
       AppManagedEntity.Schema.Virus
       ConduitTest
-      CrudTests
       EntityWrapper.CrudTest
       EntityWrapper.Data.Entity
       EntityWrapper.Data.Virus

--- a/orville-postgresql/orville-postgresql.cabal
+++ b/orville-postgresql/orville-postgresql.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 89b477ef0056a6daed9a193e17441c5e68aa7ea140b7c7dc45a4070a682745af
+-- hash: 6d370ce2609a1afe4541e3107c76ccb3e4220f15b7c6dc391a5ad37541762d73
 
 name:           orville-postgresql
 version:        0.8.3.0
@@ -148,6 +148,7 @@ test-suite spec
       AppManagedEntity.Schema
       AppManagedEntity.Schema.Virus
       ConduitTest
+      CrudTests
       EntityWrapper.CrudTest
       EntityWrapper.Data.Entity
       EntityWrapper.Data.Virus
@@ -162,6 +163,8 @@ test-suite spec
       ParameterizedEntity.Schema
       ParameterizedEntity.Schema.Virus
       PopperTest
+      StrangeFieldNames.CrudTest
+      StrangeFieldNames.Entity
       TestDB
       TransactionTest
       TriggerTest

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/OrderBy.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/OrderBy.hs
@@ -9,6 +9,7 @@ module Database.Orville.PostgreSQL.Internal.OrderBy where
 
 import Database.HDBC
 
+import Database.Orville.PostgreSQL.Internal.Expr
 import Database.Orville.PostgreSQL.Internal.QueryKey
 import Database.Orville.PostgreSQL.Internal.Types
 
@@ -43,7 +44,7 @@ class ToOrderBy a where
   toOrderBy :: a -> SortDirection -> OrderByClause
 
 instance ToOrderBy (FieldDefinition a) where
-  toOrderBy fieldDef = OrderByClause (fieldName fieldDef) []
+  toOrderBy fieldDef = OrderByClause (rawExprToSql . generateSql . NameForm Nothing $ fieldName fieldDef) []
 
 instance ToOrderBy (String, [SqlValue]) where
   toOrderBy (sql, values) = OrderByClause sql values

--- a/orville-postgresql/test/StrangeFieldNames/CrudTest.hs
+++ b/orville-postgresql/test/StrangeFieldNames/CrudTest.hs
@@ -1,0 +1,98 @@
+module StrangeFieldNames.CrudTest where
+
+import qualified Database.Orville.PostgreSQL as O
+
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertBool, assertEqual, testCase)
+
+import StrangeFieldNames.Entity
+import qualified TestDB as TestDB
+
+test_strangeNames :: TestTree
+test_strangeNames =
+  testGroup "Column name crud tests"
+    [ columnNameCrudTests "snake_case"
+    , columnNameCrudTests "camelCase"
+    , columnNameCrudTests "order"
+    ]
+
+columnNameCrudTests :: String -> TestTree
+columnNameCrudTests columnName =
+  testGroup ("crud operations work for \"" <> columnName <> "\"")
+    [ insertRecordAndSelectFirstTest columnName
+    , insertRecordManyAndSelectAllTest columnName
+    , updateRecordTest columnName
+    , deleteWhereTest columnName
+    ]
+
+insertRecordAndSelectFirstTest :: String -> TestTree
+insertRecordAndSelectFirstTest columnName = TestDB.withOrvilleRun $ \run ->
+  testCase ("insertRecord and selectFirst work with the column \"" <> columnName <> "\"") $ do
+    run (TestDB.reset [O.Table tableDef])
+    insertedEntity <- run (O.insertRecord tableDef testEntity)
+    foundEntity <- run (O.selectFirst tableDef $ O.where_ (columnDef O..== 0))
+    assertEqual
+      ("Entity found in database didn't match the inserted values using column name \"" <> columnName <> "\"")
+      (Just insertedEntity)
+      foundEntity
+  where
+    tableDef = crudEntityTable columnName
+    columnDef = crudEntityRenameableField columnName
+    testEntity = CrudEntity () 0
+
+insertRecordManyAndSelectAllTest :: String -> TestTree
+insertRecordManyAndSelectAllTest columnName = TestDB.withOrvilleRun $ \run ->
+  testCase ("insertRecordMany and selectAll work with the column \"" <> columnName <> "\"") $ do
+    run (TestDB.reset [O.Table tableDef])
+    _ <- run (O.insertRecordMany tableDef testEntities)
+    foundEntities <- run $ O.selectAll tableDef $
+      O.where_ (columnDef O..> 5)
+      <> O.order columnDef O.Descending
+    assertEqual ("Found a different number of entities in the database using column name \"" <> columnName <> "\"")
+      (length filteredEntities)
+      (length foundEntities)
+    assertBool ("List was not in the right order using column name \"" <> columnName <> "\"")
+      (checkOrder foundEntities)
+  where
+    tableDef = crudEntityTable columnName
+    columnDef = crudEntityRenameableField columnName
+    testEntities = CrudEntity () <$> [1..10]
+    filteredEntities = filter (\e -> crudEntityField e > 5) testEntities
+
+checkOrder :: [CrudEntity a] -> Bool
+checkOrder [] = True
+checkOrder (_:[]) = True
+checkOrder (x1:x2:xs) = crudEntityField x2 <= crudEntityField x1 && checkOrder (x2:xs)
+
+updateRecordTest :: String -> TestTree
+updateRecordTest columnName = TestDB.withOrvilleRun $ \run ->
+  testCase ("Updates work with the column \"" <> columnName <> "\"") $ do
+    run (TestDB.reset [O.Table tableDef])
+    insertedEntity <- run (O.insertRecord tableDef initialEntity)
+    let entityId = crudEntityId insertedEntity
+    run $ O.updateRecord tableDef entityId newEntity
+    updatedEntity <- run $ O.findRecord tableDef entityId
+    assertEqual ("The column \"" <> columnName <> "\" was not updated correctly")
+      (Just $ crudEntityField newEntity)
+      (crudEntityField <$> updatedEntity)
+  where
+    tableDef = crudEntityTable columnName
+    initialEntity = CrudEntity () 1
+    newEntity = CrudEntity () 10
+
+deleteWhereTest :: String -> TestTree
+deleteWhereTest columnName = TestDB.withOrvilleRun $ \run ->
+  testCase ("Deletes work with the column \"" <> columnName <> "\"") $ do
+    run (TestDB.reset [O.Table tableDef])
+    _ <- run (O.insertRecord tableDef testEntity)
+    _ <- run (O.deleteWhere tableDef $ [columnDef O..== 0])
+    foundEntity <- run (O.selectFirst tableDef $ O.where_ (columnDef O..== 0))
+    assertEqual
+      ("Entity found after deletion with column name \"" <> columnName <> "\"")
+      Nothing
+      foundEntity
+  where
+    tableDef = crudEntityTable columnName
+    columnDef = crudEntityRenameableField columnName
+    testEntity = CrudEntity () 0
+

--- a/orville-postgresql/test/StrangeFieldNames/CrudTest.hs
+++ b/orville-postgresql/test/StrangeFieldNames/CrudTest.hs
@@ -2,6 +2,7 @@ module StrangeFieldNames.CrudTest where
 
 import qualified Database.Orville.PostgreSQL as O
 
+import Data.Monoid ((<>))
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (assertBool, assertEqual, testCase)
 

--- a/orville-postgresql/test/StrangeFieldNames/Entity.hs
+++ b/orville-postgresql/test/StrangeFieldNames/Entity.hs
@@ -1,0 +1,43 @@
+module StrangeFieldNames.Entity where
+
+import Data.Int (Int32)
+
+import qualified Database.Orville.PostgreSQL as O
+
+-- field is generic and is meant to be used with different column names to test
+-- that crud actions work with various name styles Ex. camelCase, snake_case etc.
+data CrudEntity key = CrudEntity
+  { crudEntityId :: key
+  , crudEntityField :: Int32
+  } deriving (Show, Eq)
+
+newtype CrudEntityId = CrudEntityId
+  { unCrudEntityId :: Int32
+  } deriving (Show, Eq)
+
+-- Take in the column name so we can test different styles.
+crudEntityTable ::
+  String ->
+  O.TableDefinition (CrudEntity CrudEntityId) (CrudEntity ()) CrudEntityId
+crudEntityTable columnName =
+  O.mkTableDefinition $
+  O.TableParams
+    { O.tblName = "crudEntity"
+    , O.tblPrimaryKey = crudEntityIdField
+    , O.tblMapper =
+      CrudEntity
+        <$> O.readOnlyField crudEntityIdField
+        <*> O.attrField crudEntityField (crudEntityRenameableField columnName)
+    , O.tblGetKey = crudEntityId
+    , O.tblSafeToDelete = []
+    , O.tblComments = O.noComments
+    }
+
+crudEntityIdField :: O.FieldDefinition CrudEntityId
+crudEntityIdField =
+  O.automaticIdField "id" `O.withFlag` O.PrimaryKey `O.withConversion`
+  O.convertSqlType unCrudEntityId CrudEntityId
+
+crudEntityRenameableField :: String -> O.FieldDefinition Int32
+crudEntityRenameableField = O.int32Field
+


### PR DESCRIPTION
Fixes a bug where order by clauses would use un-quoted column names, and adds tests for crud operations with different column names. This also fixes a misspelling in the oracle codebase which would cause the build to fail.