### PR TITLE
Quoted index names in index migrations

### DIFF
--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/MigrateIndex.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/MigrateIndex.hs
@@ -30,7 +30,7 @@ createIndexPlan indexDef schemaState = do
              then "UNIQUE"
              else ""
          , "INDEX"
-         , indexName indexDef
+         , "\"" ++ indexName indexDef ++ "\""
          , "ON"
          , "\"" ++ indexTable indexDef ++ "\""
          , indexBody indexDef


### PR DESCRIPTION
Surrounds index names in double quotes when generating migration SQL in
`createIndexPlan` to preserve case sensitivity.