### PR TITLE
Adds planMaybe

### DIFF
--- a/orville-postgresql/test/PlanTest.hs
+++ b/orville-postgresql/test/PlanTest.hs
@@ -123,6 +123,11 @@ test_plan =
             QC.counterexample ("Expected: " ++ show leftAndRightEntityList) $
             QC.counterexample ("Actual: " ++ show entitiesFound) $
             entitiesFound == leftAndRightEntityList
+
+      , testRootPlan "planMaybe" run $
+          Plan.bind Plan.askParam $ \param ->
+          Plan.using (Just <$> param) $
+          Plan.planMaybe (Plan.findOne rootTable rootIdField)
       ]
 
 -- mkTreeRecords projects a Tree into the Root, Branch and Leaf entities


### PR DESCRIPTION
Lifts a `Plan scope a b` to a `Plan scope (Maybe a) (Maybe b)`

h/t @jlavelle for original implementation based on `planEither`