### PR TITLE
LibPQ: Adds marshallEntityToSql

### DIFF
--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr.hs
@@ -20,6 +20,7 @@ module Database.Orville.PostgreSQL.Internal.Expr
   , ColumnName
   , rawColumnName
   , columnNameToSql
+  , sqlToColumnName
   , WhereClause
   , whereClause
   , BooleanExpr

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/Name/ColumnName.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/Name/ColumnName.hs
@@ -8,6 +8,7 @@ module Database.Orville.PostgreSQL.Internal.Expr.Name.ColumnName
   ( ColumnName
   , rawColumnName
   , columnNameToSql
+  , sqlToColumnName
   ) where
 
 import qualified Database.Orville.PostgreSQL.Internal.RawSql as RawSql
@@ -19,3 +20,6 @@ columnNameToSql (ColumnName sql) = sql
 
 rawColumnName :: String -> ColumnName
 rawColumnName = ColumnName . RawSql.fromString
+
+sqlToColumnName :: RawSql.RawSql -> ColumnName
+sqlToColumnName = ColumnName


### PR DESCRIPTION
This adds a `marshallEntityToSql` function that can be used to convert a
Haskell entity to the SQL fields described by the marshaller. This is
implemented in as a fold-style function to allow the caller to build
whatever result type is required for their context.

Along the way I introduced the `FieldName` type to help make the
signature of `marshallEntityToSql` easier to understand. I went ahead
and made it a wrapper around `ByteString` rather than `String` since
that is mostly how we used the value.