### PR TITLE
LibPQ: Checks for NUL bytes before sending value to LibPQ

### DIFF
--- a/orville-postgresql-libpq/orville-postgresql-libpq.cabal
+++ b/orville-postgresql-libpq/orville-postgresql-libpq.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.31.1.
+-- This file has been generated from package.yaml by hpack version 0.33.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: b2a8a50eb410b173a41fd55d1299d9a5916d17df4a9896c8f43bf2e03f4c99b7
+-- hash: f24eb5b2eb38f5137d430c2153d964155e8cc13ba33bd5f602fe0fcecef54c53
 
 name:           orville-postgresql-libpq
 version:        0.9.0.0
@@ -35,6 +35,7 @@ library
       Database.Orville.PostgreSQL.Internal.ExecutionResult
       Database.Orville.PostgreSQL.Internal.Expr
       Database.Orville.PostgreSQL.Internal.FieldDefinition
+      Database.Orville.PostgreSQL.Internal.PGTextFormatValue
       Database.Orville.PostgreSQL.Internal.RawSql
       Database.Orville.PostgreSQL.Internal.SqlMarshaller
       Database.Orville.PostgreSQL.Internal.SqlType
@@ -63,8 +64,10 @@ test-suite spec
   type: exitcode-stdio-1.0
   main-is: Main.hs
   other-modules:
+      Test.Connection
       Test.Expr
       Test.FieldDefinition
+      Test.PGGen
       Test.RawSql
       Test.SqlMarshaller
       Test.SqlType
@@ -77,6 +80,7 @@ test-suite spec
     , hedgehog
     , mtl
     , orville-postgresql-libpq
+    , postgresql-libpq
     , resource-pool
     , tasty
     , tasty-hedgehog

--- a/orville-postgresql-libpq/package.yaml
+++ b/orville-postgresql-libpq/package.yaml
@@ -25,6 +25,7 @@ library:
     - Database.Orville.PostgreSQL.Internal.ExecutionResult
     - Database.Orville.PostgreSQL.Internal.Expr
     - Database.Orville.PostgreSQL.Internal.FieldDefinition
+    - Database.Orville.PostgreSQL.Internal.PGTextFormatValue
     - Database.Orville.PostgreSQL.Internal.RawSql
     - Database.Orville.PostgreSQL.Internal.SqlMarshaller
     - Database.Orville.PostgreSQL.Internal.SqlType
@@ -70,8 +71,10 @@ tests:
     source-dirs: test
     main: Main.hs
     other-modules:
+      - Test.Connection
       - Test.Expr
       - Test.FieldDefinition
+      - Test.PGGen
       - Test.RawSql
       - Test.SqlMarshaller
       - Test.SqlType
@@ -79,6 +82,7 @@ tests:
       - base
       - bytestring
       - hedgehog
+      - postgresql-libpq
       - mtl
       - orville-postgresql-libpq
       - resource-pool

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/PGTextFormatValue.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/PGTextFormatValue.hs
@@ -1,0 +1,96 @@
+module Database.Orville.PostgreSQL.Internal.PGTextFormatValue
+  ( PGTextFormatValue
+  , NULByteFoundError(NULByteFoundError)
+  , unsafeFromByteString
+  , fromByteString
+  , toByteString
+  , toBytesForLibPQ
+  ) where
+
+import qualified Data.ByteString as BS
+
+{-|
+  A 'PGTextFormatValue' represents raw bytes that will be passed to postgresql
+  via libpq. These bytes must conform to the TEXT format of values that
+  postgresql expects. In all cases postgresql will be allowed to infer the type
+  of the value based on its usage in the query.
+
+  Note that postgresql does not allow NUL bytes in text values, and the LibPQ C
+  library expects text values to be given as NULL-terminated C Strings, so
+  '\NUL' bytes cannot be included in a 'PGTextFormatValue'. If 'fromByteString'
+  is used to construct the 'PGTextFormatValue' (normally what you should do),
+  an error will be raised before libpq is called to execute the query. If
+  'unsafeFromByteString' is used, the caller is expected to ensure that no
+  '\NUL' bytes are present. If a '\NUL' byte is included with
+  'unsafeFromByteString', the value passed to the database will be truncated at
+  the '\NUL' byte because it will be interprested as the end of the C String by
+  libpq.
+-}
+data PGTextFormatValue
+  = NoAssumptionsMade BS.ByteString
+  | AssumedToHaveNoNULValues BS.ByteString
+  deriving (Show)
+
+instance Eq PGTextFormatValue where
+  left == right =
+    toBytesForLibPQ left == toBytesForLibPQ right
+
+data NULByteFoundError =
+  NULByteFoundError
+  deriving (Show, Eq)
+
+{-|
+  Constructs a 'PGTextFormatValue' from the given bytes directly, without checking
+  whether any of the bytes are '\NUL' or not. If a 'BS.ByteString' containing
+  a '\NUL' byte is given, the value will be truncated at the '\NUL' when it
+  is passed to libpq.
+
+  This function is only safe to use when you have generated the bytestring
+  in a way that guarantees no '\NUL' bytes are present, such as when serializing
+  an integer value to its decimal representation.
+-}
+unsafeFromByteString :: BS.ByteString -> PGTextFormatValue
+unsafeFromByteString =
+  AssumedToHaveNoNULValues
+
+{-|
+  Constructs a 'PGTextFormatValue' from the given bytes, which will be checked
+  to ensure none of them are '\NUL' before being passed to libpq. If a '\NUL'
+  byte is found an error will be raised.
+-}
+fromByteString :: BS.ByteString -> PGTextFormatValue
+fromByteString =
+  NoAssumptionsMade
+
+{-|
+  Converts the 'PGTextFormatValue' to bytes intended to be passed to libpq.
+  If any '\NUL' bytes are found, 'NULByteErrorFound' will be returned (unless
+  'unsafeFromByteString' was used to construct the value).
+-}
+toBytesForLibPQ :: PGTextFormatValue -> Either NULByteFoundError BS.ByteString
+toBytesForLibPQ value =
+  case value of
+    AssumedToHaveNoNULValues noNULBytes ->
+      Right noNULBytes
+
+    NoAssumptionsMade anyBytes ->
+      if
+        BS.elem 0 anyBytes
+      then
+        Left NULByteFoundError
+      else
+        Right anyBytes
+
+{-|
+  Convents the 'PGTextFormatValue' back to the bytes that were used to
+  construct it, losing the information about whether it would be checked
+  for '\NUL' bytes or not.
+-}
+toByteString :: PGTextFormatValue -> BS.ByteString
+toByteString value =
+  case value of
+    AssumedToHaveNoNULValues bytes ->
+      bytes
+
+    NoAssumptionsMade bytes ->
+      bytes

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/PGTextFormatValue.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/PGTextFormatValue.hs
@@ -23,7 +23,7 @@ import qualified Data.ByteString as BS
   'unsafeFromByteString' is used, the caller is expected to ensure that no
   '\NUL' bytes are present. If a '\NUL' byte is included with
   'unsafeFromByteString', the value passed to the database will be truncated at
-  the '\NUL' byte because it will be interprested as the end of the C String by
+  the '\NUL' byte because it will be interpreted as the end of the C String by
   libpq.
 -}
 data PGTextFormatValue

--- a/orville-postgresql-libpq/test/Main.hs
+++ b/orville-postgresql-libpq/test/Main.hs
@@ -7,6 +7,7 @@ import Test.Tasty (defaultMain, testGroup)
 import Test.Tasty.Hspec (testSpec)
 
 import Database.Orville.PostgreSQL.Connection (createConnectionPool)
+import Test.Connection (connectionTree)
 import Test.Expr (exprSpecs)
 import Test.FieldDefinition (fieldDefinitionTree)
 import Test.RawSql (rawSqlSpecs)
@@ -26,7 +27,8 @@ main = do
 
   defaultMain $
     testGroup "Tests"
-      [ specTree
+      [ connectionTree pool
+      , specTree
       , sqlMarshallerTree
       , fieldDefinitionTree pool
       ]

--- a/orville-postgresql-libpq/test/Test/Connection.hs
+++ b/orville-postgresql-libpq/test/Test/Connection.hs
@@ -1,0 +1,95 @@
+module Test.Connection
+  ( connectionTree
+  ) where
+
+import           Control.Monad.IO.Class (liftIO)
+import qualified Data.ByteString.Char8 as B8
+import           Data.Pool (Pool)
+import qualified Data.Text.Encoding as Enc
+import qualified Database.PostgreSQL.LibPQ as LibPQ
+import           Hedgehog ((===))
+import qualified Hedgehog as HH
+import qualified Hedgehog.Range as Range
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.Hedgehog (testProperty)
+
+import           Database.Orville.PostgreSQL.Connection (Connection)
+import qualified Database.Orville.PostgreSQL.Connection as Connection
+import qualified Database.Orville.PostgreSQL.Internal.PGTextFormatValue as PGTextFormatValue
+
+import qualified Test.PGGen as PGGen
+
+connectionTree :: Pool Connection -> TestTree
+connectionTree pool =
+  testGroup "Connection"
+    [ testProperty "executeRaw can pass non-null bytes equivalents whether checked for NUL or not" . HH.property $ do
+        text <- HH.forAll $ PGGen.pgText (Range.linear 0 256)
+
+        let
+          notNulBytes =
+            Enc.encodeUtf8 text
+
+        result <-
+          liftIO $ do
+            mbLibPQResult <-
+              Connection.executeRaw
+                pool
+                (B8.pack "SELECT $1::text = $2::text")
+                [ Just $ PGTextFormatValue.fromByteString notNulBytes
+                , Just $ PGTextFormatValue.unsafeFromByteString notNulBytes
+                ]
+
+            traverse (\r -> LibPQ.getvalue' r 0 0) mbLibPQResult
+
+        result === Just (Just (B8.pack "t"))
+
+    , testProperty "executeRaw returns error if nul byte is given using safe constructor" . HH.property $ do
+        textBefore <- HH.forAll $ PGGen.pgText (Range.linear 0 32)
+        textAfter <- HH.forAll $ PGGen.pgText (Range.linear 0 32)
+
+        let
+          bytesWithNul =
+            B8.concat
+              [ Enc.encodeUtf8 textBefore
+              , B8.pack "\NUL"
+              , Enc.encodeUtf8 textAfter
+              ]
+
+        result <-
+          liftIO $ do
+            Connection.executeRaw
+              pool
+              (B8.pack "SELECT $1::text")
+              [ Just $ PGTextFormatValue.fromByteString bytesWithNul
+              ]
+
+        result === Nothing
+
+    , testProperty "executeRaw truncates values at the nul byte given using unsafe constructor" . HH.property $ do
+        textBefore <- HH.forAll $ PGGen.pgText (Range.linear 0 32)
+        textAfter <- HH.forAll $ PGGen.pgText (Range.linear 0 32)
+
+        let
+          bytesBefore =
+            Enc.encodeUtf8 textBefore
+
+          bytesWithNul =
+            B8.concat
+              [ bytesBefore
+              , B8.pack "\NUL"
+              , Enc.encodeUtf8 textAfter
+              ]
+
+        result <-
+          liftIO $ do
+            mbLibPQResult <-
+              Connection.executeRaw
+                pool
+                (B8.pack "SELECT $1::text")
+                [ Just $ PGTextFormatValue.unsafeFromByteString bytesWithNul
+                ]
+
+            traverse (\r -> LibPQ.getvalue' r 0 0) mbLibPQResult
+
+        result === Just (Just bytesBefore)
+    ]

--- a/orville-postgresql-libpq/test/Test/PGGen.hs
+++ b/orville-postgresql-libpq/test/Test/PGGen.hs
@@ -1,0 +1,24 @@
+module Test.PGGen
+  ( pgText
+  , pgDouble
+  ) where
+
+import qualified Data.Text as T
+import qualified Hedgehog as HH
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+pgText :: HH.Range Int -> HH.Gen T.Text
+pgText range =
+  Gen.text range $
+    Gen.filter (/= '\NUL') Gen.unicode
+
+pgDouble :: HH.Gen Double
+pgDouble =
+  let
+    -- Necessary because PostgreSQL only stores up to 15 digits of precision
+    -- With a 3-digit range, this gives us 12 places after the decimal
+    truncateLongDouble :: Double -> Double
+    truncateLongDouble = (/1e12) . (fromIntegral :: Int -> Double) . round . (*1e12)
+  in
+    flip Gen.subterm truncateLongDouble . Gen.double $ Range.linearFracFrom 0 (-1000) 1000

--- a/orville-postgresql-libpq/test/Test/RawSql.hs
+++ b/orville-postgresql-libpq/test/Test/RawSql.hs
@@ -5,6 +5,7 @@ module Test.RawSql
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Text as T
 
+import qualified Database.Orville.PostgreSQL.Internal.PGTextFormatValue as PGTextFormatValue
 import qualified Database.Orville.PostgreSQL.Internal.RawSql as RawSql
 import qualified Database.Orville.PostgreSQL.Internal.SqlValue as SqlValue
 import           Test.Tasty.Hspec (Spec, describe, it, shouldBe)
@@ -50,9 +51,9 @@ rawSqlSpecs =
           B8.pack "SELECT * FROM foo WHERE id = $1 AND bar IN ($2,$3)"
 
         expectedParams =
-          [ Just (B8.pack "1")
-          , Just (B8.pack "pants")
-          , Just (B8.pack "cheese")
+          [ Just . PGTextFormatValue.fromByteString . B8.pack $ "1"
+          , Just . PGTextFormatValue.fromByteString . B8.pack $ "pants"
+          , Just . PGTextFormatValue.fromByteString . B8.pack $ "cheese"
           ]
 
         (actualBytes, actualParams) =

--- a/orville-postgresql-libpq/test/Test/SqlMarshaller.hs
+++ b/orville-postgresql-libpq/test/Test/SqlMarshaller.hs
@@ -19,6 +19,8 @@ import           Database.Orville.PostgreSQL.Internal.FieldDefinition (integerFi
 import           Database.Orville.PostgreSQL.Internal.SqlMarshaller (SqlMarshaller, marshallRowFromSql, marshallResultFromSql, marshallField, MarshallError(..))
 import qualified Database.Orville.PostgreSQL.Internal.SqlValue as SqlValue
 
+import qualified Test.PGGen as PGGen
+
 sqlMarshallerTree :: TestTree
 sqlMarshallerTree =
   testGroup "SqlMarshaller properties"
@@ -117,7 +119,7 @@ fooMarshaller =
 generateFoo :: HH.Gen Foo
 generateFoo =
   Foo
-    <$> Gen.text (Range.linear 0 16) Gen.unicode
+    <$> PGGen.pgText (Range.linear 0 16)
     <*> generateInt32
 
 generateNamesOtherThan :: String -> HH.Gen [String]


### PR DESCRIPTION
This adds a new type, `PGTextFormatValu,e` to track whether we know that
the bytes it contains are all non-NUL (e.g. because we constructed
directly). For any values we do _not_ know are non-NUL, we check them at
the time of building the param list to pass to lib and abort running
the query. For now `executeRow` return `Nothing`, the same as if LibPQ
returned an error. We have another story to start doing better error
handling in general, so I have left actually raising the error about
NUL bytes for that story.