### PR TITLE
LibPQ: Adds support for input parameters as part of RawSql

### DIFF
--- a/orville-postgresql-libpq/orville-postgresql-libpq.cabal
+++ b/orville-postgresql-libpq/orville-postgresql-libpq.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 897f7b4ed9ebb0c9f7ec728d6ec573c5f1f651f0d9ac04831384c5245dfe597c
+-- hash: 4aee721492e141ea9993278f95c86edfb3b04ab9e0ff1fdcbe72a67b1b62cc55
 
 name:           orville-postgresql-libpq
 version:        0.9.0.0
@@ -40,6 +40,7 @@ library
       attoparsec
     , base >=4.8 && <5
     , bytestring
+    , dlist >=0.8 && <0.9
     , postgresql-libpq >=0.9.4.2 && <0.10
     , resource-pool
     , text
@@ -50,6 +51,7 @@ test-suite spec
   type: exitcode-stdio-1.0
   main-is: Main.hs
   other-modules:
+      Test.RawSql
       Test.SqlType
   hs-source-dirs:
       test

--- a/orville-postgresql-libpq/package.yaml
+++ b/orville-postgresql-libpq/package.yaml
@@ -28,6 +28,7 @@ library:
     - base >=4.8 && <5
     - attoparsec
     - bytestring
+    - dlist >= 0.8 && < 0.9
     - postgresql-libpq >= 0.9.4.2 && <0.10
     - resource-pool
     - text
@@ -39,6 +40,7 @@ tests:
     source-dirs: test
     main: Main.hs
     other-modules:
+      - Test.RawSql
       - Test.SqlType
     dependencies:
       - base

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr.hs
@@ -81,7 +81,7 @@ insertExpr target rowValues =
       [ RawSql.fromString "INSERT INTO "
       , tableNameToSql target
       , RawSql.fromString " VALUES ("
-      , RawSql.fromBytes (B8.intercalate (B8.pack ",") rowValues)
+      , RawSql.intercalate (RawSql.fromString ",") (map RawSql.parameter rowValues)
       , RawSql.fromString ")"
     ]
 

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/RawSql.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/RawSql.hs
@@ -9,8 +9,11 @@ qualified as 'RawSql'.
 -}
 module Database.Orville.PostgreSQL.Internal.RawSql
   ( RawSql
+  , parameter
   , fromString
   , fromBytes
+  , toBytesAndParams
+  , intercalate
   , execute
   , executeVoid
   ) where
@@ -18,6 +21,9 @@ module Database.Orville.PostgreSQL.Internal.RawSql
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString.Builder as BSB
+import           Data.DList (DList)
+import qualified Data.DList as DList
+import qualified Data.List as List
 import qualified Database.PostgreSQL.LibPQ as LibPQ
 
 import           Database.Orville.PostgreSQL.Connection (Connection, Pool)
@@ -25,20 +31,103 @@ import qualified Database.Orville.PostgreSQL.Connection as Conn
 
 {-|
   'RawSql' provides a type for efficiently constructing raw sql statements
-  from smaller parts and then executing them.
+  from smaller parts and then executing them. It also supports using placeholder
+  values to pass parameters with a query without having to interpolate them
+  as part of the actual sql state and being exposed to sql injection.
 -}
-newtype RawSql =
-  RawSql BSB.Builder
+data RawSql
+  = SqlSection BSB.Builder
+  | Parameter BS.ByteString
+  | Append RawSql RawSql
 
 instance Semigroup RawSql where
-  (RawSql left) <> (RawSql right) =
-    RawSql (left <> right)
+  (SqlSection builderA) <> (SqlSection builderB) =
+    SqlSection (builderA <> builderB)
+
+  otherA <> otherB =
+    Append otherA otherB
 
 instance Monoid RawSql where
-  mempty = RawSql mempty
+  mempty = SqlSection mempty
 
 {-|
-  Constructs a 'RawSql' from a 'String' value, utf8-encoding it.
+  Constructs the actual sql bytestring and parameter values that will be
+  passed to the database to execute a 'RawSql' query.
+-}
+toBytesAndParams :: RawSql -> (BS.ByteString, [BS.ByteString])
+toBytesAndParams rawSql =
+  let
+    (byteBuilder, finalProgress) =
+      buildSqlWithProgress startingProgress rawSql
+  in
+    ( LBS.toStrict (BSB.toLazyByteString byteBuilder)
+    , DList.toList (paramValues finalProgress)
+    )
+
+{-|
+  This is an internal datatype used during the sql building process to track
+  how many params have been seen so that placeholder indices (e.g. '$1', etc)
+  can be generated to include in the sql.
+-}
+data ParamsProgress =
+  ParamsProgress
+    { paramCount :: Int
+    , paramValues :: DList BS.ByteString
+    }
+
+{-|
+  An initial value for 'ParamsProgress' that indicates no params have been been
+  encountered yet.
+-}
+startingProgress :: ParamsProgress
+startingProgress =
+  ParamsProgress
+    { paramCount = 0
+    , paramValues = DList.empty
+    }
+
+{-|
+  Adds a parameter value to the end of the params list, tracking the count
+  of parameters as it does so.
+-}
+snocParam :: ParamsProgress -> BS.ByteString -> ParamsProgress
+snocParam (ParamsProgress count values) newValue =
+  ParamsProgress
+    { paramCount = count + 1
+    , paramValues = DList.snoc values newValue
+    }
+
+{-|
+  Constructs a bytestring builder that can be executed to get the bytes for a
+  section of 'RawSql'. This function takes and returns a 'ParamsProgress' so
+  that placeholder indices (e.g. '$1') and their corresponding parameter values
+  can be tracked across multiple sections of raw sql.
+-}
+buildSqlWithProgress :: ParamsProgress
+                     -> RawSql
+                     -> (BSB.Builder, ParamsProgress)
+buildSqlWithProgress progress rawSql =
+  case rawSql of
+    SqlSection builder ->
+      (builder, progress)
+
+    Parameter value ->
+      let
+        newProgress = snocParam progress value
+      in
+        ( BSB.stringUtf8 "$" <> BSB.intDec (paramCount newProgress)
+        , newProgress
+        )
+
+    Append first second ->
+      let
+        (firstBuilder, nextProgress) = buildSqlWithProgress progress first
+        (secondBuilder, finalProgress) = buildSqlWithProgress nextProgress second
+      in
+        (firstBuilder <> secondBuilder, finalProgress)
+
+{-|
+  Constructs a 'RawSql' from a 'String' value using utf8 encoding.
 
   Note that because the string is treated as raw sql it completely up to the
   caller to protected againt sql-injections attacks when using this function.
@@ -46,7 +135,7 @@ instance Monoid RawSql where
 -}
 fromString :: String -> RawSql
 fromString =
-  RawSql . BSB.stringUtf8
+  SqlSection . BSB.stringUtf8
 
 {-|
   Constructs a 'RawSql' from a 'ByteString' value, which is assumed to be
@@ -58,15 +147,27 @@ fromString =
 -}
 fromBytes :: BS.ByteString -> RawSql
 fromBytes =
-  RawSql . BSB.byteString
+  SqlSection . BSB.byteString
 
 {-|
-  Converts a 'RawSql' value to the bytes that will be sent to the database to
-  execute it.
+  Includes an input parameter in the 'RawSql' statement that will be passed
+  using placeholders (e.g. '$1') rather than being included directly in the sql
+  statement. This is the correct way to include input from untrusted sources as
+  part of a 'RawSql' query. The parameter must be formatted in a textual
+  representation, which the database will interpret. The database type for the
+  value will be inferred by the database based on its usage in the query.
 -}
-toBytes :: RawSql -> BS.ByteString
-toBytes (RawSql builder) =
-  LBS.toStrict (BSB.toLazyByteString builder)
+parameter :: BS.ByteString -> RawSql
+parameter =
+  Parameter
+
+{-|
+  Concatenates a list of 'RawSql' values using another 'RawSql' value as
+  the a separator between the items.
+-}
+intercalate :: RawSql -> [RawSql] -> RawSql
+intercalate separator parts =
+  mconcat (List.intersperse separator parts)
 
 {-|
   Executes a 'RawSql' value using the 'Conn.executeRaw' function. Make sure
@@ -75,7 +176,11 @@ toBytes (RawSql builder) =
 -}
 execute :: Pool Connection -> RawSql -> IO (Maybe LibPQ.Result)
 execute conn rawSql =
-  Conn.executeRaw conn (toBytes rawSql)
+  let
+    (sqlBytes, params) =
+      toBytesAndParams rawSql
+  in
+    Conn.executeRaw conn sqlBytes params
 
 {-|
   Executes a 'RawSql' value using the 'Conn.executeRawVoid' function. Make sure
@@ -84,4 +189,8 @@ execute conn rawSql =
 -}
 executeVoid :: Pool Connection -> RawSql -> IO ()
 executeVoid conn rawSql =
-  Conn.executeRawVoid conn (toBytes rawSql)
+  let
+    (sqlBytes, params) =
+      toBytesAndParams rawSql
+  in
+    Conn.executeRawVoid conn sqlBytes params

--- a/orville-postgresql-libpq/test/Main.hs
+++ b/orville-postgresql-libpq/test/Main.hs
@@ -7,6 +7,7 @@ import Test.Tasty (defaultMain)
 import Test.Tasty.Hspec (testSpec)
 
 import Database.Orville.PostgreSQL.Connection (createConnectionPool)
+import Test.RawSql (rawSqlSpecs)
 import Test.SqlType (sqlTypeSpecs)
 
 main :: IO ()
@@ -14,7 +15,9 @@ main = do
   let connBStr = B8.pack "host=testdb user=orville_test password=orville"
   pool <- createConnectionPool 1 10 1 connBStr
 
-  testTree <- testSpec "specs" $ do
-    sqlTypeSpecs pool
+  testTree <-
+    testSpec "specs" $ do
+      sqlTypeSpecs pool
+      rawSqlSpecs
 
   defaultMain testTree

--- a/orville-postgresql-libpq/test/Test/RawSql.hs
+++ b/orville-postgresql-libpq/test/Test/RawSql.hs
@@ -1,0 +1,61 @@
+module Test.RawSql
+  ( rawSqlSpecs
+  ) where
+
+import qualified Data.ByteString.Char8 as B8
+
+import qualified Database.Orville.PostgreSQL.Internal.RawSql as RawSql
+import Test.Tasty.Hspec (Spec, describe, it, shouldBe)
+
+rawSqlSpecs :: Spec
+rawSqlSpecs =
+  describe "RawSql Tests" $ do
+    it "Builds concatenated sql from strings" $ do
+      let
+        rawSql =
+          RawSql.fromString "SELECT * "
+          <> RawSql.fromString "FROM foo "
+          <> RawSql.fromString "WHERE id = 1"
+
+        expectedBytes =
+          B8.pack "SELECT * FROM foo WHERE id = 1"
+
+        (actualBytes, actualParams) =
+          RawSql.toBytesAndParams rawSql
+
+      actualBytes `shouldBe` expectedBytes
+      actualParams `shouldBe` []
+
+    it "Tracks value placeholders in concatenated order" $ do
+      let
+        rawSql =
+          RawSql.fromString "SELECT * "
+          <> RawSql.fromString "FROM foo "
+          <> RawSql.fromString "WHERE id = "
+          <> RawSql.parameter (B8.pack "1")
+          <> RawSql.fromString " AND "
+          <> RawSql.fromString "bar IN ("
+          <> RawSql.intercalate (RawSql.fromString ",") bars
+          <> RawSql.fromString ")"
+
+        bars =
+          map RawSql.parameter
+            [ B8.pack "pants"
+            , B8.pack "cheese"
+            ]
+
+        expectedBytes =
+          B8.pack "SELECT * FROM foo WHERE id = $1 AND bar IN ($2,$3)"
+
+        expectedParams =
+          [ B8.pack "1"
+          , B8.pack "pants"
+          , B8.pack "cheese"
+          ]
+
+        (actualBytes, actualParams) =
+          RawSql.toBytesAndParams rawSql
+
+      actualBytes `shouldBe` expectedBytes
+      actualParams `shouldBe` expectedParams
+

--- a/orville-postgresql-libpq/test/Test/SqlType.hs
+++ b/orville-postgresql-libpq/test/Test/SqlType.hs
@@ -34,7 +34,7 @@ import qualified Database.Orville.PostgreSQL.Internal.Expr as Expr
 import qualified Database.Orville.PostgreSQL.Internal.RawSql as RawSql
 
 sqlTypeSpecs :: Pool Connection -> Spec
-sqlTypeSpecs pool = describe "Tests of SqlType decode" $ do
+sqlTypeSpecs pool = describe "SqlType decoding tests" $ do
   integerSpecs pool
   bigIntegerSpecs pool
   serialSpecs pool
@@ -192,7 +192,7 @@ unboundedTextSpecs pool = do
     runDecodingTest pool $
       DecodingTest
         { sqlTypeDDL = "TEXT"
-        , rawSqlValue = B8.pack "'abcde'"
+        , rawSqlValue = B8.pack "abcde"
         , sqlType = unboundedText
         , expectedValue = T.pack "abcde"
         }
@@ -203,7 +203,7 @@ fixedTextSpecs pool = do
     runDecodingTest pool $
       DecodingTest
         { sqlTypeDDL = "CHAR(5)"
-        , rawSqlValue = B8.pack "'abcde'"
+        , rawSqlValue = B8.pack "abcde"
         , sqlType = fixedText 5
         , expectedValue = T.pack "abcde"
         }
@@ -212,7 +212,7 @@ fixedTextSpecs pool = do
     runDecodingTest pool $
       DecodingTest
         { sqlTypeDDL = "CHAR(5)"
-        , rawSqlValue = B8.pack "'fghi'"
+        , rawSqlValue = B8.pack "fghi"
         , sqlType = fixedText 5
         , expectedValue = T.pack "fghi "
         }
@@ -223,7 +223,7 @@ boundedTextSpecs pool = do
     runDecodingTest pool $
       DecodingTest
         { sqlTypeDDL = "VARCHAR(5)"
-        , rawSqlValue = B8.pack "'abcde'"
+        , rawSqlValue = B8.pack "abcde"
         , sqlType = boundedText 5
         , expectedValue = T.pack "abcde"
         }
@@ -232,7 +232,7 @@ boundedTextSpecs pool = do
     runDecodingTest pool $
       DecodingTest
         { sqlTypeDDL = "VARCHAR(5)"
-        , rawSqlValue = B8.pack "'fghi'"
+        , rawSqlValue = B8.pack "fghi"
         , sqlType = boundedText 5
         , expectedValue = T.pack "fghi"
         }
@@ -323,6 +323,6 @@ runDecodingTest pool test = do
 
 dropAndRecreateTable :: Pool Connection -> String -> String -> IO ()
 dropAndRecreateTable pool tableName sqlTypeDDL' = do
-  executeRawVoid pool . B8.pack $ "DROP TABLE IF EXISTS " <> tableName
-  executeRawVoid pool . B8.pack $ "CREATE TABLE " <> tableName <> "(foo " <> sqlTypeDDL' <> ")"
+  executeRawVoid pool (B8.pack $ "DROP TABLE IF EXISTS " <> tableName) []
+  executeRawVoid pool (B8.pack $ "CREATE TABLE " <> tableName <> "(foo " <> sqlTypeDDL' <> ")") []
 


### PR DESCRIPTION
This adds a `parameter` constructor function to the `RawSql` interface
that allows input parameters to be specified without interpolating them
into the sql statement itself. Instead these values are passed to the
database separetely from the query, using `execParams`.