### PR TITLE
Adds mapOrvilleTriggerT

### DIFF
--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/Trigger.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/Trigger.hs
@@ -245,6 +245,15 @@ runOrvilleTriggerT triggerT pool = do
   triggers <- committedTriggers <$> liftIO (readIORef ref)
   pure (a, triggers)
 
+mapOrvilleTriggerT :: Monad n
+                   => (m a -> n b)
+                   -> OrvilleTriggerT trigger conn m a
+                   -> OrvilleTriggerT trigger conn n b
+mapOrvilleTriggerT f triggerT =
+  OrvilleTriggerT $
+    mapReaderT (O.mapOrvilleT f) $
+      unTriggerT triggerT
+
 trackTransactions :: RecordedTriggersRef trigger -> O.TransactionEvent -> IO ()
 trackTransactions recorded event =
   case event of

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Trigger.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Trigger.hs
@@ -11,6 +11,7 @@ module Database.Orville.PostgreSQL.Trigger
   , committedTriggers
   , uncommittedTriggers
   , runOrvilleTriggerT
+  , mapOrvilleTriggerT
   , askTriggers
   , clearTriggers
   ) where


### PR DESCRIPTION
Adds `mapOrvilleTriggerT` practically so that we can map the Monad in
our Monad stack during various Happstack operations ( `localRq`,
`getFilter` etc) but also to give it parity with `OrvilleT` /
`mapOrvilleT`

Co-authored-by: David <david@flipstone.com>