### PR TITLE
Tracks field nullability at the type level in `FieldDefinition`

### DIFF
--- a/orville-postgresql/sample-project/Example/Schema/Student.hs
+++ b/orville-postgresql/sample-project/Example/Schema/Student.hs
@@ -36,17 +36,17 @@ majorTable =
     , O.tblComments = O.noComments
     }
 
-majorIdField :: O.FieldDefinition MajorId
+majorIdField :: O.FieldDefinition O.NotNull MajorId
 majorIdField =
   O.automaticIdField "id" `O.withFlag` O.PrimaryKey `O.withConversion`
   O.convertSqlType majorIdInt MajorId
 
-majorNameField :: O.FieldDefinition MajorName
+majorNameField :: O.FieldDefinition O.NotNull MajorName
 majorNameField =
   O.textField "name" 255 `O.withConversion`
   O.convertSqlType majorNameText MajorName
 
-majorCollegeField :: O.FieldDefinition MajorCollege
+majorCollegeField :: O.FieldDefinition O.NotNull MajorCollege
 majorCollegeField =
   O.textField "college" 255 `O.withConversion`
   O.convertSqlType collegeMajorToText textToCollegeMajor
@@ -66,15 +66,15 @@ studentTable =
     , O.tblComments = O.noComments
     }
 
-studentIdField :: O.FieldDefinition StudentId
+studentIdField :: O.FieldDefinition O.NotNull StudentId
 studentIdField =
   O.automaticIdField "id" `O.withFlag` O.PrimaryKey `O.withConversion`
   O.convertSqlType studentIdInt StudentId
 
-studentNameField :: O.FieldDefinition StudentName
+studentNameField :: O.FieldDefinition O.NotNull StudentName
 studentNameField =
   O.textField "name" 255 `O.withConversion`
   O.convertSqlType studentNameText StudentName
 
-studentMajorField :: O.FieldDefinition MajorId
+studentMajorField :: O.FieldDefinition O.NotNull MajorId
 studentMajorField = O.foreignKeyField "major" majorTable majorIdField

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Core.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Core.hs
@@ -61,7 +61,7 @@ module Database.Orville.PostgreSQL.Core
   , FieldDefinition
   , Nullable
   , NotNull
-  , Nullability
+  , Nullability(..)
   , fieldOfType
   , textField
   , fixedTextField

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Core.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Core.hs
@@ -25,7 +25,6 @@ module Database.Orville.PostgreSQL.Core
   , textSearchVector
   , convertSqlType
   , maybeConvertSqlType
-  , nullableType
   , TableParams(..)
   , RelationalMap
   , mapAttr
@@ -60,6 +59,9 @@ module Database.Orville.PostgreSQL.Core
   , ColumnDefault(toColumnDefaultSql)
   , Now(..)
   , FieldDefinition
+  , Nullable
+  , NotNull
+  , Nullability
   , fieldOfType
   , textField
   , fixedTextField
@@ -255,7 +257,7 @@ findRecords tableDef keys = do
 findRecordsBy ::
      (Ord fieldValue, MonadOrville conn m)
   => TableDefinition readEntity writeEntity key
-  -> FieldDefinition fieldValue
+  -> FieldDefinition nullability fieldValue
   -> SelectOptions
   -> m (Map.Map fieldValue [readEntity])
 findRecordsBy tableDef field opts = do

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/FieldDefinition.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/FieldDefinition.hs
@@ -14,54 +14,110 @@ import Database.Orville.PostgreSQL.Internal.Expr.NameExpr (NameForm(..))
 import Database.Orville.PostgreSQL.Internal.SqlType
 import Database.Orville.PostgreSQL.Internal.Types
 
-textField :: String -> Int -> FieldDefinition Text
+textField :: String -> Int -> FieldDefinition NotNull Text
 textField name len = FieldDefinition name (varText len) []
 
-fixedTextField :: String -> Int -> FieldDefinition Text
+fixedTextField :: String -> Int -> FieldDefinition NotNull Text
 fixedTextField name len = FieldDefinition name (text len) []
 
-unboundedTextField :: String -> FieldDefinition Text
+unboundedTextField :: String -> FieldDefinition NotNull Text
 unboundedTextField = fieldOfType unboundedText
 
-dayField :: String -> FieldDefinition Day
+dayField :: String -> FieldDefinition NotNull Day
 dayField = fieldOfType date
 
-utcTimeField :: String -> FieldDefinition UTCTime
+utcTimeField :: String -> FieldDefinition NotNull UTCTime
 utcTimeField = fieldOfType timestamp
 
-int32Field :: String -> FieldDefinition Int32
+int32Field :: String -> FieldDefinition NotNull Int32
 int32Field = fieldOfType integer
 
-int64Field :: String -> FieldDefinition Int64
+int64Field :: String -> FieldDefinition NotNull Int64
 int64Field = fieldOfType bigInteger
 
-doubleField :: String -> FieldDefinition Double
+doubleField :: String -> FieldDefinition NotNull Double
 doubleField = fieldOfType double
 
-boolField :: String -> FieldDefinition Bool
+boolField :: String -> FieldDefinition NotNull Bool
 boolField = fieldOfType boolean
 
-automaticIdField :: String -> FieldDefinition Int32
+automaticIdField :: String -> FieldDefinition NotNull Int32
 automaticIdField = fieldOfType serial
 
-searchVectorField :: String -> FieldDefinition Text
+searchVectorField :: String -> FieldDefinition NotNull Text
 searchVectorField = fieldOfType textSearchVector
 
-nullableField :: FieldDefinition a -> FieldDefinition (Maybe a)
-nullableField field = field `withConversion` nullableType
+{-|
+  Makes a 'NotNull' field 'Nullable' by wrapping the Haskell type of the field
+  in 'Maybe'. The field will be marked as 'NULL' in the database schema and
+  the value 'Nothing' will be used to represent 'NULL' values when converting
+  to and from sql.
+-}
+nullableField :: FieldDefinition NotNull a -> FieldDefinition Nullable (Maybe a)
+nullableField field =
+  let
+    nullableType sqlType =
+      sqlType
+        { sqlTypeToSql = maybe SqlNull (sqlTypeToSql sqlType)
+        , sqlTypeFromSql =
+            \sql ->
+              case sql of
+                SqlNull ->
+                  Just Nothing
+
+                _ ->
+                  Just <$> sqlTypeFromSql sqlType sql
+        }
+  in
+    FieldDefinition
+      (fieldName field)
+      (nullableType $ fieldType field)
+      (fieldFlags field)
+
+{-|
+  Adds a `Maybe` wrapper to a field that is already nullable. (If your field is
+  'NotNull', you wanted 'nullableField' instead of this function). Note that
+  fields created using this function have assymetric encoding and decode of
+  'NULL' values. Because the provide field is 'Nullable', 'NULL' values decode
+  from the database already have a representation in the 'a' type, so 'NULL'
+  will be decoded as 'Just <value of type a for NULL>'. This means if you
+  insert a 'Nothing' value using the field, it will be read back as 'Just'
+  value. This is useful for building high level combinators that might need to
+  make fields 'Nullable' but need tho value to be decoded in its underlying
+  type when reading back (e.g. 'maybeMapper' from 'RelationalMap').
+-}
+assymmetricNullableField :: FieldDefinition Nullable a -> FieldDefinition Nullable (Maybe a)
+assymmetricNullableField field =
+  let
+    nullableType sqlType =
+      sqlType
+        { sqlTypeToSql = maybe SqlNull (sqlTypeToSql sqlType)
+        , sqlTypeFromSql = \sql -> Just <$> sqlTypeFromSql sqlType sql
+        }
+  in
+    FieldDefinition
+      (fieldName field)
+      (nullableType $ fieldType field)
+      (fieldFlags field)
+
+isFieldNullable :: Nullability nullability => FieldDefinition nullability a -> Bool
+isFieldNullable field =
+  case checkNullability field of
+    NullableField _ -> True
+    NotNullField _ -> False
 
 foreignKeyField ::
      String
   -> TableDefinition readEntity writeEntity key
-  -> FieldDefinition key
-  -> FieldDefinition key
+  -> FieldDefinition nullability key
+  -> FieldDefinition nullability key
 foreignKeyField name refTable refField =
   FieldDefinition
     name
     (foreignRefType $ fieldType refField)
     [References refTable refField]
 
-fieldOfType :: SqlType a -> String -> FieldDefinition a
+fieldOfType :: SqlType a -> String -> FieldDefinition nullability a
 fieldOfType sqlType name = FieldDefinition name sqlType []
 
 isPrimaryKey :: ColumnFlag -> Bool
@@ -72,33 +128,33 @@ isAssignedByDatabase :: ColumnFlag -> Bool
 isAssignedByDatabase AssignedByDatabase = True
 isAssignedByDatabase _ = False
 
-escapedFieldName :: FieldDefinition a -> String
+escapedFieldName :: FieldDefinition nullability a -> String
 escapedFieldName field = "\"" ++ fieldName field ++ "\""
 
-isPrimaryKeyField :: FieldDefinition a -> Bool
+isPrimaryKeyField :: FieldDefinition nullability a -> Bool
 isPrimaryKeyField field = any isPrimaryKey $ fieldFlags field
 
-withFlag :: FieldDefinition a -> ColumnFlag -> FieldDefinition a
+withFlag :: FieldDefinition nullability a -> ColumnFlag -> FieldDefinition nullability a
 withFlag field newFlag = field {fieldFlags = newFlag : fieldFlags field}
 
-withName :: FieldDefinition a -> String -> FieldDefinition a
+withName :: FieldDefinition nullability a -> String -> FieldDefinition nullability a
 withName field newName = field {fieldName = newName}
 
 withConversion ::
-     FieldDefinition a -> (SqlType a -> SqlType b) -> FieldDefinition b
+     FieldDefinition nullability a -> (SqlType a -> SqlType b) -> FieldDefinition nullability b
 withConversion field mapType = field {fieldType = mapType $ fieldType field}
 
-isAssignedByDatabaseField :: FieldDefinition a -> Bool
+isAssignedByDatabaseField :: FieldDefinition nullability a -> Bool
 isAssignedByDatabaseField field = any isAssignedByDatabase $ fieldFlags field
 
-withPrefix :: FieldDefinition a -> String -> FieldDefinition a
+withPrefix :: FieldDefinition nullability a -> String -> FieldDefinition nullability a
 withPrefix field prefix = field `withName` (prefix ++ "_" ++ fieldName field)
 
-fieldToNameForm :: FieldDefinition a -> NameForm
+fieldToNameForm :: FieldDefinition nullability a -> NameForm
 fieldToNameForm field = NameForm Nothing (fieldName field)
 
-fieldToSqlValue :: FieldDefinition a -> a -> SqlValue
+fieldToSqlValue :: FieldDefinition nullability a -> a -> SqlValue
 fieldToSqlValue = sqlTypeToSql . fieldType
 
-fieldFromSqlValue :: FieldDefinition a -> SqlValue -> Maybe a
+fieldFromSqlValue :: FieldDefinition nullability a -> SqlValue -> Maybe a
 fieldFromSqlValue = sqlTypeFromSql . fieldType

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/FieldDefinition.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/FieldDefinition.hs
@@ -78,13 +78,13 @@ nullableField field =
 {-|
   Adds a `Maybe` wrapper to a field that is already nullable. (If your field is
   'NotNull', you wanted 'nullableField' instead of this function). Note that
-  fields created using this function have asymetric encoding and decode of
-  'NULL' values. Because the provide field is 'Nullable', 'NULL' values decode
+  fields created using this function have asymetric encoding and decoding of
+  'NULL' values. Because the provided field is 'Nullable', 'NULL' values decode
   from the database already have a representation in the 'a' type, so 'NULL'
   will be decoded as 'Just <value of type a for NULL>'. This means if you
   insert a 'Nothing' value using the field, it will be read back as 'Just'
   value. This is useful for building high level combinators that might need to
-  make fields 'Nullable' but need tho value to be decoded in its underlying
+  make fields 'Nullable' but need the value to be decoded in its underlying
   type when reading back (e.g. 'maybeMapper' from 'RelationalMap').
 -}
 asymmetricNullableField :: FieldDefinition Nullable a -> FieldDefinition Nullable (Maybe a)

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/FieldDefinition.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/FieldDefinition.hs
@@ -78,7 +78,7 @@ nullableField field =
 {-|
   Adds a `Maybe` wrapper to a field that is already nullable. (If your field is
   'NotNull', you wanted 'nullableField' instead of this function). Note that
-  fields created using this function have assymetric encoding and decode of
+  fields created using this function have asymetric encoding and decode of
   'NULL' values. Because the provide field is 'Nullable', 'NULL' values decode
   from the database already have a representation in the 'a' type, so 'NULL'
   will be decoded as 'Just <value of type a for NULL>'. This means if you
@@ -87,8 +87,8 @@ nullableField field =
   make fields 'Nullable' but need tho value to be decoded in its underlying
   type when reading back (e.g. 'maybeMapper' from 'RelationalMap').
 -}
-assymmetricNullableField :: FieldDefinition Nullable a -> FieldDefinition Nullable (Maybe a)
-assymmetricNullableField field =
+asymmetricNullableField :: FieldDefinition Nullable a -> FieldDefinition Nullable (Maybe a)
+asymmetricNullableField field =
   let
     nullableType sqlType =
       sqlType
@@ -138,9 +138,6 @@ isAssignedByDatabase _ = False
 
 escapedFieldName :: FieldDefinition nullability a -> String
 escapedFieldName field = "\"" ++ fieldName field ++ "\""
-
-isPrimaryKeyField :: FieldDefinition nullability a -> Bool
-isPrimaryKeyField field = any isPrimaryKey $ fieldFlags field
 
 withFlag :: FieldDefinition nullability a -> ColumnFlag -> FieldDefinition nullability a
 withFlag field newFlag = field {fieldFlags = newFlag : fieldFlags field}

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/FieldDefinition.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/FieldDefinition.hs
@@ -15,10 +15,10 @@ import Database.Orville.PostgreSQL.Internal.SqlType
 import Database.Orville.PostgreSQL.Internal.Types
 
 textField :: String -> Int -> FieldDefinition NotNull Text
-textField name len = FieldDefinition name (varText len) []
+textField name len = fieldOfType (varText len) name
 
 fixedTextField :: String -> Int -> FieldDefinition NotNull Text
-fixedTextField name len = FieldDefinition name (text len) []
+fixedTextField name len = fieldOfType (text len) name
 
 unboundedTextField :: String -> FieldDefinition NotNull Text
 unboundedTextField = fieldOfType unboundedText
@@ -73,6 +73,7 @@ nullableField field =
       (fieldName field)
       (nullableType $ fieldType field)
       (fieldFlags field)
+      Nullable
 
 {-|
   Adds a `Maybe` wrapper to a field that is already nullable. (If your field is
@@ -99,8 +100,9 @@ assymmetricNullableField field =
       (fieldName field)
       (nullableType $ fieldType field)
       (fieldFlags field)
+      Nullable
 
-isFieldNullable :: Nullability nullability => FieldDefinition nullability a -> Bool
+isFieldNullable :: FieldDefinition nullability a -> Bool
 isFieldNullable field =
   case checkNullability field of
     NullableField _ -> True
@@ -116,9 +118,15 @@ foreignKeyField name refTable refField =
     name
     (foreignRefType $ fieldType refField)
     [References refTable refField]
+    (fieldNullability refField)
 
-fieldOfType :: SqlType a -> String -> FieldDefinition nullability a
-fieldOfType sqlType name = FieldDefinition name sqlType []
+fieldOfType :: SqlType a -> String -> FieldDefinition NotNull a
+fieldOfType sqlType name =
+  FieldDefinition
+    name
+    sqlType
+    []
+    NotNull
 
 isPrimaryKey :: ColumnFlag -> Bool
 isPrimaryKey PrimaryKey = True

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/FieldUpdate.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/FieldUpdate.hs
@@ -10,11 +10,11 @@ module Database.Orville.PostgreSQL.Internal.FieldUpdate where
 import Database.Orville.PostgreSQL.Internal.FieldDefinition
 import Database.Orville.PostgreSQL.Internal.Types
 
-fieldUpdate :: FieldDefinition a -> a -> FieldUpdate
+fieldUpdate :: Nullability nullability => FieldDefinition nullability a -> a -> FieldUpdate
 fieldUpdate fieldDef a =
   FieldUpdate (SomeField fieldDef) (fieldToSqlValue fieldDef a)
 
-(.:=) :: FieldDefinition a -> a -> FieldUpdate
+(.:=) :: Nullability nullability => FieldDefinition nullability a -> a -> FieldUpdate
 (.:=) = fieldUpdate
 
 fieldUpdateName :: FieldUpdate -> String

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/FieldUpdate.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/FieldUpdate.hs
@@ -10,11 +10,11 @@ module Database.Orville.PostgreSQL.Internal.FieldUpdate where
 import Database.Orville.PostgreSQL.Internal.FieldDefinition
 import Database.Orville.PostgreSQL.Internal.Types
 
-fieldUpdate :: Nullability nullability => FieldDefinition nullability a -> a -> FieldUpdate
+fieldUpdate :: FieldDefinition nullability a -> a -> FieldUpdate
 fieldUpdate fieldDef a =
   FieldUpdate (SomeField fieldDef) (fieldToSqlValue fieldDef a)
 
-(.:=) :: Nullability nullability => FieldDefinition nullability a -> a -> FieldUpdate
+(.:=) :: FieldDefinition nullability a -> a -> FieldUpdate
 (.:=) = fieldUpdate
 
 fieldUpdateName :: FieldUpdate -> String

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/FromSql.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/FromSql.hs
@@ -31,7 +31,7 @@ convertFromSql =
 col :: (ColumnSpecifier col, Convertible SqlValue a) => col -> FromSql a
 col spec = joinFromSqlError (convertFromSql <$> getColumn (selectForm spec))
 
-fieldFromSql :: FieldDefinition a -> FromSql a
+fieldFromSql :: FieldDefinition nullability a -> FromSql a
 fieldFromSql field =
   joinFromSqlError (fromSqlValue <$> getColumn (selectForm field))
   where
@@ -53,7 +53,7 @@ instance ColumnSpecifier SelectForm where
 instance ColumnSpecifier NameForm where
   selectForm = selectColumn
 
-instance ColumnSpecifier (FieldDefinition a) where
+instance ColumnSpecifier (FieldDefinition nullability a) where
   selectForm = selectColumn . fromString . fieldName
 
 instance ColumnSpecifier [Char] where

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/GroupBy.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/GroupBy.hs
@@ -28,7 +28,7 @@ groupingValues (GroupByClause _ values) = values
 class ToGroupBy a where
   toGroupBy :: a -> GroupByClause
 
-instance ToGroupBy (FieldDefinition a) where
+instance ToGroupBy (FieldDefinition nullability a) where
   toGroupBy fieldDef = GroupByClause (fieldName fieldDef) []
 
 instance ToGroupBy (String, [SqlValue]) where

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/MigrateTable.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/MigrateTable.hs
@@ -58,8 +58,7 @@ mkMigrateTableDDL columns tableDef =
       List.concatMap dropStmt fieldNamesToDelete
     cols = List.intercalate ", " $ stmts
 
-mkMigrateColumnTypeDDL :: Nullability nullability
-                       => FieldDefinition nullability a
+mkMigrateColumnTypeDDL :: FieldDefinition nullability a
                        -> SqlColDesc
                        -> Maybe String
 mkMigrateColumnTypeDDL fieldDef colDesc =
@@ -73,8 +72,7 @@ mkMigrateColumnTypeDDL fieldDef colDesc =
              " SET DATA TYPE " ++ sqlTypeDDL (fieldType fieldDef)
         else Nothing
 
-mkMigrateColumnNullDDL :: Nullability nullability
-                       => FieldDefinition nullability a
+mkMigrateColumnNullDDL :: FieldDefinition nullability a
                        -> SqlColDesc
                        -> Maybe String
 mkMigrateColumnNullDDL fieldDef colDesc =
@@ -89,8 +87,7 @@ mkMigrateColumnNullDDL fieldDef colDesc =
                     "ALTER COLUMN " ++ name ++ " SET NOT NULL"
                else Nothing
 
-mkMigrateColumnDDL :: Nullability nullability
-                   => FieldDefinition nullability a
+mkMigrateColumnDDL :: FieldDefinition nullability a
                    -> Maybe SqlColDesc
                    -> [String]
 mkMigrateColumnDDL fieldDef Nothing = ["ADD COLUMN " ++ mkFieldDDL fieldDef]
@@ -113,7 +110,7 @@ mkFlagDDL (References table field) =
 mkFlagDDL (ColumnDescription _) = Nothing
 mkFlagDDL AssignedByDatabase = Nothing
 
-mkFieldDDL :: Nullability nullability => FieldDefinition nullability a -> String
+mkFieldDDL :: FieldDefinition nullability a -> String
 mkFieldDDL field = name ++ " " ++ sqlType ++ " " ++ flagSql
   where
     name = rawExprToSql . generateSql . NameForm Nothing . fieldName $ field
@@ -135,7 +132,7 @@ mkCreateTableDDL tableDef =
 mkDropTableDDL :: String -> String
 mkDropTableDDL name = "DROP TABLE \"" ++ name ++ "\""
 
-sqlFieldDesc :: Nullability nullability => FieldDefinition nullability a -> SqlColDesc
+sqlFieldDesc :: FieldDefinition nullability a -> SqlColDesc
 sqlFieldDesc field =
   SqlColDesc
     { colType = sqlTypeId $ fieldType field

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/OrderBy.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/OrderBy.hs
@@ -43,7 +43,7 @@ sortingValues (OrderByClause _ values _) = values
 class ToOrderBy a where
   toOrderBy :: a -> SortDirection -> OrderByClause
 
-instance ToOrderBy (FieldDefinition a) where
+instance ToOrderBy (FieldDefinition nullability a) where
   toOrderBy fieldDef = OrderByClause (rawExprToSql . generateSql . NameForm Nothing $ fieldName fieldDef) []
 
 instance ToOrderBy (String, [SqlValue]) where

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/QueryCache.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/QueryCache.hs
@@ -111,7 +111,7 @@ findRecordCached tableDef key =
 findRecordsByCached ::
      (Ord fieldValue, MonadThrow m, MonadOrville conn m)
   => TableDefinition readEntity writeEntity key
-  -> FieldDefinition fieldValue
+  -> FieldDefinition nullability fieldValue
   -> SelectOptions
   -> QueryCached m (Map.Map fieldValue [readEntity])
 findRecordsByCached tableDef field opts = do

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/RelationalMap.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/RelationalMap.hs
@@ -95,7 +95,7 @@ mkTableDefinition (TableParams {..}) =
     }
 
 data RelationalMap a b where
-  RM_Field :: Nullability nullability => FieldDefinition nullability a -> RelationalMap a a
+  RM_Field :: FieldDefinition nullability a -> RelationalMap a a
   RM_Nest :: (a -> b) -> RelationalMap b c -> RelationalMap a c
   RM_Pure :: b -> RelationalMap a b
   RM_Apply
@@ -119,7 +119,7 @@ instance Profunctor RelationalMap where
 mapAttr :: (a -> b) -> RelationalMap b c -> RelationalMap a c
 mapAttr = RM_Nest
 
-mapField :: Nullability nullability => FieldDefinition nullability a -> RelationalMap a a
+mapField :: FieldDefinition nullability a -> RelationalMap a a
 mapField = RM_Field
 
 partialMap :: RelationalMap a (Either String a) -> RelationalMap a a
@@ -128,10 +128,10 @@ partialMap = RM_Partial
 readOnlyMap :: RelationalMap a b -> RelationalMap c b
 readOnlyMap = RM_ReadOnly
 
-attrField :: Nullability nullability => (a -> b) -> FieldDefinition nullability b -> RelationalMap a b
+attrField :: (a -> b) -> FieldDefinition nullability b -> RelationalMap a b
 attrField get = mapAttr get . mapField
 
-readOnlyField :: Nullability nullability => FieldDefinition nullability a -> RelationalMap b a
+readOnlyField :: FieldDefinition nullability a -> RelationalMap b a
 readOnlyField = readOnlyMap . mapField
 
 prefixMap :: String -> RelationalMap a b -> RelationalMap a b

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/RelationalMap.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/RelationalMap.hs
@@ -162,9 +162,9 @@ maybeMapper
         NullableField nullField ->
           -- When the underlying field is already nullable we need to make sure
           -- that 'NULL' is decoded to a 'Just'. Otherwise when the field is
-          -- 'NULL' it cause the entire 'RelationalMap' to resolve to a
+          -- 'NULL' it causes the entire 'RelationalMap' to resolve to a
           -- 'Nothing' as if _all_ fields were 'NULL', even if they were not.
-          RM_Field (assymmetricNullableField nullField)
+          RM_Field (asymmetricNullableField nullField)
 
     go (RM_Pure a) = RM_Pure (pure a)
     go (RM_Apply rmF rmA) = RM_Apply (fmap (<*>) $ go rmF) (go rmA)

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/Select.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/Select.hs
@@ -72,5 +72,5 @@ rowFromSql =
     , runFromSql = Right <$> ask
     }
 
-selectField :: FieldDefinition a -> SelectForm
+selectField :: FieldDefinition nulability a -> SelectForm
 selectField field = selectColumn (fieldToNameForm field)

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/SqlType.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/SqlType.hs
@@ -35,9 +35,9 @@ data SqlType a = SqlType
     -- ^ The raw SQL DDL to use when creating/migrating columns of this type
     -- (not including any NULL or NOT NULL declarations)
   , sqlTypeReferenceDDL :: Maybe String
-    -- ^ Indicates whether columns should be marked NULL or NOT NULL in the
-    -- database schema. If this is 'True', then 'sqlTypeFromSql' should
-    -- provide a handling of 'SqlNull' that returns an 'a', not 'Nothing'.
+    -- ^ The raw SQL DDL to use when creating/migrating columns with foreign
+    -- keys to this type. This is used foreignRefType to build a new SqlType
+    -- when making foreign key fields
   , sqlTypeId :: HDBC.SqlTypeId
     -- ^ 'sqlTypeId' will be compared to the 'colType' field found in the
     -- 'HDBC.SqlColDesc' return by 'describeTable' when determining whether

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/Types.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/Types.hs
@@ -62,18 +62,35 @@ instance ColumnDefault Bool where
   toColumnDefaultSql True = "true"
   toColumnDefaultSql False = "false"
 
+-- | 'Nullable' is a values-less type used to track that a 'FieldDefinition'
+-- represents a field that is marked nullable in the database schema. See the
+-- 'Nullability' type for the value-level representation of field nullability.
 data Nullable
+
+-- | 'NotNull is a values-less type used to track that a 'FieldDefinition'
+-- represents a field that is marked not-null in the database schema.  See the
+-- 'Nullability' type for the value-level representation of field nullability.
 data NotNull
 
+-- | 'Nullability' represents whether a field will be marked as 'NULL' or 'NOT
+-- NULL' in the database schema. It is a GADT so that the value constructors
+-- can be used to record this knowledge in the type system as well. This allows
+-- functions that work only on 'Nullable' or 'NotNull' fields to indicate this
+-- in their type signatures as appropriate.
 data Nullability nullability where
   Nullable :: Nullability Nullable
   NotNull  :: Nullability NotNull
 
+-- | A 'NullabilityCheck' is returned by the 'checkNullability' function, which
+-- can be used when a function works on both 'Nullable' and 'NotNull' functions
+-- but needs to deal with each type of field separately. It adds wrapper
+-- constructors around the 'FieldDefinition' that you can pattern match on to
+-- then work with a concrete 'Nullable' or 'NotNull' field.
 data NullabilityCheck a
   = NullableField (FieldDefinition Nullable a)
   | NotNullField (FieldDefinition NotNull a)
 
--- | Resolves the 'nullablity' of a field to a concreted type based on its
+-- | Resolves the 'nullablity' of a field to a concrete type based on its
 -- 'fieldNullability'. You can do this directly by pattern matching on the
 -- value of 'fieldNullability' if you have the GADTs extension turned on, but
 -- this function will do that for you so you don't need to turn GADTs on.

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/Where.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/Where.hs
@@ -187,10 +187,10 @@ whereQualified tableDef cond = Qualified tableDef cond
 whereRaw :: String -> [SqlValue] -> WhereCondition
 whereRaw str values = WhereConditionExpr . expr $ E.whereRaw str values
 
-isNull :: FieldDefinition nullability a -> WhereCondition
+isNull :: FieldDefinition Nullable a -> WhereCondition
 isNull = WhereConditionExpr . expr . E.whereNull . fieldToNameForm
 
-isNotNull :: FieldDefinition nullability a -> WhereCondition
+isNotNull :: FieldDefinition Nullable a -> WhereCondition
 isNotNull = WhereConditionExpr . expr . E.whereNotNull . fieldToNameForm
 
 whereClause :: [WhereCondition] -> String

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/Where.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/Where.hs
@@ -69,46 +69,46 @@ instance QueryKeyable WhereCondition where
   queryKey (And conds) = qkOp "And" conds
   queryKey (Qualified _ cond) = queryKey cond
 
-(.==) :: FieldDefinition a -> a -> WhereCondition
+(.==) :: FieldDefinition nullability a -> a -> WhereCondition
 fieldDef .== a = WhereConditionExpr . expr $ nameForm E..== sqlValue
   where
     nameForm = fieldToNameForm fieldDef
     sqlValue = fieldToSqlValue fieldDef a
 
-(.<>) :: FieldDefinition a -> a -> WhereCondition
+(.<>) :: FieldDefinition nullability a -> a -> WhereCondition
 fieldDef .<> a = WhereConditionExpr . expr $ nameForm E..<> sqlValue
   where
     nameForm = fieldToNameForm fieldDef
     sqlValue = fieldToSqlValue fieldDef a
 
-(.>) :: FieldDefinition a -> a -> WhereCondition
+(.>) :: FieldDefinition nullability a -> a -> WhereCondition
 fieldDef .> a = WhereConditionExpr . expr $ nameForm E..> sqlValue
   where
     nameForm = fieldToNameForm fieldDef
     sqlValue = fieldToSqlValue fieldDef a
 
-(.>=) :: FieldDefinition a -> a -> WhereCondition
+(.>=) :: FieldDefinition nullability a -> a -> WhereCondition
 fieldDef .>= a = WhereConditionExpr . expr $ nameForm E..>= sqlValue
   where
     nameForm = fieldToNameForm fieldDef
     sqlValue = fieldToSqlValue fieldDef a
 
-(.<) :: FieldDefinition a -> a -> WhereCondition
+(.<) :: FieldDefinition nullability a -> a -> WhereCondition
 fieldDef .< a = WhereConditionExpr . expr $ nameForm E..< sqlValue
   where
     nameForm = fieldToNameForm fieldDef
     sqlValue = fieldToSqlValue fieldDef a
 
-(.<=) :: FieldDefinition a -> a -> WhereCondition
+(.<=) :: FieldDefinition nullability a -> a -> WhereCondition
 fieldDef .<= a = WhereConditionExpr . expr $ nameForm E..<= sqlValue
   where
     nameForm = fieldToNameForm fieldDef
     sqlValue = fieldToSqlValue fieldDef a
 
-(.<-) :: FieldDefinition a -> [a] -> WhereCondition
+(.<-) :: FieldDefinition nullability a -> [a] -> WhereCondition
 fieldDef .<- as = whereIn fieldDef as
 
-(%==) :: FieldDefinition a -> a -> WhereCondition
+(%==) :: FieldDefinition nullability a -> a -> WhereCondition
 fieldDef %== a = WhereConditionExpr . expr $ nameForm E.%== sqlValue
   where
     nameForm = fieldToNameForm fieldDef
@@ -159,22 +159,22 @@ whereAnd = And
 whereOr :: [WhereCondition] -> WhereCondition
 whereOr = Or
 
-whereIn :: FieldDefinition a -> [a] -> WhereCondition
+whereIn :: FieldDefinition nullability a -> [a] -> WhereCondition
 whereIn fieldDef values =
   WhereConditionExpr . expr $
   E.whereIn (fieldToNameForm fieldDef) (map (fieldToSqlValue fieldDef) values)
 
-whereLike :: FieldDefinition a -> String -> WhereCondition
+whereLike :: FieldDefinition nullability a -> String -> WhereCondition
 whereLike fieldDef raw =
   WhereConditionExpr . expr $
   E.whereLike (fieldToNameForm fieldDef) (toSql raw)
 
-whereLikeInsensitive :: FieldDefinition a -> String -> WhereCondition
+whereLikeInsensitive :: FieldDefinition nullability a -> String -> WhereCondition
 whereLikeInsensitive fieldDef raw =
   WhereConditionExpr . expr $
   E.whereLikeInsensitive (fieldToNameForm fieldDef) (toSql raw)
 
-whereNotIn :: FieldDefinition a -> [a] -> WhereCondition
+whereNotIn :: FieldDefinition nullability a -> [a] -> WhereCondition
 whereNotIn fieldDef values =
   WhereConditionExpr . expr $
   E.whereNotIn
@@ -187,10 +187,10 @@ whereQualified tableDef cond = Qualified tableDef cond
 whereRaw :: String -> [SqlValue] -> WhereCondition
 whereRaw str values = WhereConditionExpr . expr $ E.whereRaw str values
 
-isNull :: FieldDefinition a -> WhereCondition
+isNull :: FieldDefinition nullability a -> WhereCondition
 isNull = WhereConditionExpr . expr . E.whereNull . fieldToNameForm
 
-isNotNull :: FieldDefinition a -> WhereCondition
+isNotNull :: FieldDefinition nullability a -> WhereCondition
 isNotNull = WhereConditionExpr . expr . E.whereNotNull . fieldToNameForm
 
 whereClause :: [WhereCondition] -> String

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Popper.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Popper.hs
@@ -134,21 +134,21 @@ popMaybe = PopMaybe
 hasMany ::
      Ord fieldValue
   => TableDefinition readEntity writeEntity key
-  -> FieldDefinition fieldValue
+  -> FieldDefinition nullability fieldValue
   -> Popper fieldValue [readEntity]
 hasMany tableDef fieldDef = PopPrim (PrimRecordManyBy tableDef fieldDef mempty)
 
 hasOneIn ::
      Ord fieldValue
   => TableDefinition readEntity writeEntity key
-  -> FieldDefinition fieldValue
+  -> FieldDefinition nullability fieldValue
   -> Popper [fieldValue] (Map.Map fieldValue readEntity)
 hasOneIn tableDef fieldDef = PopPrim (PrimRecordsBy tableDef fieldDef mempty)
 
 hasManyIn ::
      Ord fieldValue
   => TableDefinition readEntity writeEntity key
-  -> FieldDefinition fieldValue
+  -> FieldDefinition nullability fieldValue
   -> Popper [fieldValue] (Map.Map fieldValue [readEntity])
 hasManyIn tableDef fieldDef =
   PopPrim (PrimRecordsManyBy tableDef fieldDef mempty)
@@ -156,7 +156,7 @@ hasManyIn tableDef fieldDef =
 hasManyWhere ::
      Ord fieldValue
   => TableDefinition readEntity writeEntity key
-  -> FieldDefinition fieldValue
+  -> FieldDefinition nullability fieldValue
   -> SelectOptions
   -> Popper fieldValue [readEntity]
 hasManyWhere tableDef fieldDef opts =
@@ -165,7 +165,7 @@ hasManyWhere tableDef fieldDef opts =
 hasManyInWhere ::
      Ord fieldValue
   => TableDefinition readEntity writeEntity key
-  -> FieldDefinition fieldValue
+  -> FieldDefinition nullability fieldValue
   -> SelectOptions
   -> Popper [fieldValue] (Map.Map fieldValue [readEntity])
 hasManyInWhere tableDef fieldDef opts =
@@ -174,14 +174,14 @@ hasManyInWhere tableDef fieldDef opts =
 hasOne ::
      Ord fieldValue
   => TableDefinition readEntity writeEntity key
-  -> FieldDefinition fieldValue
+  -> FieldDefinition nullability fieldValue
   -> Popper fieldValue (Maybe readEntity)
 hasOne tableDef fieldDef = hasOneWhere tableDef fieldDef mempty
 
 hasOneWhere ::
      Ord fieldValue
   => TableDefinition readEntity writeEntity key
-  -> FieldDefinition fieldValue
+  -> FieldDefinition nullability fieldValue
   -> SelectOptions
   -> Popper fieldValue (Maybe readEntity)
 hasOneWhere tableDef fieldDef opts =
@@ -190,14 +190,14 @@ hasOneWhere tableDef fieldDef opts =
 hasOne' ::
      Ord fieldValue
   => TableDefinition readEntity writeEntity key
-  -> FieldDefinition fieldValue
+  -> FieldDefinition nullability fieldValue
   -> Popper fieldValue readEntity
 hasOne' tableDef fieldDef =
   certainly' (popMissingRecord tableDef fieldDef) (hasOne tableDef fieldDef)
 
 popMissingRecord ::
      TableDefinition readEntity writeEntity key
-  -> FieldDefinition fieldValue
+  -> FieldDefinition nullability fieldValue
   -> Popper fieldValue PopError
 popMissingRecord tableDef fieldDef = fromKern (MissingRecord tableDef fieldDef)
 
@@ -297,9 +297,10 @@ onPopMany = PopOnMany
 
 -- The Popper guts
 data PopError
-  = forall readEntity writeEntity key fieldValue. MissingRecord (TableDefinition readEntity writeEntity key)
-                                                                (FieldDefinition fieldValue)
-                                                                fieldValue
+  = forall readEntity writeEntity key fieldValue nullability.
+    MissingRecord (TableDefinition readEntity writeEntity key)
+                  (FieldDefinition nullability fieldValue)
+                  fieldValue
   | Unpoppable String
 
 instance Show PopError where
@@ -309,7 +310,7 @@ instance Show PopError where
 
 missingRecordMessage ::
      TableDefinition readEntity writeEntity key
-  -> FieldDefinition fieldValue
+  -> FieldDefinition nullability fieldValue
   -> fieldValue
   -> String
 missingRecordMessage tableDef fieldDef fieldValue =
@@ -353,26 +354,26 @@ data Prim a b
   PrimRecordBy
     :: Ord fieldValue
     => TableDefinition readEntity writeEntity key
-    -> FieldDefinition fieldValue
+    -> FieldDefinition nullability fieldValue
     -> SelectOptions
     -> Prim fieldValue (Maybe readEntity)
   PrimRecordManyBy
     :: Ord fieldValue
     => TableDefinition readEntity writeEntity key
-    -> FieldDefinition fieldValue
+    -> FieldDefinition nullability fieldValue
     -> SelectOptions
     -> Prim fieldValue [readEntity]
   --  The many primitives (each of these is a fixed point -- its own many)
   PrimRecordsBy
     :: Ord fieldValue
     => TableDefinition readEntity writeEntity key
-    -> FieldDefinition fieldValue
+    -> FieldDefinition nullability fieldValue
     -> SelectOptions
     -> Prim [fieldValue] (Map.Map fieldValue readEntity)
   PrimRecordsManyBy
     :: Ord fieldValue
     => TableDefinition readEntity writeEntity key
-    -> FieldDefinition fieldValue
+    -> FieldDefinition nullability fieldValue
     -> SelectOptions
     -> Prim [fieldValue] (Map.Map fieldValue [readEntity])
 

--- a/orville-postgresql/test/AppManagedEntity/Schema/Virus.hs
+++ b/orville-postgresql/test/AppManagedEntity/Schema/Virus.hs
@@ -29,17 +29,17 @@ virusTable =
     , O.tblComments = O.noComments
     }
 
-virusIdField :: O.FieldDefinition VirusId
+virusIdField :: O.FieldDefinition O.NotNull VirusId
 virusIdField =
   O.int64Field "id" `O.withFlag` O.PrimaryKey `O.withConversion`
   O.convertSqlType unVirusId VirusId
 
-virusNameField :: O.FieldDefinition VirusName
+virusNameField :: O.FieldDefinition O.NotNull VirusName
 virusNameField =
   O.textField "name" 255 `O.withConversion`
   O.convertSqlType unVirusName VirusName
 
-virusDiscoveredAtField :: O.FieldDefinition VirusDiscoveredAt
+virusDiscoveredAtField :: O.FieldDefinition O.NotNull VirusDiscoveredAt
 virusDiscoveredAtField =
   O.utcTimeField "discovered_at" `O.withConversion`
   O.convertSqlType unVirusDiscoveredAt VirusDiscoveredAt

--- a/orville-postgresql/test/EntityWrapper/Schema/Virus.hs
+++ b/orville-postgresql/test/EntityWrapper/Schema/Virus.hs
@@ -25,12 +25,12 @@ virusTable =
     , O.tblComments = O.noComments
     }
 
-virusIdField :: O.FieldDefinition VirusId
+virusIdField :: O.FieldDefinition O.NotNull VirusId
 virusIdField =
   O.automaticIdField "id" `O.withFlag` O.PrimaryKey `O.withConversion`
   O.convertSqlType unVirusId VirusId
 
-virusNameField :: O.FieldDefinition VirusName
+virusNameField :: O.FieldDefinition O.NotNull VirusName
 virusNameField =
   O.textField "name" 255 `O.withConversion`
   O.convertSqlType unVirusName VirusName

--- a/orville-postgresql/test/ErrorsTest.hs
+++ b/orville-postgresql/test/ErrorsTest.hs
@@ -49,7 +49,7 @@ data BadVirus = BadVirus
   , badVirusName :: Int32 -- Virus name is actually Text, not Int32!
   } deriving (Show)
 
-badVirusNameField :: O.FieldDefinition Int32
+badVirusNameField :: O.FieldDefinition O.NotNull Int32
 badVirusNameField = virusNameField `O.withConversion` const O.integer
 
 badVirusFromSql :: O.FromSql BadVirus

--- a/orville-postgresql/test/Migrations/Entity.hs
+++ b/orville-postgresql/test/Migrations/Entity.hs
@@ -20,7 +20,6 @@ newtype MigrationEntityId = MigrationEntityId
 -- Take in the field definition so we can force different names and field types
 -- during testing.
 migrationEntityTable ::
-  O.Nullability nullability =>
   O.FieldDefinition nullability a ->
   O.TableDefinition (MigrationEntity a MigrationEntityId) (MigrationEntity a ()) MigrationEntityId
 migrationEntityTable fieldDef =

--- a/orville-postgresql/test/Migrations/Entity.hs
+++ b/orville-postgresql/test/Migrations/Entity.hs
@@ -20,7 +20,8 @@ newtype MigrationEntityId = MigrationEntityId
 -- Take in the field definition so we can force different names and field types
 -- during testing.
 migrationEntityTable ::
-  O.FieldDefinition a ->
+  O.Nullability nullability =>
+  O.FieldDefinition nullability a ->
   O.TableDefinition (MigrationEntity a MigrationEntityId) (MigrationEntity a ()) MigrationEntityId
 migrationEntityTable fieldDef =
   O.mkTableDefinition $
@@ -54,7 +55,7 @@ migrationEntityTableWithDroppedColumn columnName =
     , O.tblComments = O.noComments
     }
 
-migrationEntityIdField :: O.FieldDefinition MigrationEntityId
+migrationEntityIdField :: O.FieldDefinition O.NotNull MigrationEntityId
 migrationEntityIdField =
   O.automaticIdField "id" `O.withFlag` O.PrimaryKey `O.withConversion`
   O.convertSqlType unMigrationEntityId MigrationEntityId

--- a/orville-postgresql/test/OptionalMap/CrudTest.hs
+++ b/orville-postgresql/test/OptionalMap/CrudTest.hs
@@ -1,0 +1,30 @@
+module OptionalMap.CrudTest where
+
+import qualified Database.Orville.PostgreSQL as O
+
+import Control.Monad (void)
+import Data.Monoid ((<>))
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertEqual, testCase)
+
+import OptionalMap.Entity
+import qualified TestDB as TestDB
+
+test_optionalMaps :: TestTree
+test_optionalMaps =
+  testGroup ("crud operations work for RelationalMaps with optional fields")
+    [ insertRecordAndSelectFirstTest "Bad map" badCrudEntityTable
+    ]
+
+insertRecordAndSelectFirstTest :: String -> O.TableDefinition (CrudEntity CrudEntityId) (CrudEntity ()) CrudEntityId -> TestTree
+insertRecordAndSelectFirstTest descr tableDef = TestDB.withOrvilleRun $ \run ->
+  testCase ("insertRecord and selectFirst work with " <> descr) $ do
+    run (TestDB.reset [O.Table tableDef])
+    void $ run (O.insertRecord tableDef testEntity)
+    foundComplexField <- fmap crudEntityComplexField <$> run (O.selectFirst tableDef mempty)
+    assertEqual
+      ("Entity found in database didn't match the inserted values")
+      (Just $ crudEntityComplexField testEntity)
+      foundComplexField
+  where
+    testEntity = CrudEntity () (Just $ ComplexField 0 Nothing)

--- a/orville-postgresql/test/OptionalMap/Entity.hs
+++ b/orville-postgresql/test/OptionalMap/Entity.hs
@@ -36,7 +36,7 @@ badCrudEntityTable =
     , O.tblComments = O.noComments
     }
 
-crudEntityIdField :: O.FieldDefinition CrudEntityId
+crudEntityIdField :: O.FieldDefinition O.NotNull CrudEntityId
 crudEntityIdField =
   O.automaticIdField "id" `O.withFlag` O.PrimaryKey `O.withConversion`
   O.convertSqlType unCrudEntityId CrudEntityId
@@ -46,9 +46,9 @@ badComplexFieldMap =
   ComplexField <$> O.attrField complexFieldPart1 complexFieldPart1Field
                <*> O.attrField complexFieldPart2 (O.nullableField complexFieldPart2Field)
 
-complexFieldPart1Field :: O.FieldDefinition Int32
+complexFieldPart1Field :: O.FieldDefinition O.NotNull Int32
 complexFieldPart1Field = O.int32Field "part_1"
 
-complexFieldPart2Field :: O.FieldDefinition T.Text
+complexFieldPart2Field :: O.FieldDefinition O.NotNull T.Text
 complexFieldPart2Field =
   O.withConversion (O.textField "part_2" 255) $ O.maybeConvertSqlType id Just

--- a/orville-postgresql/test/OptionalMap/Entity.hs
+++ b/orville-postgresql/test/OptionalMap/Entity.hs
@@ -1,0 +1,54 @@
+module OptionalMap.Entity where
+
+import Data.Int (Int32)
+import qualified Data.Text as T
+
+import qualified Database.Orville.PostgreSQL as O
+
+data CrudEntity key = CrudEntity
+  { crudEntityId :: key
+  , crudEntityComplexField :: Maybe ComplexField
+  } deriving (Show, Eq)
+
+newtype CrudEntityId = CrudEntityId
+  { unCrudEntityId :: Int32
+  } deriving (Show, Eq)
+
+data ComplexField =
+  ComplexField { complexFieldPart1 :: Int32
+               , complexFieldPart2 :: Maybe T.Text
+               } deriving (Show, Eq)
+
+-- Take in the column name so we can test different styles.
+badCrudEntityTable ::
+  O.TableDefinition (CrudEntity CrudEntityId) (CrudEntity ()) CrudEntityId
+badCrudEntityTable =
+  O.mkTableDefinition $
+  O.TableParams
+    { O.tblName = "crudEntity"
+    , O.tblPrimaryKey = crudEntityIdField
+    , O.tblMapper =
+      CrudEntity
+        <$> O.readOnlyField crudEntityIdField
+        <*> O.mapAttr crudEntityComplexField (O.maybeMapper badComplexFieldMap)
+    , O.tblGetKey = crudEntityId
+    , O.tblSafeToDelete = []
+    , O.tblComments = O.noComments
+    }
+
+crudEntityIdField :: O.FieldDefinition CrudEntityId
+crudEntityIdField =
+  O.automaticIdField "id" `O.withFlag` O.PrimaryKey `O.withConversion`
+  O.convertSqlType unCrudEntityId CrudEntityId
+
+badComplexFieldMap :: O.RelationalMap ComplexField ComplexField
+badComplexFieldMap =
+  ComplexField <$> O.attrField complexFieldPart1 complexFieldPart1Field
+               <*> O.attrField complexFieldPart2 (O.nullableField complexFieldPart2Field)
+
+complexFieldPart1Field :: O.FieldDefinition Int32
+complexFieldPart1Field = O.int32Field "part_1"
+
+complexFieldPart2Field :: O.FieldDefinition T.Text
+complexFieldPart2Field =
+  O.withConversion (O.textField "part_2" 255) $ O.maybeConvertSqlType id Just

--- a/orville-postgresql/test/ParameterizedEntity/Schema/Virus.hs
+++ b/orville-postgresql/test/ParameterizedEntity/Schema/Virus.hs
@@ -24,12 +24,12 @@ virusTable =
     , O.tblComments = O.noComments
     }
 
-virusIdField :: O.FieldDefinition VirusId
+virusIdField :: O.FieldDefinition O.NotNull VirusId
 virusIdField =
   O.automaticIdField "id" `O.withFlag` O.PrimaryKey `O.withConversion`
   O.convertSqlType unVirusId VirusId
 
-virusNameField :: O.FieldDefinition VirusName
+virusNameField :: O.FieldDefinition O.NotNull VirusName
 virusNameField =
   O.textField "name" 255 `O.withConversion`
   O.convertSqlType unVirusName VirusName

--- a/orville-postgresql/test/PopperTest.hs
+++ b/orville-postgresql/test/PopperTest.hs
@@ -138,23 +138,23 @@ newtype LeafId = LeafId
   { leafIdToInt :: Int32
   } deriving (Eq, Ord, Show, Arbitrary)
 
-idField :: O.FieldDefinition Int32
+idField :: O.FieldDefinition O.NotNull Int32
 idField = O.int32Field "id"
 
-rootIdField :: O.FieldDefinition RootId
+rootIdField :: O.FieldDefinition O.NotNull RootId
 rootIdField = idField `O.withConversion` O.convertSqlType rootIdToInt RootId
 
-branchIdField :: O.FieldDefinition BranchId
+branchIdField :: O.FieldDefinition O.NotNull BranchId
 branchIdField =
   idField `O.withConversion` O.convertSqlType branchIdToInt BranchId
 
-branchForeignIdField :: O.FieldDefinition BranchId
+branchForeignIdField :: O.FieldDefinition O.NotNull BranchId
 branchForeignIdField = branchIdField `O.withName` "branch_id"
 
-leafIdField :: O.FieldDefinition LeafId
+leafIdField :: O.FieldDefinition O.NotNull LeafId
 leafIdField = idField `O.withConversion` O.convertSqlType leafIdToInt LeafId
 
-treeIdField :: O.FieldDefinition TreeId
+treeIdField :: O.FieldDefinition O.NotNull TreeId
 treeIdField =
   O.int32Field "tree_id" `O.withConversion` O.convertSqlType treeIdToInt TreeId
 

--- a/orville-postgresql/test/StrangeFieldNames/Entity.hs
+++ b/orville-postgresql/test/StrangeFieldNames/Entity.hs
@@ -33,11 +33,11 @@ crudEntityTable columnName =
     , O.tblComments = O.noComments
     }
 
-crudEntityIdField :: O.FieldDefinition CrudEntityId
+crudEntityIdField :: O.FieldDefinition O.NotNull CrudEntityId
 crudEntityIdField =
   O.automaticIdField "id" `O.withFlag` O.PrimaryKey `O.withConversion`
   O.convertSqlType unCrudEntityId CrudEntityId
 
-crudEntityRenameableField :: String -> O.FieldDefinition Int32
+crudEntityRenameableField :: String -> O.FieldDefinition O.NotNull Int32
 crudEntityRenameableField = O.int32Field
 

--- a/orville-postgresql/test/WhereConditionTest.hs
+++ b/orville-postgresql/test/WhereConditionTest.hs
@@ -140,17 +140,17 @@ orderTable =
     , O.tblComments = O.noComments
     }
 
-orderIdField :: O.FieldDefinition OrderId
+orderIdField :: O.FieldDefinition O.NotNull OrderId
 orderIdField =
   O.int64Field "id" `O.withFlag` O.PrimaryKey `O.withConversion`
   O.convertSqlType unOrderId OrderId
 
-customerFkIdField :: O.FieldDefinition CustomerId
+customerFkIdField :: O.FieldDefinition O.NotNull CustomerId
 customerFkIdField =
   O.int64Field "customer_id" `O.withConversion`
   O.convertSqlType unCustomerId CustomerId
 
-orderNameField :: O.FieldDefinition OrderName
+orderNameField :: O.FieldDefinition O.NotNull OrderName
 orderNameField =
   O.textField "name" 255 `O.withConversion`
   O.convertSqlType unOrderName OrderName
@@ -217,12 +217,12 @@ customerTable =
     , O.tblComments = O.noComments
     }
 
-customerIdField :: O.FieldDefinition CustomerId
+customerIdField :: O.FieldDefinition O.NotNull CustomerId
 customerIdField =
   O.int64Field "id" `O.withFlag` O.PrimaryKey `O.withConversion`
   O.convertSqlType unCustomerId CustomerId
 
-customerNameField :: O.FieldDefinition CustomerName
+customerNameField :: O.FieldDefinition O.NotNull CustomerName
 customerNameField =
   O.textField "name" 255 `O.withConversion`
   O.convertSqlType unCustomerName CustomerName


### PR DESCRIPTION
This fixes `maybeMapper` being used on already nullable fields by
tracking nullability as a new type parameter on `FieldDefinition` to
prevent `nullableField` ever being called on an already nullable field.
This replaces the `sqlTypeNullable` field on `SqlType` completely.

I opted to put the type parameter on `FieldDefinition` rather than
`SqlType` for several reasons

1) It has to be there anyway for enforcement on `nullableField` to work

2) Avoiding `SqlType` minimizes the number of types impacted by the
extra parameter.

3) It seems more accurate to model _fields_ as nullable rathar than
_types_. In a (probably too quick) perusal of the PostgreSQL docs on
types I couldn't actually find a reference to nullability.

Constructorless tag types `Nullable` and `NotNull` are used to fill the
parameter with concrete types as appropriate. Each implements the
`Nullability` class, which provides the `checkNullability` function for
evaluating the nullability at run time.

With `nullableField` barred from being called on `Nullable` fields,
`maybeMapper` now required a new function to handle cases where it is
used over such fields. I added `assymmetricNullableField` to satisfy its
need.

Compare with #101 for a fix that does not involve adding type-level tracking