### PR TITLE
Adds support for composite primary keys

### DIFF
--- a/orville-postgresql/orville-postgresql.cabal
+++ b/orville-postgresql/orville-postgresql.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: ba90a571910116899596b5b6a86caa405d8511000be2aeedd6483a4a0f8d3d49
+-- hash: d621d9ed1dc2b9c1b8543913b05cf997d4924fc1316a47dabf01a390156ccc9f
 
 name:           orville-postgresql
 version:        0.8.3.0
@@ -63,6 +63,7 @@ library
       Database.Orville.PostgreSQL.Internal.MigrationPlan
       Database.Orville.PostgreSQL.Internal.Monad
       Database.Orville.PostgreSQL.Internal.OrderBy
+      Database.Orville.PostgreSQL.Internal.PrimaryKey
       Database.Orville.PostgreSQL.Internal.QueryCache
       Database.Orville.PostgreSQL.Internal.QueryKey
       Database.Orville.PostgreSQL.Internal.RelationalMap
@@ -150,6 +151,10 @@ test-suite spec
       AppManagedEntity.Data.Virus
       AppManagedEntity.Schema
       AppManagedEntity.Schema.Virus
+      CompositePrimaryKey.CrudTest
+      CompositePrimaryKey.Data.Virus
+      CompositePrimaryKey.Schema
+      CompositePrimaryKey.Schema.Virus
       ConduitTest
       EntityWrapper.CrudTest
       EntityWrapper.Data.Entity
@@ -160,6 +165,8 @@ test-suite spec
       Migrations.Entity
       Migrations.MigrateTest
       MonadBaseControlTest
+      OptionalMap.CrudTest
+      OptionalMap.Entity
       ParameterizedEntity.CrudTest
       ParameterizedEntity.Data.Virus
       ParameterizedEntity.Schema

--- a/orville-postgresql/sample-project/Example/Schema/Student.hs
+++ b/orville-postgresql/sample-project/Example/Schema/Student.hs
@@ -26,7 +26,7 @@ majorTable =
   O.mkTableDefinition $
   O.TableParams
     { O.tblName = "majors"
-    , O.tblPrimaryKey = majorIdField
+    , O.tblPrimaryKey = O.primaryKey majorIdField
     , O.tblMapper =
         Major <$> O.readOnlyField majorIdField <*>
         O.attrField majorName majorNameField <*>
@@ -38,7 +38,7 @@ majorTable =
 
 majorIdField :: O.FieldDefinition O.NotNull MajorId
 majorIdField =
-  O.automaticIdField "id" `O.withFlag` O.PrimaryKey `O.withConversion`
+  O.automaticIdField "id" `O.withConversion`
   O.convertSqlType majorIdInt MajorId
 
 majorNameField :: O.FieldDefinition O.NotNull MajorName
@@ -56,7 +56,7 @@ studentTable =
   O.mkTableDefinition $
   O.TableParams
     { O.tblName = "students"
-    , O.tblPrimaryKey = studentIdField
+    , O.tblPrimaryKey = O.primaryKey studentIdField
     , O.tblMapper =
         Student <$> O.readOnlyField studentIdField <*>
         O.attrField studentName studentNameField <*>
@@ -68,7 +68,7 @@ studentTable =
 
 studentIdField :: O.FieldDefinition O.NotNull StudentId
 studentIdField =
-  O.automaticIdField "id" `O.withFlag` O.PrimaryKey `O.withConversion`
+  O.automaticIdField "id" `O.withConversion`
   O.convertSqlType studentIdInt StudentId
 
 studentNameField :: O.FieldDefinition O.NotNull StudentName

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Conduit.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Conduit.hs
@@ -179,13 +179,15 @@ feedRows builder query = do
 #if MIN_VERSION_conduit(1,3,0)
 -- | Build a conduit source that is fed by querying one page worth of results
 -- at a time. When the last row of the last page is consumed, the stream ends.
-streamPages :: (MonadOrville conn m, Bounded key, Enum key)
+streamPages :: (MonadOrville conn m, Bounded orderField, Enum orderField)
             => TableDefinition readEnt write key
+            -> FieldDefinition NotNull orderField
+            -> (readEnt -> orderField)
             -> Maybe WhereCondition
             -> Word -- ^ number of rows fetched per page
             -> ConduitT () readEnt m ()
-streamPages tableDef mbWhereCond pageSize =
-  loop =<< lift (buildPagination tableDef mbWhereCond pageSize)
+streamPages tableDef orderField getOrderField mbWhereCond pageSize =
+  loop =<< lift (buildPagination tableDef orderField getOrderField mbWhereCond pageSize)
     where
       loop pagination = do
         yieldMany (pageRows pagination)

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/FieldDefinition.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/FieldDefinition.hs
@@ -128,10 +128,6 @@ fieldOfType sqlType name =
     []
     NotNull
 
-isPrimaryKey :: ColumnFlag -> Bool
-isPrimaryKey PrimaryKey = True
-isPrimaryKey _ = False
-
 isAssignedByDatabase :: ColumnFlag -> Bool
 isAssignedByDatabase AssignedByDatabase = True
 isAssignedByDatabase _ = False

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/PrimaryKey.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/PrimaryKey.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE RankNTypes #-}
+module Database.Orville.PostgreSQL.Internal.PrimaryKey
+  ( primaryKeyIn
+  , primaryKeyEquals
+  , primaryKeyDescription
+  , primaryKeyToSql
+  , primaryKey
+  , compositePrimaryKey
+  , primaryKeyPart
+  , mapPrimaryKeyParts
+  ) where
+
+import qualified Data.List as List
+import qualified Database.HDBC as HDBC
+
+import Database.Orville.PostgreSQL.Internal.FieldDefinition (fieldToSqlValue)
+import Database.Orville.PostgreSQL.Internal.Types (PrimaryKey(..), PrimaryKeyPart(..), FieldDefinition(fieldName), NotNull)
+import Database.Orville.PostgreSQL.Internal.Where (WhereCondition, (.<-), (.==), whereAnd, whereOr)
+
+primaryKeyIn :: PrimaryKey key -> [key] -> WhereCondition
+primaryKeyIn keyDef@(PrimaryKey first rest) keys =
+  case rest of
+    [] ->
+      -- Special case the single field case to an in clause rather
+      -- than a large OR
+      case first of
+        PrimaryKeyPart getPart field ->
+          field .<- map getPart keys
+    _ ->
+      whereOr (map (primaryKeyEquals keyDef) keys)
+
+primaryKeyEquals :: PrimaryKey key -> key -> WhereCondition
+primaryKeyEquals keyDef key =
+  let
+    partEq getPart partField =
+      partField .== getPart key
+  in
+    whereAnd (mapPrimaryKeyParts partEq keyDef)
+
+primaryKeyDescription :: PrimaryKey key -> String
+primaryKeyDescription keyDef =
+  let
+    partName _ field =
+      fieldName field
+  in
+    List.intercalate ", " (mapPrimaryKeyParts partName keyDef)
+
+primaryKeyToSql :: PrimaryKey key -> key -> [HDBC.SqlValue]
+primaryKeyToSql keyDef key =
+  let
+    partSqlValue getPart partField =
+      fieldToSqlValue partField (getPart key)
+  in
+    mapPrimaryKeyParts partSqlValue keyDef
+
+primaryKey :: FieldDefinition NotNull key -> PrimaryKey key
+primaryKey fieldDef =
+  PrimaryKey (PrimaryKeyPart id fieldDef) []
+
+compositePrimaryKey :: PrimaryKeyPart key
+                    -> [PrimaryKeyPart key]
+                    -> PrimaryKey key
+compositePrimaryKey =
+  PrimaryKey
+
+primaryKeyPart :: (key -> part)
+               -> FieldDefinition NotNull part
+               -> PrimaryKeyPart key
+primaryKeyPart =
+  PrimaryKeyPart
+
+mapPrimaryKeyParts :: (forall part.
+                         (key -> part)
+                        -> FieldDefinition NotNull part
+                        -> a
+                      )
+                   -> PrimaryKey key
+                   -> [a]
+mapPrimaryKeyParts f (PrimaryKey first rest) =
+  let
+    doPart (PrimaryKeyPart getPart field) =
+      f getPart field
+  in
+    map doPart (first:rest)

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/PrimaryKey.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/PrimaryKey.hs
@@ -15,8 +15,14 @@ import qualified Database.HDBC as HDBC
 
 import Database.Orville.PostgreSQL.Internal.FieldDefinition (fieldToSqlValue)
 import Database.Orville.PostgreSQL.Internal.Types (PrimaryKey(..), PrimaryKeyPart(..), FieldDefinition(fieldName), NotNull)
-import Database.Orville.PostgreSQL.Internal.Where (WhereCondition, (.<-), (.==), whereAnd, whereOr)
+import Database.Orville.PostgreSQL.Internal.Where (WhereCondition, whereIn, (.==), whereAnd, whereOr)
 
+{-|
+  'primaryKeyIn' builds a 'WhereCondition' that will match all rows where the
+  primary key is equal to one of the given values. For single-field primary
+  keys this is equivalent to 'whereIn', but 'primaryKeyIn' also handles
+  composite primary keys.
+-}
 primaryKeyIn :: PrimaryKey key -> [key] -> WhereCondition
 primaryKeyIn keyDef@(PrimaryKey first rest) keys =
   case rest of
@@ -25,10 +31,16 @@ primaryKeyIn keyDef@(PrimaryKey first rest) keys =
       -- than a large OR
       case first of
         PrimaryKeyPart getPart field ->
-          field .<- map getPart keys
+          whereIn field (map getPart keys)
     _ ->
       whereOr (map (primaryKeyEquals keyDef) keys)
 
+{-|
+  'primaryKeyEquals' builds a 'WhereCondition' that will match the row where
+  the primary key is equal to the given value. For single-field primary keys
+  this is equivalent to '.==', but 'primaryKeyEquals also handles composite
+  primary keys.
+-}
 primaryKeyEquals :: PrimaryKey key -> key -> WhereCondition
 primaryKeyEquals keyDef key =
   let
@@ -37,6 +49,11 @@ primaryKeyEquals keyDef key =
   in
     whereAnd (mapPrimaryKeyParts partEq keyDef)
 
+{-|
+  'primaryKeyDescription' builds a user-readable representation of the
+  primary key for use in error messages and such. It is a comma-delimited
+  list of the names of the fields that make up the primary key.
+-}
 primaryKeyDescription :: PrimaryKey key -> String
 primaryKeyDescription keyDef =
   let
@@ -45,6 +62,11 @@ primaryKeyDescription keyDef =
   in
     List.intercalate ", " (mapPrimaryKeyParts partName keyDef)
 
+{-|
+  'primaryKeyToSql' converts a Haskell value for a primary key into the
+  (possibly multiple) sql values that represent the primary key in the
+  database.
+-}
 primaryKeyToSql :: PrimaryKey key -> key -> [HDBC.SqlValue]
 primaryKeyToSql keyDef key =
   let
@@ -53,22 +75,51 @@ primaryKeyToSql keyDef key =
   in
     mapPrimaryKeyParts partSqlValue keyDef
 
+{-|
+  'primaryKey' constructs a single-field primary key from the 'FieldDefinition'
+  that corresponds to the primary key's column. This is generally used while
+  building a 'TableDefinition'.
+-}
 primaryKey :: FieldDefinition NotNull key -> PrimaryKey key
 primaryKey fieldDef =
   PrimaryKey (PrimaryKeyPart id fieldDef) []
 
+{-|
+  'compositePrimaryKey' constructs a multi-field primary key from the given
+  parts, each of which corresponds to one field in the primary key.  You should
+  use this while building a 'TableDefinition' for a table that you want to have
+  a multi-column primary key. See 'primaryKeyPart' for how to build the parts
+  to be passed as parameters. Note: there is no special significance to the
+  first argument other than requiring that there is at least one field in the
+  primary key.
+-}
 compositePrimaryKey :: PrimaryKeyPart key
                     -> [PrimaryKeyPart key]
                     -> PrimaryKey key
 compositePrimaryKey =
   PrimaryKey
 
+{-|
+  'primaryKeyPart' builds on section of a composite primary key based on the
+  field definition that corresponds to that column of the primary key. The
+  function given is used to decompose the Haskell value for the composite key
+  into the individual parts so they can be converted to sql for things like
+  building 'WhereCondition'
+-}
 primaryKeyPart :: (key -> part)
                -> FieldDefinition NotNull part
                -> PrimaryKeyPart key
 primaryKeyPart =
   PrimaryKeyPart
 
+{-|
+  'mapPrimaryKeyParts' provides a way to access the innards of a 'PrimaryKey'
+  definition to extract information. The given function will be called on
+  each part of the primary key in order and the list of results is returned.
+  Note that single-field and multi-field primary keys are treated the same by
+  this function, with the single-field case simply behaving as composite key
+  with just one part.
+-}
 mapPrimaryKeyParts :: (forall part.
                          (key -> part)
                         -> FieldDefinition NotNull part

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/RelationalMap.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/RelationalMap.hs
@@ -49,7 +49,7 @@ data TableParams readEntity writeEntity key = TableParams
   , tblSafeToDelete :: [String]
       -- ^ A list of any columns that may be deleted from the table by Orville.
       -- (Orville will never delete a column without being told it is safe)
-  , tblPrimaryKey :: FieldDefinition NotNull key
+  , tblPrimaryKey :: PrimaryKey key
       -- ^ A function to set the key on the entity
   , tblGetKey :: readEntity -> key
       -- ^ A function to get the key on the entity

--- a/orville-postgresql/test/AppManagedEntity/CrudTest.hs
+++ b/orville-postgresql/test/AppManagedEntity/CrudTest.hs
@@ -1,6 +1,7 @@
 module AppManagedEntity.CrudTest where
 
 import Control.Monad (void)
+import qualified Data.Map as Map
 
 import qualified Database.Orville.PostgreSQL as O
 
@@ -37,7 +38,23 @@ test_crud =
             "Virus found in database didn't match the originally inserted values"
             (Just insertedVirus)
             foundVirus
-        --
+
+      , testCase "Insert and find many" $ do
+          let bpsId = VirusId 1234
+              brnId = VirusId 5678
+
+              bpsVirus = Virus bpsId bpsVirusName bpsDiscoveredAt
+              brnVirus = Virus brnId brnVirusName brnDiscoveredAt
+
+          run (TestDB.reset schema)
+          () <- run (O.insertRecordMany virusTable [bpsVirus, brnVirus])
+
+          foundViruses <- run $ O.findRecords virusTable [bpsId, brnId]
+          assertEqual
+            "Viruses found in database didn't match the originally inserted values"
+            (Map.fromList [(bpsId, bpsVirus), (brnId, brnVirus)])
+            foundViruses
+
       , testCase "Update" $ do
           let testId = VirusId 1234
               bpsVirus = Virus testId bpsVirusName bpsDiscoveredAt

--- a/orville-postgresql/test/AppManagedEntity/Data/Virus.hs
+++ b/orville-postgresql/test/AppManagedEntity/Data/Virus.hs
@@ -24,7 +24,7 @@ data Virus = Virus
 
 newtype VirusId = VirusId
   { unVirusId :: Int64
-  } deriving (Bounded, Enum, Eq, Show)
+  } deriving (Bounded, Enum, Eq, Show, Ord)
 
 newtype VirusName = VirusName
   { unVirusName :: Text

--- a/orville-postgresql/test/AppManagedEntity/Schema/Virus.hs
+++ b/orville-postgresql/test/AppManagedEntity/Schema/Virus.hs
@@ -18,7 +18,7 @@ virusTable =
   O.mkTableDefinition $
   O.TableParams
     { O.tblName = "virus"
-    , O.tblPrimaryKey = virusIdField
+    , O.tblPrimaryKey = O.primaryKey virusIdField
     , O.tblMapper =
         Virus
         <$> O.attrField virusId virusIdField
@@ -31,7 +31,7 @@ virusTable =
 
 virusIdField :: O.FieldDefinition O.NotNull VirusId
 virusIdField =
-  O.int64Field "id" `O.withFlag` O.PrimaryKey `O.withConversion`
+  O.int64Field "id" `O.withConversion`
   O.convertSqlType unVirusId VirusId
 
 virusNameField :: O.FieldDefinition O.NotNull VirusName

--- a/orville-postgresql/test/CompositePrimaryKey/CrudTest.hs
+++ b/orville-postgresql/test/CompositePrimaryKey/CrudTest.hs
@@ -1,0 +1,100 @@
+module CompositePrimaryKey.CrudTest where
+
+import Control.Monad (void)
+import qualified Control.Monad.Catch as Catch
+import qualified Data.Map as Map
+import qualified Data.Text as T
+import qualified Database.HDBC as HDBC
+
+import qualified Database.Orville.PostgreSQL as O
+
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertEqual, assertFailure, testCase)
+
+import CompositePrimaryKey.Data.Virus
+  ( Virus(..)
+  , VirusName(..)
+  , bpsVirus
+  , brnVirus
+  , virusKey
+  )
+import CompositePrimaryKey.Schema (schema, virusTable)
+import qualified TestDB as TestDB
+
+test_crud :: TestTree
+test_crud =
+  TestDB.withOrvilleRun $ \run ->
+    testGroup
+      "CompositePrimaryKey CRUD Test"
+      [ testCase "Insert and find" $ do
+          run (TestDB.reset schema)
+          insertedVirus <- run (O.insertRecord virusTable bpsVirus)
+          assertEqual
+            "Virus returned from insertRecord didn't match input virus"
+            bpsVirus
+            insertedVirus
+          foundVirus <- run $ O.findRecord virusTable (virusKey bpsVirus)
+          assertEqual
+            "Virus found in database didn't match the originally inserted values"
+            (Just insertedVirus)
+            foundVirus
+
+      , testCase "Insert and find many" $ do
+          let
+            bpsKey = virusKey bpsVirus
+            brnKey = virusKey brnVirus
+
+          run (TestDB.reset schema)
+          () <- run (O.insertRecordMany virusTable [bpsVirus, brnVirus])
+
+          foundViruses <- run $ O.findRecords virusTable [bpsKey, brnKey]
+          assertEqual
+            "Viruses found in database didn't match the originally inserted values"
+            (Map.fromList [(bpsKey, bpsVirus), (brnKey, brnVirus)])
+            foundViruses
+
+      , testCase "Update" $ do
+          let
+            newBPSVirus =
+              bpsVirus
+                { virusName = VirusName (T.pack "Bovine UNpopular stomachitis")
+                }
+
+          run (TestDB.reset schema)
+          void (run (O.insertRecord virusTable bpsVirus))
+          run $ O.updateRecord virusTable (virusKey bpsVirus) newBPSVirus
+
+          newlyFoundVirus <- run $ O.findRecord virusTable (virusKey bpsVirus)
+          assertEqual
+            "Virus found in database didn't match the values passed in for update"
+            (Just newBPSVirus)
+            newlyFoundVirus
+        --
+      , testCase "Delete" $ do
+          run (TestDB.reset schema)
+          foundDeletedVirus <-
+            run $ do
+              void $ O.insertRecord virusTable bpsVirus
+              O.deleteRecord virusTable (virusKey bpsVirus)
+              O.findRecord virusTable (virusKey bpsVirus)
+          assertEqual
+            "Virus was found in the database, but it should have been deleted"
+            Nothing
+            foundDeletedVirus
+
+      , testCase "Insert conflicting primary keys" $ do
+          run (TestDB.reset schema)
+          eitherErrorVirus <- run $ do
+            void $ O.insertRecord virusTable bpsVirus
+            Catch.try (O.insertRecord virusTable bpsVirus)
+
+          case eitherErrorVirus of
+            Left sqlError ->
+              assertEqual
+                "Expected a duplicate key constraint violation"
+                "23505"
+                (HDBC.seState sqlError)
+
+            Right _ ->
+              assertFailure "Expected second insert to fail, but it did not!"
+      ]

--- a/orville-postgresql/test/CompositePrimaryKey/Data/Virus.hs
+++ b/orville-postgresql/test/CompositePrimaryKey/Data/Virus.hs
@@ -1,0 +1,56 @@
+module CompositePrimaryKey.Data.Virus
+  ( Virus(..)
+  , VirusType(..)
+  , VirusSubType(..)
+  , VirusName(..)
+  , VirusKey
+  , virusKey
+  , bpsVirus
+  , brnVirus
+  ) where
+
+import Data.Text (Text)
+import qualified Data.Text as T
+
+data Virus = Virus
+  { virusType     :: VirusType
+  , virusSubType  :: VirusSubType
+  , virusName     :: VirusName
+  } deriving (Show, Eq)
+
+newtype VirusType = VirusType
+  { unVirusType :: Text
+  } deriving (Show, Eq, Ord)
+
+newtype VirusSubType = VirusSubType
+  { unVirusSubType :: Text
+  } deriving (Show, Eq, Ord)
+
+newtype VirusName = VirusName
+  { unVirusName :: Text
+  } deriving (Show, Eq)
+
+type VirusKey = (VirusType, VirusSubType)
+
+virusKey :: Virus -> VirusKey
+virusKey virus =
+  ( virusType virus
+  , virusSubType virus
+  )
+
+bpsVirus :: Virus
+bpsVirus =
+  Virus
+    { virusType     = VirusType (T.pack "stomachitis")
+    , virusSubType  = VirusSubType (T.pack "bovine")
+    , virusName     = VirusName (T.pack "Bovine popular stomachitis")
+    }
+
+brnVirus :: Virus
+brnVirus =
+  Virus
+    { virusType     = VirusType (T.pack "necrosis")
+    , virusSubType  = VirusSubType (T.pack "black-raspberry")
+    , virusName     = VirusName (T.pack "Black raspberry necrosis")
+    }
+

--- a/orville-postgresql/test/CompositePrimaryKey/Schema.hs
+++ b/orville-postgresql/test/CompositePrimaryKey/Schema.hs
@@ -1,0 +1,11 @@
+module CompositePrimaryKey.Schema
+  ( module CompositePrimaryKey.Schema
+  , module CompositePrimaryKey.Schema.Virus
+  ) where
+
+import qualified Database.Orville.PostgreSQL as O
+
+import CompositePrimaryKey.Schema.Virus
+
+schema :: O.SchemaDefinition
+schema = [O.Table virusTable]

--- a/orville-postgresql/test/CompositePrimaryKey/Schema/Virus.hs
+++ b/orville-postgresql/test/CompositePrimaryKey/Schema/Virus.hs
@@ -1,0 +1,53 @@
+module CompositePrimaryKey.Schema.Virus
+  ( virusTable
+  , virusTypeField
+  , virusSubTypeField
+  , virusNameField
+  ) where
+
+import qualified Database.Orville.PostgreSQL as O
+
+import CompositePrimaryKey.Data.Virus(
+    Virus(..)
+  , VirusKey
+  , VirusType(..)
+  , VirusSubType(..)
+  , VirusName(..)
+  , virusKey
+  )
+
+virusTable :: O.TableDefinition Virus Virus VirusKey
+virusTable =
+  O.mkTableDefinition $
+  O.TableParams
+    { O.tblName = "virus"
+    , O.tblPrimaryKey =
+      O.compositePrimaryKey
+         (O.primaryKeyPart fst virusTypeField)
+         [O.primaryKeyPart snd virusSubTypeField]
+
+    , O.tblMapper =
+        Virus
+        <$> O.attrField virusType virusTypeField
+        <*> O.attrField virusSubType virusSubTypeField
+        <*> O.attrField virusName virusNameField
+    , O.tblGetKey = virusKey
+    , O.tblSafeToDelete = []
+    , O.tblComments = O.noComments
+    }
+
+virusTypeField :: O.FieldDefinition O.NotNull VirusType
+virusTypeField =
+  O.textField "type" 255 `O.withConversion`
+  O.convertSqlType unVirusType VirusType
+
+virusSubTypeField :: O.FieldDefinition O.NotNull VirusSubType
+virusSubTypeField =
+  O.textField "subtype" 255 `O.withConversion`
+  O.convertSqlType unVirusSubType VirusSubType
+
+virusNameField :: O.FieldDefinition O.NotNull VirusName
+virusNameField =
+  O.textField "name" 255 `O.withConversion`
+  O.convertSqlType unVirusName VirusName
+

--- a/orville-postgresql/test/ConduitTest.hs
+++ b/orville-postgresql/test/ConduitTest.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module ConduitTest where
 
 import Control.Monad.Trans.Resource (runResourceT)
@@ -14,7 +15,7 @@ import Test.Tasty.HUnit (assertEqual, testCase)
 
 import qualified TestDB
 
-import AppManagedEntity.Data.Virus (bpsVirus, brnVirus)
+import AppManagedEntity.Data.Virus (bpsVirus, brnVirus, virusId)
 import AppManagedEntity.Schema (schema, virusIdField, virusTable)
 
 test_conduit :: TestTree
@@ -40,6 +41,7 @@ test_conduit =
             [bpsVirus, brnVirus]
             actual
 
+#if MIN_VERSION_conduit(1,3,0)
     , TestDB.withOrvilleRun $ \run -> do
         testCase "streamPages can read all result rows" $ do
           actual <-
@@ -51,6 +53,8 @@ test_conduit =
                 fuse
                   (OC.streamPages
                      virusTable
+                     virusIdField
+                     virusId
                      Nothing
                      20)
                   consume
@@ -58,4 +62,5 @@ test_conduit =
             "Expected all viruses to be loaded by conduit"
             [bpsVirus, brnVirus]
             actual
+#endif
     ]

--- a/orville-postgresql/test/EntityWrapper/Schema/Virus.hs
+++ b/orville-postgresql/test/EntityWrapper/Schema/Virus.hs
@@ -14,7 +14,7 @@ virusTable =
   O.mkTableDefinition $
   O.TableParams
     { O.tblName = "virus"
-    , O.tblPrimaryKey = virusIdField
+    , O.tblPrimaryKey = O.primaryKey virusIdField
     , O.tblMapper
       -- hindent ;(
        =
@@ -27,7 +27,7 @@ virusTable =
 
 virusIdField :: O.FieldDefinition O.NotNull VirusId
 virusIdField =
-  O.automaticIdField "id" `O.withFlag` O.PrimaryKey `O.withConversion`
+  O.automaticIdField "id" `O.withConversion`
   O.convertSqlType unVirusId VirusId
 
 virusNameField :: O.FieldDefinition O.NotNull VirusName

--- a/orville-postgresql/test/Migrations/Entity.hs
+++ b/orville-postgresql/test/Migrations/Entity.hs
@@ -26,7 +26,7 @@ migrationEntityTable fieldDef =
   O.mkTableDefinition $
   O.TableParams
     { O.tblName = "migrationEntity"
-    , O.tblPrimaryKey = migrationEntityIdField
+    , O.tblPrimaryKey = O.primaryKey migrationEntityIdField
     , O.tblMapper =
       MigrationEntity
         <$> O.readOnlyField migrationEntityIdField
@@ -44,7 +44,7 @@ migrationEntityTableWithDroppedColumn columnName =
   O.mkTableDefinition $
   O.TableParams
     { O.tblName = "migrationEntity"
-    , O.tblPrimaryKey = migrationEntityIdField
+    , O.tblPrimaryKey = O.primaryKey migrationEntityIdField
     , O.tblMapper =
       MigrationEntity
         <$> O.readOnlyField migrationEntityIdField
@@ -56,6 +56,6 @@ migrationEntityTableWithDroppedColumn columnName =
 
 migrationEntityIdField :: O.FieldDefinition O.NotNull MigrationEntityId
 migrationEntityIdField =
-  O.automaticIdField "id" `O.withFlag` O.PrimaryKey `O.withConversion`
+  O.automaticIdField "id" `O.withConversion`
   O.convertSqlType unMigrationEntityId MigrationEntityId
 

--- a/orville-postgresql/test/OptionalMap/Entity.hs
+++ b/orville-postgresql/test/OptionalMap/Entity.hs
@@ -26,7 +26,7 @@ badCrudEntityTable =
   O.mkTableDefinition $
   O.TableParams
     { O.tblName = "crudEntity"
-    , O.tblPrimaryKey = crudEntityIdField
+    , O.tblPrimaryKey = O.primaryKey crudEntityIdField
     , O.tblMapper =
       CrudEntity
         <$> O.readOnlyField crudEntityIdField
@@ -38,7 +38,7 @@ badCrudEntityTable =
 
 crudEntityIdField :: O.FieldDefinition O.NotNull CrudEntityId
 crudEntityIdField =
-  O.automaticIdField "id" `O.withFlag` O.PrimaryKey `O.withConversion`
+  O.automaticIdField "id" `O.withConversion`
   O.convertSqlType unCrudEntityId CrudEntityId
 
 badComplexFieldMap :: O.RelationalMap ComplexField ComplexField

--- a/orville-postgresql/test/ParameterizedEntity/Schema/Virus.hs
+++ b/orville-postgresql/test/ParameterizedEntity/Schema/Virus.hs
@@ -13,7 +13,7 @@ virusTable =
   O.mkTableDefinition $
   O.TableParams
     { O.tblName = "virus"
-    , O.tblPrimaryKey = virusIdField
+    , O.tblPrimaryKey = O.primaryKey virusIdField
     , O.tblMapper
       -- hindent ;(
        =
@@ -26,7 +26,7 @@ virusTable =
 
 virusIdField :: O.FieldDefinition O.NotNull VirusId
 virusIdField =
-  O.automaticIdField "id" `O.withFlag` O.PrimaryKey `O.withConversion`
+  O.automaticIdField "id" `O.withConversion`
   O.convertSqlType unVirusId VirusId
 
 virusNameField :: O.FieldDefinition O.NotNull VirusName

--- a/orville-postgresql/test/PopperTest.hs
+++ b/orville-postgresql/test/PopperTest.hs
@@ -166,7 +166,7 @@ rootTable =
   O.mkTableDefinition $
   O.TableParams
     { O.tblName = "root"
-    , O.tblPrimaryKey = rootIdField
+    , O.tblPrimaryKey = O.primaryKey rootIdField
     , O.tblMapper =
         Root <$> O.attrField rootId rootIdField <*>
         O.attrField rootTreeId treeIdField
@@ -180,7 +180,7 @@ branchTable =
   O.mkTableDefinition $
   O.TableParams
     { O.tblName = "branch"
-    , O.tblPrimaryKey = branchIdField
+    , O.tblPrimaryKey = O.primaryKey branchIdField
     , O.tblMapper =
         Branch <$> O.attrField branchId branchIdField <*>
         O.attrField branchTreeId treeIdField
@@ -194,7 +194,7 @@ leafTable =
   O.mkTableDefinition $
   O.TableParams
     { O.tblName = "leaf"
-    , O.tblPrimaryKey = leafIdField
+    , O.tblPrimaryKey = O.primaryKey leafIdField
     , O.tblMapper =
         Leaf <$> O.attrField leafId leafIdField <*>
         O.attrField leafBranchId branchForeignIdField

--- a/orville-postgresql/test/StrangeFieldNames/Entity.hs
+++ b/orville-postgresql/test/StrangeFieldNames/Entity.hs
@@ -23,7 +23,7 @@ crudEntityTable columnName =
   O.mkTableDefinition $
   O.TableParams
     { O.tblName = "crudEntity"
-    , O.tblPrimaryKey = crudEntityIdField
+    , O.tblPrimaryKey = O.primaryKey crudEntityIdField
     , O.tblMapper =
       CrudEntity
         <$> O.readOnlyField crudEntityIdField
@@ -35,7 +35,7 @@ crudEntityTable columnName =
 
 crudEntityIdField :: O.FieldDefinition O.NotNull CrudEntityId
 crudEntityIdField =
-  O.automaticIdField "id" `O.withFlag` O.PrimaryKey `O.withConversion`
+  O.automaticIdField "id" `O.withConversion`
   O.convertSqlType unCrudEntityId CrudEntityId
 
 crudEntityRenameableField :: String -> O.FieldDefinition O.NotNull Int32

--- a/orville-postgresql/test/WhereConditionTest.hs
+++ b/orville-postgresql/test/WhereConditionTest.hs
@@ -130,7 +130,7 @@ orderTable =
   O.mkTableDefinition $
   O.TableParams
     { O.tblName = "order"
-    , O.tblPrimaryKey = orderIdField
+    , O.tblPrimaryKey = O.primaryKey orderIdField
     , O.tblMapper =
         Order <$> O.attrField orderId orderIdField <*>
         O.attrField customerFkId customerFkIdField <*>
@@ -142,7 +142,7 @@ orderTable =
 
 orderIdField :: O.FieldDefinition O.NotNull OrderId
 orderIdField =
-  O.int64Field "id" `O.withFlag` O.PrimaryKey `O.withConversion`
+  O.int64Field "id" `O.withConversion`
   O.convertSqlType unOrderId OrderId
 
 customerFkIdField :: O.FieldDefinition O.NotNull CustomerId
@@ -208,7 +208,7 @@ customerTable =
   O.mkTableDefinition $
   O.TableParams
     { O.tblName = "customer"
-    , O.tblPrimaryKey = customerIdField
+    , O.tblPrimaryKey = O.primaryKey customerIdField
     , O.tblMapper =
         Customer <$> O.attrField customerId customerIdField <*>
         O.attrField customerName customerNameField
@@ -219,7 +219,7 @@ customerTable =
 
 customerIdField :: O.FieldDefinition O.NotNull CustomerId
 customerIdField =
-  O.int64Field "id" `O.withFlag` O.PrimaryKey `O.withConversion`
+  O.int64Field "id" `O.withConversion`
   O.convertSqlType unCustomerId CustomerId
 
 customerNameField :: O.FieldDefinition O.NotNull CustomerName


### PR DESCRIPTION
This gives the `tablePrimaryKey` field of `TableDefinition` a rich
`PrimaryKey` data type that can represent composite primary keys and
updates the requisite places to make this work.

The `PrimaryKey` flag is now removed and the migration logic uses the
`tablePrimaryKey` field to determine how to create the primary key.
(Primary key migration is not currently support, and will not be until
we get moved to libpq at which point we may re-evaluate it).

The API remains relatively unchanged in most parts. The streaming
pagination needed to be changed to take a field defintion rather use
`tablePrimaryKey` to determine the ordering of the pagination because
using a composite primary key as the key for pagination will not work
due to ambiguity of ordering correctly on the multiple fields. On the
bright side, this means you can now pagination on any field you choose
rather than being restricted to the primary key field.