### PR TITLE
LibPQ: Adds SqlValue to represent values exchanged with DB

### DIFF
--- a/orville-postgresql-libpq/orville-postgresql-libpq.cabal
+++ b/orville-postgresql-libpq/orville-postgresql-libpq.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 4aee721492e141ea9993278f95c86edfb3b04ab9e0ff1fdcbe72a67b1b62cc55
+-- hash: 45492f65597dba99916a20a02069b8d6123d1e00340c4bb108176a3e135316f6
 
 name:           orville-postgresql-libpq
 version:        0.9.0.0
@@ -31,6 +31,7 @@ library
       Database.Orville.PostgreSQL.Internal.Expr
       Database.Orville.PostgreSQL.Internal.RawSql
       Database.Orville.PostgreSQL.Internal.SqlType
+      Database.Orville.PostgreSQL.Internal.SqlValue
   other-modules:
       Paths_orville_postgresql_libpq
   hs-source-dirs:

--- a/orville-postgresql-libpq/package.yaml
+++ b/orville-postgresql-libpq/package.yaml
@@ -20,6 +20,7 @@ library:
     - Database.Orville.PostgreSQL.Internal.Expr
     - Database.Orville.PostgreSQL.Internal.RawSql
     - Database.Orville.PostgreSQL.Internal.SqlType
+    - Database.Orville.PostgreSQL.Internal.SqlValue
   ghc-options:
     - -Wall
     - -fwarn-incomplete-uni-patterns

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Connection.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Connection.hs
@@ -41,7 +41,7 @@ createConnectionPool stripes linger maxRes connectionString =
  of the results are not iterated through immediately *and* the data copied.
  Use with caution.
 -}
-executeRaw :: Pool Connection -> ByteString -> [ByteString] -> IO (Maybe LibPQ.Result)
+executeRaw :: Pool Connection -> ByteString -> [Maybe ByteString] -> IO (Maybe LibPQ.Result)
 executeRaw pool bs params =
   withResource pool (underlyingExecute bs params)
 
@@ -49,7 +49,7 @@ executeRaw pool bs params =
  'executeRawVoid' a version of 'executeRaw' that completely ignores the result.
  Use with caution.
 -}
-executeRawVoid :: Pool Connection -> ByteString -> [ByteString] -> IO ()
+executeRawVoid :: Pool Connection -> ByteString -> [Maybe ByteString] -> IO ()
 executeRawVoid pool bs params =
   void (executeRaw pool bs params)
 
@@ -132,7 +132,7 @@ close (Connection handle') =
   (in which case it can't be used for this  function in the first place).
 -}
 underlyingExecute :: ByteString
-                  -> [ByteString]
+                  -> [Maybe ByteString]
                   -> Connection
                   -> IO (Maybe LibPQ.Result)
 underlyingExecute bs params (Connection handle') = do
@@ -145,9 +145,14 @@ underlyingExecute bs params (Connection handle') = do
   This uses Oid 0 to cause the database to infer the type of the paremeter and
   explicitly marks the parameter as being in Text format.
 -}
-mkInferredTextParam :: ByteString -> Maybe (LibPQ.Oid, ByteString, LibPQ.Format)
-mkInferredTextParam value =
-  Just (LibPQ.Oid 0, value, LibPQ.Text)
+mkInferredTextParam :: Maybe ByteString -> Maybe (LibPQ.Oid, ByteString, LibPQ.Format)
+mkInferredTextParam mbValue =
+  case mbValue of
+    Nothing ->
+      Nothing
+
+    Just value ->
+      Just (LibPQ.Oid 0, value, LibPQ.Text)
 
 data ConnectionError = ConnectionError { errorMessage :: String
                                        , underlyingError :: Maybe ByteString

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr.hs
@@ -19,10 +19,9 @@ module Database.Orville.PostgreSQL.Internal.Expr
   , insertExprToSql
   ) where
 
-import qualified Data.ByteString.Char8 as B8
-
 import           Database.Orville.PostgreSQL.Internal.RawSql (RawSql)
 import qualified Database.Orville.PostgreSQL.Internal.RawSql as RawSql
+import           Database.Orville.PostgreSQL.Internal.SqlValue (SqlValue)
 
 -- This is a rough model of "query specification" see https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#_7_16_query_specification for more detail than you probably want
 newtype QueryExpr =
@@ -74,7 +73,7 @@ rawTableName =
 newtype InsertExpr =
   InsertExpr RawSql
 
-insertExpr :: TableName -> [B8.ByteString] -> InsertExpr
+insertExpr :: TableName -> [SqlValue] -> InsertExpr
 insertExpr target rowValues =
   InsertExpr $
     mconcat

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/SqlValue.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/SqlValue.hs
@@ -1,0 +1,264 @@
+{-|
+
+Module    : Database.Orville.PostgreSQL.Internal.SqlValue
+Copyright : Flipstone Technology Partners 2016-2021
+License   : MIT
+
+The funtions in this module are named with the intent that it is imported
+qualified as 'SqlValue.
+
+-}
+module Database.Orville.PostgreSQL.Internal.SqlValue
+  ( SqlValue
+  , isSqlNull
+  , sqlNull
+  , fromInt32
+  , toInt32
+  , fromInt64
+  , toInt64
+  , fromDouble
+  , toDouble
+  , fromBool
+  , toBool
+  , fromText
+  , toText
+  , fromDay
+  , toDay
+  , fromUTCTime
+  , toUTCTime
+  , fromRawBytes
+  , fromRawBytesNullable
+  , toRawBytes
+  ) where
+
+import qualified Data.Attoparsec.ByteString as AttoBS
+import qualified Data.Attoparsec.ByteString.Char8 as AttoB8
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.ByteString.Builder as BSB
+import           Data.Int (Int32, Int64)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TextEnc
+import qualified Data.Time as Time
+
+data SqlValue
+  = SqlValue BS.ByteString
+  | SqlNull
+
+{-|
+  Checks whether the 'SqlValue' represents a sql NULL value in the database.
+-}
+isSqlNull :: SqlValue -> Bool
+isSqlNull sqlValue =
+  case sqlValue of
+    SqlValue _ -> False
+    SqlNull    -> True
+
+{-|
+  A value of 'SqlValue' that will be interpreted as a sql NULL value when
+  pasesed to the database.
+-}
+sqlNull :: SqlValue
+sqlNull =
+  SqlNull
+
+{-|
+  Converts a 'SqlValue' to its underlying raw bytes as it will be represented
+  when sent to the database. The output should be recognizable as similar to
+  to values you would write in query. If the value represents a sql NULL
+  value, 'Nothing' is returned
+-}
+toRawBytes :: SqlValue -> Maybe BS.ByteString
+toRawBytes sqlValue =
+  case sqlValue of
+    SqlValue bytes ->
+      Just bytes
+
+    SqlNull ->
+      Nothing
+
+{-|
+  Creates a 'SqlValue' from a raw byte string as if the bytes had returned
+  by the database. This function does not interpret the bytes in any way,
+  but the using decode functions on them might fail depending on whether the
+  bytes can be parsed as the requested type.
+
+  Note: A value to present a sql NULL cannot be constructed using this
+  function. See 'fromRawBytesNullable' for how to represent a nullable
+  raw value.
+-}
+fromRawBytes :: BS.ByteString -> SqlValue
+fromRawBytes =
+  SqlValue
+
+{-|
+  Creates a 'SqlValue' from a raw byte string. If 'Nothing' is specified as the
+  input parameter then the resulting 'SqlValue' will represent a NULL value in
+  sql. Otherwise the bytes given are used in the same way as 'fromRawBytes'
+-}
+fromRawBytesNullable :: Maybe BS.ByteString -> SqlValue
+fromRawBytesNullable =
+  maybe sqlNull fromRawBytes
+
+{-|
+  Encodes an 'Int32' value for usage with database
+-}
+fromInt32 :: Int32 -> SqlValue
+fromInt32 =
+  fromBSBuilder BSB.int32Dec
+
+{-|
+  Attempts to decode a 'SqlValue' a Haskell 'Int32' value. If decoding fails
+  'Nothing' is returned.
+-}
+toInt32 :: SqlValue -> Maybe Int32
+toInt32 =
+  toParsedValue (AttoB8.signed AttoB8.decimal)
+
+{-|
+  Encodes an 'Int64' value for usage with database
+-}
+fromInt64 :: Int64 -> SqlValue
+fromInt64 =
+  fromBSBuilder BSB.int64Dec
+
+{-|
+  Attempts to decode a 'SqlValue' a Haskell 'Int64' value. If decoding fails
+  'Nothing' is returned.
+-}
+toInt64 :: SqlValue -> Maybe Int64
+toInt64 =
+  toParsedValue (AttoB8.signed AttoB8.decimal)
+
+{-|
+  Encodes a 'Double' value for usage with database
+-}
+fromDouble :: Double -> SqlValue
+fromDouble =
+  fromBSBuilder BSB.doubleDec
+
+{-|
+  Attempts to decode a 'SqlValue' a Haskell 'Double' value. If decoding fails
+  'Nothing' is returned.
+-}
+toDouble :: SqlValue -> Maybe Double
+toDouble =
+  toParsedValue (AttoB8.signed AttoB8.double)
+
+{-|
+  Encodes a 'Bool' value for usage with database
+-}
+fromBool :: Bool -> SqlValue
+fromBool =
+  fromBSBuilder $ \bool ->
+    case bool of
+      True -> BSB.char8 't'
+      False -> BSB.char8 'f'
+
+{-|
+  Attempts to decode a 'SqlValue' a Haskell 'Bool' value. If decoding fails
+  'Nothing' is returned.
+-}
+toBool :: SqlValue -> Maybe Bool
+toBool =
+  toParsedValue $ do
+    char <- AttoB8.anyChar
+    case char of
+      't' -> pure True
+      'f' -> pure False
+      _   -> fail "Invalid boolean character value"
+
+{-|
+  Encodes a 'T.Text' value as utf8 so that it can be used with the database.
+-}
+fromText :: T.Text -> SqlValue
+fromText =
+  SqlValue . TextEnc.encodeUtf8
+
+{-|
+  Attempts to decode a 'SqlValue' as UTF-8 text. If the decoding fails,
+  'Nothing' is returned.
+
+  Note: This decoding _only_ fails if the bytes returned from the database
+  are not a value UTF-8 sequence of bytes. Otherwise it always succeeds.
+-}
+toText :: SqlValue -> Maybe T.Text
+toText =
+  toBytesValue $ \bytes ->
+    case TextEnc.decodeUtf8' bytes of
+      Right t -> Just t
+      Left _  -> Nothing
+
+{-|
+  Encodes a 'Time.Day' value as text in YYYY-MM-DD format so that it can be
+  used with the database.
+-}
+fromDay :: Time.Day -> SqlValue
+fromDay =
+  SqlValue . B8.pack . Time.showGregorian
+
+{-|
+  Attempts to decode a 'SqlValue' as into a 'Time.Day' value by parsing it
+  from YYYY-MM-DD format. If the decoding fails 'Nothing' is returned.
+-}
+toDay :: SqlValue -> Maybe Time.Day
+toDay sqlValue = do
+  txt <- toText sqlValue
+  Time.parseTimeM
+    False
+    Time.defaultTimeLocale
+    (Time.iso8601DateFormat Nothing)
+    (T.unpack txt)
+
+{-|
+  Encodes a 'Time.UTCTime' in ISO 8601 format for usage with the database.
+-}
+fromUTCTime :: Time.UTCTime -> SqlValue
+fromUTCTime =
+  SqlValue . B8.pack . Time.formatTime Time.defaultTimeLocale (Time.iso8601DateFormat Nothing)
+
+{-|
+  Attempts to decode a 'SqlValue' as a 'Time.UTCTime' formatted in iso8601
+  format. If the decoding fails, 'Nothing' is returned.
+-}
+toUTCTime :: SqlValue -> Maybe Time.UTCTime
+toUTCTime sqlValue = do
+  -- N.B. There are dragons here... Notably the iso8601DateFormat (at least as of time-1.9.x)
+  -- However PostgreSQL adheres to a different version of the standard which ommitted the 'T' and instead used a space.
+  -- Further... PostgreSQL uses the short format for the UTC offset and the haskell library does not support this.
+  -- Leading to the ugly hacks below.
+  txt <- toText sqlValue
+  Time.parseTimeM False Time.defaultTimeLocale "%F %T%Q%Z" (T.unpack txt <> "00")
+
+{-|
+  A internal helper function that constructs a 'SqlValue' via a byte string builder
+-}
+fromBSBuilder :: (a -> BSB.Builder) -> a -> SqlValue
+fromBSBuilder builder =
+  SqlValue . LBS.toStrict . BSB.toLazyByteString . builder
+
+{-|
+  A internal helper function that parses 'SqlValue' via an Attoparsec parser.
+-}
+toParsedValue :: AttoB8.Parser a -> SqlValue -> Maybe a
+toParsedValue parser =
+  toBytesValue $ \bytes ->
+    case AttoBS.parseOnly parser bytes of
+      Left _  -> Nothing
+      Right i -> Just i
+
+{-|
+  An internal helper function that parses the bytes from a 'SqlValue'
+  with the given parsing function. If the 'SqlValue' is NULL, 'Nothing'
+  is returned. If the parsing function fails (by returning 'Nothing'), then
+  'Nothing' is returned from this function as well.
+-}
+toBytesValue :: (BS.ByteString -> Maybe a) -> SqlValue -> Maybe a
+toBytesValue byteParser sqlValue =
+  case sqlValue of
+    SqlNull ->
+      Nothing
+
+    SqlValue bytes ->
+      byteParser bytes

--- a/orville-postgresql-libpq/test/Test/RawSql.hs
+++ b/orville-postgresql-libpq/test/Test/RawSql.hs
@@ -3,8 +3,10 @@ module Test.RawSql
   ) where
 
 import qualified Data.ByteString.Char8 as B8
+import qualified Data.Text as T
 
 import qualified Database.Orville.PostgreSQL.Internal.RawSql as RawSql
+import qualified Database.Orville.PostgreSQL.Internal.SqlValue as SqlValue
 import Test.Tasty.Hspec (Spec, describe, it, shouldBe)
 
 rawSqlSpecs :: Spec
@@ -32,7 +34,7 @@ rawSqlSpecs =
           RawSql.fromString "SELECT * "
           <> RawSql.fromString "FROM foo "
           <> RawSql.fromString "WHERE id = "
-          <> RawSql.parameter (B8.pack "1")
+          <> RawSql.parameter (SqlValue.fromInt32 1)
           <> RawSql.fromString " AND "
           <> RawSql.fromString "bar IN ("
           <> RawSql.intercalate (RawSql.fromString ",") bars
@@ -40,17 +42,17 @@ rawSqlSpecs =
 
         bars =
           map RawSql.parameter
-            [ B8.pack "pants"
-            , B8.pack "cheese"
+            [ SqlValue.fromText (T.pack "pants")
+            , SqlValue.fromText (T.pack "cheese")
             ]
 
         expectedBytes =
           B8.pack "SELECT * FROM foo WHERE id = $1 AND bar IN ($2,$3)"
 
         expectedParams =
-          [ B8.pack "1"
-          , B8.pack "pants"
-          , B8.pack "cheese"
+          [ Just (B8.pack "1")
+          , Just (B8.pack "pants")
+          , Just (B8.pack "cheese")
           ]
 
         (actualBytes, actualParams) =


### PR DESCRIPTION
This adds a new `SqlValue` type to be used when dealing with values that
are passed to or received from the database. The various encoding
function that lived as helpers in the `SqlType` module have been
promoted to functions exported from `SqlValue`.

This also exposed that the handling of sql NULL values was not correct.
NULL values are reflected a null pointeds in `libpq` rather than actual
string values, so `SqlValue` has a dedicated `SqlNull` constructor to
handle them.