### PR TITLE
LibPQ: Makes Expr-types newtypes around RawSql

### DIFF
--- a/orville-postgresql-libpq/orville-postgresql-libpq.cabal
+++ b/orville-postgresql-libpq/orville-postgresql-libpq.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 32bd0864232131518a5654486809c178b592bb4fd0655d263c88747afa571b07
+-- hash: 897f7b4ed9ebb0c9f7ec728d6ec573c5f1f651f0d9ac04831384c5245dfe597c
 
 name:           orville-postgresql-libpq
 version:        0.9.0.0
@@ -29,6 +29,7 @@ library
       Database.Orville.PostgreSQL.Connection
       Database.Orville.PostgreSQL.Internal.ExecutionResult
       Database.Orville.PostgreSQL.Internal.Expr
+      Database.Orville.PostgreSQL.Internal.RawSql
       Database.Orville.PostgreSQL.Internal.SqlType
   other-modules:
       Paths_orville_postgresql_libpq

--- a/orville-postgresql-libpq/package.yaml
+++ b/orville-postgresql-libpq/package.yaml
@@ -18,6 +18,7 @@ library:
     - Database.Orville.PostgreSQL.Connection
     - Database.Orville.PostgreSQL.Internal.ExecutionResult
     - Database.Orville.PostgreSQL.Internal.Expr
+    - Database.Orville.PostgreSQL.Internal.RawSql
     - Database.Orville.PostgreSQL.Internal.SqlType
   ghc-options:
     - -Wall

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/RawSql.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/RawSql.hs
@@ -1,0 +1,87 @@
+{-|
+Module    : Database.Orville.PostgreSQL.Internal.RawSql
+Copyright : Flipstone Technology Partners 2016-2020
+License   : MIT
+
+The funtions in this module are named with the intent that it is imported
+qualified as 'RawSql'.
+
+-}
+module Database.Orville.PostgreSQL.Internal.RawSql
+  ( RawSql
+  , fromString
+  , fromBytes
+  , execute
+  , executeVoid
+  ) where
+
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.ByteString.Builder as BSB
+import qualified Database.PostgreSQL.LibPQ as LibPQ
+
+import           Database.Orville.PostgreSQL.Connection (Connection, Pool)
+import qualified Database.Orville.PostgreSQL.Connection as Conn
+
+{-|
+  'RawSql' provides a type for efficiently constructing raw sql statements
+  from smaller parts and then executing them.
+-}
+newtype RawSql =
+  RawSql BSB.Builder
+
+instance Semigroup RawSql where
+  (RawSql left) <> (RawSql right) =
+    RawSql (left <> right)
+
+instance Monoid RawSql where
+  mempty = RawSql mempty
+
+{-|
+  Constructs a 'RawSql' from a 'String' value, utf8-encoding it.
+
+  Note that because the string is treated as raw sql it completely up to the
+  caller to protected againt sql-injections attacks when using this function.
+  Never use this function with input read from an untrusted source.
+-}
+fromString :: String -> RawSql
+fromString =
+  RawSql . BSB.stringUtf8
+
+{-|
+  Constructs a 'RawSql' from a 'ByteString' value, which is assumed to be
+  encoded sensibly for the database to handle.
+
+  Note that because the string is treated as raw sql it completely up to the
+  caller to protected againt sql-injections attacks when using this function.
+  Never use this function with input read from an untrusted source.
+-}
+fromBytes :: BS.ByteString -> RawSql
+fromBytes =
+  RawSql . BSB.byteString
+
+{-|
+  Converts a 'RawSql' value to the bytes that will be sent to the database to
+  execute it.
+-}
+toBytes :: RawSql -> BS.ByteString
+toBytes (RawSql builder) =
+  LBS.toStrict (BSB.toLazyByteString builder)
+
+{-|
+  Executes a 'RawSql' value using the 'Conn.executeRaw' function. Make sure
+  to read the documentation of 'Conn.executeRaw' for caveats and warnings.
+  Use with caution.
+-}
+execute :: Pool Connection -> RawSql -> IO (Maybe LibPQ.Result)
+execute conn rawSql =
+  Conn.executeRaw conn (toBytes rawSql)
+
+{-|
+  Executes a 'RawSql' value using the 'Conn.executeRawVoid' function. Make sure
+  to read the documentation of 'Conn.executeRawVoid' for caveats and warnings.
+  Use with caution.
+-}
+executeVoid :: Pool Connection -> RawSql -> IO ()
+executeVoid conn rawSql =
+  Conn.executeRawVoid conn (toBytes rawSql)

--- a/orville-postgresql-libpq/test/Test/SqlType.hs
+++ b/orville-postgresql-libpq/test/Test/SqlType.hs
@@ -9,10 +9,11 @@ import qualified Data.Text as T
 import qualified Data.Time as Time
 import Test.Tasty.Hspec (Spec, describe, it, shouldBe, expectationFailure)
 
-import Database.Orville.PostgreSQL.Connection (Connection, executeRawVoid, executeRaw)
+import Database.Orville.PostgreSQL.Connection (Connection, executeRawVoid)
 import Database.Orville.PostgreSQL.Internal.ExecutionResult (decodeRows)
-import Database.Orville.PostgreSQL.Internal.SqlType (-- numeric types
-                                                      integer
+import Database.Orville.PostgreSQL.Internal.SqlType (SqlType
+                                                     -- numeric types
+                                                    , integer
                                                     , serial
                                                     , bigInteger
                                                     , bigserial
@@ -30,6 +31,7 @@ import Database.Orville.PostgreSQL.Internal.SqlType (-- numeric types
                                                     , timestamp
                                                     )
 import qualified Database.Orville.PostgreSQL.Internal.Expr as Expr
+import qualified Database.Orville.PostgreSQL.Internal.RawSql as RawSql
 
 sqlTypeSpecs :: Pool Connection -> Spec
 sqlTypeSpecs pool = describe "Tests of SqlType decode" $ do
@@ -49,412 +51,278 @@ sqlTypeSpecs pool = describe "Tests of SqlType decode" $ do
 integerSpecs :: Pool Connection -> Spec
 integerSpecs pool = do
   it "Testing the decode of INTEGER with value 0" $ do
-    dropAndRecreateTable pool "myinteger" "INTEGER"
-
-    executeRawVoid pool $ Expr.insertExprToSql (Expr.InsertExpr (B8.pack "myinteger") [B8.pack $ show (0 :: Int)])
-
-    let selectBS = Expr.queryExprToSql (Expr.QueryExpr [B8.pack "*"] $ Expr.TableExpr (B8.pack "myinteger"))
-    maybeResult <- executeRaw pool selectBS
-
-    case maybeResult of
-      Nothing ->
-        expectationFailure "select returned nothing"
-
-      Just res -> do
-        (maybeA:_) <- decodeRows res integer
-        shouldBe maybeA (Just 0)
+    runDecodingTest pool $
+      DecodingTest
+        { sqlTypeDDL = "INTEGER"
+        , rawSqlValue = B8.pack $ show (0 :: Int)
+        , sqlType = integer
+        , expectedValue = 0
+        }
 
   it "Testing the decode of INTEGER with value 2147483647" $ do
-    dropAndRecreateTable pool "myinteger" "INTEGER"
-
-    executeRawVoid pool $ Expr.insertExprToSql (Expr.InsertExpr (B8.pack "myinteger") [B8.pack $ show (2147483647 :: Int)])
-
-    let selectBS = Expr.queryExprToSql (Expr.QueryExpr [B8.pack "*"] $ Expr.TableExpr (B8.pack "myinteger"))
-    maybeResult <- executeRaw pool selectBS
-
-    case maybeResult of
-      Nothing ->
-        expectationFailure "select returned nothing"
-
-      Just res -> do
-        (maybeA:_) <- decodeRows res integer
-        shouldBe maybeA (Just 2147483647)
+    runDecodingTest pool $
+      DecodingTest
+        { sqlTypeDDL = "INTEGER"
+        , rawSqlValue = B8.pack $ show (2147483647 :: Int)
+        , sqlType = integer
+        , expectedValue = 2147483647
+        }
 
   it "Testing the decode of INTEGER with value -2147483648" $ do
-    dropAndRecreateTable pool "myinteger" "INTEGER"
-
-    executeRawVoid pool $ Expr.insertExprToSql (Expr.InsertExpr (B8.pack "myinteger") [B8.pack $ show (-2147483648 :: Int)])
-
-    let selectBS = Expr.queryExprToSql (Expr.QueryExpr [B8.pack "*"] $ Expr.TableExpr (B8.pack "myinteger"))
-    maybeResult <- executeRaw pool selectBS
-
-    case maybeResult of
-      Nothing ->
-        expectationFailure "select returned nothing"
-
-      Just res -> do
-        (maybeA:_) <- decodeRows res integer
-        shouldBe maybeA (Just (-2147483648))
+    runDecodingTest pool $
+      DecodingTest
+        { sqlTypeDDL = "INTEGER"
+        , rawSqlValue = B8.pack $ show (-2147483648 :: Int)
+        , sqlType = integer
+        , expectedValue = -2147483648
+        }
 
 bigIntegerSpecs :: Pool Connection -> Spec
 bigIntegerSpecs pool = do
   it "Testing the decode of BIGINT with value 0" $ do
-    dropAndRecreateTable pool "mybiginteger" "BIGINT"
-
-    executeRawVoid pool $ Expr.insertExprToSql (Expr.InsertExpr (B8.pack "mybiginteger") [B8.pack $ show (0 :: Int64)])
-
-    let selectBS = Expr.queryExprToSql (Expr.QueryExpr [B8.pack "*"] $ Expr.TableExpr (B8.pack "mybiginteger"))
-    maybeResult <- executeRaw pool selectBS
-
-    case maybeResult of
-      Nothing ->
-        expectationFailure "select returned nothing"
-
-      Just res -> do
-        (maybeA:_) <- decodeRows res bigInteger
-        shouldBe maybeA (Just 0 :: Maybe Int64)
+    runDecodingTest pool $
+      DecodingTest
+        { sqlTypeDDL = "BIGINT"
+        , rawSqlValue = B8.pack $ show (0 :: Int64)
+        , sqlType = bigInteger
+        , expectedValue = 0
+        }
 
   it "Testing the decode of BIGINT with value 21474836470" $ do
-    dropAndRecreateTable pool "mybiginteger" "BIGINT"
-
-    executeRawVoid pool $ Expr.insertExprToSql (Expr.InsertExpr (B8.pack "mybiginteger") [B8.pack $ show (21474836470 :: Int64)])
-
-    let selectBS = Expr.queryExprToSql (Expr.QueryExpr [B8.pack "*"] $ Expr.TableExpr (B8.pack "mybiginteger"))
-    maybeResult <- executeRaw pool selectBS
-
-    case maybeResult of
-      Nothing ->
-        expectationFailure "select returned nothing"
-
-      Just res -> do
-        (maybeA:_) <- decodeRows res bigInteger
-        shouldBe maybeA (Just 21474836470 :: Maybe Int64)
+    runDecodingTest pool $
+      DecodingTest
+        { sqlTypeDDL = "BIGINT"
+        , rawSqlValue = B8.pack $ show (21474836470 :: Int64)
+        , sqlType = bigInteger
+        , expectedValue = 21474836470
+        }
 
 serialSpecs :: Pool Connection -> Spec
 serialSpecs pool = do
   it "Testing the decode of SERIAL with value 0" $ do
-    dropAndRecreateTable pool "myserial" "SERIAL"
-
-    executeRawVoid pool $ Expr.insertExprToSql (Expr.InsertExpr (B8.pack "myserial") [B8.pack $ show (0 :: Int)])
-
-    let selectBS = Expr.queryExprToSql (Expr.QueryExpr [B8.pack "*"] $ Expr.TableExpr (B8.pack "myserial"))
-    maybeResult <- executeRaw pool selectBS
-
-    case maybeResult of
-      Nothing ->
-        expectationFailure "select returned nothing"
-
-      Just res -> do
-        (maybeA:_) <- decodeRows res serial
-        shouldBe maybeA (Just 0)
+    runDecodingTest pool $
+      DecodingTest
+        { sqlTypeDDL = "SERIAL"
+        , rawSqlValue = B8.pack $ show (0 :: Int)
+        , sqlType = serial
+        , expectedValue = 0
+        }
 
   it "Testing the decode of SERIAL with value 2147483647" $ do
-    dropAndRecreateTable pool "myserial" "SERIAL"
-
-    executeRawVoid pool $ Expr.insertExprToSql (Expr.InsertExpr (B8.pack "myserial") [B8.pack $ show (2147483647 ::Int)])
-
-    let selectBS = Expr.queryExprToSql (Expr.QueryExpr [B8.pack "*"] $ Expr.TableExpr (B8.pack "myserial"))
-    maybeResult <- executeRaw pool selectBS
-
-    case maybeResult of
-      Nothing ->
-        expectationFailure "select returned nothing"
-
-      Just res -> do
-        (maybeA:_) <- decodeRows res serial
-        shouldBe maybeA (Just 2147483647)
+    runDecodingTest pool $
+      DecodingTest
+        { sqlTypeDDL = "SERIAL"
+        , rawSqlValue = B8.pack $ show (2147483647 :: Int)
+        , sqlType = serial
+        , expectedValue = 2147483647
+        }
 
   it "Testing the decode of SERIAL with value -2147483648" $ do
-    dropAndRecreateTable pool "myserial" "SERIAL"
-
-    executeRawVoid pool $ Expr.insertExprToSql (Expr.InsertExpr (B8.pack "myserial") [B8.pack $ show (-2147483648 :: Int)])
-
-    let selectBS = Expr.queryExprToSql (Expr.QueryExpr [B8.pack "*"] $ Expr.TableExpr (B8.pack "myserial"))
-    maybeResult <- executeRaw pool selectBS
-
-    case maybeResult of
-      Nothing ->
-        expectationFailure "select returned nothing"
-
-      Just res -> do
-        (maybeA:_) <- decodeRows res serial
-        shouldBe maybeA (Just (-2147483648))
+    runDecodingTest pool $
+      DecodingTest
+        { sqlTypeDDL = "SERIAL"
+        , rawSqlValue = B8.pack $ show (-2147483648 :: Int)
+        , sqlType = serial
+        , expectedValue = -2147483648
+        }
 
 bigSerialSpecs :: Pool Connection -> Spec
 bigSerialSpecs pool = do
   it "Testing the decode of BIGSERIAL with value 0" $ do
-    dropAndRecreateTable pool "mybigserial" "BIGSERIAL"
-
-    executeRawVoid pool $ Expr.insertExprToSql (Expr.InsertExpr (B8.pack "mybigserial") [B8.pack $ show (0 :: Int64)])
-
-    let selectBS = Expr.queryExprToSql (Expr.QueryExpr [B8.pack "*"] $ Expr.TableExpr (B8.pack "mybigserial"))
-    maybeResult <- executeRaw pool selectBS
-
-    case maybeResult of
-      Nothing ->
-        expectationFailure "select returned nothing"
-
-      Just res -> do
-        (maybeA:_) <- decodeRows res bigserial
-        shouldBe maybeA (Just 0 :: Maybe Int64)
+    runDecodingTest pool $
+      DecodingTest
+        { sqlTypeDDL = "BIGSERIAL"
+        , rawSqlValue = B8.pack $ show (0 :: Int64)
+        , sqlType = bigserial
+        , expectedValue = 0
+        }
 
   it "Testing the decode of BIGSERIAL with value 21474836470" $ do
-    dropAndRecreateTable pool "mybigserial" "BIGSERIAL"
-
-    executeRawVoid pool $ Expr.insertExprToSql (Expr.InsertExpr (B8.pack "mybigserial") [B8.pack $ show (21474836470 :: Int64)])
-
-    let selectBS = Expr.queryExprToSql (Expr.QueryExpr [B8.pack "*"] $ Expr.TableExpr (B8.pack "mybigserial"))
-    maybeResult <- executeRaw pool selectBS
-
-    case maybeResult of
-      Nothing ->
-        expectationFailure "select returned nothing"
-
-      Just res -> do
-        (maybeA:_) <- decodeRows res bigserial
-        shouldBe maybeA (Just 21474836470 :: Maybe Int64)
+    runDecodingTest pool $
+      DecodingTest
+        { sqlTypeDDL = "BIGSERIAL"
+        , rawSqlValue = B8.pack $ show (21474836470 :: Int64)
+        , sqlType = bigserial
+        , expectedValue = 21474836470
+        }
 
 doubleSpecs :: Pool Connection -> Spec
 doubleSpecs pool = do
   it "Testing the decode of DOUBLE PRECISION with value 0" $ do
-    dropAndRecreateTable pool "mydouble" "DOUBLE PRECISION"
-
-    executeRawVoid pool $ Expr.insertExprToSql (Expr.InsertExpr (B8.pack "mydouble") [B8.pack $ show (0.0 :: Double)])
-
-    let selectBS = Expr.queryExprToSql (Expr.QueryExpr [B8.pack "*"] $ Expr.TableExpr (B8.pack "mydouble"))
-    maybeResult <- executeRaw pool selectBS
-
-    case maybeResult of
-      Nothing ->
-        expectationFailure "select returned nothing"
-
-      Just res -> do
-        (maybeA:_) <- decodeRows res double
-        shouldBe maybeA (Just 0.0)
+    runDecodingTest pool $
+      DecodingTest
+        { sqlTypeDDL = "DOUBLE PRECISION"
+        , rawSqlValue = B8.pack $ show (0.0 :: Double)
+        , sqlType = double
+        , expectedValue = 0.0
+        }
 
   it "Testing the decode of DOUBLE PRECISION with value 1.5" $ do
-    dropAndRecreateTable pool "mydouble" "DOUBLE PRECISION"
-
-    executeRawVoid pool $ Expr.insertExprToSql (Expr.InsertExpr (B8.pack "mydouble") [B8.pack $ show (1.5 :: Double)])
-
-    let selectBS = Expr.queryExprToSql (Expr.QueryExpr [B8.pack "*"] $ Expr.TableExpr (B8.pack "mydouble"))
-    maybeResult <- executeRaw pool selectBS
-
-    case maybeResult of
-      Nothing ->
-        expectationFailure "select returned nothing"
-
-      Just res -> do
-        (maybeA:_) <- decodeRows res double
-        shouldBe maybeA (Just 1.5)
+    runDecodingTest pool $
+      DecodingTest
+        { sqlTypeDDL = "DOUBLE PRECISION"
+        , rawSqlValue = B8.pack $ show (1.5 :: Double)
+        , sqlType = double
+        , expectedValue = 1.5
+        }
 
 boolSpecs :: Pool Connection -> Spec
 boolSpecs pool = do
   it "Testing the decode of BOOL with value False" $ do
-    dropAndRecreateTable pool "mybool" "BOOL"
-    let tableBS = B8.pack "mybool"
-    executeRawVoid pool $ Expr.insertExprToSql (Expr.InsertExpr tableBS [B8.pack $ show False])
-
-    let selectBS = Expr.queryExprToSql (Expr.QueryExpr [B8.pack "*"] $ Expr.TableExpr tableBS)
-    maybeResult <- executeRaw pool selectBS
-
-    case maybeResult of
-      Nothing ->
-        expectationFailure "select returned nothing"
-
-      Just res -> do
-        (maybeA:_) <- decodeRows res boolean
-        shouldBe maybeA (Just False)
+    runDecodingTest pool $
+      DecodingTest
+        { sqlTypeDDL = "BOOL"
+        , rawSqlValue = B8.pack $ show False
+        , sqlType = boolean
+        , expectedValue = False
+        }
 
   it "Testing the decode of BOOL with value True" $ do
-    dropAndRecreateTable pool "mybool" "BOOL"
-    let tableBS = B8.pack "mybool"
-    executeRawVoid pool $ Expr.insertExprToSql (Expr.InsertExpr tableBS [B8.pack $ show True])
-
-    let selectBS = Expr.queryExprToSql (Expr.QueryExpr [B8.pack "*"] $ Expr.TableExpr tableBS)
-    maybeResult <- executeRaw pool selectBS
-
-    case maybeResult of
-      Nothing ->
-        expectationFailure "select returned nothing"
-
-      Just res -> do
-        (maybeA:_) <- decodeRows res boolean
-        shouldBe maybeA (Just True)
+    runDecodingTest pool $
+      DecodingTest
+        { sqlTypeDDL = "BOOL"
+        , rawSqlValue = B8.pack $ show True
+        , sqlType = boolean
+        , expectedValue = True
+        }
 
 unboundedTextSpecs :: Pool Connection -> Spec
 unboundedTextSpecs pool = do
   it "Testing the decode of TEXT with value abcde" $ do
-    dropAndRecreateTable pool "myunboundedtext" "TEXT"
-    let tableBS = B8.pack "myunboundedtext"
-    executeRawVoid pool $ Expr.insertExprToSql (Expr.InsertExpr tableBS [B8.pack "'abcde'"])
-
-    let selectBS = Expr.queryExprToSql (Expr.QueryExpr [B8.pack "*"] $ Expr.TableExpr tableBS)
-    maybeResult <- executeRaw pool selectBS
-
-    case maybeResult of
-      Nothing ->
-        expectationFailure "select returned nothing"
-
-      Just res -> do
-        (maybeA:_) <- decodeRows res unboundedText
-        shouldBe maybeA (Just (T.pack "abcde"))
+    runDecodingTest pool $
+      DecodingTest
+        { sqlTypeDDL = "TEXT"
+        , rawSqlValue = B8.pack "'abcde'"
+        , sqlType = unboundedText
+        , expectedValue = T.pack "abcde"
+        }
 
 fixedTextSpecs :: Pool Connection -> Spec
 fixedTextSpecs pool = do
   it "Testing the decode of CHAR(5) with value 'abcde'" $ do
-    dropAndRecreateTable pool "myfixedtext" "CHAR(5)"
-    let tableBS = B8.pack "myfixedtext"
-    executeRawVoid pool $ Expr.insertExprToSql (Expr.InsertExpr tableBS [B8.pack "'abcde'"])
-
-    let selectBS = Expr.queryExprToSql (Expr.QueryExpr [B8.pack "*"] $ Expr.TableExpr tableBS)
-    maybeResult <- executeRaw pool selectBS
-
-    case maybeResult of
-      Nothing ->
-        expectationFailure "select returned nothing"
-
-      Just res -> do
-        (maybeA:_) <- decodeRows res (fixedText 5)
-        shouldBe maybeA (Just (T.pack "abcde"))
+    runDecodingTest pool $
+      DecodingTest
+        { sqlTypeDDL = "CHAR(5)"
+        , rawSqlValue = B8.pack "'abcde'"
+        , sqlType = fixedText 5
+        , expectedValue = T.pack "abcde"
+        }
 
   it "Testing the decode of CHAR(5) with value 'fghi'" $ do
-    dropAndRecreateTable pool "myfixedtext" "CHAR(5)"
-    let tableBS = B8.pack "myfixedtext"
-    executeRawVoid pool $ Expr.insertExprToSql (Expr.InsertExpr tableBS [B8.pack "'fghi'"])
-
-    let selectBS = Expr.queryExprToSql (Expr.QueryExpr [B8.pack "*"] $ Expr.TableExpr tableBS)
-    maybeResult <- executeRaw pool selectBS
-
-    case maybeResult of
-      Nothing ->
-        expectationFailure "select returned nothing"
-
-      Just res -> do
-        (maybeA:_) <- decodeRows res (fixedText 5)
-        shouldBe maybeA (Just (T.pack "fghi "))
+    runDecodingTest pool $
+      DecodingTest
+        { sqlTypeDDL = "CHAR(5)"
+        , rawSqlValue = B8.pack "'fghi'"
+        , sqlType = fixedText 5
+        , expectedValue = T.pack "fghi "
+        }
 
 boundedTextSpecs :: Pool Connection -> Spec
 boundedTextSpecs pool = do
   it "Testing the decode of VARCHAR(5) with value 'abcde'" $ do
-    dropAndRecreateTable pool "myboundedtext" "VARCHAR(5)"
-    let tableBS = B8.pack "myboundedtext"
-    executeRawVoid pool $ Expr.insertExprToSql (Expr.InsertExpr tableBS [B8.pack "'abcde'"])
-
-    let selectBS = Expr.queryExprToSql (Expr.QueryExpr [B8.pack "*"] $ Expr.TableExpr tableBS)
-    maybeResult <- executeRaw pool selectBS
-
-    case maybeResult of
-      Nothing ->
-        expectationFailure "select returned nothing"
-
-      Just res -> do
-        (maybeA:_) <- decodeRows res (boundedText 5)
-        shouldBe maybeA (Just (T.pack "abcde"))
+    runDecodingTest pool $
+      DecodingTest
+        { sqlTypeDDL = "VARCHAR(5)"
+        , rawSqlValue = B8.pack "'abcde'"
+        , sqlType = boundedText 5
+        , expectedValue = T.pack "abcde"
+        }
 
   it "Testing the decode of VARCHAR(5) with value 'fghi'" $ do
-    dropAndRecreateTable pool "myboundedtext" "VARCHAR(5)"
-    let tableBS = B8.pack "myboundedtext"
-    executeRawVoid pool $ Expr.insertExprToSql (Expr.InsertExpr tableBS [B8.pack "'fghi'"])
-
-    let selectBS = Expr.queryExprToSql (Expr.QueryExpr [B8.pack "*"] $ Expr.TableExpr tableBS)
-    maybeResult <- executeRaw pool selectBS
-
-    case maybeResult of
-      Nothing ->
-        expectationFailure "select returned nothing"
-
-      Just res -> do
-        (maybeA:_) <- decodeRows res (boundedText 5)
-        shouldBe maybeA (Just (T.pack "fghi"))
+    runDecodingTest pool $
+      DecodingTest
+        { sqlTypeDDL = "VARCHAR(5)"
+        , rawSqlValue = B8.pack "'fghi'"
+        , sqlType = boundedText 5
+        , expectedValue = T.pack "fghi"
+        }
 
 textSearchVectorSpecs :: Pool Connection -> Spec
 textSearchVectorSpecs pool = do
   it "Testing the decode of TSVECTOR with value 'abcde'" $ do
-    dropAndRecreateTable pool "mytsvector" "TSVECTOR"
-    let tableBS = B8.pack "mytsvector"
-    executeRawVoid pool $ Expr.insertExprToSql (Expr.InsertExpr tableBS [B8.pack "'abcde'"])
-
-    let selectBS = Expr.queryExprToSql (Expr.QueryExpr [B8.pack "*"] $ Expr.TableExpr tableBS)
-    maybeResult <- executeRaw pool selectBS
-
-    case maybeResult of
-      Nothing ->
-        expectationFailure "select returned nothing"
-
-      Just res -> do
-        (maybeA:_) <- decodeRows res textSearchVector
-        shouldBe maybeA (Just (T.pack "'abcde'"))
+    runDecodingTest pool $
+      DecodingTest
+        { sqlTypeDDL = "TSVECTOR"
+        , rawSqlValue = B8.pack "'abcde'"
+        , sqlType = textSearchVector
+        , expectedValue = T.pack "'abcde'"
+        }
 
   it "Testing the decode of TSVECTOR with value 'fghi'" $ do
     dropAndRecreateTable pool "mytsvector" "TSVECTOR"
-    let tableBS = B8.pack "mytsvector"
-    executeRawVoid pool $ Expr.insertExprToSql (Expr.InsertExpr tableBS [B8.pack "'fhgi'"])
-
-    let selectBS = Expr.queryExprToSql (Expr.QueryExpr [B8.pack "*"] $ Expr.TableExpr tableBS)
-    maybeResult <- executeRaw pool selectBS
-
-    case maybeResult of
-      Nothing ->
-        expectationFailure "select returned nothing"
-
-      Just res -> do
-        (maybeA:_) <- decodeRows res textSearchVector
-        shouldBe maybeA (Just (T.pack "'fhgi'"))
+    runDecodingTest pool $
+      DecodingTest
+        { sqlTypeDDL = "TSVECTOR"
+        , rawSqlValue = B8.pack "'fghi'"
+        , sqlType = textSearchVector
+        , expectedValue = T.pack "'fghi'"
+        }
 
 dateSpecs :: Pool Connection -> Spec
 dateSpecs pool = do
   it "Testing the decode of DATE with value 2020-12-21" $ do
-    dropAndRecreateTable pool "mydate" "DATE"
-    let tableBS = B8.pack "mydate"
-    executeRawVoid pool $ Expr.insertExprToSql (Expr.InsertExpr tableBS [B8.pack "'2020-12-21'"])
-
-    let selectBS = Expr.queryExprToSql (Expr.QueryExpr [B8.pack "*"] $ Expr.TableExpr tableBS)
-    maybeResult <- executeRaw pool selectBS
-
-    case maybeResult of
-      Nothing ->
-        expectationFailure "select returned nothing"
-
-      Just res -> do
-        (maybeA:_) <- decodeRows res date
-        shouldBe maybeA (Just (Time.fromGregorian 2020 12 21))
+    runDecodingTest pool $
+      DecodingTest
+        { sqlTypeDDL = "DATE"
+        , rawSqlValue = B8.pack "'2020-12-21'"
+        , sqlType = date
+        , expectedValue = Time.fromGregorian 2020 12 21
+        }
 
 timestampSpecs :: Pool Connection -> Spec
 timestampSpecs pool = do
   it "Testing the decode of TIMESTAMP WITH TIME ZONE with value '2020-12-21 00:00:32-00'" $ do
-    dropAndRecreateTable pool "myutctime" "TIMESTAMP WITH TIME ZONE"
-    let tableBS = B8.pack "myutctime"
-    executeRawVoid pool $ Expr.insertExprToSql (Expr.InsertExpr tableBS [B8.pack "'2020-12-21 00:00:32-00'"])
-
-    let selectBS = Expr.queryExprToSql (Expr.QueryExpr [B8.pack "*"] $ Expr.TableExpr tableBS)
-    maybeResult <- executeRaw pool selectBS
-
-    case maybeResult of
-      Nothing ->
-        expectationFailure "select returned nothing"
-
-      Just res -> do
-        (maybeA:_) <- decodeRows res timestamp
-        shouldBe maybeA (Just (Time.UTCTime (Time.fromGregorian 2020 12 21) (Time.secondsToDiffTime 32)))
+    runDecodingTest pool $
+      DecodingTest
+        { sqlTypeDDL = "TIMESTAMP WITH TIME ZONE"
+        , rawSqlValue = B8.pack "'2020-12-21 00:00:32-00'"
+        , sqlType = timestamp
+        , expectedValue = Time.UTCTime (Time.fromGregorian 2020 12 21) (Time.secondsToDiffTime 32)
+        }
 
   it "Testing the decode of TIMESTAMP WITH TIME ZONE with value '2020-12-21 00:00:32+00'" $ do
-    dropAndRecreateTable pool "myutctime" "TIMESTAMP WITH TIME ZONE"
-    let tableBS = B8.pack "myutctime"
-    executeRawVoid pool $ Expr.insertExprToSql (Expr.InsertExpr tableBS [B8.pack "'2020-12-21 00:00:32+00'"])
+    runDecodingTest pool $
+      DecodingTest
+        { sqlTypeDDL = "TIMESTAMP WITH TIME ZONE"
+        , rawSqlValue = B8.pack "'2020-12-21 00:00:32+00'"
+        , sqlType = timestamp
+        , expectedValue = Time.UTCTime (Time.fromGregorian 2020 12 21) (Time.secondsToDiffTime 32)
+        }
 
-    let selectBS = Expr.queryExprToSql (Expr.QueryExpr [B8.pack "*"] $ Expr.TableExpr tableBS)
-    maybeResult <- executeRaw pool selectBS
+data DecodingTest a =
+  DecodingTest
+    { sqlTypeDDL :: String
+    , rawSqlValue :: B8.ByteString
+    , sqlType :: SqlType a
+    , expectedValue :: a
+    }
 
-    case maybeResult of
-      Nothing ->
-        expectationFailure "select returned nothing"
+runDecodingTest :: (Show a, Eq a) => Pool Connection -> DecodingTest a -> IO ()
+runDecodingTest pool test = do
+  dropAndRecreateTable pool "decoding_test" (sqlTypeDDL test)
 
-      Just res -> do
-        (maybeA:_) <- decodeRows res timestamp
-        shouldBe maybeA (Just (Time.UTCTime (Time.fromGregorian 2020 12 21) (Time.secondsToDiffTime 32)))
+  let
+    tableName = Expr.rawTableName "decoding_test"
+
+  RawSql.executeVoid pool $
+    Expr.insertExprToSql $
+      Expr.insertExpr tableName [rawSqlValue test]
+
+  maybeResult <-
+    RawSql.execute pool $
+      Expr.queryExprToSql $
+        Expr.queryExpr Expr.selectStar (Expr.tableExpr tableName)
+
+  case maybeResult of
+    Nothing ->
+      expectationFailure "select returned nothing"
+
+    Just res -> do
+      (maybeA:_) <- decodeRows res (sqlType test)
+      shouldBe maybeA (Just (expectedValue test))
 
 dropAndRecreateTable :: Pool Connection -> String -> String -> IO ()
 dropAndRecreateTable pool tableName sqlTypeDDL' = do
   executeRawVoid pool . B8.pack $ "DROP TABLE IF EXISTS " <> tableName
   executeRawVoid pool . B8.pack $ "CREATE TABLE " <> tableName <> "(foo " <> sqlTypeDDL' <> ")"
+


### PR DESCRIPTION
This introduces a new type, `RawSql`, for managing building raw sql
expressions. It's a thin wrapper around the bytestring `Builder` type
right now, though it may need to be expanded in the future to handle
values being put in for placeholders in prepared statements.

I changed all the types in `Expr` to be simple wrappers around the new
`RawSql` type rather than being direct models of expression structure.
The expression structure is now reflected in the smart constructors that
build expr values rather than the values themselves. This makes it easy
for us to expose a constructor to inject user-defined `RawSql` at any
level of the expression tree.

I also re-wrote the decoding tests to not duplicate the test structure
to avoid having to update each test every small change to `Expr` things.