### PR TITLE
Add streaming pagination

### DIFF
--- a/orville-postgresql/orville-postgresql.cabal
+++ b/orville-postgresql/orville-postgresql.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: e1bd1160c7d4a30389711c2985b88bf253ec618f282d7f423d140084c58e058e
+-- hash: ba90a571910116899596b5b6a86caa405d8511000be2aeedd6483a4a0f8d3d49
 
 name:           orville-postgresql
 version:        0.8.3.0
@@ -75,6 +75,7 @@ library
       Database.Orville.PostgreSQL.Internal.Trigger
       Database.Orville.PostgreSQL.Internal.Types
       Database.Orville.PostgreSQL.Internal.Where
+      Database.Orville.PostgreSQL.Pagination
       Paths_orville_postgresql
   hs-source-dirs:
       src
@@ -96,6 +97,7 @@ library
     , profunctors >=5.2
     , resource-pool >=0.2
     , resourcet >=1.1
+    , safe
     , text
     , time >=1.5
     , transformers >=0.4
@@ -132,6 +134,7 @@ executable orville-sample-exe
     , profunctors >=5.2
     , resource-pool >=0.2
     , resourcet >=1.1
+    , safe
     , text
     , time >=1.5
     , transformers >=0.4
@@ -191,6 +194,7 @@ test-suite spec
     , profunctors >=5.2
     , resource-pool
     , resourcet >=1.1
+    , safe
     , tasty
     , tasty-discover
     , tasty-hunit

--- a/orville-postgresql/package.yaml
+++ b/orville-postgresql/package.yaml
@@ -35,6 +35,7 @@ dependencies:
   - profunctors >= 5.2
   - resource-pool >=0.2
   - resourcet >= 1.1
+  - safe
   - text
   - time >=1.5
   - transformers >=0.4

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Core.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Core.hs
@@ -143,6 +143,8 @@ module Database.Orville.PostgreSQL.Core
   , MigrationPlan
   , MigrationItem(..)
   , migrationPlanItems
+  , Pagination(..)
+  , buildPagination
   , selectAll
   , selectFirst
   , deleteRecord
@@ -191,6 +193,7 @@ import Database.Orville.PostgreSQL.Internal.SqlType
 import Database.Orville.PostgreSQL.Internal.TableDefinition
 import Database.Orville.PostgreSQL.Internal.Types
 import Database.Orville.PostgreSQL.Internal.Where
+import Database.Orville.PostgreSQL.Pagination
 import Database.Orville.PostgreSQL.Raw
 import Database.Orville.PostgreSQL.Select
 

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Pagination.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Pagination.hs
@@ -1,0 +1,50 @@
+module Database.Orville.PostgreSQL.Pagination
+  ( Pagination(..)
+  , buildPagination
+  ) where
+
+import Data.Maybe (maybeToList)
+import Safe (lastMay)
+
+import Database.Orville.PostgreSQL.Internal.Monad (MonadOrville)
+import Database.Orville.PostgreSQL.Internal.OrderBy (SortDirection(Ascending))
+import Database.Orville.PostgreSQL.Internal.SelectOptions (limit, order, where_)
+import Database.Orville.PostgreSQL.Internal.Types (TableDefinition(..))
+import Database.Orville.PostgreSQL.Internal.Where ((.>=), WhereCondition, whereAnd)
+import Database.Orville.PostgreSQL.Select (runSelect, selectQueryTable)
+
+data Pagination m entity =
+  Pagination
+    { pageRows :: [entity]
+    , pageNext :: Maybe (m (Pagination m entity))
+    }
+
+buildPagination :: (MonadOrville conn m, Bounded key, Enum key)
+                => TableDefinition readEnt write key
+                -> Maybe WhereCondition
+                -> Word
+                -> m (Pagination m readEnt)
+buildPagination tableDef mbWhereCond pageSize =
+  let selectOpts bound
+        = order (tablePrimaryKey tableDef) Ascending
+       <> limit (fromIntegral pageSize)
+       <> where_ (whereAnd $ tablePrimaryKey tableDef .>= bound
+                           : maybeToList mbWhereCond
+                 )
+
+      selectAll = runSelect . selectQueryTable tableDef
+      mkPagination bound = do
+        rows <- selectAll $ selectOpts bound
+
+        let nxt =
+              case lastMay rows of
+                Just lst | length rows == fromIntegral pageSize ->
+                  Just . mkPagination . succ $ tableGetKey tableDef lst
+                _ -> Nothing
+
+        pure $ Pagination
+                 { pageRows = rows
+                 , pageNext = nxt
+                 }
+
+   in mkPagination minBound

--- a/orville-postgresql/test/AppManagedEntity/Data/Virus.hs
+++ b/orville-postgresql/test/AppManagedEntity/Data/Virus.hs
@@ -24,7 +24,7 @@ data Virus = Virus
 
 newtype VirusId = VirusId
   { unVirusId :: Int64
-  } deriving (Show, Eq)
+  } deriving (Bounded, Enum, Eq, Show)
 
 newtype VirusName = VirusName
   { unVirusName :: Text

--- a/orville-postgresql/test/ConduitTest.hs
+++ b/orville-postgresql/test/ConduitTest.hs
@@ -12,7 +12,7 @@ import qualified Database.Orville.PostgreSQL.Select as OS
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (assertEqual, testCase)
 
-import qualified TestDB as TestDB
+import qualified TestDB
 
 import AppManagedEntity.Data.Virus (bpsVirus, brnVirus)
 import AppManagedEntity.Schema (schema, virusIdField, virusTable)
@@ -34,6 +34,25 @@ test_conduit =
                      (OS.selectQueryTable
                         virusTable
                         (O.order virusIdField O.Ascending)))
+                  consume
+          assertEqual
+            "Expected all viruses to be loaded by conduit"
+            [bpsVirus, brnVirus]
+            actual
+
+    , TestDB.withOrvilleRun $ \run -> do
+        testCase "streamPages can read all result rows" $ do
+          actual <-
+            run $ do
+              TestDB.reset schema
+              O.insertRecordMany virusTable [bpsVirus, brnVirus]
+              runResourceT $
+                runConduit $
+                fuse
+                  (OC.streamPages
+                     virusTable
+                     Nothing
+                     20)
                   consume
           assertEqual
             "Expected all viruses to be loaded by conduit"


### PR DESCRIPTION
The `conduitSelect` function does not work as intended - the entire
query result is loaded into memory before the stream can begin. This is
because if single row mode is not used, postgres collects all the
results before returning to the application (see
https://www.postgresql.org/docs/9.2/libpq-single-row-mode.html).

It would be possible to implement the correct streaming functionality
using low level libpq functions, but hdbc-postgres would need to provide
an interface for them which it does not.

This PR implements the next best thing, which is page based streaming.