### PR TITLE
Add beginnings of SqlMarshaller as a start of 'higher-level' interface.

### DIFF
--- a/orville-postgresql-libpq/orville-postgresql-libpq.cabal
+++ b/orville-postgresql-libpq/orville-postgresql-libpq.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 4aee721492e141ea9993278f95c86edfb3b04ab9e0ff1fdcbe72a67b1b62cc55
+-- hash: a36e1464f0d1ddf17c1a901a1ead5f0a983a558c7cf4f6c613ad02d738b377dd
 
 name:           orville-postgresql-libpq
 version:        0.9.0.0
@@ -23,6 +23,11 @@ source-repository head
   type: git
   location: git@github.com:flipstone/orville.git
 
+flag ci
+  description: More strict ghc options used for development and ci, not intended for end-use.
+  manual: True
+  default: False
+
 library
   exposed-modules:
       Database.Orville.PostgreSQL
@@ -30,12 +35,12 @@ library
       Database.Orville.PostgreSQL.Internal.ExecutionResult
       Database.Orville.PostgreSQL.Internal.Expr
       Database.Orville.PostgreSQL.Internal.RawSql
+      Database.Orville.PostgreSQL.Internal.SqlMarshaller
       Database.Orville.PostgreSQL.Internal.SqlType
   other-modules:
       Paths_orville_postgresql_libpq
   hs-source-dirs:
       src
-  ghc-options: -Wall -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
   build-depends:
       attoparsec
     , base >=4.8 && <5
@@ -45,6 +50,10 @@ library
     , resource-pool
     , text
     , time >=1.5
+  if flag(ci)
+    ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-patterns -Wincomplete-record-updates -Wmissing-local-signatures -Wmissing-export-lists -Wnoncanonical-monad-instances -Wredundant-constraints -Wpartial-fields -Wmissed-specialisations -Wno-implicit-prelude -Wno-safe -Wno-unsafe
+  else
+    ghc-options: -Wall -Wcompat -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
   default-language: Haskell2010
 
 test-suite spec
@@ -52,6 +61,7 @@ test-suite spec
   main-is: Main.hs
   other-modules:
       Test.RawSql
+      Test.SqlMarshaller
       Test.SqlType
   hs-source-dirs:
       test
@@ -59,10 +69,12 @@ test-suite spec
   build-depends:
       base
     , bytestring
+    , hedgehog
     , mtl
     , orville-postgresql-libpq
     , resource-pool
     , tasty
+    , tasty-hedgehog
     , tasty-hspec
     , text
     , time

--- a/orville-postgresql-libpq/package.yaml
+++ b/orville-postgresql-libpq/package.yaml
@@ -11,6 +11,12 @@ tested-with: GHC == 8.6.5
 extra-source-files:
   - README.md
 
+flags:
+  ci:
+    description: More strict ghc options used for development and ci, not intended for end-use.
+    manual: true
+    default: false
+
 library:
   source-dirs: src
   exposed-modules:
@@ -19,11 +25,34 @@ library:
     - Database.Orville.PostgreSQL.Internal.ExecutionResult
     - Database.Orville.PostgreSQL.Internal.Expr
     - Database.Orville.PostgreSQL.Internal.RawSql
+    - Database.Orville.PostgreSQL.Internal.SqlMarshaller
     - Database.Orville.PostgreSQL.Internal.SqlType
-  ghc-options:
-    - -Wall
-    - -fwarn-incomplete-uni-patterns
-    - -fwarn-incomplete-record-updates
+  when:
+    - condition: flag(ci)
+      then:
+        ghc-options:
+          - -Wall
+          - -Werror
+          - -Wcompat
+          - -Widentities
+          - -Wincomplete-uni-patterns
+          - -Wincomplete-patterns
+          - -Wincomplete-record-updates
+          - -Wmissing-local-signatures
+          - -Wmissing-export-lists
+          - -Wnoncanonical-monad-instances
+          - -Wredundant-constraints
+          - -Wpartial-fields
+          - -Wmissed-specialisations
+          - -Wno-implicit-prelude
+          - -Wno-safe
+          - -Wno-unsafe
+      else:
+        ghc-options:
+          - -Wall
+          - -Wcompat
+          - -fwarn-incomplete-uni-patterns
+          - -fwarn-incomplete-record-updates
   dependencies:
     - base >=4.8 && <5
     - attoparsec
@@ -34,21 +63,23 @@ library:
     - text
     - time >=1.5
 
-
 tests:
   spec:
     source-dirs: test
     main: Main.hs
     other-modules:
       - Test.RawSql
+      - Test.SqlMarshaller
       - Test.SqlType
     dependencies:
       - base
       - bytestring
+      - hedgehog
       - mtl
       - orville-postgresql-libpq
       - resource-pool
       - tasty
+      - tasty-hedgehog
       - tasty-hspec
       - text
       - time

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Connection.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Connection.hs
@@ -114,9 +114,11 @@ connect connectionString = do
 -}
 close :: Connection -> IO ()
 close (Connection handle') =
-  let underlyingFinish restore = do
-        underlyingConnection <- tryTakeMVar handle'
-        restore (traverse LibPQ.finish underlyingConnection)
+  let
+    underlyingFinish :: (IO (Maybe ()) -> IO b) -> IO b
+    underlyingFinish restore = do
+      underlyingConnection <- tryTakeMVar handle'
+      restore (traverse LibPQ.finish underlyingConnection)
   in
     void $ mask underlyingFinish
 

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/SqlMarshaller.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/SqlMarshaller.hs
@@ -1,0 +1,48 @@
+{-|
+Module    : Database.Orville.PostgreSQL.Internal.SqlMarshaller
+Copyright : Flipstone Technology Partners 2016-2021
+License   : MIT
+-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE GADTs #-}
+module Database.Orville.PostgreSQL.Internal.SqlMarshaller
+  ( SqlMarshaller
+  , marshallFromSql
+  ) where
+
+import qualified Data.ByteString as BS
+
+-- | 'SqlMarshaller' is how we group the lowest level translation of single fields
+-- into a higher level marshalling of full sql records into Haskell records.
+-- This is a flexible abstraction that allows us to ultimately model SQL tables and work with them
+-- as potentially nested Haskell records.
+-- We can then "marshall" the data as we want to model it in sql and Haskell.
+data SqlMarshaller a b where
+-- Once we have a `FieldDefinition` we'd like to be able to marshall with it. For now this is here to sketch future development
+--  MarshallField :: FieldDefinition a -> SqlMarshaller a a
+
+  -- | Our representation of `pure` in the `Applicative` sense
+  MarshallPure  :: b -> SqlMarshaller a b
+  -- | Representation of application like `<*>` from `Applicative`
+  MarshallApply :: SqlMarshaller a (b -> c) -> SqlMarshaller a b -> SqlMarshaller a c
+
+  -- | Nest an arbitrary function, this is used when modeling a SQL table as nested Haskell records
+  MarshallNest :: (a -> b) -> SqlMarshaller b c -> SqlMarshaller a c
+
+instance Functor (SqlMarshaller a) where
+  fmap f marsh = MarshallApply (MarshallPure f) marsh
+
+instance Applicative (SqlMarshaller a) where
+  pure = MarshallPure
+  (<*>) = MarshallApply
+
+marshallFromSql :: SqlMarshaller writeEntity readEntity -> [(String, BS.ByteString)] -> Either String readEntity
+marshallFromSql marshaller sqlValues =
+  case marshaller of
+    MarshallPure readEntity ->
+      pure readEntity
+    MarshallApply marshallF marshallEntity ->
+      (marshallFromSql marshallF sqlValues) <*>
+      (marshallFromSql marshallEntity sqlValues)
+    MarshallNest _ someMarshaller ->
+      marshallFromSql someMarshaller sqlValues

--- a/orville-postgresql-libpq/test-loop
+++ b/orville-postgresql-libpq/test-loop
@@ -14,4 +14,4 @@ echo "Starting test loop using $STACK_YAML. Use \`docker-compose run --rm dev ./
 # This used to use ghcid, but I was not able to get ghcid to both run the test
 # suite *and* compile the sample project to detect errors there.  stack test
 # --fast is a bit slower than ghcid, but we need to catch all the errors :(
-stack --stack-yaml "$STACK_YAML" test --ghc-options=-j --fast --file-watch
+stack --stack-yaml "$STACK_YAML" test --ghc-options=-j --fast --file-watch --flag orville-postgresql-libpq:ci

--- a/orville-postgresql-libpq/test/Main.hs
+++ b/orville-postgresql-libpq/test/Main.hs
@@ -3,21 +3,24 @@ module Main
   ) where
 
 import qualified Data.ByteString.Char8 as B8
-import Test.Tasty (defaultMain)
+import Test.Tasty (defaultMain, testGroup)
 import Test.Tasty.Hspec (testSpec)
 
 import Database.Orville.PostgreSQL.Connection (createConnectionPool)
 import Test.RawSql (rawSqlSpecs)
 import Test.SqlType (sqlTypeSpecs)
+import Test.SqlMarshaller (sqlMarshallerTree)
 
 main :: IO ()
 main = do
   let connBStr = B8.pack "host=testdb user=orville_test password=orville"
   pool <- createConnectionPool 1 10 1 connBStr
 
-  testTree <-
+  specTree <-
     testSpec "specs" $ do
       sqlTypeSpecs pool
       rawSqlSpecs
 
-  defaultMain testTree
+  defaultMain $ testGroup "Tests" [ specTree
+                                  , sqlMarshallerTree
+                                  ]

--- a/orville-postgresql-libpq/test/Test/SqlMarshaller.hs
+++ b/orville-postgresql-libpq/test/Test/SqlMarshaller.hs
@@ -1,0 +1,33 @@
+module Test.SqlMarshaller
+  ( sqlMarshallerTree
+  ) where
+
+import qualified Hedgehog as HH
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+import Test.Tasty.Hedgehog (testProperty)
+import Test.Tasty (TestTree, testGroup)
+
+import Database.Orville.PostgreSQL.Internal.SqlMarshaller (marshallFromSql)
+
+sqlMarshallerTree :: TestTree
+sqlMarshallerTree =
+  testGroup "SqlMarshaller properties" [ roundTripSqlMarshaller
+                                       , canCombineSqlMarshaller
+                                       ]
+
+roundTripSqlMarshaller :: TestTree
+roundTripSqlMarshaller =
+  testProperty "Can round trip an int through SqlMarshaller" . HH.property $ do
+    someInt <- HH.forAll generateInt
+    (marshallFromSql (pure someInt) []) HH.=== (Right someInt)
+
+canCombineSqlMarshaller :: TestTree
+canCombineSqlMarshaller =
+  testProperty "Can combine SqlMarshallers with <*>" . HH.property $ do
+    firstInt <- HH.forAll generateInt
+    secondInt <- HH.forAll generateInt
+    marshallFromSql ((pure (+ firstInt)) <*> (pure secondInt)) [] HH.=== (Right (firstInt + secondInt))
+
+generateInt :: HH.MonadGen m => m Int
+generateInt = Gen.int $ Range.exponential 1 1024


### PR DESCRIPTION
- Adds a very much work in progress SqlMarshaller and some small tests
  - Still needs to be tied into `SqlType`
  - Tests are a Hedgehog test tree and are added slightly differently.
- Adds a cabal flag, "ci", and enables much more strict compiler checks with it.
- ci flag is enabled in the test-loop script