### PR TITLE
Exposes the ability to default columns. 

### DIFF
--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Core.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Core.hs
@@ -57,6 +57,7 @@ module Database.Orville.PostgreSQL.Core
   , withCachedConnection
   , withTransaction
   , ColumnFlag(..)
+  , ColumnDefault(toColumnDefaultSql)
   , Now(..)
   , FieldDefinition
   , fieldOfType


### PR DESCRIPTION
Previously a default could be given but this exposes the typeclass needed so that users can default more types if they chose.