### PR TITLE
This brings the libpq `SqlType` module up to parity with the current version in terms of types supported.

### DIFF
--- a/orville-postgresql-libpq/orville-postgresql-libpq.cabal
+++ b/orville-postgresql-libpq/orville-postgresql-libpq.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 764b2916ff3cee43c61e16ca12b3d7f83230b6c18e2c8ca5fed5ab7505323169
+-- hash: 05815b8a9220e968f85058f84cfa17fd16c98fddcee29c1a53b54183b7ba5140
 
 name:           orville-postgresql-libpq
 version:        0.9.0.0
@@ -39,5 +39,6 @@ library
     , bytestring
     , postgresql-libpq >=0.9.4.2 && <0.10
     , resource-pool
+    , text
     , time >=1.5
   default-language: Haskell2010

--- a/orville-postgresql-libpq/package.yaml
+++ b/orville-postgresql-libpq/package.yaml
@@ -20,6 +20,7 @@ dependencies:
   - bytestring
   - postgresql-libpq >= 0.9.4.2 && <0.10
   - resource-pool
+  - text
   - time >=1.5
 
 library:

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/SqlType.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/SqlType.hs
@@ -14,16 +14,43 @@ module Database.Orville.PostgreSQL.Internal.SqlType
            , sqlTypeToSql
            , sqlTypeFromSql
            )
+
+  -- numeric types
   , integer
+  , serial
+  , bigInteger
+  , bigserial
+  , double
+
+  -- textual-ish types
+  , boolean
+  , text
+  , boundedText
+  , varText
+  , textSearchVector
+
+  -- date types
+  , date
+  , timestamp
+
+  -- type conversions
+  , nullableType
+  , foreignRefType
+  , convertSqlType
+  , maybeConvertSqlType
   ) where
 
 import Data.Attoparsec.ByteString (parseOnly)
-import Data.Attoparsec.ByteString.Char8 (signed, decimal)
+import qualified Data.Attoparsec.ByteString.Char8 as AttoB8
 import Data.ByteString (ByteString)
-import Data.ByteString.Builder (int32Dec, toLazyByteString)
+import qualified Data.ByteString.Char8 as B8
+import Data.ByteString.Builder (char8, doubleDec, int64Dec, int32Dec, stringUtf8, toLazyByteString)
 import Data.ByteString.Lazy (toStrict)
-import Data.Int (Int32)
+import Data.Int (Int32, Int64)
 import qualified Database.PostgreSQL.LibPQ as LibPQ
+import Data.Text (Text, unpack)
+import Data.Text.Encoding (decodeUtf8', encodeUtf8)
+import qualified Data.Time as Time
 
 {-|
   SqlType defines the mapping of a Haskell type (`a`) to a SQL column type in the
@@ -71,10 +98,301 @@ integer =
     , sqlTypeFromSql = int32FromBS
     }
 
+{-|
+  'serial' defines a 32-bit auto-incrementing column type. This corresponds to
+  the "SERIAL" type in PostgreSQL.
+  -}
+serial :: SqlType Int32
+serial =
+  SqlType
+    { sqlTypeDDL = "SERIAL"
+    , sqlTypeReferenceDDL = Just "INTEGER"
+    , sqlTypeNullable = False
+    , sqlTypeId = LibPQ.Oid 23
+    , sqlTypeSqlSize = Just 4
+    , sqlTypeToSql = int32ToBS
+    , sqlTypeFromSql = int32FromBS
+    }
+
+{-|
+  'bigInteger' defines a 64-bit integer type. This corresponds to the "BIGINT"
+  type in SQL.
+  -}
+bigInteger :: SqlType Int64
+bigInteger =
+  SqlType
+    { sqlTypeDDL = "BIGINT"
+    , sqlTypeReferenceDDL = Nothing
+    , sqlTypeNullable = False
+    , sqlTypeId = LibPQ.Oid 20
+    , sqlTypeSqlSize = Just 8
+    , sqlTypeToSql = int64ToBS
+    , sqlTypeFromSql = int64FromBS
+    }
+
+{-|
+  'bigserial' defines a 64-bit auto-incrementing column type. This corresponds to
+  the "BIGSERIAL" type in PostgresSQL.
+  -}
+bigserial :: SqlType Int64
+bigserial =
+  SqlType
+    { sqlTypeDDL = "BIGSERIAL"
+    , sqlTypeReferenceDDL = Just "BIGINT"
+    , sqlTypeNullable = False
+    , sqlTypeId = LibPQ.Oid 20
+    , sqlTypeSqlSize = Just 8
+    , sqlTypeToSql = int64ToBS
+    , sqlTypeFromSql = int64FromBS
+    }
+
+{-|
+  'double' defines a floating point numeric type. This corresponds to the "DOUBLE
+  PRECISION" type in SQL.
+  -}
+double :: SqlType Double
+double =
+  SqlType
+    { sqlTypeDDL = "DOUBLE PRECISION"
+    , sqlTypeReferenceDDL = Nothing
+    , sqlTypeNullable = False
+    , sqlTypeId = LibPQ.Oid 701
+    , sqlTypeSqlSize = Just 8
+    , sqlTypeToSql = doubleToBS
+    , sqlTypeFromSql = doubleFromBS
+    }
+
+{-|
+  'boolean' defines a True/False boolean type. This corresponds to the "BOOLEAN"
+  type in SQL.
+  -}
+boolean :: SqlType Bool
+boolean =
+  SqlType
+    { sqlTypeDDL = "BOOLEAN"
+    , sqlTypeReferenceDDL = Nothing
+    , sqlTypeNullable = False
+    , sqlTypeId = LibPQ.Oid 16
+    , sqlTypeSqlSize = Just 1
+    , sqlTypeToSql = booleanToBS
+    , sqlTypeFromSql = booleanFromBS
+    }
+
+{-|
+  'text' defines a fixed length text field type. This corresponds to a
+  "TEXT" type in PostgreSQL.
+  -}
+text :: SqlType Text
+text =
+  SqlType
+    { sqlTypeDDL = "TEXT"
+    , sqlTypeReferenceDDL = Nothing
+    , sqlTypeNullable = False
+    , sqlTypeId = LibPQ.Oid 25
+    , sqlTypeSqlSize = Nothing
+    , sqlTypeToSql = textToBS
+    , sqlTypeFromSql = textFromBS
+    }
+
+{-|
+  'boundedText' defines a fixed length text field type. This corresponds to a
+  "CHAR(len)" type in PostgreSQL.
+  -}
+boundedText :: Int -> SqlType Text
+boundedText len =
+  SqlType
+    { sqlTypeDDL = "CHAR(" <> show len <> ")"
+    , sqlTypeReferenceDDL = Nothing
+    , sqlTypeNullable = False
+    , sqlTypeId = LibPQ.Oid 1042
+    , sqlTypeSqlSize = Just  len
+    , sqlTypeToSql = textToBS
+    , sqlTypeFromSql = textFromBS
+    }
+
+{-|
+  'varText' defines a variable length text field type. This corresponds to a
+  "VARCHAR(len)" type in PostgreSQL.
+  -}
+varText :: Int -> SqlType Text
+varText len =
+  SqlType
+    { sqlTypeDDL = "VARCHAR(" <> show len <> ")"
+    , sqlTypeReferenceDDL = Nothing
+    , sqlTypeNullable = False
+    , sqlTypeId = LibPQ.Oid 1043
+    , sqlTypeSqlSize = Just  len
+    , sqlTypeToSql = textToBS
+    , sqlTypeFromSql = textFromBS
+    }
+
+{-|
+  'date' defines a type representing a calendar date (without time zone). It corresponds
+  to the "DATE" type in SQL.
+  -}
+date :: SqlType Time.Day
+date =
+  SqlType
+    { sqlTypeDDL = "DATE"
+    , sqlTypeReferenceDDL = Nothing
+    , sqlTypeNullable = False
+    , sqlTypeId = LibPQ.Oid 1082
+    , sqlTypeSqlSize = Just 4
+    , sqlTypeToSql = dayToBS
+    , sqlTypeFromSql = dayFromBS
+    }
+
+{-|
+  'timestamp' defines a type representing a particular point in time (without time zone).
+  It corresponds to the "TIMESTAMP with time zone" type in SQL.
+
+  Note: This is NOT a typo. The "TIMESTAMP with time zone" type in SQL does not include
+  any actual time zone information. For an excellent explanation of the complexities
+  involving this type, please see Chris Clark's blog post about it:
+  http://blog.untrod.com/2016/08/actually-understanding-timezones-in-postgresql.html
+  -}
+timestamp :: SqlType Time.UTCTime
+timestamp =
+  SqlType
+    { sqlTypeDDL = "TIMESTAMP with time zone"
+    , sqlTypeReferenceDDL = Nothing
+    , sqlTypeNullable = False
+    , sqlTypeId = LibPQ.Oid 1184
+    , sqlTypeSqlSize = Just 8
+    , sqlTypeToSql = utcTimeToBS
+    , sqlTypeFromSql = utcTimeFromBS
+    }
+
+{-|
+  'textSearchVector' defines a type for indexed text searching. It corresponds to the
+  "TSVECTOR" type in PostgreSQL.
+  -}
+textSearchVector :: SqlType Text
+textSearchVector =
+  SqlType
+    { sqlTypeDDL = "TSVECTOR"
+    , sqlTypeReferenceDDL = Nothing
+    , sqlTypeNullable = False
+    , sqlTypeId = LibPQ.Oid 3614
+    , sqlTypeSqlSize = Nothing
+    , sqlTypeToSql = textToBS
+    , sqlTypeFromSql = textFromBS
+    }
+
+{-|
+   'nullableType' creates a nullable version of an existing 'SqlType'. The underlying
+   sql type will be the same as the original, but column will be created with a 'NULL'
+   constraint instead a 'NOT NULL' constraint. The Haskell value 'Nothing' will be used
+   represent NULL values when converting to and from sql.
+  -}
+nullableType :: SqlType a -> SqlType (Maybe a)
+nullableType sqlType =
+  sqlType
+    { sqlTypeNullable = True
+    , sqlTypeToSql = maybe (toStrict . toLazyByteString $ stringUtf8 "null") (sqlTypeToSql sqlType)
+    , sqlTypeFromSql =
+        \sql ->
+          if sql == (toStrict . toLazyByteString $ stringUtf8 "null") then
+            Just Nothing
+          else
+            fmap Just (sqlTypeFromSql sqlType sql)
+    }
+
+{-|
+  'foreignRefType' creates a 'SqlType' suitable for columns will be foreign
+  keys referencing a column of the given 'SqlType'. For most types the
+  underlying sql type with be identical, but for special types (such as
+  autoincrementing primary keys), the type construted by 'foreignRefType' with
+  have regular underlying sql type. Each 'SqlType' definition must specify any
+  special handling required when creating foreign reference types by setting
+  the 'sqlTypeReferenceDDL' field to an appropriate value.
+  -}
+foreignRefType :: SqlType a -> SqlType a
+foreignRefType sqlType =
+  case sqlTypeReferenceDDL sqlType of
+    Nothing -> sqlType
+    Just refDDL -> sqlType {sqlTypeDDL = refDDL, sqlTypeReferenceDDL = Nothing}
+
+{-|
+  'maybeConvertSqlType' changes the Haskell type used by a 'SqlType' which changing
+  the column type that will be used in the database schema. The functions given
+  will be used to convert the now Haskell type to and from the original type when
+  reading and writing values from the database. When reading an 'a' value from
+  the database, the conversion function should produce 'Nothing' if the value
+  cannot be successfully converted to a 'b'
+  -}
+maybeConvertSqlType :: (b -> a) -> (a -> Maybe b) -> SqlType a -> SqlType b
+maybeConvertSqlType bToA aToB sqlType =
+  sqlType
+    { sqlTypeToSql = sqlTypeToSql sqlType . bToA
+    , sqlTypeFromSql = \sql -> do
+        a <- sqlTypeFromSql sqlType sql
+        aToB a
+    }
+
+{-|
+  'convertSqlType' changes the Haskell type used by a 'SqlType' in the same manner
+  as 'maybeConvertSqlType' in cases where an 'a' can always be converted to a 'b'.
+  -}
+convertSqlType :: (b -> a) -> (a -> b) -> SqlType a -> SqlType b
+convertSqlType bToA aToB = maybeConvertSqlType bToA (Just . aToB)
+
+
 int32ToBS :: Int32 -> ByteString
 int32ToBS = toStrict . toLazyByteString . int32Dec
 
 int32FromBS :: ByteString -> Maybe Int32
-int32FromBS bs = case parseOnly (signed decimal) bs of
+int32FromBS bs = case parseOnly (AttoB8.signed AttoB8.decimal) bs of
   Left _ -> Nothing
   Right i -> Just i
+
+int64ToBS :: Int64 -> ByteString
+int64ToBS = toStrict . toLazyByteString . int64Dec
+
+int64FromBS :: ByteString -> Maybe Int64
+int64FromBS bs = case parseOnly (AttoB8.signed AttoB8.decimal) bs of
+  Left _ -> Nothing
+  Right i -> Just i
+
+doubleToBS :: Double -> ByteString
+doubleToBS = toStrict . toLazyByteString . doubleDec
+
+doubleFromBS :: ByteString -> Maybe Double
+doubleFromBS bs = case parseOnly (AttoB8.signed AttoB8.double) bs of
+  Left _ -> Nothing
+  Right i -> Just i
+
+booleanToBS :: Bool -> ByteString
+booleanToBS True = toStrict . toLazyByteString $ char8 't'
+booleanToBS False = toStrict . toLazyByteString $ char8 'f'
+
+booleanFromBS :: ByteString -> Maybe Bool
+booleanFromBS bs = case parseOnly AttoB8.anyChar bs of
+  Right 't' -> Just True
+  Right 'f' -> Just False
+  Right _ -> Nothing
+  Left _ -> Nothing
+
+textToBS :: Text -> ByteString
+textToBS = encodeUtf8
+
+textFromBS :: ByteString -> Maybe Text
+textFromBS bs = case decodeUtf8' bs of
+  Right t -> Just t
+  Left _ -> Nothing
+
+dayToBS :: Time.Day -> ByteString
+dayToBS = B8.pack . Time.showGregorian
+
+dayFromBS :: ByteString -> Maybe Time.Day
+dayFromBS bs = do
+  txt <- textFromBS bs
+  Time.parseTimeM False Time.defaultTimeLocale (Time.iso8601DateFormat Nothing) (unpack txt)
+
+utcTimeToBS :: Time.UTCTime -> ByteString
+utcTimeToBS = B8.pack . Time.formatTime Time.defaultTimeLocale (Time.iso8601DateFormat Nothing)
+
+utcTimeFromBS :: ByteString -> Maybe Time.UTCTime
+utcTimeFromBS bs = do
+  txt <- textFromBS bs
+  Time.parseTimeM False Time.defaultTimeLocale (Time.iso8601DateFormat Nothing) (unpack txt)


### PR DESCRIPTION
Oids were manually verified first in psql