### PR TITLE
LibPQ: Adds multi-insert and where clauses to `Expr`

### DIFF
--- a/orville-postgresql-libpq/orville-postgresql-libpq.cabal
+++ b/orville-postgresql-libpq/orville-postgresql-libpq.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 45492f65597dba99916a20a02069b8d6123d1e00340c4bb108176a3e135316f6
+-- hash: 52827d1fa637a46d6aa5917d28223273c5ad630ff13518f602ee84c086cfedd2
 
 name:           orville-postgresql-libpq
 version:        0.9.0.0
@@ -52,6 +52,7 @@ test-suite spec
   type: exitcode-stdio-1.0
   main-is: Main.hs
   other-modules:
+      Test.Expr
       Test.RawSql
       Test.SqlType
   hs-source-dirs:

--- a/orville-postgresql-libpq/package.yaml
+++ b/orville-postgresql-libpq/package.yaml
@@ -41,6 +41,7 @@ tests:
     source-dirs: test
     main: Main.hs
     other-modules:
+      - Test.Expr
       - Test.RawSql
       - Test.SqlType
     dependencies:

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/ExecutionResult.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/ExecutionResult.hs
@@ -6,32 +6,68 @@ License   : MIT
 
 module Database.Orville.PostgreSQL.Internal.ExecutionResult
   ( decodeRows
+  , readRows
   ) where
 
+import qualified Data.ByteString as BS
 import qualified Database.PostgreSQL.LibPQ as LibPQ
 
-import Database.Orville.PostgreSQL.Internal.SqlType (SqlType(sqlTypeFromSql))
+import           Database.Orville.PostgreSQL.Internal.SqlType (SqlType(sqlTypeFromSql))
+import           Database.Orville.PostgreSQL.Internal.SqlValue (SqlValue)
 import qualified Database.Orville.PostgreSQL.Internal.SqlValue as SqlValue
+
+readRows :: LibPQ.Result -> IO [[(Maybe BS.ByteString, SqlValue)]]
+readRows res = do
+  nrows <- LibPQ.ntuples res
+  nfields <- LibPQ.nfields res
+
+  let
+    rowIndices =
+      listOfIndicesByCount nrows
+
+    fieldIndices =
+      listOfIndicesByCount nfields
+
+    -- N.B. the usage of `getvalue'` here is important as this version returns a
+    -- _copy_ of the data in the `Result` rather than a _reference_.
+    -- This allows the `Result` to be garbage collected instead of being held onto indefinitely.
+    readValue rowIndex fieldIndex = do
+      name <- LibPQ.fname res fieldIndex
+      rawValue <- LibPQ.getvalue' res rowIndex fieldIndex
+      pure $
+        ( name
+        , SqlValue.fromRawBytesNullable rawValue
+        )
+
+    readRow rowIndex =
+      traverse (readValue rowIndex) fieldIndices
+
+  traverse readRow rowIndices
+
+listOfIndicesByCount :: (Num n, Ord n, Enum n) => n -> [n]
+listOfIndicesByCount n =
+  if
+    n > 0
+  then
+    [0..(n - 1)]
+  else
+    []
+
 
 -- N.B. This only works for the first column of a table currently.
 -- If there are no results in the given `Result` then we return an empty list
 -- Otherwise we attempt to decode each result with the given `SqlType`.
 decodeRows :: LibPQ.Result -> SqlType a -> IO [Maybe a]
 decodeRows res sqlType = do
-  nrows <- LibPQ.ntuples res
-  let
-    rowList =
-      if
-        nrows > 0
-      then
-        [0..(nrows - 1)]
-      else
-        []
-    -- N.B. the usage of `getvalue'` here is important as this version returns a
-    -- _copy_ of the data in the `Result` rather than a _reference_.
-    -- This allows the `Result` to be garbage collected instead of being held onto indefinitely.
-    decodeValue row =
-      sqlTypeFromSql sqlType . SqlValue.fromRawBytesNullable
-        <$> LibPQ.getvalue' res row (LibPQ.toColumn (0::Int))
+  rows <- readRows res
 
-  traverse decodeValue rowList
+  let
+    decodeValue row =
+      case row of
+        [] ->
+          Nothing
+
+        (_, sqlValue) : _ ->
+          sqlTypeFromSql sqlType sqlValue
+
+  pure $ map decodeValue rows

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr.hs
@@ -25,6 +25,11 @@ module Database.Orville.PostgreSQL.Internal.Expr
   , andExpr
   , parenthesized
   , comparison
+  , columnEquals
+  , columnGreaterThan
+  , columnLessThan
+  , columnGreaterThanOrEqualTo
+  , columnLessThanOrEqualTo
   , RowValuePredicand
   , columnReference
   , comparisonValue
@@ -135,7 +140,7 @@ andExpr :: BooleanExpr -> BooleanExpr -> BooleanExpr
 andExpr left right =
   BooleanExpr $
     booleanExprToSql left
-    <> RawSql.fromString " OR "
+    <> RawSql.fromString " AND "
     <> booleanExprToSql right
 
 parenthesized :: BooleanExpr -> BooleanExpr
@@ -185,6 +190,26 @@ greaterThanOrEqualsOp =
 lessThanOrEqualsOp :: ComparisonOperator
 lessThanOrEqualsOp =
   ComparisonOperator (RawSql.fromString "<=")
+
+columnEquals :: ColumnName -> SqlValue -> BooleanExpr
+columnEquals name value =
+  comparison (columnReference name) equalsOp (comparisonValue value)
+
+columnGreaterThan :: ColumnName -> SqlValue -> BooleanExpr
+columnGreaterThan name value =
+  comparison (columnReference name) greaterThanOp (comparisonValue value)
+
+columnLessThan :: ColumnName -> SqlValue -> BooleanExpr
+columnLessThan name value =
+  comparison (columnReference name) lessThanOp (comparisonValue value)
+
+columnGreaterThanOrEqualTo :: ColumnName -> SqlValue -> BooleanExpr
+columnGreaterThanOrEqualTo name value =
+  comparison (columnReference name) greaterThanOrEqualsOp (comparisonValue value)
+
+columnLessThanOrEqualTo :: ColumnName -> SqlValue -> BooleanExpr
+columnLessThanOrEqualTo name value =
+  comparison (columnReference name) lessThanOrEqualsOp (comparisonValue value)
 
 newtype RowValuePredicand =
   RowValuePredicand RawSql

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr.hs
@@ -7,16 +7,42 @@ License   : MIT
 module Database.Orville.PostgreSQL.Internal.Expr
   ( QueryExpr
   , queryExpr
+  , queryExprToSql
   , SelectList
   , selectStar
+  , selectColumns
   , TableExpr
   , tableExpr
   , TableName
+  , tableNameToSql
   , rawTableName
+  , ColumnName
+  , rawColumnName
+  , WhereClause
+  , whereClause
+  , BooleanExpr
+  , orExpr
+  , andExpr
+  , parenthesized
+  , comparison
+  , RowValuePredicand
+  , columnReference
+  , comparisonValue
+  , ComparisonOperator
+  , equalsOp
+  , notEqualsOp
+  , greaterThanOp
+  , lessThanOp
+  , greaterThanOrEqualsOp
+  , lessThanOrEqualsOp
   , InsertExpr
   , insertExpr
-  , queryExprToSql
   , insertExprToSql
+  , InsertSource
+  , insertSqlValues
+  , insertRowValues
+  , RowValues
+  , rowValues
   ) where
 
 import           Database.Orville.PostgreSQL.Internal.RawSql (RawSql)
@@ -47,6 +73,13 @@ selectStar :: SelectList
 selectStar =
   SelectList (RawSql.fromString "*")
 
+selectColumns :: [ColumnName] -> SelectList
+selectColumns columnNames =
+  SelectList $
+    RawSql.intercalate
+      (RawSql.fromString ",")
+      (map columnNameToSql columnNames)
+
 selectListToSql :: SelectList -> RawSql
 selectListToSql (SelectList sql) =
   sql
@@ -57,8 +90,12 @@ newtype TableExpr =
 tableExprToSql :: TableExpr -> RawSql
 tableExprToSql (TableExpr sql) = sql
 
-tableExpr :: TableName -> TableExpr
-tableExpr = TableExpr . tableNameToSql
+tableExpr :: TableName -> Maybe WhereClause -> TableExpr
+tableExpr tableName mbWhereClause =
+  TableExpr $
+    tableNameToSql tableName
+    <> RawSql.fromString " "
+    <> maybe mempty whereClauseToSql mbWhereClause
 
 newtype TableName =
   TableName RawSql
@@ -70,19 +107,152 @@ rawTableName :: String -> TableName
 rawTableName =
   TableName . RawSql.fromString
 
+newtype WhereClause =
+  WhereClause RawSql
+
+whereClauseToSql :: WhereClause -> RawSql
+whereClauseToSql (WhereClause sql) = sql
+
+whereClause :: BooleanExpr -> WhereClause
+whereClause booleanExpr =
+  WhereClause $
+    RawSql.fromString "WHERE " <> booleanExprToSql booleanExpr
+
+newtype BooleanExpr =
+  BooleanExpr RawSql
+
+booleanExprToSql :: BooleanExpr -> RawSql
+booleanExprToSql (BooleanExpr sql) = sql
+
+orExpr :: BooleanExpr -> BooleanExpr -> BooleanExpr
+orExpr left right =
+  BooleanExpr $
+    booleanExprToSql left
+    <> RawSql.fromString " OR "
+    <> booleanExprToSql right
+
+andExpr :: BooleanExpr -> BooleanExpr -> BooleanExpr
+andExpr left right =
+  BooleanExpr $
+    booleanExprToSql left
+    <> RawSql.fromString " OR "
+    <> booleanExprToSql right
+
+parenthesized :: BooleanExpr -> BooleanExpr
+parenthesized expr =
+  BooleanExpr $
+    RawSql.fromString "(" <> booleanExprToSql expr <> RawSql.fromString ")"
+
+comparison :: RowValuePredicand
+           -> ComparisonOperator
+           -> RowValuePredicand
+           -> BooleanExpr
+comparison left op right =
+  BooleanExpr $
+    rowValuePredicandToSql left
+    <> RawSql.fromString " "
+    <> comparisonOperatiorToSql op
+    <> RawSql.fromString " "
+    <> rowValuePredicandToSql right
+
+
+newtype ComparisonOperator =
+  ComparisonOperator RawSql
+
+comparisonOperatiorToSql :: ComparisonOperator -> RawSql
+comparisonOperatiorToSql (ComparisonOperator sql) = sql
+
+equalsOp :: ComparisonOperator
+equalsOp =
+  ComparisonOperator (RawSql.fromString "=")
+
+notEqualsOp :: ComparisonOperator
+notEqualsOp =
+  ComparisonOperator (RawSql.fromString "<>")
+
+greaterThanOp :: ComparisonOperator
+greaterThanOp =
+  ComparisonOperator (RawSql.fromString ">")
+
+lessThanOp :: ComparisonOperator
+lessThanOp =
+  ComparisonOperator (RawSql.fromString "<")
+
+greaterThanOrEqualsOp :: ComparisonOperator
+greaterThanOrEqualsOp =
+  ComparisonOperator (RawSql.fromString ">=")
+
+lessThanOrEqualsOp :: ComparisonOperator
+lessThanOrEqualsOp =
+  ComparisonOperator (RawSql.fromString "<=")
+
+newtype RowValuePredicand =
+  RowValuePredicand RawSql
+
+rowValuePredicandToSql :: RowValuePredicand -> RawSql
+rowValuePredicandToSql (RowValuePredicand sql) = sql
+
+columnReference :: ColumnName -> RowValuePredicand
+columnReference =
+  RowValuePredicand . columnNameToSql
+
+comparisonValue :: SqlValue -> RowValuePredicand
+comparisonValue =
+  RowValuePredicand . RawSql.parameter
+
+newtype ColumnName =
+  ColumnName RawSql
+
+columnNameToSql :: ColumnName -> RawSql
+columnNameToSql (ColumnName sql) = sql
+
+rawColumnName :: String -> ColumnName
+rawColumnName =
+  ColumnName . RawSql.fromString
+
 newtype InsertExpr =
   InsertExpr RawSql
 
-insertExpr :: TableName -> [SqlValue] -> InsertExpr
-insertExpr target rowValues =
+insertExpr :: TableName -> InsertSource -> InsertExpr
+insertExpr target source =
   InsertExpr $
     mconcat
       [ RawSql.fromString "INSERT INTO "
       , tableNameToSql target
-      , RawSql.fromString " VALUES ("
-      , RawSql.intercalate (RawSql.fromString ",") (map RawSql.parameter rowValues)
+      , RawSql.fromString " "
+      , insertSourceToSql source
+      ]
+
+newtype InsertSource =
+  InsertSource RawSql
+
+insertSourceToSql :: InsertSource -> RawSql
+insertSourceToSql (InsertSource sql) = sql
+
+insertRowValues :: [RowValues] -> InsertSource
+insertRowValues rows =
+  InsertSource $
+    RawSql.fromString "VALUES "
+    <> RawSql.intercalate (RawSql.fromString ",") (map rowValuesToSql rows)
+
+insertSqlValues :: [[SqlValue]] -> InsertSource
+insertSqlValues rows =
+  insertRowValues (map rowValues rows)
+
+newtype RowValues =
+  RowValues RawSql
+
+rowValuesToSql :: RowValues -> RawSql
+rowValuesToSql (RowValues sql) = sql
+
+rowValues :: [SqlValue] -> RowValues
+rowValues values =
+  RowValues $
+    mconcat
+      [ RawSql.fromString "("
+      , RawSql.intercalate (RawSql.fromString ",") (map RawSql.parameter values)
       , RawSql.fromString ")"
-    ]
+      ]
 
 insertExprToSql :: InsertExpr -> RawSql
 insertExprToSql (InsertExpr sql) = sql

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/SqlValue.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/SqlValue.hs
@@ -45,6 +45,7 @@ import qualified Data.Time as Time
 data SqlValue
   = SqlValue BS.ByteString
   | SqlNull
+  deriving (Show, Eq)
 
 {-|
   Checks whether the 'SqlValue' represents a sql NULL value in the database.

--- a/orville-postgresql-libpq/test/Main.hs
+++ b/orville-postgresql-libpq/test/Main.hs
@@ -8,6 +8,7 @@ import Test.Tasty.Hspec (testSpec)
 
 import Database.Orville.PostgreSQL.Connection (createConnectionPool)
 import Test.RawSql (rawSqlSpecs)
+import Test.Expr (exprSpecs)
 import Test.SqlType (sqlTypeSpecs)
 
 main :: IO ()
@@ -17,7 +18,8 @@ main = do
 
   testTree <-
     testSpec "specs" $ do
-      sqlTypeSpecs pool
       rawSqlSpecs
+      exprSpecs pool
+      sqlTypeSpecs pool
 
   defaultMain testTree

--- a/orville-postgresql-libpq/test/Test/Expr.hs
+++ b/orville-postgresql-libpq/test/Test/Expr.hs
@@ -1,0 +1,148 @@
+module Test.Expr
+  ( exprSpecs
+  ) where
+
+
+import qualified Data.ByteString.Char8 as B8
+import           Data.Int (Int32)
+import           Data.Pool (Pool)
+
+import           Database.Orville.PostgreSQL.Connection (Connection)
+import qualified Database.Orville.PostgreSQL.Internal.ExecutionResult as ExecResult
+import qualified Database.Orville.PostgreSQL.Internal.Expr as Expr
+import qualified Database.Orville.PostgreSQL.Internal.RawSql as RawSql
+import           Database.Orville.PostgreSQL.Internal.SqlValue (SqlValue)
+import qualified Database.Orville.PostgreSQL.Internal.SqlValue as SqlValue
+import           Test.Tasty.Hspec (Spec, describe, it, shouldBe)
+
+exprSpecs :: Pool Connection -> Spec
+exprSpecs pool =
+  describe "Expr Tests" $ do
+    describe "WhereClause" $ do
+      it "Returns all rows when where clause is specified" $ do
+        runWhereConditionTest pool $
+          WhereConditionTest
+            { valuesToInsert = [1,2,3]
+            , expectedQueryResults = [1,2,3]
+            , whereClause = Nothing
+            }
+
+      it "equalsOp matches exact value" $ do
+        runWhereConditionTest pool $
+          WhereConditionTest
+            { valuesToInsert = [1,2,3]
+            , expectedQueryResults = [2]
+            , whereClause =
+                Just . Expr.whereClause $
+                  Expr.comparison
+                    (Expr.columnReference fooColumn)
+                    Expr.equalsOp
+                    (Expr.comparisonValue (SqlValue.fromInt32 2))
+            }
+
+      it "greaterThanOp matches greater values" $ do
+        runWhereConditionTest pool $
+          WhereConditionTest
+            { valuesToInsert = [1,2,3]
+            , expectedQueryResults = [3]
+            , whereClause =
+                Just . Expr.whereClause $
+                  Expr.comparison
+                    (Expr.columnReference fooColumn)
+                    Expr.greaterThanOp
+                    (Expr.comparisonValue (SqlValue.fromInt32 2))
+            }
+
+      it "greaterThanOrEqualsOp matches greater or equal values" $ do
+        runWhereConditionTest pool $
+          WhereConditionTest
+            { valuesToInsert = [1,2,3]
+            , expectedQueryResults = [2,3]
+            , whereClause =
+                Just . Expr.whereClause $
+                  Expr.comparison
+                    (Expr.columnReference fooColumn)
+                    Expr.greaterThanOrEqualsOp
+                    (Expr.comparisonValue (SqlValue.fromInt32 2))
+            }
+
+      it "lessThanOp matches lesser values" $ do
+        runWhereConditionTest pool $
+          WhereConditionTest
+            { valuesToInsert = [1,2,3]
+            , expectedQueryResults = [1]
+            , whereClause =
+                Just . Expr.whereClause $
+                  Expr.comparison
+                    (Expr.columnReference fooColumn)
+                    Expr.lessThanOp
+                    (Expr.comparisonValue (SqlValue.fromInt32 2))
+            }
+
+      it "lessThanOrEqualsOp matches lesser or equal values" $ do
+        runWhereConditionTest pool $
+          WhereConditionTest
+            { valuesToInsert = [1,2,3]
+            , expectedQueryResults = [1,2]
+            , whereClause =
+                Just . Expr.whereClause $
+                  Expr.comparison
+                    (Expr.columnReference fooColumn)
+                    Expr.lessThanOrEqualsOp
+                    (Expr.comparisonValue (SqlValue.fromInt32 2))
+            }
+
+data WhereConditionTest =
+  WhereConditionTest
+    { valuesToInsert       :: [Int32]
+    , whereClause          :: Maybe Expr.WhereClause
+    , expectedQueryResults :: [Int32]
+    }
+
+mkTestInsertSource :: WhereConditionTest -> Expr.InsertSource
+mkTestInsertSource test =
+  let
+    mkRow n = [SqlValue.fromInt32 n]
+  in
+    Expr.insertSqlValues (map mkRow $ valuesToInsert test)
+
+mkTestExpectedRows :: WhereConditionTest -> [[(Maybe B8.ByteString, SqlValue)]]
+mkTestExpectedRows test =
+  let
+    mkRow n = [(Just (B8.pack "foo"), SqlValue.fromInt32 n)]
+  in
+    map mkRow (expectedQueryResults test)
+
+runWhereConditionTest :: Pool Connection -> WhereConditionTest -> IO ()
+runWhereConditionTest pool test = do
+  dropAndRecreateTestTable pool
+
+  let
+    exprTestTable = Expr.rawTableName "expr_test"
+
+  RawSql.executeVoid pool $
+    Expr.insertExprToSql $
+      Expr.insertExpr exprTestTable (mkTestInsertSource test)
+
+  result <- RawSql.execute pool $
+    Expr.queryExprToSql $
+      Expr.queryExpr
+        (Expr.selectColumns [fooColumn])
+        (Expr.tableExpr exprTestTable (whereClause test))
+
+  rows <- traverse ExecResult.readRows result
+  rows `shouldBe` Just (mkTestExpectedRows test)
+
+testTable :: Expr.TableName
+testTable =
+  Expr.rawTableName "expr_test"
+
+fooColumn :: Expr.ColumnName
+fooColumn =
+  Expr.rawColumnName "foo"
+
+dropAndRecreateTestTable :: Pool Connection -> IO ()
+dropAndRecreateTestTable pool = do
+  RawSql.executeVoid pool (RawSql.fromString "DROP TABLE IF EXISTS " <> Expr.tableNameToSql testTable)
+  RawSql.executeVoid pool (RawSql.fromString "CREATE TABLE " <> Expr.tableNameToSql testTable <> RawSql.fromString "(foo INTEGER)")
+

--- a/orville-postgresql-libpq/test/Test/RawSql.hs
+++ b/orville-postgresql-libpq/test/Test/RawSql.hs
@@ -7,7 +7,7 @@ import qualified Data.Text as T
 
 import qualified Database.Orville.PostgreSQL.Internal.RawSql as RawSql
 import qualified Database.Orville.PostgreSQL.Internal.SqlValue as SqlValue
-import Test.Tasty.Hspec (Spec, describe, it, shouldBe)
+import           Test.Tasty.Hspec (Spec, describe, it, shouldBe)
 
 rawSqlSpecs :: Spec
 rawSqlSpecs =

--- a/orville-postgresql-libpq/test/Test/SqlType.hs
+++ b/orville-postgresql-libpq/test/Test/SqlType.hs
@@ -340,12 +340,14 @@ runDecodingTest pool test = do
 
   RawSql.executeVoid pool $
     Expr.insertExprToSql $
-      Expr.insertExpr tableName [SqlValue.fromRawBytesNullable (rawSqlValue test)]
+      Expr.insertExpr
+        tableName
+        (Expr.insertSqlValues [[SqlValue.fromRawBytesNullable (rawSqlValue test)]])
 
   maybeResult <-
     RawSql.execute pool $
       Expr.queryExprToSql $
-        Expr.queryExpr Expr.selectStar (Expr.tableExpr tableName)
+        Expr.queryExpr Expr.selectStar (Expr.tableExpr tableName Nothing)
 
   case maybeResult of
     Nothing ->


### PR DESCRIPTION
This adds a bit more support to the `Expr` module with types and
constructors for building multi-row insert statements and an initial cut
at basic where comparisons.

Along the way I added a new `readRows` function that reads the rows from
the `LibPQ` result into `SqlValue` lists for further consumption by the
caller. I imagine this will get modified eventually based on the needs
of `SqlMashaller`.