### PR TITLE
Removes `streamPages` if Conduit is less than 1.3

### DIFF
--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Pagination.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Pagination.hs
@@ -3,6 +3,7 @@ module Database.Orville.PostgreSQL.Pagination
   , buildPagination
   ) where
 
+import Data.Monoid
 import Data.Maybe (maybeToList)
 import Safe (lastMay)
 


### PR DESCRIPTION
The previous incarnation was preventing compilation on conduit < 1.3 as
parts of Pagination weren't imported then so this just removes that
function completely.