### PR TITLE
Generalize Transactions Over an OrvilleEnv

### DIFF
--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Raw.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Raw.hs
@@ -11,12 +11,14 @@ module Database.Orville.PostgreSQL.Raw
   , updateSql
   , withConnection
   , withTransaction
+  , withTransactionOverEnv
   ) where
 
 import Control.Exception (finally)
 import Control.Monad
 import Control.Monad.IO.Class
 import Data.IORef
+import Data.Pool
 import Database.HDBC hiding (withTransaction)
 
 import Database.Orville.PostgreSQL.Internal.Execute
@@ -45,33 +47,63 @@ startTransaction :: ConnectionEnv conn -> ConnectionEnv conn
 startTransaction c = c {ormTransactionOpen = True}
 
 withTransaction :: MonadOrville conn m => m a -> m a
-withTransaction action =
-  withConnectionEnv $ \connected ->
-    if ormTransactionOpen connected
-      then action
-      else localOrvilleEnv
-             (setConnectionEnv $ startTransaction connected)
-             doTransaction
-  where
-    doTransaction =
-      withConnection $ \conn -> do
-        txnCallback <- ormEnvTransactionCallback <$> getOrvilleEnv
-        committed <- liftIO $ newIORef False
-        startTran <- startTransactionSQL
-        let doAction = do
-              liftIO $ do
-                (executeRaw =<< prepare conn startTran)
-                txnCallback TransactionStart
-              value <- action
-              liftIO $ do
-                commit conn
-                writeIORef committed True
-                txnCallback TransactionCommit
-              return value
-        let rollbackUncommitted =
-              liftIO $ do
-                finished <- readIORef committed
-                when (not finished) $ do
-                  rollback conn
-                  txnCallback TransactionRollback
-        liftFinally finally doAction rollbackUncommitted
+withTransaction =
+  withTransactionOverEnv getOrvilleEnv (localOrvilleEnv . const)
+
+-- | Variant of 'withTransaction' that does not use 'MonadOrville'. This is
+-- useful if your context has multiple 'OrvilleEnv's and you want to have
+-- transactions over them interdependently.
+withTransactionOverEnv
+  :: (IConnection conn, MonadIO m, MonadOrvilleControl m)
+  => m (OrvilleEnv conn) -- ^ Get the env from the context
+  -> (OrvilleEnv conn -> m a -> m a) -- ^ Set the env in the context
+  -> m a -> m a
+withTransactionOverEnv getEnv setEnv action = do
+  ormEnv <- getEnv
+
+  let doTransactionWithConn connected =
+        let newOrmEnv = setConnectionEnv (startTransaction connected) ormEnv
+         in doTransaction
+              (ormConnection connected)
+              newOrmEnv
+              (setEnv newOrmEnv action)
+
+  case ormEnvConnectionEnv ormEnv of
+    Just connected ->
+      if ormTransactionOpen connected
+         then action
+         else doTransactionWithConn connected
+
+    Nothing -> do
+      let pool = ormEnvPool ormEnv
+      liftWithConnection (withResource pool) $ \conn ->
+        let connected = newConnectionEnv conn
+         in doTransactionWithConn connected
+
+doTransaction :: (IConnection conn, MonadOrvilleControl m, MonadIO m)
+              => conn -> OrvilleEnv conn -> m a -> m a
+doTransaction conn ormEnv action = do
+  let txnCallback = ormEnvTransactionCallback ormEnv
+      startTran = ormEnvStartTransactionSQL ormEnv
+
+  committed <- liftIO $ newIORef False
+
+  let doAction = do
+        liftIO $ do
+          executeRaw =<< prepare conn startTran
+          txnCallback TransactionStart
+        value <- action
+        liftIO $ do
+          commit conn
+          writeIORef committed True
+          txnCallback TransactionCommit
+        return value
+
+      rollbackUncommitted =
+        liftIO $ do
+          finished <- readIORef committed
+          unless finished $ do
+            rollback conn
+            txnCallback TransactionRollback
+
+  liftFinally finally doAction rollbackUncommitted


### PR DESCRIPTION
Exposes a new function, `withTransactionOverEnv` which can be used to
layer transactions over multiple databases - something that WIMS benefits
greatly from.