### PR TITLE
Adds Alternative and MonadPlus to OrvilleTriggerT

### DIFF
--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/Trigger.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/Trigger.hs
@@ -7,6 +7,8 @@
 
 module Database.Orville.PostgreSQL.Internal.Trigger where
 
+import Control.Applicative (Alternative)
+import Control.Monad (MonadPlus)
 import Control.Monad.Base (MonadBase)
 import Control.Monad.Catch (MonadCatch, MonadMask, MonadThrow)
 import Control.Monad.Except (MonadError(..))
@@ -144,6 +146,7 @@ rollbackTriggerTxn ref =
 newtype OrvilleTriggerT trigger conn m a = OrvilleTriggerT
   { unTriggerT :: ReaderT (RecordedTriggersRef trigger) (O.OrvilleT conn m) a
   } deriving ( Functor
+             , Alternative
              , Applicative
              , Monad
              , MonadIO
@@ -151,6 +154,7 @@ newtype OrvilleTriggerT trigger conn m a = OrvilleTriggerT
              , MonadThrow
              , MonadCatch
              , MonadMask
+             , MonadPlus
 #if MIN_VERSION_base (4,11,0)
              , MonadFail
 #endif


### PR DESCRIPTION
This adds a deriving clause for `Alternative` and `MonadPlus` to
`OrvilleTriggerT` (like `OrvilleT` hass) so that stacks it's used in can
use its underlying instances without having to (presumably) run their
respective OrvilleTriggerT's to unwrap them far enough to do so. We need
it in particular for a Happstack Monad stack.