### PR TITLE
Adds `liftOrville` to Trigger module

### DIFF
--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/Trigger.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/Trigger.hs
@@ -258,6 +258,9 @@ mapOrvilleTriggerT f triggerT =
     mapReaderT (O.mapOrvilleT f) $
       unTriggerT triggerT
 
+liftOrville :: Monad m => O.OrvilleT conn m a -> OrvilleTriggerT trigger conn m a
+liftOrville = OrvilleTriggerT . lift
+
 trackTransactions :: RecordedTriggersRef trigger -> O.TransactionEvent -> IO ()
 trackTransactions recorded event =
   case event of

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Trigger.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Trigger.hs
@@ -12,6 +12,7 @@ module Database.Orville.PostgreSQL.Trigger
   , uncommittedTriggers
   , runOrvilleTriggerT
   , mapOrvilleTriggerT
+  , liftOrville
   , askTriggers
   , clearTriggers
   ) where


### PR DESCRIPTION
This adds a `liftOrville` operation for putting an `OrvilleT` into an
`OrvilleTriggerT` to make mixing the two Monad's more straight forward.
Without this one would have to run an `OrvilleT` which is more verbose
and potentially error prone.