### PR TITLE
Adds a `withCachedConnection` which will checkout a connection before running an action.

### DIFF
--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Core.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Core.hs
@@ -54,6 +54,7 @@ module Database.Orville.PostgreSQL.Core
   , defaultLiftWithConnection
   , defaultLiftFinally
   , QueryType(..)
+  , withCachedConnection
   , withTransaction
   , ColumnFlag(..)
   , Now(..)

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Raw.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Raw.hs
@@ -45,7 +45,10 @@ updateSql sql values =
 startTransaction :: ConnectionEnv conn -> ConnectionEnv conn
 startTransaction c = c {ormTransactionOpen = True}
 
--- | Runs an action with a cached connection
+-- | Runs an action with a cached connection.
+--   Without using this, or wrapping calls in a transaction using `withTransaction`, successive
+--   calls to functions like `insertRecord` and `updateRecord` are *not* guaranteed to occur on the
+--   same connection.
 withCachedConnection :: MonadOrville conn m => m a -> m a
 withCachedConnection action =
   withConnectionEnv (const action)

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Raw.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Raw.hs
@@ -11,6 +11,7 @@ module Database.Orville.PostgreSQL.Raw
   , updateSql
   , withConnection
   , withTransaction
+  , withCachedConnection
   ) where
 
 import Control.Exception (finally)
@@ -43,6 +44,11 @@ updateSql sql values =
 
 startTransaction :: ConnectionEnv conn -> ConnectionEnv conn
 startTransaction c = c {ormTransactionOpen = True}
+
+-- | Runs an action with a cached connection
+withCachedConnection :: MonadOrville conn m => m a -> m a
+withCachedConnection action =
+  withConnectionEnv (const action)
 
 withTransaction :: MonadOrville conn m => m a -> m a
 withTransaction action =


### PR DESCRIPTION
This is similar to `withTransaction`, except this does *not* do any of the transaction setup.

Note that all the heavy lifting is actually done by `withConnectionEnv` and this is just a thin wrapper
around that function which we expose out of the library.