### PR TITLE
LibPQ: Adds `marshallField` to `SqlMarshaller`

### DIFF
--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/FieldDefinition.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/FieldDefinition.hs
@@ -82,7 +82,7 @@ fieldNullability = _fieldNullability
   Mashalls a Haskell value to be stored in the field to its 'SqlValue'
   representation.
 -}
-fieldValueToSqlValue :: FieldDefinition NotNull a -> a -> SqlValue
+fieldValueToSqlValue :: FieldDefinition nullability a -> a -> SqlValue
 fieldValueToSqlValue =
   SqlType.sqlTypeToSql . fieldType
 
@@ -90,7 +90,7 @@ fieldValueToSqlValue =
   Marshalls a 'SqlValue' from the database into the Haskell value that represents it.
   This may fail, in which case 'Nothing' is returned.
 -}
-fieldValueFromSqlValue :: FieldDefinition NotNull a -> SqlValue -> Maybe a
+fieldValueFromSqlValue :: FieldDefinition nullability a -> SqlValue -> Maybe a
 fieldValueFromSqlValue =
   SqlType.sqlTypeFromSql . fieldType
 

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/SqlMarshaller.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/SqlMarshaller.hs
@@ -7,20 +7,22 @@ License   : MIT
 {-# LANGUAGE GADTs #-}
 module Database.Orville.PostgreSQL.Internal.SqlMarshaller
   ( SqlMarshaller
+  , MarshallError(..)
   , marshallFromSql
+  , mashallField
   ) where
 
-import qualified Data.ByteString as BS
+import           Database.Orville.PostgreSQL.Internal.FieldDefinition (FieldDefinition, fieldName, fieldValueFromSqlValue)
+import           Database.Orville.PostgreSQL.Internal.SqlValue (SqlValue)
 
--- | 'SqlMarshaller' is how we group the lowest level translation of single fields
--- into a higher level marshalling of full sql records into Haskell records.
--- This is a flexible abstraction that allows us to ultimately model SQL tables and work with them
--- as potentially nested Haskell records.
--- We can then "marshall" the data as we want to model it in sql and Haskell.
+{-|
+  'SqlMarshaller' is how we group the lowest level translation of single fields
+  into a higher level marshalling of full sql records into Haskell records.
+  This is a flexible abstraction that allows us to ultimately model SQL tables
+  and work with them as potentially nested Haskell records.  We can then
+  "marshall" the data as we want to model it in sql and Haskell.
+-}
 data SqlMarshaller a b where
--- Once we have a `FieldDefinition` we'd like to be able to marshall with it. For now this is here to sketch future development
---  MarshallField :: FieldDefinition a -> SqlMarshaller a a
-
   -- | Our representation of `pure` in the `Applicative` sense
   MarshallPure  :: b -> SqlMarshaller a b
   -- | Representation of application like `<*>` from `Applicative`
@@ -29,6 +31,9 @@ data SqlMarshaller a b where
   -- | Nest an arbitrary function, this is used when modeling a SQL table as nested Haskell records
   MarshallNest :: (a -> b) -> SqlMarshaller b c -> SqlMarshaller a c
 
+  -- | Mashall a SQL column using the given 'FieldDefinition'
+  MarshallField :: FieldDefinition nullability a -> SqlMarshaller a a
+
 instance Functor (SqlMarshaller a) where
   fmap f marsh = MarshallApply (MarshallPure f) marsh
 
@@ -36,13 +41,92 @@ instance Applicative (SqlMarshaller a) where
   pure = MarshallPure
   (<*>) = MarshallApply
 
-marshallFromSql :: SqlMarshaller writeEntity readEntity -> [(String, BS.ByteString)] -> Either String readEntity
+{-|
+  A 'MarshallError' may be returned from 'marshallFromSql' if the result set
+  being decoded from the database doesn't meet the expectations of the
+  'SqlMarshaller' that is decoding it.
+-}
+data MarshallError
+  = -- | Indicates that a particular value in a column could not be decoded
+    FailedToDecodeValue
+    -- | Indicates that an expected column was not found in the result set
+  | FieldNotFoundInResultSet
+  deriving Eq
+
+-- NOTE: We want to be sure that the 'Show' instance of Marshall error does
+-- not expose any values read from the database, so we implement it explicitly
+-- here rather than deriving it.
+instance Show MarshallError where
+  show err =
+    case err of
+      FailedToDecodeValue      -> "FailedToDecodeValue"
+      FieldNotFoundInResultSet -> "FieldNotFoundInResultSet"
+
+{-|
+  Decodes a result set row from the database using the given 'SqlMarshaller'.
+  This will lookup the values in the result set based on the field names in all
+  the 'FieldDefinition's used in the 'SqlMarshaller' and attempt to convert the
+  'SqlValue's into their more specific Haskell types. Any failures in this
+  process will cause the entire row to fail to decode and return a
+  'MarshallError' in the result.
+-}
+marshallFromSql :: SqlMarshaller writeEntity readEntity -- ^ 'SqlMarshaller' to use for decoding
+                -> [(String, SqlValue)] -- ^ A row of field name, value pairs to decode
+                -> Either MarshallError readEntity
 marshallFromSql marshaller sqlValues =
   case marshaller of
     MarshallPure readEntity ->
       pure readEntity
+
     MarshallApply marshallF marshallEntity ->
       (marshallFromSql marshallF sqlValues) <*>
       (marshallFromSql marshallEntity sqlValues)
+
     MarshallNest _ someMarshaller ->
       marshallFromSql someMarshaller sqlValues
+
+    MarshallField fieldDef ->
+      marshallFieldFromSql fieldDef sqlValues
+
+{-|
+  A internal helper function for decoding a single field from a result set row
+-}
+marshallFieldFromSql :: FieldDefinition nullability a -> [(String, SqlValue)] -> Either MarshallError a
+marshallFieldFromSql fieldDef sqlValues =
+  case lookup (fieldName fieldDef) sqlValues of
+    Just sqlValue ->
+      case fieldValueFromSqlValue fieldDef sqlValue of
+        Just value ->
+          Right value
+
+        Nothing ->
+          Left FailedToDecodeValue
+
+    Nothing ->
+      Left FieldNotFoundInResultSet
+
+{-|
+  Builds a 'SqlMarshaller' that maps a single field of a Haskell entity to
+  a single column in the database. That value to store in the database will
+  be retried from the entity using provided accessor function. This function
+  is intended to be used inside of a stanza of 'Applicative' syntax that will
+  pass values read from the database a constructor function to rebuild the
+  entity containing the field, like so:
+
+  @
+
+  data Foo = Foo { bar :: Int32, baz :: Text }
+
+  fooMarshaller :: SqlMarshaller Foo Foo
+  fooMarshaller =
+    Foo
+      <$> marshallField bar (integerField "bar")
+      <*> marshallField baz (unboundedTextField "baz")
+
+  @
+-}
+mashallField :: (writeEntity -> fieldValue)
+             -> FieldDefinition nullability fieldValue
+             -> SqlMarshaller writeEntity fieldValue
+mashallField accessor fieldDef =
+  MarshallNest accessor (MarshallField fieldDef)

--- a/orville-postgresql-libpq/test/Test/SqlMarshaller.hs
+++ b/orville-postgresql-libpq/test/Test/SqlMarshaller.hs
@@ -2,32 +2,88 @@ module Test.SqlMarshaller
   ( sqlMarshallerTree
   ) where
 
+import           Data.Int (Int32)
+import           Hedgehog ((===))
 import qualified Hedgehog as HH
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
-import Test.Tasty.Hedgehog (testProperty)
-import Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.Hedgehog (testProperty)
+import           Test.Tasty (TestTree, testGroup)
 
-import Database.Orville.PostgreSQL.Internal.SqlMarshaller (marshallFromSql)
+import           Database.Orville.PostgreSQL.Internal.FieldDefinition (integerField)
+import           Database.Orville.PostgreSQL.Internal.SqlMarshaller (marshallFromSql, mashallField, MarshallError(..))
+import qualified Database.Orville.PostgreSQL.Internal.SqlValue as SqlValue
 
 sqlMarshallerTree :: TestTree
 sqlMarshallerTree =
-  testGroup "SqlMarshaller properties" [ roundTripSqlMarshaller
-                                       , canCombineSqlMarshaller
-                                       ]
+  testGroup "SqlMarshaller properties"
+    [ testProperty "Can round read a pure Int via SqlMarshaller" . HH.property $ do
+        someInt <- HH.forAll generateInt
+        (marshallFromSql (pure someInt) []) === (Right someInt)
 
-roundTripSqlMarshaller :: TestTree
-roundTripSqlMarshaller =
-  testProperty "Can round trip an int through SqlMarshaller" . HH.property $ do
-    someInt <- HH.forAll generateInt
-    (marshallFromSql (pure someInt) []) HH.=== (Right someInt)
+    , testProperty "Can combine SqlMarshallers with <*>" . HH.property $ do
+        firstInt <- HH.forAll generateInt
+        secondInt <- HH.forAll generateInt
+        marshallFromSql ((pure (+ firstInt)) <*> (pure secondInt)) [] === (Right (firstInt + secondInt))
 
-canCombineSqlMarshaller :: TestTree
-canCombineSqlMarshaller =
-  testProperty "Can combine SqlMarshallers with <*>" . HH.property $ do
-    firstInt <- HH.forAll generateInt
-    secondInt <- HH.forAll generateInt
-    marshallFromSql ((pure (+ firstInt)) <*> (pure secondInt)) [] HH.=== (Right (firstInt + secondInt))
+    , testProperty "Read a single field from a result row using mashallField" . HH.property $ do
+        (targetName, targetValue) <- HH.forAll (generateNamedInt32 generateName)
+        valuesBefore  <- HH.forAll (generateOtherFieldInt32s targetName)
+        valuesAfter   <- HH.forAll (generateOtherFieldInt32s targetName)
+
+        let
+          fieldDef = integerField targetName
+          marshaller = mashallField id fieldDef
+          input =
+            map
+             (\(name, value) -> (name, SqlValue.fromInt32 value))
+             (valuesBefore ++ (targetName, targetValue) : valuesAfter)
+
+        marshallFromSql marshaller input === Right targetValue
+
+    , testProperty "mashallField fails gracefully when decoding a non-existent column" . HH.property $ do
+        targetName  <- HH.forAll generateName
+        otherValues <- HH.forAll (generateOtherFieldInt32s targetName)
+
+        let
+          fieldDef = integerField targetName
+          marshaller = mashallField id fieldDef
+          input =
+            map
+             (\(name, value) -> (name, SqlValue.fromInt32 value))
+             otherValues
+
+        marshallFromSql marshaller input === Left FieldNotFoundInResultSet
+
+    , testProperty "mashallField fails gracefully when decoding a bad value" . HH.property $ do
+        targetName     <- HH.forAll generateName
+        nonIntegerText <- HH.forAll (Gen.text (Range.linear 0 10) Gen.alpha)
+
+        let
+          fieldDef = integerField targetName
+          marshaller = mashallField id fieldDef
+          input = [(targetName, SqlValue.fromText nonIntegerText)]
+
+        marshallFromSql marshaller input === Left FailedToDecodeValue
+    ]
+
+generateOtherFieldInt32s :: String -> HH.Gen [(String, Int32)]
+generateOtherFieldInt32s specialName =
+  Gen.list
+    (Range.linear 0 10)
+    (generateNamedInt32 (generateNameOtherThan specialName))
+
+generateNamedInt32 :: HH.Gen String -> HH.Gen (String, Int32)
+generateNamedInt32 genName =
+  (,) <$> genName <*> Gen.int32 (Range.exponentialFrom 0 minBound maxBound)
+
+generateNameOtherThan :: String -> HH.Gen String
+generateNameOtherThan specialName =
+  Gen.filter (/= specialName) generateName
+
+generateName :: HH.Gen String
+generateName =
+  Gen.string (Range.linear 1 256) Gen.unicode
 
 generateInt :: HH.MonadGen m => m Int
 generateInt = Gen.int $ Range.exponential 1 1024


### PR DESCRIPTION
This adds the ability to marshall a field from sql using a
`SqlMarshaller` with a `FieldDefinition`.