### PR TITLE
LibPQ: Surfaces SQL Execution Errors

### DIFF
--- a/orville-postgresql-libpq/docker-compose.yml
+++ b/orville-postgresql-libpq/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       TEST_CONN_STRING: "host=testdb user=orville_test"
     command:
       - ./test-loop
-      - stack.yml
+      - stack-lts-17.3.yml
     # A TTY is required for the test-loop script to use
     # stack test. stdin_open would be sufficient, but
     # allocating a tty provides colorful test output :)

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Connection.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Connection.hs
@@ -260,7 +260,7 @@ instance Show ConnectionError where
               Left decodingErr ->
                 "Error decoding libPQ messages as utf8: " <> show decodingErr
      in
-      connectionErrorMessage err <> libPQErrorMsg
+      connectionErrorMessage err <> ": " <> libPQErrorMsg
 
 instance Exception ConnectionError
 

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/PGTextFormatValue.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/PGTextFormatValue.hs
@@ -7,6 +7,7 @@ module Database.Orville.PostgreSQL.Internal.PGTextFormatValue
   , toBytesForLibPQ
   ) where
 
+import           Control.Exception (Exception)
 import qualified Data.ByteString as BS
 
 {-|
@@ -38,6 +39,8 @@ instance Eq PGTextFormatValue where
 data NULByteFoundError =
   NULByteFoundError
   deriving (Show, Eq)
+
+instance Exception NULByteFoundError where
 
 {-|
   Constructs a 'PGTextFormatValue' from the given bytes directly, without checking

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/RawSql.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/RawSql.hs
@@ -178,7 +178,7 @@ intercalate separator parts =
   to read the documentation of 'Conn.executeRaw' for caveats and warnings.
   Use with caution.
 -}
-execute :: Pool Connection -> RawSql -> IO (Maybe LibPQ.Result)
+execute :: Pool Connection -> RawSql -> IO LibPQ.Result
 execute conn rawSql =
   let
     (sqlBytes, params) =

--- a/orville-postgresql-libpq/stack.yaml
+++ b/orville-postgresql-libpq/stack.yaml
@@ -1,1 +1,0 @@
-stack-lts-17.3.yml

--- a/orville-postgresql-libpq/test/Test/Expr.hs
+++ b/orville-postgresql-libpq/test/Test/Expr.hs
@@ -197,8 +197,8 @@ runOrderByTest pool test = do
         (Expr.selectColumns [fooColumn, barColumn])
         (Expr.tableExpr exprTestTable Nothing (orderByClause test))
 
-  rows <- traverse ExecResult.readRows result
-  rows `shouldBe` Just (mkOrderByTestExpectedRows test)
+  rows <- ExecResult.readRows result
+  rows `shouldBe` mkOrderByTestExpectedRows test
 
 data WhereConditionTest =
   WhereConditionTest
@@ -244,8 +244,8 @@ runWhereConditionTest pool test = do
         (Expr.selectColumns [fooColumn, barColumn])
         (Expr.tableExpr exprTestTable (whereClause test) Nothing)
 
-  rows <- traverse ExecResult.readRows result
-  rows `shouldBe` Just (mkTestExpectedRows test)
+  rows <- ExecResult.readRows result
+  rows `shouldBe` mkTestExpectedRows test
 
 testTable :: Expr.TableName
 testTable =

--- a/orville-postgresql-libpq/test/Test/FieldDefinition.hs
+++ b/orville-postgresql-libpq/test/Test/FieldDefinition.hs
@@ -150,19 +150,16 @@ runRoundTripTest pool testCase = do
             (Expr.selectColumns [FieldDef.fieldColumnName fieldDef])
             (Expr.tableExpr testTable Nothing Nothing)
 
-    traverse readRows result
+    readRows result
 
   let
     roundTripResult =
       case rows of
-        Just [[(_, sqlValue)]] ->
+        [[(_, sqlValue)]] ->
           Right (FieldDef.fieldValueFromSqlValue fieldDef sqlValue)
 
-        Just _ ->
+        _ ->
           Left ("Expected one row with one value in results, but got: " ++ show rows)
-
-        Nothing ->
-          Left "Query failed to run"
 
   roundTripResult === Right (Just value)
 

--- a/orville-postgresql-libpq/test/Test/SqlType.hs
+++ b/orville-postgresql-libpq/test/Test/SqlType.hs
@@ -7,7 +7,7 @@ import qualified Data.ByteString.Char8 as B8
 import Data.Int (Int64)
 import qualified Data.Text as T
 import qualified Data.Time as Time
-import Test.Tasty.Hspec (Spec, describe, it, shouldBe, expectationFailure)
+import Test.Tasty.Hspec (Spec, describe, it, shouldBe)
 
 import Database.Orville.PostgreSQL.Connection (Connection, executeRawVoid)
 import Database.Orville.PostgreSQL.Internal.ExecutionResult (decodeRows)
@@ -344,18 +344,13 @@ runDecodingTest pool test = do
         tableName
         (Expr.insertSqlValues [[SqlValue.fromRawBytesNullable (rawSqlValue test)]])
 
-  maybeResult <-
+  result <-
     RawSql.execute pool $
       Expr.queryExprToSql $
         Expr.queryExpr Expr.selectStar (Expr.tableExpr tableName Nothing Nothing)
 
-  case maybeResult of
-    Nothing ->
-      expectationFailure "select returned nothing"
-
-    Just res -> do
-      (maybeA:_) <- decodeRows res (sqlType test)
-      shouldBe maybeA (Just (expectedValue test))
+  (maybeA:_) <- decodeRows result (sqlType test)
+  shouldBe maybeA (Just (expectedValue test))
 
 dropAndRecreateTable :: Pool Connection -> String -> String -> IO ()
 dropAndRecreateTable pool tableName columnTypeDDL = do


### PR DESCRIPTION
This raises errors that can happen during exection as `Exception` values
in the `IO` Monad. These can be errors detected on the client side (e.g.
connection closed, null bytes found in input parameters) or returned
from the database sql (e.g. sql syntax error).

Once we start adding the high-level interfaces (in particular, using
orville within monad stacks) we may decide we want this lower level
interface to offer non-IO based error handling. We can address that
question once we get to it.

Side note: this removes the `stack.yaml` symlink because `docker-compose
up` was failing with a complaint that it could not find the file.