### PR TITLE
LibPQ: Hooks SqlMarshaller up to LibPQ Result Sets

### DIFF
--- a/orville-postgresql-libpq/orville-postgresql-libpq.cabal
+++ b/orville-postgresql-libpq/orville-postgresql-libpq.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 4a4b3d9ac6876772074dc3464efcfb643f60d828c2d15ae2eca63a8973f9489e
+-- hash: b2a8a50eb410b173a41fd55d1299d9a5916d17df4a9896c8f43bf2e03f4c99b7
 
 name:           orville-postgresql-libpq
 version:        0.9.0.0
@@ -47,6 +47,7 @@ library
       attoparsec
     , base >=4.8 && <5
     , bytestring
+    , containers >=0.6 && <0.7
     , dlist >=0.8 && <0.9
     , postgresql-libpq >=0.9.4.2 && <0.10
     , resource-pool

--- a/orville-postgresql-libpq/package.yaml
+++ b/orville-postgresql-libpq/package.yaml
@@ -60,6 +60,7 @@ library:
     - bytestring
     - dlist >= 0.8 && < 0.9
     - postgresql-libpq >= 0.9.4.2 && <0.10
+    - containers >= 0.6 && < 0.7
     - resource-pool
     - text
     - time >=1.5

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/ExecutionResult.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/ExecutionResult.hs
@@ -3,18 +3,154 @@ Module    : Database.Orville.PostgreSQL.SqlType
 Copyright : Flipstone Technology Partners 2016-2020
 License   : MIT
 -}
-
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Database.Orville.PostgreSQL.Internal.ExecutionResult
-  ( decodeRows
+  ( ExecutionResult(..)
+  , Column(..)
+  , Row(..)
+  , FakeLibPQResult
+  , mkFakeLibPQResult
+  , decodeRows
   , readRows
   ) where
 
 import qualified Data.ByteString as BS
+import           Data.Foldable (foldl')
+import qualified Data.Map.Strict as Map
 import qualified Database.PostgreSQL.LibPQ as LibPQ
 
 import           Database.Orville.PostgreSQL.Internal.SqlType (SqlType(sqlTypeFromSql))
 import           Database.Orville.PostgreSQL.Internal.SqlValue (SqlValue)
 import qualified Database.Orville.PostgreSQL.Internal.SqlValue as SqlValue
+
+{-|
+  A trivial wrapper for `Int` to help keep track of column vs row number
+-}
+newtype Column =
+  Column Int
+  deriving (Eq, Ord, Enum)
+
+{-|
+  A trivial wrapper for `Int` to help keep track of column vs row number
+-}
+newtype Row =
+  Row Int
+  deriving (Eq, Ord, Enum)
+
+{-|
+  `ExecutionResult` is a common interface for types that represent a result
+  set returned from the database. For real, live database interactions this
+  the concrete type will be a `LibPQ.Result`, but the `FakeLibPQResult`
+  may be useful as well if you are writing custom code for decoding result
+  sets and want to test aspects of the decoding that don't require a real
+  database.
+-}
+class ExecutionResult result where
+  maxRowNumber    :: result -> IO (Maybe Row)
+  maxColumnNumber :: result -> IO (Maybe Column)
+  columnName      :: result -> Column -> IO (Maybe BS.ByteString)
+  getValue        :: result -> Row -> Column -> IO SqlValue
+
+instance ExecutionResult LibPQ.Result where
+  maxRowNumber result = do
+    rowCount <- fmap fromEnum (LibPQ.ntuples result)
+    pure $
+      if
+        rowCount > 0
+      then
+        Just $ Row (rowCount - 1)
+      else
+        Nothing
+
+  maxColumnNumber result = do
+    columnCount <- fmap fromEnum (LibPQ.nfields result)
+    pure $
+      if
+        columnCount > 0
+      then
+        Just $ Column (columnCount - 1)
+      else
+        Nothing
+
+
+  columnName result =
+    LibPQ.fname result . LibPQ.toColumn . fromEnum
+
+  getValue result (Row row) (Column column) =
+    SqlValue.fromRawBytesNullable <$>
+      LibPQ.getvalue' result (LibPQ.toRow row) (LibPQ.toColumn column)
+
+{-|
+  `FakeLibPQResult` provides a fake, in memory implementation of
+  `ExecutionResult`.  This is mostly useful for writing automated tests that
+  can assume a result set has been loaded and just need to test decoding the
+  results.
+-}
+data FakeLibPQResult =
+  FakeLibPQResult
+    { fakeLibPQColumns     :: Map.Map Column BS.ByteString
+    , fakeLibPQMaxColumn   :: Maybe Column
+    , fakeLibPQMaxRow      :: Maybe Row
+    , fakeLibPQValues      :: Map.Map (Row, Column) SqlValue
+    }
+
+{-|
+  Constructs a `FakeLibPQResult`. The column names given as associated with
+  the values for each row by their position in list. Any missing values (e.g.
+  because a row is shorter than the heeader list) are treated as a SQL Null
+  value.
+-}
+mkFakeLibPQResult :: [BS.ByteString] -- ^ The column names for the result set
+                  -> [[SqlValue]] -- ^ The row data for the result set
+                  -> FakeLibPQResult
+mkFakeLibPQResult columnList valuesList =
+  let
+    indexedValues = do
+      (rowNumber, row) <- zip [Row 0..] valuesList
+      (columnNumber, value) <- zip [Column 0..] row
+      pure ((rowNumber, columnNumber), value)
+
+    maxIndex :: (Row, Column) -> (Row, Column) -> (Row, Column)
+    maxIndex (rowA, columnA) (rowB, columnB) =
+      (max rowA rowB, max columnA columnB)
+
+    (maxRow, maxColumn) =
+      case map fst indexedValues of
+        [] ->
+          (Nothing, Nothing)
+
+        firstIndex : rest ->
+          let
+            (row, column) =
+              foldl' maxIndex firstIndex rest
+          in
+            (Just row, Just column)
+
+  in
+    FakeLibPQResult
+      { fakeLibPQColumns     = Map.fromList (zip [Column 0..] columnList)
+      , fakeLibPQValues      = Map.fromList indexedValues
+      , fakeLibPQMaxRow      = maxRow
+      , fakeLibPQMaxColumn   = maxColumn
+      }
+
+instance ExecutionResult FakeLibPQResult where
+  maxRowNumber = pure . fakeLibPQMaxRow
+  maxColumnNumber = pure . fakeLibPQMaxColumn
+  columnName result = pure . fakeLibPQColumnName result
+  getValue result column = pure . fakeLibPQGetValue result column
+
+fakeLibPQColumnName :: FakeLibPQResult -> Column -> (Maybe BS.ByteString)
+fakeLibPQColumnName result column =
+  Map.lookup column (fakeLibPQColumns result)
+
+fakeLibPQGetValue :: FakeLibPQResult -> Row -> Column -> SqlValue
+fakeLibPQGetValue result rowNumber columnNumber =
+  Map.findWithDefault
+    SqlValue.sqlNull
+    (rowNumber, columnNumber)
+    (fakeLibPQValues result)
+
 
 readRows :: LibPQ.Result -> IO [[(Maybe BS.ByteString, SqlValue)]]
 readRows res = do

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/FieldDefinition.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/FieldDefinition.hs
@@ -49,8 +49,8 @@ import           Database.Orville.PostgreSQL.Internal.SqlValue (SqlValue)
 -}
 data FieldDefinition nullability a =
   FieldDefinition
-    { _fieldName :: String
-    , _fieldType :: SqlType a
+    { _fieldName        :: String
+    , _fieldType        :: SqlType a
     , _fieldNullability :: Nullability nullability
     }
 

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/SqlMarshaller.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/SqlMarshaller.hs
@@ -8,12 +8,24 @@ License   : MIT
 module Database.Orville.PostgreSQL.Internal.SqlMarshaller
   ( SqlMarshaller
   , MarshallError(..)
-  , marshallFromSql
-  , mashallField
+  , marshallResultFromSql
+  , marshallRowFromSql
+  , marshallField
+  , mkRowSource
+  , RowSource
+  , mapRowSource
+  , applyRowSource
+  , constRowSource
+  , failRowSource
   ) where
 
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.Map.Strict as Map
+import           Data.Maybe (catMaybes)
+
+import           Database.Orville.PostgreSQL.Internal.ExecutionResult (ExecutionResult, Column(..), Row(..))
+import qualified Database.Orville.PostgreSQL.Internal.ExecutionResult as Result
 import           Database.Orville.PostgreSQL.Internal.FieldDefinition (FieldDefinition, fieldName, fieldValueFromSqlValue)
-import           Database.Orville.PostgreSQL.Internal.SqlValue (SqlValue)
 
 {-|
   'SqlMarshaller' is how we group the lowest level translation of single fields
@@ -63,6 +75,168 @@ instance Show MarshallError where
       FieldNotFoundInResultSet -> "FieldNotFoundInResultSet"
 
 {-|
+  Decodes all the rows found in a execution result at once. The first row that
+  fails to decode will return the `MarshallError` that results, otherwise all
+  decoded rows will be returned.
+
+  Note that this function loads are decoded rows into memory at once, so it
+  should only be used with result sets that you know will fit into memory.
+-}
+marshallResultFromSql :: ExecutionResult result
+                      => SqlMarshaller writeEntity readEntity
+                      -> result
+                      -> IO (Either MarshallError [readEntity])
+marshallResultFromSql marshaller result = do
+  mbMaxRow <- Result.maxRowNumber result
+
+  case mbMaxRow of
+    Nothing ->
+      pure (Right [])
+
+    Just maxRow -> do
+      rowSource <- mkRowSource marshaller result
+      traverseSequence (decodeRow rowSource) [Row 0 .. maxRow]
+
+traverseSequence :: (a -> IO (Either err b)) -> [a] -> IO (Either err [b])
+traverseSequence f =
+  go
+    where
+      go as =
+        case as of
+          [] ->
+            pure (Right [])
+
+          a : rest -> do
+            eitherB <- f a
+            case eitherB of
+              Left err ->
+                pure (Left err)
+
+              Right b -> do
+                eitherBS <- go rest
+                case eitherBS of
+                  Left err ->
+                    pure (Left err)
+
+                  Right bs ->
+                    pure (Right (b:bs))
+
+
+{-|
+  A `RowSource` can fetch and decode rows from a database result set. Using
+  a `RowSource` gives random access to the rows in the result set, only
+  attempting to decode them when they are requested by the use via `decodeRow`.
+
+  Note that even though the rows are not decoded into Haskell until `decodeRow`
+  is called, all the rows returned from the query are held in memory on the
+  client waiting to be decoded until the `RowSource` is garbage collected.
+  As such, you can't use `RowSource` (alone) to achieve any form of streaming
+  or pagination of rows between the database server and the client.
+-}
+newtype RowSource readEntity =
+  RowSource (Row -> IO (Either MarshallError readEntity))
+
+instance Functor RowSource where
+  fmap = mapRowSource
+
+instance Applicative RowSource where
+  pure = constRowSource
+  (<*>) = applyRowSource
+
+{-|
+  Attempts to decode a result set row that has already been fetched from the
+  database server into a Haskell value. If the decoding fails, a `MarshallError`
+  will be returned.
+-}
+decodeRow :: RowSource readEntity -> Row -> IO (Either MarshallError readEntity)
+decodeRow (RowSource source) =
+  source
+
+{-|
+  Adds a function to the decoding proocess to transform the value returned
+  by a `RowSource`.
+-}
+mapRowSource :: (a -> b) -> RowSource a -> RowSource b
+mapRowSource f (RowSource decodeA) =
+  RowSource $ \row -> fmap (fmap f) (decodeA row)
+
+{-|
+  Creates a `RowSource` that always returns the value given, rather than
+  attempting to access the result set and decoding anything.
+-}
+constRowSource :: readEntity -> RowSource readEntity
+constRowSource =
+  RowSource . const . pure . Right
+
+{-|
+  Applies a function that will be decoded from the result set to another
+  value decode from the result set.
+-}
+applyRowSource :: RowSource (a -> b) -> RowSource a -> RowSource b
+applyRowSource (RowSource decodeAtoB) (RowSource decodeA) =
+  RowSource $ \row -> do
+    eitherAToB <- decodeAtoB row
+
+    case eitherAToB of
+      Left err ->
+        pure (Left err)
+
+      Right aToB -> do
+        eitherA <- decodeA row
+        pure (fmap aToB eitherA)
+
+{-|
+  Creates a `RowSource` that will always fail to decode by returning the
+  provided error. This can be used in cases where a `RowSource` must
+  be provided but it is already known at run time that decoding is impossible.
+  For instance, this is used internally when a `FieldDefinition` references
+  a column that does not exist in the result set.
+-}
+failRowSource :: MarshallError -> RowSource a
+failRowSource =
+  RowSource . const . pure . Left
+
+{-|
+  Uses the `SqlMarshaller` given to build a `RowSource` that will decode
+  from the given result set. The returned `RowSource` can then be used to
+  decode rows as desired by the user. Note that the entire result set is
+  held in memory for potential decoding until the `RowSource` is garbage
+  collected.
+-}
+mkRowSource :: ExecutionResult result
+            => SqlMarshaller writeEntity readEntity
+            -> result
+            -> IO (RowSource readEntity)
+mkRowSource marshaller result = do
+  columnMap <- prepareColumnMap result
+
+  let
+    mkSource :: SqlMarshaller a b -> RowSource b
+    mkSource marshallerPart =
+      -- Note, this case statement is evaluated before the row argument is
+      -- ever passed to a `RowSource` to ensure that a single `RowSource`
+      -- operation is build and re-used when decoding many rows.
+      case marshallerPart of
+        MarshallPure readEntity ->
+          constRowSource readEntity
+
+        MarshallApply marshallAToB marshallA ->
+          mkSource marshallAToB <*> mkSource marshallA
+
+        MarshallNest _ someMarshaller ->
+          mkSource someMarshaller
+
+        MarshallField fieldDef ->
+          case Map.lookup (B8.pack $ fieldName fieldDef) columnMap of
+            Just columnNumber ->
+              mkColumnRowSource fieldDef result columnNumber
+
+            Nothing ->
+              failRowSource FieldNotFoundInResultSet
+
+  pure . mkSource $ marshaller
+
+{-|
   Decodes a result set row from the database using the given 'SqlMarshaller'.
   This will lookup the values in the result set based on the field names in all
   the 'FieldDefinition's used in the 'SqlMarshaller' and attempt to convert the
@@ -70,40 +244,65 @@ instance Show MarshallError where
   process will cause the entire row to fail to decode and return a
   'MarshallError' in the result.
 -}
-marshallFromSql :: SqlMarshaller writeEntity readEntity -- ^ 'SqlMarshaller' to use for decoding
-                -> [(String, SqlValue)] -- ^ A row of field name, value pairs to decode
-                -> Either MarshallError readEntity
-marshallFromSql marshaller sqlValues =
-  case marshaller of
-    MarshallPure readEntity ->
-      pure readEntity
-
-    MarshallApply marshallF marshallEntity ->
-      (marshallFromSql marshallF sqlValues) <*>
-      (marshallFromSql marshallEntity sqlValues)
-
-    MarshallNest _ someMarshaller ->
-      marshallFromSql someMarshaller sqlValues
-
-    MarshallField fieldDef ->
-      marshallFieldFromSql fieldDef sqlValues
+marshallRowFromSql :: ExecutionResult result
+                   => SqlMarshaller writeEntity readEntity -- ^ 'SqlMarshaller' to use for decoding
+                   -> Row -- ^ A row number to decode
+                   -> result -- ^ result set to decode from
+                   -> IO (Either MarshallError readEntity)
+marshallRowFromSql marshaller rowNumber result = do
+  rowSource <- mkRowSource marshaller result
+  decodeRow rowSource rowNumber
 
 {-|
-  A internal helper function for decoding a single field from a result set row
+  An internal helper function that finds all the column names in a result set
+  and associates them with the respective column numbers for easier lookup.
 -}
-marshallFieldFromSql :: FieldDefinition nullability a -> [(String, SqlValue)] -> Either MarshallError a
-marshallFieldFromSql fieldDef sqlValues =
-  case lookup (fieldName fieldDef) sqlValues of
-    Just sqlValue ->
-      case fieldValueFromSqlValue fieldDef sqlValue of
-        Just value ->
-          Right value
+prepareColumnMap :: ExecutionResult result
+                 => result
+                 -> IO (Map.Map B8.ByteString Column)
+prepareColumnMap result = do
+  mbMaxColumn <- Result.maxColumnNumber result
 
-        Nothing ->
-          Left FailedToDecodeValue
+  let
+    mkNameEntry columnNumber = do
+      mbColumnName <- Result.columnName result columnNumber
 
+      pure $
+        case mbColumnName of
+          Just name ->
+            Just (name, columnNumber)
+
+          Nothing ->
+            Nothing
+
+  case mbMaxColumn of
     Nothing ->
-      Left FieldNotFoundInResultSet
+      pure Map.empty
+
+    Just maxColumn -> do
+      entries <- traverse mkNameEntry [Column 0 .. maxColumn]
+      pure $ Map.fromList (catMaybes entries)
+
+{-|
+  A internal helper function for to build a `RowSource` that retrieves and
+  decodes a single column value form the result set.
+-}
+mkColumnRowSource :: ExecutionResult result
+                  => FieldDefinition nullability a
+                  -> result
+                  -> Column
+                  -> RowSource a
+mkColumnRowSource fieldDef result column =
+  RowSource $ \row -> do
+    sqlValue <- Result.getValue result row column
+
+    case fieldValueFromSqlValue fieldDef sqlValue of
+      Just value ->
+        pure (Right value)
+
+      Nothing ->
+        pure (Left FailedToDecodeValue)
+
 
 {-|
   Builds a 'SqlMarshaller' that maps a single field of a Haskell entity to
@@ -125,8 +324,8 @@ marshallFieldFromSql fieldDef sqlValues =
 
   @
 -}
-mashallField :: (writeEntity -> fieldValue)
+marshallField :: (writeEntity -> fieldValue)
              -> FieldDefinition nullability fieldValue
              -> SqlMarshaller writeEntity fieldValue
-mashallField accessor fieldDef =
+marshallField accessor fieldDef =
   MarshallNest accessor (MarshallField fieldDef)

--- a/orville-postgresql-libpq/test/Test/SqlMarshaller.hs
+++ b/orville-postgresql-libpq/test/Test/SqlMarshaller.hs
@@ -2,7 +2,10 @@ module Test.SqlMarshaller
   ( sqlMarshallerTree
   ) where
 
+import qualified Data.ByteString.Char8 as B8
 import           Data.Int (Int32)
+import qualified Data.Text as T
+import           Control.Monad.IO.Class (liftIO)
 import           Hedgehog ((===))
 import qualified Hedgehog as HH
 import qualified Hedgehog.Gen as Gen
@@ -10,8 +13,10 @@ import qualified Hedgehog.Range as Range
 import           Test.Tasty.Hedgehog (testProperty)
 import           Test.Tasty (TestTree, testGroup)
 
-import           Database.Orville.PostgreSQL.Internal.FieldDefinition (integerField)
-import           Database.Orville.PostgreSQL.Internal.SqlMarshaller (marshallFromSql, mashallField, MarshallError(..))
+import           Database.Orville.PostgreSQL.Internal.ExecutionResult (Row(..))
+import qualified Database.Orville.PostgreSQL.Internal.ExecutionResult as Result
+import           Database.Orville.PostgreSQL.Internal.FieldDefinition (integerField, unboundedTextField)
+import           Database.Orville.PostgreSQL.Internal.SqlMarshaller (SqlMarshaller, marshallRowFromSql, marshallResultFromSql, marshallField, MarshallError(..))
 import qualified Database.Orville.PostgreSQL.Internal.SqlValue as SqlValue
 
 sqlMarshallerTree :: TestTree
@@ -19,63 +24,115 @@ sqlMarshallerTree =
   testGroup "SqlMarshaller properties"
     [ testProperty "Can round read a pure Int via SqlMarshaller" . HH.property $ do
         someInt <- HH.forAll generateInt
-        (marshallFromSql (pure someInt) []) === (Right someInt)
+        result <- liftIO $ marshallRowFromSql (pure someInt) (Row 0) (Result.mkFakeLibPQResult [] [])
+        result === Right someInt
 
     , testProperty "Can combine SqlMarshallers with <*>" . HH.property $ do
         firstInt <- HH.forAll generateInt
         secondInt <- HH.forAll generateInt
-        marshallFromSql ((pure (+ firstInt)) <*> (pure secondInt)) [] === (Right (firstInt + secondInt))
+        result <- liftIO $ marshallRowFromSql ((pure (+ firstInt)) <*> (pure secondInt)) (Row 0) (Result.mkFakeLibPQResult [] [])
+        result === Right (firstInt + secondInt)
 
-    , testProperty "Read a single field from a result row using mashallField" . HH.property $ do
-        (targetName, targetValue) <- HH.forAll (generateNamedInt32 generateName)
-        valuesBefore  <- HH.forAll (generateOtherFieldInt32s targetName)
-        valuesAfter   <- HH.forAll (generateOtherFieldInt32s targetName)
-
-        let
-          fieldDef = integerField targetName
-          marshaller = mashallField id fieldDef
-          input =
-            map
-             (\(name, value) -> (name, SqlValue.fromInt32 value))
-             (valuesBefore ++ (targetName, targetValue) : valuesAfter)
-
-        marshallFromSql marshaller input === Right targetValue
-
-    , testProperty "mashallField fails gracefully when decoding a non-existent column" . HH.property $ do
+    , testProperty "Read a single field from a result row using marshallField" . HH.property $ do
         targetName  <- HH.forAll generateName
-        otherValues <- HH.forAll (generateOtherFieldInt32s targetName)
+        targetValue <- HH.forAll generateInt32
+
+        namesBefore <- HH.forAll (generateNamesOtherThan targetName)
+        namesAfter  <- HH.forAll (generateNamesOtherThan targetName)
+
+        valuesBefore  <- HH.forAll (generateAssociatedValues namesBefore generateInt32)
+        valuesAfter   <- HH.forAll (generateAssociatedValues namesAfter generateInt32)
 
         let
           fieldDef = integerField targetName
-          marshaller = mashallField id fieldDef
+          marshaller = marshallField id fieldDef
           input =
-            map
-             (\(name, value) -> (name, SqlValue.fromInt32 value))
-             otherValues
+            Result.mkFakeLibPQResult
+              (map B8.pack (namesBefore ++ (targetName : namesAfter)))
+              [map SqlValue.fromInt32 (valuesBefore ++ (targetValue : valuesAfter))]
 
-        marshallFromSql marshaller input === Left FieldNotFoundInResultSet
+        result <- liftIO $ marshallRowFromSql marshaller (Row 0) input
+        result === Right targetValue
 
-    , testProperty "mashallField fails gracefully when decoding a bad value" . HH.property $ do
+    , testProperty "marshallField fails gracefully when decoding a non-existent column" . HH.property $ do
+        targetName  <- HH.forAll generateName
+        otherNames  <- HH.forAll (generateNamesOtherThan targetName)
+        otherValues <- HH.forAll (generateAssociatedValues otherNames generateInt32)
+
+        let
+          fieldDef = integerField targetName
+          marshaller = marshallField id fieldDef
+          input =
+            Result.mkFakeLibPQResult
+              (map B8.pack otherNames)
+              [map SqlValue.fromInt32 otherValues]
+
+        result <- liftIO $ marshallRowFromSql marshaller (Row 0) input
+        result === Left FieldNotFoundInResultSet
+
+    , testProperty "marshallField fails gracefully when decoding a bad value" . HH.property $ do
         targetName     <- HH.forAll generateName
         nonIntegerText <- HH.forAll (Gen.text (Range.linear 0 10) Gen.alpha)
 
         let
           fieldDef = integerField targetName
-          marshaller = mashallField id fieldDef
-          input = [(targetName, SqlValue.fromText nonIntegerText)]
+          marshaller = marshallField id fieldDef
+          input =
+            Result.mkFakeLibPQResult
+              [B8.pack targetName]
+              [[SqlValue.fromText nonIntegerText]]
 
-        marshallFromSql marshaller input === Left FailedToDecodeValue
+        result <- liftIO $ marshallRowFromSql marshaller (Row 0) input
+        result === Left FailedToDecodeValue
+
+    , testProperty "marshallResultFromSql decodes all rows in result set" . HH.property $ do
+        foos <- HH.forAll $ Gen.list (Range.linear 0 10) generateFoo
+
+        let
+          mkRowValues foo =
+            [SqlValue.fromText (fooName foo), SqlValue.fromInt32 (fooSize foo)]
+
+          input =
+            Result.mkFakeLibPQResult
+              [B8.pack "name", B8.pack "size"]
+              (map mkRowValues foos)
+
+
+        result <- liftIO $ marshallResultFromSql fooMarshaller input
+        result === Right foos
     ]
 
-generateOtherFieldInt32s :: String -> HH.Gen [(String, Int32)]
-generateOtherFieldInt32s specialName =
+data Foo =
+  Foo
+    { fooName :: T.Text
+    , fooSize :: Int32
+    } deriving (Eq, Show)
+
+fooMarshaller :: SqlMarshaller Foo Foo
+fooMarshaller =
+  Foo
+    <$> marshallField fooName (unboundedTextField "name")
+    <*> marshallField fooSize (integerField "size")
+
+generateFoo :: HH.Gen Foo
+generateFoo =
+  Foo
+    <$> Gen.text (Range.linear 0 16) Gen.unicode
+    <*> generateInt32
+
+generateNamesOtherThan :: String -> HH.Gen [String]
+generateNamesOtherThan specialName =
   Gen.list
     (Range.linear 0 10)
-    (generateNamedInt32 (generateNameOtherThan specialName))
+    (generateNameOtherThan specialName)
 
-generateNamedInt32 :: HH.Gen String -> HH.Gen (String, Int32)
-generateNamedInt32 genName =
-  (,) <$> genName <*> Gen.int32 (Range.exponentialFrom 0 minBound maxBound)
+generateAssociatedValues :: [key] -> HH.Gen value -> HH.Gen [value]
+generateAssociatedValues keys genValue =
+  traverse (const genValue) keys
+
+generateInt32 :: HH.Gen Int32
+generateInt32 =
+  Gen.int32 (Range.exponentialFrom 0 minBound maxBound)
 
 generateNameOtherThan :: String -> HH.Gen String
 generateNameOtherThan specialName =
@@ -83,7 +140,7 @@ generateNameOtherThan specialName =
 
 generateName :: HH.Gen String
 generateName =
-  Gen.string (Range.linear 1 256) Gen.unicode
+  Gen.string (Range.linear 1 256) Gen.alphaNum
 
 generateInt :: HH.MonadGen m => m Int
 generateInt = Gen.int $ Range.exponential 1 1024


### PR DESCRIPTION
This adds an `ExecutionResult` typeclass whose functions mimic those of
LibPQ's `Result` type. The `SqlMarshaller` functions were then changed
to take use types that that satisfy this typeclass, which required
changing the how it interacts with the source data to match LibPQ's
access pattern.

I've provided `FakeLibPQResult` implementation of `ExecutionResult` as
well so that we can continue to write tests that don't have to touch the
database, but can still closely mimic lower layers of the integration
that have already been tested.