### PR TITLE
Make DataRowError More Informative

### DIFF
--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Core.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Core.hs
@@ -101,6 +101,13 @@ module Database.Orville.PostgreSQL.Core
   , dropConstraint
   , FromSql
   , FromSqlError(..)
+  , RowDataErrorDetails(..)
+  , RowDataErrorReason(..)
+  , MissingColumnDetails(..)
+  , ConversionErrorDetails(..)
+  , showFromSqlErrorMinimal
+  , showFromSqlErrorForLogging
+  , showSqlValueType
   , ColumnSpecifier(..)
   , col
   , ToSql

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/FieldDefinition.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/FieldDefinition.hs
@@ -157,5 +157,5 @@ fieldToNameForm field = NameForm Nothing (fieldName field)
 fieldToSqlValue :: FieldDefinition nullability a -> a -> SqlValue
 fieldToSqlValue = sqlTypeToSql . fieldType
 
-fieldFromSqlValue :: FieldDefinition nullability a -> SqlValue -> Either String a
+fieldFromSqlValue :: FieldDefinition nullability a -> SqlValue -> Either RowDataErrorReason a
 fieldFromSqlValue = sqlTypeFromSql . fieldType

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/FieldDefinition.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/FieldDefinition.hs
@@ -63,7 +63,7 @@ nullableField field =
             \sql ->
               case sql of
                 SqlNull ->
-                  Just Nothing
+                  Right Nothing
 
                 _ ->
                   Just <$> sqlTypeFromSql sqlType sql
@@ -157,5 +157,5 @@ fieldToNameForm field = NameForm Nothing (fieldName field)
 fieldToSqlValue :: FieldDefinition nullability a -> a -> SqlValue
 fieldToSqlValue = sqlTypeToSql . fieldType
 
-fieldFromSqlValue :: FieldDefinition nullability a -> SqlValue -> Maybe a
+fieldFromSqlValue :: FieldDefinition nullability a -> SqlValue -> Either String a
 fieldFromSqlValue = sqlTypeFromSql . fieldType

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/FromSql.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/FromSql.hs
@@ -37,12 +37,12 @@ fieldFromSql field =
   where
     fromSqlValue sql =
       case fieldFromSqlValue field sql of
-        Just a -> Right a
-        Nothing ->
+        Right a -> Right a
+        Left err ->
           Left $
           RowDataError $
           concat
-            ["Error decoding data from column ", fieldName field, " value"]
+            ["Error decoding data from column '", fieldName field, "': ", err]
 
 class ColumnSpecifier col where
   selectForm :: col -> SelectForm

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/SqlType.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/SqlType.hs
@@ -15,6 +15,7 @@ module Database.Orville.PostgreSQL.Internal.SqlType
   , foreignRefType
   , convertSqlType
   , maybeConvertSqlType
+  , eitherConvertSqlType
   ) where
 
 import Control.Monad ((<=<))
@@ -49,11 +50,11 @@ data SqlType a = SqlType
   , sqlTypeToSql :: a -> HDBC.SqlValue
     -- ^ A function for converting Haskell values of this type into values to
     -- be stored in the database.
-  , sqlTypeFromSql :: HDBC.SqlValue -> Maybe a
+  , sqlTypeFromSql :: HDBC.SqlValue -> Either String a
     -- ^ A function for converting values of this are stored in the database
-    -- into Haskell values. This function should return 'Nothing' to indicate
-    -- an error if the conversion is impossible. Otherwise it should return
-    -- 'Just' the corresponding 'a' value.
+    -- into Haskell values. This function should return 'Left String' to
+    -- indicate an error if the conversion is impossible. Otherwise it should
+    -- return 'Right' the corresponding @a@ value.
   }
 
 {-|
@@ -257,15 +258,27 @@ foreignRefType sqlType =
     Just refDDL -> sqlType {sqlTypeDDL = refDDL, sqlTypeReferenceDDL = Nothing}
 
 {-|
-  'maybeConvertSqlType' changes the Haskell type used by a 'SqlType' which changing
-  the column type that will be used in the database schema. The functions given
-  will be used to convert the now Haskell type to and from the original type when
-  reading and writing values from the database. When reading an 'a' value from
-  the database, the conversion function should produce 'Nothing' if the value
-  cannot be successfully converted to a 'b'
+  'maybeConvertSqlType' changes the Haskell type used by a 'SqlType' without
+  changing the column type that will be used in the database schema. The
+  functions given will be used to convert the now Haskell type to and from the
+  original type when reading and writing values from the database. When reading
+  an @a@ value from the database, the conversion function should produce
+  'Nothing' if the value cannot be successfully converted to a @b@.
   -}
 maybeConvertSqlType :: (b -> a) -> (a -> Maybe b) -> SqlType a -> SqlType b
-maybeConvertSqlType bToA aToB sqlType =
+maybeConvertSqlType bToA aToB =
+  eitherConvertSqlType bToA (maybe (Left "Conversion failed") Right . aToB)
+
+{-|
+  'eitherConvertSqlType' changes the Haskell type used by a 'SqlType' without
+  changing the column type that will be used in the database schema. The
+  functions given will be used to convert the new Haskell type to and from the
+  original type when reading and writing values from the database. When reading
+  an @a@ value from the database, the conversion function should produce
+  @Left "reason"@ if the value cannot be successfully converted to a @b@.
+-}
+eitherConvertSqlType :: (b -> a) -> (a -> Either String b) -> SqlType a -> SqlType b
+eitherConvertSqlType bToA aToB sqlType =
   sqlType
     { sqlTypeToSql = sqlTypeToSql sqlType . bToA
     , sqlTypeFromSql = aToB <=< sqlTypeFromSql sqlType
@@ -281,75 +294,107 @@ convertSqlType bToA aToB = maybeConvertSqlType bToA (Just . aToB)
 int32ToSql :: Int.Int32 -> HDBC.SqlValue
 int32ToSql = HDBC.SqlInt32
 
-int32FromSql :: HDBC.SqlValue -> Maybe Int.Int32
+int32FromSql :: HDBC.SqlValue -> Either String Int.Int32
 int32FromSql sql =
   case sql of
-    HDBC.SqlInt32 n -> Just n
+    HDBC.SqlInt32 n -> Right n
     HDBC.SqlInteger n -> toBoundedInteger n
-    _ -> Nothing
+    sqlValue -> Left $ mismatchError "int32" sqlValue
 
 int64ToSql :: Int.Int64 -> HDBC.SqlValue
 int64ToSql = HDBC.SqlInt64
 
-int64FromSql :: HDBC.SqlValue -> Maybe Int.Int64
+int64FromSql :: HDBC.SqlValue -> Either String Int.Int64
 int64FromSql sql =
   case sql of
-    HDBC.SqlInt64 n -> Just n
+    HDBC.SqlInt64 n -> Right n
     HDBC.SqlInteger n -> toBoundedInteger n
-    _ -> Nothing
+    sqlValue -> Left $ mismatchError "int64" sqlValue
 
 textToSql :: T.Text -> HDBC.SqlValue
 textToSql = HDBC.SqlByteString . Enc.encodeUtf8
 
-textFromSql :: HDBC.SqlValue -> Maybe T.Text
+textFromSql :: HDBC.SqlValue -> Either String T.Text
 textFromSql sql =
   case sql of
-    HDBC.SqlByteString bytes -> Just $ Enc.decodeUtf8 bytes
-    HDBC.SqlString string -> Just $ T.pack string
-    _ -> Nothing
+    HDBC.SqlByteString bytes -> Right $ Enc.decodeUtf8 bytes
+    HDBC.SqlString string -> Right $ T.pack string
+    sqlValue -> Left $ mismatchError "text" sqlValue
 
 doubleToSql :: Double -> HDBC.SqlValue
 doubleToSql = HDBC.SqlDouble
 
-doubleFromSql :: HDBC.SqlValue -> Maybe Double
+doubleFromSql :: HDBC.SqlValue -> Either String Double
 doubleFromSql sql =
   case sql of
-    HDBC.SqlDouble d -> Just d
-    _ -> Nothing
+    HDBC.SqlDouble d -> Right d
+    sqlValue -> Left $ mismatchError "double" sqlValue
 
 booleanToSql :: Bool -> HDBC.SqlValue
 booleanToSql = HDBC.SqlBool
 
-booleanFromSql :: HDBC.SqlValue -> Maybe Bool
+booleanFromSql :: HDBC.SqlValue -> Either String Bool
 booleanFromSql sql =
   case sql of
-    HDBC.SqlBool b -> Just b
-    _ -> Nothing
+    HDBC.SqlBool b -> Right b
+    sqlValue -> Left $ mismatchError "boolean" sqlValue
 
 dayToSql :: Time.Day -> HDBC.SqlValue
 dayToSql = HDBC.SqlLocalDate
 
-dayFromSql :: HDBC.SqlValue -> Maybe Time.Day
+dayFromSql :: HDBC.SqlValue -> Either String Time.Day
 dayFromSql sql =
   case sql of
-    HDBC.SqlLocalDate d -> Just d
-    _ -> Nothing
+    HDBC.SqlLocalDate d -> Right d
+    sqlValue -> Left $ mismatchError "day" sqlValue
 
 utcTimeToSql :: Time.UTCTime -> HDBC.SqlValue
 utcTimeToSql = HDBC.SqlUTCTime
 
-utcTimeFromSql :: HDBC.SqlValue -> Maybe Time.UTCTime
+utcTimeFromSql :: HDBC.SqlValue -> Either String Time.UTCTime
 utcTimeFromSql sql =
   case sql of
-    HDBC.SqlUTCTime   t -> Just t
-    HDBC.SqlZonedTime t -> Just (Time.zonedTimeToUTC t)
-    _ -> Nothing
+    HDBC.SqlUTCTime   t -> Right t
+    HDBC.SqlZonedTime t -> Right (Time.zonedTimeToUTC t)
+    sqlValue -> Left $ mismatchError "UTC time" sqlValue
 
-toBoundedInteger :: (Bounded num, Integral num) => Integer -> Maybe num
+toBoundedInteger :: (Bounded num, Integral num) => Integer -> Either String num
 toBoundedInteger source =
   let truncated = fromInteger source
       upper = toInteger (maxBound `asTypeOf` truncated)
       lower = toInteger (minBound `asTypeOf` truncated)
    in if lower <= source && source <= upper
-        then Just truncated
-        else Nothing
+        then Right truncated
+        else Left "Integral out of range"
+
+-- | Error text for when the expected type doesn't match the Sql type
+mismatchError :: String -> HDBC.SqlValue -> String
+mismatchError expected actual =
+  "Expected " <> expected <> ", got " <> sqlValueIdentifier actual
+
+-- | User friendly identifier labels for 'SqlValues'
+sqlValueIdentifier :: HDBC.SqlValue -> String
+sqlValueIdentifier v =
+  case v of
+    HDBC.SqlString _ -> "string"
+    HDBC.SqlByteString _ -> "bytestring"
+    HDBC.SqlWord32 _ -> "word32"
+    HDBC.SqlWord64 _ -> "word64"
+    HDBC.SqlInt32 _ -> "int32"
+    HDBC.SqlInt64 _ -> "int64"
+    HDBC.SqlInteger _ -> "integer"
+    HDBC.SqlChar _ -> "char"
+    HDBC.SqlBool _ -> "bool"
+    HDBC.SqlDouble _ -> "double"
+    HDBC.SqlRational _ -> "rational"
+    HDBC.SqlLocalDate _ -> "local date"
+    HDBC.SqlLocalTimeOfDay _ -> "time of day"
+    HDBC.SqlZonedLocalTimeOfDay _ _ -> "zoned local time of day"
+    HDBC.SqlLocalTime _ -> "local time"
+    HDBC.SqlZonedTime _ -> "zoned time"
+    HDBC.SqlUTCTime _ -> "utc time"
+    HDBC.SqlDiffTime _ -> "diff time"
+    HDBC.SqlPOSIXTime _ -> "POSIX time"
+    HDBC.SqlEpochTime _ -> "epoch time"
+    HDBC.SqlTimeDiff _ -> "time diff"
+    HDBC.SqlNull -> "null"

--- a/orville-postgresql/test/ErrorsTest.hs
+++ b/orville-postgresql/test/ErrorsTest.hs
@@ -8,7 +8,7 @@ import qualified Database.Orville.PostgreSQL as O
 import qualified Database.Orville.PostgreSQL.Select as S
 
 import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.HUnit (assertFailure, testCase)
+import Test.Tasty.HUnit (assertEqual, assertFailure, testCase)
 
 import ParameterizedEntity.Data.Virus (VirusId, bpsVirus)
 
@@ -42,6 +42,17 @@ test_errors =
             Right rows ->
               assertFailure
                 ("Expected RowDataError, but got these rows: " ++ show rows)
+
+      , testCase "Includes primary key in error message" $ do
+          run (TestDB.reset schema)
+          void $ run (O.insertRecord virusTable bpsVirus)
+          result <- run $ try (O.selectAll badVirusTable mempty)
+          let expectedErr =
+                "Error decoding data from column 'name': Expected int32, got bytestring (id: SqlInteger 1)"
+          case result of
+            Left (O.RowDataError err) ->
+              assertEqual "Error message contains primary key" expectedErr err
+            _ -> assertFailure "Did not raise a RowDataError"
       ]
 
 data BadVirus = BadVirus
@@ -55,3 +66,18 @@ badVirusNameField = virusNameField `O.withConversion` const O.integer
 badVirusFromSql :: O.FromSql BadVirus
 badVirusFromSql =
   BadVirus <$> O.fieldFromSql virusIdField <*> O.fieldFromSql badVirusNameField
+
+badVirusTable :: O.TableDefinition BadVirus BadVirus VirusId
+badVirusTable =
+  O.mkTableDefinition $
+  O.TableParams
+    { O.tblName = "virus"
+    , O.tblPrimaryKey = O.primaryKey virusIdField
+    , O.tblMapper =
+        BadVirus
+        <$> O.attrField badVirusId virusIdField
+        <*> O.attrField badVirusName badVirusNameField
+    , O.tblGetKey = badVirusId
+    , O.tblSafeToDelete = []
+    , O.tblComments = O.noComments
+    }

--- a/orville-postgresql/test/ErrorsTest.hs
+++ b/orville-postgresql/test/ErrorsTest.hs
@@ -48,11 +48,14 @@ test_errors =
           void $ run (O.insertRecord virusTable bpsVirus)
           result <- run $ try (O.selectAll badVirusTable mempty)
           let expectedErr =
-                "Error decoding data from column 'name': Expected int32, got bytestring (id: SqlInteger 1)"
+                "Error decoding data from column 'name': expected int32 but got bytestring (id: 1)"
           case result of
-            Left (O.RowDataError err) ->
-              assertEqual "Error message contains primary key" expectedErr err
-            _ -> assertFailure "Did not raise a RowDataError"
+            Left err ->
+              assertEqual "Error message contains primary key"
+                expectedErr
+                (O.showFromSqlErrorForLogging err)
+
+            _ -> assertFailure "Did not result in error"
       ]
 
 data BadVirus = BadVirus


### PR DESCRIPTION
- Changes the result of `sqlTypeFromSql` to `Either String a` instead of
`Maybe a`. The failure reason is included in the RowDataError message.
- When decoding table rows, the RowDataError message includes the primary
key of the row that failed to decode.