### PR TITLE
Fixes ordering being inverted in queries that use map helpers.

### DIFF
--- a/orville-postgresql/orville-postgresql.cabal
+++ b/orville-postgresql/orville-postgresql.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: cb9f60aed3d13e8c20dd9694909584a5bb05857b41365b9170a80e00d7f41c38
+-- hash: 74017f0307dc27bc8d19386229570049793a10df5261a59bb0dfbdd327ee404e
 
 name:           orville-postgresql
 version:        0.8.3.0
@@ -171,6 +171,7 @@ test-suite spec
       MonadBaseControlTest
       OptionalMap.CrudTest
       OptionalMap.Entity
+      OrderByTest
       ParameterizedEntity.CrudTest
       ParameterizedEntity.Data.Virus
       ParameterizedEntity.Schema

--- a/orville-postgresql/src/Data/Map/Helpers.hs
+++ b/orville-postgresql/src/Data/Map/Helpers.hs
@@ -16,7 +16,7 @@ groupBy keyFunc = groupBy' mkEntry
     mkEntry a = (keyFunc a, a)
 
 groupBy' :: Ord k => (a -> (k, v)) -> [a] -> Map.Map k [v]
-groupBy' mkEntry as = Map.fromListWith (++) (map mkListEntry as)
+groupBy' mkEntry as = Map.fromListWith (flip (++)) (map mkListEntry as)
   where
     mkListEntry a =
       let (k, v) = mkEntry a

--- a/orville-postgresql/src/Data/Map/Helpers.hs
+++ b/orville-postgresql/src/Data/Map/Helpers.hs
@@ -9,6 +9,7 @@ module Data.Map.Helpers
   ) where
 
 import qualified Data.Map.Strict as Map
+import qualified Data.DList as DList
 
 groupBy :: Ord k => (a -> k) -> [a] -> Map.Map k [a]
 groupBy keyFunc = groupBy' mkEntry
@@ -16,8 +17,8 @@ groupBy keyFunc = groupBy' mkEntry
     mkEntry a = (keyFunc a, a)
 
 groupBy' :: Ord k => (a -> (k, v)) -> [a] -> Map.Map k [v]
-groupBy' mkEntry as = Map.fromListWith (flip (++)) (map mkListEntry as)
+groupBy' mkEntry as = fmap DList.toList $ Map.fromListWith (flip DList.append) (fmap mkListEntry as)
   where
     mkListEntry a =
       let (k, v) = mkEntry a
-       in (k, [v])
+       in (k, DList.singleton v)

--- a/orville-postgresql/test/OrderByTest.hs
+++ b/orville-postgresql/test/OrderByTest.hs
@@ -1,0 +1,201 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module OrderByTest where
+
+import qualified Data.Map as M
+import qualified Data.Text as T
+import qualified Database.Orville.PostgreSQL as O
+import qualified Database.Orville.PostgreSQL.Select as S
+import qualified TestDB as TestDB
+
+import Control.Monad (void)
+import Data.Int (Int64)
+import Database.Orville.PostgreSQL.Expr (aliased, qualified)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertEqual, testCase)
+
+test_order_by :: TestTree
+test_order_by =
+  TestDB.withOrvilleRun $ \run ->
+    testGroup
+      "Order by queries"
+      [ testCase "Sort Ascending" $ do
+          run (TestDB.reset schema)
+          void $ run (O.insertRecord orderTable foobarOrder)
+          void $ run (O.insertRecord orderTable anotherFoobarOrder)
+          void $ run (O.insertRecord orderTable orderNamedAlice)
+          result <- run (O.findRecordsBy orderTable customerFkIdField $
+                          O.order orderNameField O.Ascending
+                        )
+          let lookupResult =
+                case M.lookup (CustomerId 2) result of
+                  Just res -> fmap orderName res
+                  Nothing -> []
+
+          assertEqual
+            "Order returned didn't match expected result"
+            [ orderName orderNamedAlice
+            , orderName anotherFoobarOrder
+            ]
+            lookupResult
+      , testCase "Sort Descending" $ do
+          run (TestDB.reset schema)
+          void $ run (O.insertRecord orderTable foobarOrder)
+          void $ run (O.insertRecord orderTable anotherFoobarOrder)
+          void $ run (O.insertRecord orderTable orderNamedAlice)
+          result <- run (O.findRecordsBy orderTable customerFkIdField $
+                          O.order orderNameField O.Descending
+                        )
+          let lookupResult =
+                case M.lookup (CustomerId 2) result of
+                  Just res -> fmap orderName res
+                  Nothing -> []
+
+          assertEqual
+            "Order returned didn't match expected result"
+            [ orderName anotherFoobarOrder
+            , orderName orderNamedAlice
+            ]
+            lookupResult
+      ]
+
+data CompleteOrder = CompleteOrder
+  { order :: T.Text
+  , customer :: T.Text
+  } deriving (Eq, Show)
+
+completeOrderSelect :: O.SelectOptions -> S.Select CompleteOrder
+completeOrderSelect = S.selectQuery buildCompleteOrder orderCustomerFrom
+
+buildCompleteOrder :: O.FromSql CompleteOrder
+buildCompleteOrder =
+  CompleteOrder <$>
+  O.col
+    (S.selectField orderNameField `qualified` "order" `aliased` "order_name") <*>
+  O.col
+    (S.selectField customerNameField `qualified` "customer" `aliased`
+     "customer_name")
+
+orderCustomerFrom :: S.FromClause
+orderCustomerFrom =
+  S.fromClauseRaw
+    "FROM \"order\" INNER JOIN \"customer\" ON \"order\".\"customer_id\" = \"customer\".\"id\""
+
+schema :: O.SchemaDefinition
+schema = [O.Table orderTable, O.Table customerTable]
+
+-- Order definitions
+orderTable :: O.TableDefinition Order Order OrderId
+orderTable =
+  O.mkTableDefinition $
+  O.TableParams
+    { O.tblName = "order"
+    , O.tblPrimaryKey = O.primaryKey orderIdField
+    , O.tblMapper =
+        Order <$> O.attrField orderId orderIdField <*>
+        O.attrField customerFkId customerFkIdField <*>
+        O.attrField orderName orderNameField
+    , O.tblGetKey = orderId
+    , O.tblSafeToDelete = []
+    , O.tblComments = O.noComments
+    }
+
+orderIdField :: O.FieldDefinition O.NotNull OrderId
+orderIdField =
+  O.int64Field "id" `O.withConversion`
+  O.convertSqlType unOrderId OrderId
+
+customerFkIdField :: O.FieldDefinition O.NotNull CustomerId
+customerFkIdField =
+  O.int64Field "customer_id" `O.withConversion`
+  O.convertSqlType unCustomerId CustomerId
+
+orderNameField :: O.FieldDefinition O.NotNull OrderName
+orderNameField =
+  O.textField "name" 255 `O.withConversion`
+  O.convertSqlType unOrderName OrderName
+
+data Order = Order
+  { orderId :: OrderId
+  , customerFkId :: CustomerId
+  , orderName :: OrderName
+  } deriving (Show, Eq)
+
+newtype OrderId = OrderId
+  { unOrderId :: Int64
+  } deriving (Show, Eq)
+
+newtype OrderName = OrderName
+  { unOrderName :: T.Text
+  } deriving (Show, Eq)
+
+foobarOrder :: Order
+foobarOrder =
+  Order
+    { orderId = OrderId 1
+    , customerFkId = CustomerId 1
+    , orderName = OrderName "foobar"
+    }
+
+anotherFoobarOrder :: Order
+anotherFoobarOrder =
+  Order
+    { orderId = OrderId 3
+    , customerFkId = CustomerId 2
+    , orderName = OrderName "Foobar"
+    }
+
+orderNamedAlice :: Order
+orderNamedAlice =
+  Order
+    { orderId = OrderId 2
+    , customerFkId = CustomerId 2
+    , orderName = OrderName "Alice"
+    }
+
+orderNameSelect :: O.SelectOptions -> S.Select OrderName
+orderNameSelect = S.selectQuery buildOrderName orderNameFrom
+
+buildOrderName :: O.FromSql OrderName
+buildOrderName = OrderName <$> O.col (S.selectField orderNameField)
+
+orderNameFrom :: S.FromClause
+orderNameFrom = S.fromClauseTable orderTable
+
+-- Customer definitions
+customerTable :: O.TableDefinition Customer Customer CustomerId
+customerTable =
+  O.mkTableDefinition $
+  O.TableParams
+    { O.tblName = "customer"
+    , O.tblPrimaryKey = O.primaryKey customerIdField
+    , O.tblMapper =
+        Customer <$> O.attrField customerId customerIdField <*>
+        O.attrField customerName customerNameField
+    , O.tblGetKey = customerId
+    , O.tblSafeToDelete = []
+    , O.tblComments = O.noComments
+    }
+
+customerIdField :: O.FieldDefinition O.NotNull CustomerId
+customerIdField =
+  O.int64Field "id" `O.withConversion`
+  O.convertSqlType unCustomerId CustomerId
+
+customerNameField :: O.FieldDefinition O.NotNull CustomerName
+customerNameField =
+  O.textField "name" 255 `O.withConversion`
+  O.convertSqlType unCustomerName CustomerName
+
+data Customer = Customer
+  { customerId :: CustomerId
+  , customerName :: CustomerName
+  } deriving (Show, Eq)
+
+newtype CustomerId = CustomerId
+  { unCustomerId :: Int64
+  } deriving (Show, Eq, Ord)
+
+newtype CustomerName = CustomerName
+  { unCustomerName :: T.Text
+  } deriving (Show, Eq)


### PR DESCRIPTION
This is to address #124 

Tests added are adapted from the `WhereCondition` test module for expediency.