### PR TITLE
Fixes `maybeMapper` breaking on already nullable fields

### DIFF
--- a/orville-postgresql/test/OptionalMap/CrudTest.hs
+++ b/orville-postgresql/test/OptionalMap/CrudTest.hs
@@ -1,0 +1,30 @@
+module OptionalMap.CrudTest where
+
+import qualified Database.Orville.PostgreSQL as O
+
+import Control.Monad (void)
+import Data.Monoid ((<>))
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertEqual, testCase)
+
+import OptionalMap.Entity
+import qualified TestDB as TestDB
+
+test_optionalMaps :: TestTree
+test_optionalMaps =
+  testGroup ("crud operations work for RelationalMaps with optional fields")
+    [ insertRecordAndSelectFirstTest "Bad map" badCrudEntityTable
+    ]
+
+insertRecordAndSelectFirstTest :: String -> O.TableDefinition (CrudEntity CrudEntityId) (CrudEntity ()) CrudEntityId -> TestTree
+insertRecordAndSelectFirstTest descr tableDef = TestDB.withOrvilleRun $ \run ->
+  testCase ("insertRecord and selectFirst work with " <> descr) $ do
+    run (TestDB.reset [O.Table tableDef])
+    void $ run (O.insertRecord tableDef testEntity)
+    foundComplexField <- fmap crudEntityComplexField <$> run (O.selectFirst tableDef mempty)
+    assertEqual
+      ("Entity found in database didn't match the inserted values")
+      (Just $ crudEntityComplexField testEntity)
+      foundComplexField
+  where
+    testEntity = CrudEntity () (Just $ ComplexField 0 Nothing)

--- a/orville-postgresql/test/OptionalMap/Entity.hs
+++ b/orville-postgresql/test/OptionalMap/Entity.hs
@@ -1,0 +1,54 @@
+module OptionalMap.Entity where
+
+import Data.Int (Int32)
+import qualified Data.Text as T
+
+import qualified Database.Orville.PostgreSQL as O
+
+data CrudEntity key = CrudEntity
+  { crudEntityId :: key
+  , crudEntityComplexField :: Maybe ComplexField
+  } deriving (Show, Eq)
+
+newtype CrudEntityId = CrudEntityId
+  { unCrudEntityId :: Int32
+  } deriving (Show, Eq)
+
+data ComplexField =
+  ComplexField { complexFieldPart1 :: Int32
+               , complexFieldPart2 :: Maybe T.Text
+               } deriving (Show, Eq)
+
+-- Take in the column name so we can test different styles.
+badCrudEntityTable ::
+  O.TableDefinition (CrudEntity CrudEntityId) (CrudEntity ()) CrudEntityId
+badCrudEntityTable =
+  O.mkTableDefinition $
+  O.TableParams
+    { O.tblName = "crudEntity"
+    , O.tblPrimaryKey = crudEntityIdField
+    , O.tblMapper =
+      CrudEntity
+        <$> O.readOnlyField crudEntityIdField
+        <*> O.mapAttr crudEntityComplexField (O.maybeMapper badComplexFieldMap)
+    , O.tblGetKey = crudEntityId
+    , O.tblSafeToDelete = []
+    , O.tblComments = O.noComments
+    }
+
+crudEntityIdField :: O.FieldDefinition CrudEntityId
+crudEntityIdField =
+  O.automaticIdField "id" `O.withFlag` O.PrimaryKey `O.withConversion`
+  O.convertSqlType unCrudEntityId CrudEntityId
+
+badComplexFieldMap :: O.RelationalMap ComplexField ComplexField
+badComplexFieldMap =
+  ComplexField <$> O.attrField complexFieldPart1 complexFieldPart1Field
+               <*> O.attrField complexFieldPart2 (O.nullableField complexFieldPart2Field)
+
+complexFieldPart1Field :: O.FieldDefinition Int32
+complexFieldPart1Field = O.int32Field "part_1"
+
+complexFieldPart2Field :: O.FieldDefinition T.Text
+complexFieldPart2Field =
+  O.withConversion (O.textField "part_2" 255) $ O.maybeConvertSqlType id Just


### PR DESCRIPTION
This changes `nullableType` to be aware of whether it is wrapping itself
around a type that is already nullable. In that case it uses the inner
type's 'NULL' decode rather than returning a `Nothing`. Essentially this
preserves as much information as possible about the value at the time of
decoding.

Compare with #102 for an alternative, less subtle fix.