### PR TITLE
Show the SqlType stuff in action - albeit rough action

### DIFF
--- a/orville-postgresql-libpq/orville-postgresql-libpq.cabal
+++ b/orville-postgresql-libpq/orville-postgresql-libpq.cabal
@@ -29,7 +29,6 @@ library
   other-modules:
       Database.Orville.PostgreSQL.Connection
       Database.Orville.PostgreSQL.Internal.ExecutionResult
-      Database.Orville.PostgreSQL.Internal.Monad
       Database.Orville.PostgreSQL.Internal.SqlType
       Paths_orville_postgresql_libpq
   hs-source-dirs:

--- a/orville-postgresql-libpq/orville-postgresql-libpq.cabal
+++ b/orville-postgresql-libpq/orville-postgresql-libpq.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 05815b8a9220e968f85058f84cfa17fd16c98fddcee29c1a53b54183b7ba5140
+-- hash: 6c03f5a93af3aa287fb17898b9ff0cc413e54bc427def02c1085f92026f95023
 
 name:           orville-postgresql-libpq
 version:        0.9.0.0
@@ -28,6 +28,8 @@ library
       Database.Orville.PostgreSQL
   other-modules:
       Database.Orville.PostgreSQL.Connection
+      Database.Orville.PostgreSQL.Internal.ExecutionResult
+      Database.Orville.PostgreSQL.Internal.Monad
       Database.Orville.PostgreSQL.Internal.SqlType
       Paths_orville_postgresql_libpq
   hs-source-dirs:

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL.hs
@@ -15,7 +15,29 @@ module Database.Orville.PostgreSQL
             , sqlTypeToSql
             , sqlTypeFromSql
             )
+    -- numeric types
   , integer
+  , serial
+  , bigInteger
+  , bigserial
+  , double
+
+    -- textual-ish types
+  , boolean
+  , unboundedText
+  , fixedText
+  , boundedText
+  , textSearchVector
+
+    -- date types
+  , date
+  , timestamp
+
+    -- type conversions
+  , nullableType
+  , foreignRefType
+  , convertSqlType
+  , maybeConvertSqlType
   ) where
 
 import Database.Orville.PostgreSQL.Connection (createConnectionPool)
@@ -28,5 +50,27 @@ import Database.Orville.PostgreSQL.Internal.SqlType (SqlType ( SqlType
                                                              , sqlTypeToSql
                                                              , sqlTypeFromSql
                                                              )
+                                                      -- numeric types
                                                     , integer
+                                                    , serial
+                                                    , bigInteger
+                                                    , bigserial
+                                                    , double
+
+                                                      -- textual-ish types
+                                                    , boolean
+                                                    , unboundedText
+                                                    , fixedText
+                                                    , boundedText
+                                                    , textSearchVector
+
+                                                    -- date types
+                                                    , date
+                                                    , timestamp
+
+                                                    -- type conversions
+                                                    , nullableType
+                                                    , foreignRefType
+                                                    , convertSqlType
+                                                    , maybeConvertSqlType
                                                     )

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Connection.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Connection.hs
@@ -5,9 +5,10 @@ License   : MIT
 -}
 
 module Database.Orville.PostgreSQL.Connection
-  ( createConnectionPool
+  ( Connection
+  , createConnectionPool
   , executeRaw
-  , executeRaw'
+  , executeRawVoid
   ) where
 
 import Control.Concurrent (threadWaitRead, threadWaitWrite)
@@ -47,8 +48,8 @@ executeRaw pool bs =
  `executeRaw'` a version of `executeRaw` that completely ignores the result.
  Use with caution.
 -}
-executeRaw' :: Pool Connection -> ByteString -> IO ()
-executeRaw' = fmap void . executeRaw
+executeRawVoid :: Pool Connection -> ByteString -> IO ()
+executeRawVoid = fmap void . executeRaw
 
 {-|
  The basic connection interface.

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Connection.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Connection.hs
@@ -5,20 +5,22 @@ License   : MIT
 -}
 
 module Database.Orville.PostgreSQL.Connection
-  (createConnectionPool)
-where
+  ( createConnectionPool
+  , executeRaw
+  , executeRaw'
+  ) where
 
 import Control.Concurrent (threadWaitRead, threadWaitWrite)
-import Control.Concurrent.MVar (MVar, newMVar, tryTakeMVar)
+import Control.Concurrent.MVar (MVar, newMVar, tryTakeMVar, readMVar)
 import Control.Exception(Exception, mask, throwIO)
 import Control.Monad (void)
 import Data.ByteString (ByteString)
-import Data.Pool (Pool, createPool)
+import Data.Pool (Pool, createPool, withResource)
 import Data.Time (NominalDiffTime)
 import qualified Database.PostgreSQL.LibPQ as LibPQ
 
 {-|
- 'createConnectionPool' allocates a pool of connections to a PosgreSQL
+ `createConnectionPool` allocates a pool of connections to a PosgreSQL
  server.
 -}
 createConnectionPool ::
@@ -29,6 +31,24 @@ createConnectionPool ::
   -> IO (Pool Connection)
 createConnectionPool stripes linger maxRes connectionString =
   createPool (connect connectionString) close stripes linger maxRes
+
+{-|
+ `executeRaw` runs a given SQL statement returning the raw underlying result.
+ All handling of stepping through the result set is left to the caller.
+ This potentially leaves connections open much longer than one would expect if all of the results
+ are not iterated through immediately *and* the data copied.
+ Use with caution.
+-}
+executeRaw :: Pool Connection -> ByteString -> IO (Maybe LibPQ.Result)
+executeRaw pool bs =
+  withResource pool (underlyingExecute bs)
+
+{-|
+ `executeRaw'` a version of `executeRaw` that completely ignores the result.
+ Use with caution.
+-}
+executeRaw' :: Pool Connection -> ByteString -> IO ()
+executeRaw' = fmap void . executeRaw
 
 {-|
  The basic connection interface.
@@ -87,6 +107,18 @@ close (Connection handle') =
   in
     void $ mask underlyingFinish
 
+{-|
+ `underlyingExecute` is the internal, primitive execute function.
+  This is not intended to be directly exposed to end users, but instead wrapped in something using a pool.
+  Note there are potential dragons here in that this calls `readMVar` which is a blocking operation if the `MVar` is not full.
+  The intent is to never expose the ability to empty the `MVar` outside of this module, so unless a connection has been closed
+  it *should* never be empty. And a connection should be closed upon removal from a resource pool (in which case it can't be used
+  for this  function in the first place).
+-}
+underlyingExecute :: ByteString -> Connection -> IO (Maybe LibPQ.Result)
+underlyingExecute bs (Connection handle') = do
+  conn <- readMVar handle'
+  LibPQ.exec conn bs
 
 data ConnectionError = ConnectionError { errorMessage :: String
                                        , underlyingError :: Maybe ByteString

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/ExecutionResult.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/ExecutionResult.hs
@@ -1,0 +1,39 @@
+{-|
+Module    : Database.Orville.PostgreSQL.SqlType
+Copyright : Flipstone Technology Partners 2016-2020
+License   : MIT
+-}
+
+module Database.Orville.PostgreSQL.Internal.ExecutionResult
+  ( decodeRows
+  ) where
+
+import qualified Database.PostgreSQL.LibPQ as LibPQ
+
+import Database.Orville.PostgreSQL.Internal.SqlType (SqlType(sqlTypeFromSql))
+
+-- N.B. This only works for the first column of a table currently.
+-- If there are no results in the given `Result` then we return an empty list
+-- Otherwise we attempt to decode each result with the given `SqlType`.
+decodeRows :: LibPQ.Result -> SqlType a -> IO [Maybe a]
+decodeRows res sqlType = do
+  nrows <- LibPQ.ntuples res
+  let
+    rowList =
+      if
+        nrows > 0
+      then
+        [0..(nrows - 1)]
+      else
+        []
+    -- N.B. the usage of `getvalue'` here is important as this version returns a
+    -- _copy_ of the data in the `Result` rather than a _reference_.
+    -- This allows the `Result` to be garbage collected instead of being held onto indefinitely.
+    getValue row =
+      LibPQ.getvalue' res row (LibPQ.toColumn (0::Int))
+    applySqlConv maybeBS =
+      case maybeBS of
+        Just bs -> sqlTypeFromSql sqlType bs
+        Nothing -> Nothing
+  maybeBSs <- traverse getValue rowList
+  pure $ fmap applySqlConv maybeBSs

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/SqlType.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/SqlType.hs
@@ -178,7 +178,7 @@ boolean =
     }
 
 {-|
-  'unboundedText' defines a fixed length text field type. This corresponds to a
+  'unboundedText' defines a unbounded length text field type. This corresponds to a
   "TEXT" type in PostgreSQL.
 -}
 unboundedText :: SqlType Text
@@ -226,6 +226,22 @@ boundedText len =
     }
 
 {-|
+  'textSearchVector' defines a type for indexed text searching. It corresponds to the
+  "TSVECTOR" type in PostgreSQL.
+-}
+textSearchVector :: SqlType Text
+textSearchVector =
+  SqlType
+    { sqlTypeDDL = "TSVECTOR"
+    , sqlTypeReferenceDDL = Nothing
+    , sqlTypeNullable = False
+    , sqlTypeId = LibPQ.Oid 3614
+    , sqlTypeSqlSize = Nothing
+    , sqlTypeToSql = textToBS
+    , sqlTypeFromSql = textFromBS
+    }
+
+{-|
   'date' defines a type representing a calendar date (without time zone). It corresponds
   to the "DATE" type in SQL.
 -}
@@ -260,22 +276,6 @@ timestamp =
     , sqlTypeSqlSize = Just 8
     , sqlTypeToSql = utcTimeToBS
     , sqlTypeFromSql = utcTimeFromBS
-    }
-
-{-|
-  'textSearchVector' defines a type for indexed text searching. It corresponds to the
-  "TSVECTOR" type in PostgreSQL.
--}
-textSearchVector :: SqlType Text
-textSearchVector =
-  SqlType
-    { sqlTypeDDL = "TSVECTOR"
-    , sqlTypeReferenceDDL = Nothing
-    , sqlTypeNullable = False
-    , sqlTypeId = LibPQ.Oid 3614
-    , sqlTypeSqlSize = Nothing
-    , sqlTypeToSql = textToBS
-    , sqlTypeFromSql = textFromBS
     }
 
 {-|

--- a/orville-postgresql-libpq/test/Test.hs
+++ b/orville-postgresql-libpq/test/Test.hs
@@ -1,0 +1,157 @@
+module Test
+  ( runVisualTests
+  ) where
+
+import Data.Pool (Pool)
+import Data.Foldable (traverse_)
+import qualified Data.ByteString.Char8 as B8
+
+import Database.Orville.PostgreSQL.Connection (Connection, createConnectionPool, executeRawVoid, executeRaw)
+import Database.Orville.PostgreSQL.Internal.ExecutionResult (decodeRows)
+import Database.Orville.PostgreSQL.Internal.SqlType (SqlType
+                                                      -- numeric types
+                                                    , integer
+                                                    , serial
+                                                    , bigInteger
+                                                    , bigserial
+                                                    , double
+
+                                                    -- textual-ish types
+                                                    , boolean
+                                                    , unboundedText
+                                                    , fixedText
+                                                    , boundedText
+                                                    , textSearchVector
+
+                                                    -- date types
+                                                    , date
+                                                    , timestamp
+                                                    )
+
+{- The following are just the beginnings of tests that for now at least let us inspect manually
+  if the sqltypes are in fact
+-}
+runVisualTests :: String -> String -> IO ()
+runVisualTests user pass = do
+  let connBStr = B8.pack $ "host=localhost user=" <> user <> " password=" <> pass
+  pool <- createConnectionPool 1 10 1 connBStr
+
+-- integer
+  visualTest
+    pool
+    integer
+    "myinteger"
+    "INTEGER"
+    -- Note that "21474836470" and "-21474836480" are outside the acceptable range and shouldn't be reported
+    ["0", "2147483647", "21474836470","-2147483648", "-21474836480"]
+
+-- serial
+  visualTest
+    pool
+    serial
+    "myserial"
+    "SERIAL"
+    -- Note that "21474836470" and "-21474836480" are outside the acceptable range and shouldn't be reported
+    ["0", "2147483647", "21474836470","-2147483648", "-21474836480"]
+
+-- bigInteger
+  visualTest
+    pool
+    bigInteger
+    "mybiginteger"
+    "BIGINT"
+    ["0", "21474836470"]
+
+-- bigserial
+  visualTest
+    pool
+    bigserial
+    "mybigserial"
+    "BIGSERIAL"
+    ["0", "21474836470"]
+
+-- DOUBLE
+  visualTest
+    pool
+    double
+    "mydouble"
+    "DOUBLE PRECISION"
+    ["0.0", "1.5"]
+
+-- BOOL
+  visualTest
+    pool
+    boolean
+    "mybool"
+    "BOOL"
+    ["'f'", "'t'"]
+
+-- TEXT
+  visualTest
+    pool
+    unboundedText
+    "myunboundedtext"
+    "TEXT"
+    [ "'abcde'", "'THIS IS A REALLY LONG STRING OF SHORT DEFINITION REALLY LONGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'"]
+
+-- CHAR
+  visualTest
+    pool
+    (fixedText 5)
+    "myfixedtext"
+    "CHAR(5)"
+    [ "'abcde'", "'fghi'"]
+
+-- VARCHAR
+  visualTest
+    pool
+    (boundedText 5)
+    "myboundedtext"
+    "VARCHAR(5)"
+    [ "'abcde'", "'fghi'"]
+
+-- TSVector
+  visualTest
+    pool
+    (textSearchVector)
+    "mytsvector"
+    "TSVECTOR"
+    [ "'abcde'", "'fghi'"]
+
+-- Date
+  visualTest
+    pool
+    date
+    "mydate"
+    "DATE"
+    [ "'2020-12-21 14:30:32-00'", "'2020-12-21 14:30:32+00'" ]
+
+-- UTCTime
+  visualTest
+    pool
+    timestamp
+    "myutctime"
+    "Timestamp with time zone"
+    [ "'2020-12-21 14:30:32-00'", "'2020-12-21 14:30:32+00'" ]
+
+
+visualTest :: Show a => Pool Connection -> SqlType a -> String -> String -> [String] -> IO ()
+visualTest pool sqlType tableName sqlTypeDDL' values = do
+  putStrLn $ "Testing the insert/decode of " <> sqlTypeDDL'
+  executeRawVoid pool $ B8.pack $ "create table if not exists " <> tableName <> "(foo " <> sqlTypeDDL' <> ")"
+  executeRawVoid pool $ B8.pack $ "truncate table " <> tableName
+
+  let insertValue value =
+        executeRawVoid pool . B8.pack $ "insert into " <> tableName <> " values (" <> value <> ")"
+  traverse_ insertValue values
+
+  maybeResult <- executeRaw pool $ B8.pack $ "select * from " <> tableName
+
+  case maybeResult of
+    Nothing ->
+      putStrLn $ "No result for " <> sqlTypeDDL' <> " type!"
+
+    Just res -> do
+      maybeA <- decodeRows res sqlType
+      print maybeA
+  putStrLn ""


### PR DESCRIPTION
A bunch of stuff going on here:
- Fixes an issue (and adds some comment) around the UTCTime decoding
- Adds a very "Raw" execution interface
- Includes a naive way to decode rows with the intent of showing the SQLType stuff working
- Has a manual 'visual test' set that can be loaded at the repl to manually show the various SQLType decoding do in fact work

The test should be turned into a real test suite with better values, docker, and CI. But that's being left for future PRs.