### PR TITLE
Support years between 0 and 1000

### DIFF
--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/SqlValue.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/SqlValue.hs
@@ -240,7 +240,7 @@ fromUTCTime =
   SqlValue
   . PGTextFormatValue.unsafeFromByteString
   . B8.pack
-  . Time.formatTime Time.defaultTimeLocale (Time.iso8601DateFormat (Just "%H:%M:%S"))
+  . Time.formatTime Time.defaultTimeLocale "%0Y-%m-%dT%H:%M:%S"
 
 {-|
   Attempts to decode a 'SqlValue' as a 'Time.UTCTime' formatted in iso8601

--- a/orville-postgresql-libpq/test/Test/FieldDefinition.hs
+++ b/orville-postgresql-libpq/test/Test/FieldDefinition.hs
@@ -111,7 +111,7 @@ utcTimeGen =
 
 dayGen :: HH.Gen Time.Day
 dayGen = do
-  year <- Gen.integral (Range.linearFrom 2000 1000 3000)
+  year <- Gen.integral (Range.linearFrom 2000 0 3000)
   month <- Gen.integral (Range.constant 1 12)
   day <- Gen.integral (Range.constant 1 (Time.gregorianMonthLength year month))
 


### PR DESCRIPTION
Expands a round-trip test's domain by formatting years to always have four digits