### PR TITLE
Formats the LibPQ codebase with fourmolu

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - checkout
       - run:
           name: make sure dockerfile is built
-          command: cd orville-postgresql-libpq && docker-compose build
+          command: cd orville-postgresql-libpq && docker-compose build -q
       - run:
           name: run tests against ghc8.10.4 (stackage lts-17.3)
           command: cd orville-postgresql-libpq && docker-compose run --rm dev stack --stack-yaml stack-lts-17.3.yml test --ghc-options=-j --flag orville-postgresql-libpq:ci
@@ -20,7 +20,7 @@ jobs:
       - checkout
       - run:
           name: make sure dockerfile is built
-          command: cd orville-postgresql-libpq && docker-compose build
+          command: cd orville-postgresql-libpq && docker-compose build -q
       - run:
           name: run tests against ghc8.10.3 (stackage lts-17.0)
           command: cd orville-postgresql-libpq && docker-compose run --rm dev stack --stack-yaml stack-lts-17.0.yml test --ghc-options=-j --flag orville-postgresql-libpq:ci
@@ -32,10 +32,34 @@ jobs:
       - checkout
       - run:
           name: make sure dockerfile is built
-          command: cd orville-postgresql-libpq && docker-compose build
+          command: cd orville-postgresql-libpq && docker-compose build -q
       - run:
           name: run tests against ghc8.8.4 (stackage lts-16.12)
           command: cd orville-postgresql-libpq && docker-compose run --rm dev stack --stack-yaml stack-lts-16.12.yml test --ghc-options=-j --flag orville-postgresql-libpq:ci
+
+  formatting-check:
+    machine:
+      image: ubuntu-2004:202101-01
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            # Note that format-repo.sh is where we have the version of fourmolu set
+            - tooling-lint-v1-{{ checksum "orville-postgresql-libpq/scripts/format-repo.sh" }}
+      - run:
+          name: make sure dockerfile is built
+          command: cd orville-postgresql-libpq && docker-compose -f docker-compose.ci-lint.yml build -q
+      - run:
+          name: run formatting so we can see if there is a diff
+          command: cd orville-postgresql-libpq && docker-compose -f docker-compose.ci-lint.yml run --rm lint sh -c ./scripts/format-repo.sh && sudo chown -R circleci:circleci .stack-root
+      - save_cache:
+          paths:
+            - orville-postgresql-libpq/.stack-root
+          # Note that format-repo.sh is where we have the version of fourmolu set
+          key: tooling-lint-v1-{{ checksum "orville-postgresql-libpq/scripts/format-repo.sh" }}
+      - run:
+          name: check for formatting diff
+          command: cd orville-postgresql-libpq && sh -c scripts/format-check-ci.sh
 
 workflows:
   version: 2.0
@@ -44,3 +68,4 @@ workflows:
       - postgresql-96-and-ghc884
       - postgresql-96-and-ghc8103
       - postgresql-96-and-ghc8104
+      - formatting-check

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ docker-compose.tools-override.yml
 
 #
 instantclient*
+
+# We use a ci compose file that keeps some extra bits locally to cache
+# They are ignored below to avoid them being included in various operations, locally and in ci
+.stack-root

--- a/orville-postgresql-libpq/docker-compose.ci-lint.yml
+++ b/orville-postgresql-libpq/docker-compose.ci-lint.yml
@@ -1,0 +1,21 @@
+---
+version: "3"
+services:
+  # This entire file to help with ci, it is not recommended for local use
+  # as it keeps certain things on the filesystem to help with caching.
+  lint:
+    build: .
+    volumes:
+      - ..:/orville
+      - stack-work:/orville/orville-postgresql-libpq/.stack-work
+      - .stack-root:/stack-root
+    working_dir: /orville/orville-postgresql-libpq
+    environment:
+      STACK_ROOT: /stack-root
+    command:
+      # For now we are only running the format-repo script by "default".
+      # But the idea here is to be able to expand this with other tooling as we desire
+      - ./scripts/format-repo.sh
+    tty: true
+volumes:
+  stack-work:

--- a/orville-postgresql-libpq/fourmolu.yaml
+++ b/orville-postgresql-libpq/fourmolu.yaml
@@ -1,0 +1,9 @@
+---
+indentation: 2
+comma-style: leading
+record-brace-space: true
+indent-wheres: true
+diff-friendly-import-export: false
+respectful: true
+haddock-style: multi-line
+newlines-between-decls: 1

--- a/orville-postgresql-libpq/scripts/format-check-ci.sh
+++ b/orville-postgresql-libpq/scripts/format-check-ci.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+NUM_FILES_CHANGED=$(git status --porcelain | wc -l)
+if [ "$NUM_FILES_CHANGED" -gt 0 ]; then
+    printf "Formatting resulted in a diff! Please run the formatting in the repo\n"
+    exit 1;
+fi

--- a/orville-postgresql-libpq/scripts/format-repo.sh
+++ b/orville-postgresql-libpq/scripts/format-repo.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [ "$(command -v fourmolu)" = "" ] ; then
+    stack --silent --allow-different-user install fourmolu-0.3.0.0
+fi
+
+find . -name '*.hs' | xargs -P0 fourmolu -i

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL.hs
@@ -1,78 +1,71 @@
-{-|
+{- |
 Module    : Database.Orville.PostgreSQL.Raw
 Copyright : Flipstone Technology Partners 2020-2021
 License   : MIT
 -}
-
 module Database.Orville.PostgreSQL
-  ( createConnectionPool
-  , SqlType ( SqlType
-            , sqlTypeExpr
-            , sqlTypeReferenceExpr
-            , sqlTypeNullable
-            , sqlTypeId
-            , sqlTypeSqlSize
-            , sqlTypeToSql
-            , sqlTypeFromSql
-            )
+  ( createConnectionPool,
+    SqlType
+      ( SqlType,
+        sqlTypeExpr,
+        sqlTypeReferenceExpr,
+        sqlTypeNullable,
+        sqlTypeId,
+        sqlTypeSqlSize,
+        sqlTypeToSql,
+        sqlTypeFromSql
+      ),
     -- numeric types
-  , integer
-  , serial
-  , bigInteger
-  , bigSerial
-  , double
-
+    integer,
+    serial,
+    bigInteger,
+    bigSerial,
+    double,
     -- textual-ish types
-  , boolean
-  , unboundedText
-  , fixedText
-  , boundedText
-  , textSearchVector
-
+    boolean,
+    unboundedText,
+    fixedText,
+    boundedText,
+    textSearchVector,
     -- date types
-  , date
-  , timestamp
-
+    date,
+    timestamp,
     -- type conversions
-  , nullableType
-  , foreignRefType
-  , convertSqlType
-  , maybeConvertSqlType
-  , Expr.QueryExpr
-  ) where
+    nullableType,
+    foreignRefType,
+    convertSqlType,
+    maybeConvertSqlType,
+    Expr.QueryExpr,
+  )
+where
 
 import Database.Orville.PostgreSQL.Connection (createConnectionPool)
-import Database.Orville.PostgreSQL.Internal.SqlType (SqlType ( SqlType
-                                                             , sqlTypeExpr
-                                                             , sqlTypeReferenceExpr
-                                                             , sqlTypeNullable
-                                                             , sqlTypeId
-                                                             , sqlTypeSqlSize
-                                                             , sqlTypeToSql
-                                                             , sqlTypeFromSql
-                                                             )
-                                                      -- numeric types
-                                                    , integer
-                                                    , serial
-                                                    , bigInteger
-                                                    , bigSerial
-                                                    , double
-
-                                                      -- textual-ish types
-                                                    , boolean
-                                                    , unboundedText
-                                                    , fixedText
-                                                    , boundedText
-                                                    , textSearchVector
-
-                                                    -- date types
-                                                    , date
-                                                    , timestamp
-
-                                                    -- type conversions
-                                                    , nullableType
-                                                    , foreignRefType
-                                                    , convertSqlType
-                                                    , maybeConvertSqlType
-                                                    )
 import qualified Database.Orville.PostgreSQL.Internal.Expr as Expr
+import Database.Orville.PostgreSQL.Internal.SqlType
+  ( SqlType
+      ( SqlType,
+        sqlTypeExpr,
+        sqlTypeFromSql,
+        sqlTypeId,
+        sqlTypeNullable,
+        sqlTypeReferenceExpr,
+        sqlTypeSqlSize,
+        sqlTypeToSql
+      ),
+    bigInteger,
+    bigSerial,
+    boolean,
+    boundedText,
+    convertSqlType,
+    date,
+    double,
+    fixedText,
+    foreignRefType,
+    integer,
+    maybeConvertSqlType,
+    nullableType,
+    serial,
+    textSearchVector,
+    timestamp,
+    unboundedText,
+  )

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Connection.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Connection.hs
@@ -1,48 +1,52 @@
-{-|
+{- |
 Module    : Database.Orville.PostgreSQL.Connection
 Copyright : Flipstone Technology Partners 2016-2021
 License   : MIT
 -}
-
 module Database.Orville.PostgreSQL.Connection
-  ( Connection
-  , Pool
-  , ConnectionUsedAfterCloseError
-  , ConnectionError
-  , SqlExecutionError(..)
-  , createConnectionPool
-  , executeRaw
-  , executeRawVoid
-  ) where
+  ( Connection,
+    Pool,
+    ConnectionUsedAfterCloseError,
+    ConnectionError,
+    SqlExecutionError (..),
+    createConnectionPool,
+    executeRaw,
+    executeRawVoid,
+  )
+where
 
-import           Control.Concurrent (threadWaitRead, threadWaitWrite)
-import           Control.Concurrent.MVar (MVar, newMVar, tryTakeMVar, tryReadMVar)
-import           Control.Exception(Exception, mask, throwIO)
-import           Control.Monad (void)
+import Control.Concurrent (threadWaitRead, threadWaitWrite)
+import Control.Concurrent.MVar (MVar, newMVar, tryReadMVar, tryTakeMVar)
+import Control.Exception (Exception, mask, throwIO)
+import Control.Monad (void)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
-import           Data.Maybe (fromMaybe)
-import           Data.Pool (Pool, createPool, withResource)
-import           Data.Time (NominalDiffTime)
+import Data.Maybe (fromMaybe)
+import Data.Pool (Pool, createPool, withResource)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as Enc
+import Data.Time (NominalDiffTime)
 import qualified Database.PostgreSQL.LibPQ as LibPQ
 
-import           Database.Orville.PostgreSQL.Internal.PGTextFormatValue (PGTextFormatValue, NULByteFoundError(NULByteFoundError), toBytesForLibPQ)
+import Database.Orville.PostgreSQL.Internal.PGTextFormatValue (NULByteFoundError (NULByteFoundError), PGTextFormatValue, toBytesForLibPQ)
 
-{-|
+{- |
  'createConnectionPool' allocates a pool of connections to a PosgreSQL server.
 -}
 createConnectionPool ::
-     Int -- ^ Number of stripes in the connection pool
-  -> NominalDiffTime -- ^ Linger time before closing an idle connection
-  -> Int -- ^ Max number of connections to allocate per stripe
-  -> BS.ByteString -- ^ A PostgreSQL connection string
-  -> IO (Pool Connection)
+  -- | Number of stripes in the connection pool
+  Int ->
+  -- | Linger time before closing an idle connection
+  NominalDiffTime ->
+  -- | Max number of connections to allocate per stripe
+  Int ->
+  -- | A PostgreSQL connection string
+  BS.ByteString ->
+  IO (Pool Connection)
 createConnectionPool stripes linger maxRes connectionString =
   createPool (connect connectionString) close stripes linger maxRes
 
-{-|
+{- |
  'executeRaw' runs a given SQL statement returning the raw underlying result.
 
  All handling of stepping through the result set is left to the caller.  This
@@ -50,19 +54,19 @@ createConnectionPool stripes linger maxRes connectionString =
  of the results are not iterated through immediately *and* the data copied.
  Use with caution.
 -}
-executeRaw :: Pool Connection
-           -> BS.ByteString
-           -> [Maybe PGTextFormatValue]
-           -> IO LibPQ.Result
+executeRaw ::
+  Pool Connection ->
+  BS.ByteString ->
+  [Maybe PGTextFormatValue] ->
+  IO LibPQ.Result
 executeRaw pool bs params =
   case traverse (traverse toBytesForLibPQ) params of
     Left NULByteFoundError ->
       throwIO NULByteFoundError
-
     Right paramBytes ->
       withResource pool (underlyingExecute bs paramBytes)
 
-{-|
+{- |
  'executeRawVoid' a version of 'executeRaw' that completely ignores the result.
  If an error occurs it is raised as an exception.
  Use with caution.
@@ -71,12 +75,12 @@ executeRawVoid :: Pool Connection -> BS.ByteString -> [Maybe PGTextFormatValue] 
 executeRawVoid pool bs params =
   void $ executeRaw pool bs params
 
-{-|
+{- |
  The basic connection interface.
 -}
 newtype Connection = Connection (MVar LibPQ.Connection)
 
-{-|
+{- |
  'connect' is the internal, primitive connection function.
 
  This should not be exposed to end users, but instead wrapped in something to create a pool.
@@ -86,38 +90,32 @@ newtype Connection = Connection (MVar LibPQ.Connection)
 -}
 connect :: BS.ByteString -> IO Connection
 connect connectionString =
-  let
-    checkSocketAndThreadWait conn threadWaitFn = do
-      fd <- LibPQ.socket conn
-      case fd of
-        Nothing -> do
-          throwConnectionError "connect: failed to get file descriptor for socket" conn
+  let checkSocketAndThreadWait conn threadWaitFn = do
+        fd <- LibPQ.socket conn
+        case fd of
+          Nothing -> do
+            throwConnectionError "connect: failed to get file descriptor for socket" conn
+          Just fd' -> do
+            threadWaitFn fd'
+            poll conn
 
-        Just fd' -> do
-          threadWaitFn fd'
-          poll conn
+      poll conn = do
+        pollStatus <- LibPQ.connectPoll conn
+        case pollStatus of
+          LibPQ.PollingFailed -> do
+            throwConnectionError "connect: polling failed while connecting to database server" conn
+          LibPQ.PollingReading ->
+            checkSocketAndThreadWait conn threadWaitRead
+          LibPQ.PollingWriting ->
+            checkSocketAndThreadWait conn threadWaitWrite
+          LibPQ.PollingOk -> do
+            connectionHandle <- newMVar conn
+            pure (Connection connectionHandle)
+   in do
+        connection <- LibPQ.connectStart connectionString
+        poll connection
 
-    poll conn = do
-      pollStatus <- LibPQ.connectPoll conn
-      case pollStatus of
-        LibPQ.PollingFailed -> do
-          throwConnectionError "connect: polling failed while connecting to database server" conn
-
-        LibPQ.PollingReading ->
-          checkSocketAndThreadWait conn threadWaitRead
-
-        LibPQ.PollingWriting ->
-          checkSocketAndThreadWait conn threadWaitWrite
-
-        LibPQ.PollingOk -> do
-          connectionHandle <- newMVar conn
-          pure (Connection connectionHandle)
-
-  in do
-    connection <- LibPQ.connectStart connectionString
-    poll connection
-
-{-|
+{- |
   'close' has many subtleties to it.
 
   First note that async exceptions are masked.  'mask' though, only works for
@@ -131,19 +129,16 @@ connect connectionString =
   both the non-blocking semantics to protect from async exceptions with 'mask'
   _and_ should never truly return an empty unless two threads were racing to
   close the connection, in which case.. one of them will close the connection.
-
 -}
 close :: Connection -> IO ()
 close (Connection handle') =
-  let
-    underlyingFinish :: (IO (Maybe ()) -> IO b) -> IO b
-    underlyingFinish restore = do
-      underlyingConnection <- tryTakeMVar handle'
-      restore (traverse LibPQ.finish underlyingConnection)
-  in
-    void $ mask underlyingFinish
+  let underlyingFinish :: (IO (Maybe ()) -> IO b) -> IO b
+      underlyingFinish restore = do
+        underlyingConnection <- tryTakeMVar handle'
+        restore (traverse LibPQ.finish underlyingConnection)
+   in void $ mask underlyingFinish
 
-{-|
+{- |
  'underlyingExecute' is the internal, primitive execute function.
 
   This is not intended to be directly exposed to end users, but instead wrapped
@@ -154,17 +149,17 @@ close (Connection handle') =
   And a connection should be closed upon removal from a resource pool (in which
   case it can't be used for this  function in the first place).
 -}
-underlyingExecute :: BS.ByteString
-                  -> [Maybe BS.ByteString]
-                  -> Connection
-                  -> IO LibPQ.Result
+underlyingExecute ::
+  BS.ByteString ->
+  [Maybe BS.ByteString] ->
+  Connection ->
+  IO LibPQ.Result
 underlyingExecute bs params (Connection handle') = do
   mbConn <- tryReadMVar handle'
 
   case mbConn of
     Nothing ->
       throwIO ConnectionUsedAfterCloseError
-
     Just conn -> do
       mbResult <-
         LibPQ.execParams conn bs (map mkInferredTextParam params) LibPQ.Text
@@ -172,17 +167,13 @@ underlyingExecute bs params (Connection handle') = do
       case mbResult of
         Nothing -> do
           throwConnectionError "No result returned from exec by libpq" conn
-
         Just result -> do
           execStatus <- LibPQ.resultStatus result
 
-          if
-            isRowReadableStatus execStatus
-          then
-            pure result
-          else do
-            throwLibPQResultError result execStatus
-
+          if isRowReadableStatus execStatus
+            then pure result
+            else do
+              throwLibPQResultError result execStatus
 
 throwConnectionError :: String -> LibPQ.Connection -> IO a
 throwConnectionError message conn = do
@@ -194,9 +185,10 @@ throwConnectionError message conn = do
       , connectionErrorLibPQMessage = mbLibPQError
       }
 
-throwLibPQResultError :: LibPQ.Result
-                      -> LibPQ.ExecStatus
-                      -> IO a
+throwLibPQResultError ::
+  LibPQ.Result ->
+  LibPQ.ExecStatus ->
+  IO a
 throwLibPQResultError result execStatus = do
   mbLibPQError <- LibPQ.resultErrorMessage result
   mbSqlState <- LibPQ.resultErrorField result LibPQ.DiagSqlstate
@@ -204,26 +196,25 @@ throwLibPQResultError result execStatus = do
   throwIO $
     SqlExecutionError
       { sqlExecutionErrorExecStatus = execStatus
-      , sqlExecutionErrorMessage    = fromMaybe (B8.pack "No error message available from LibPQ") mbLibPQError
-      , sqlExecutionErrorSqlState   = mbSqlState
+      , sqlExecutionErrorMessage = fromMaybe (B8.pack "No error message available from LibPQ") mbLibPQError
+      , sqlExecutionErrorSqlState = mbSqlState
       }
 
 isRowReadableStatus :: LibPQ.ExecStatus -> Bool
 isRowReadableStatus status =
   case status of
-    LibPQ.CommandOk     -> True  -- ??
-    LibPQ.TuplesOk      -> True  -- Returned on successful query, even if there are 0 rows.
-    LibPQ.SingleTuple   -> True  -- Only returned when a query is executed is single row mode
-
-    LibPQ.EmptyQuery    -> False
-    LibPQ.CopyOut       -> False
-    LibPQ.CopyIn        -> False
-    LibPQ.CopyBoth      -> False -- CopyBoth is only used for streaming replication, so should not occur in ordinary applications
-    LibPQ.BadResponse   -> False
+    LibPQ.CommandOk -> True -- ??
+    LibPQ.TuplesOk -> True -- Returned on successful query, even if there are 0 rows.
+    LibPQ.SingleTuple -> True -- Only returned when a query is executed is single row mode
+    LibPQ.EmptyQuery -> False
+    LibPQ.CopyOut -> False
+    LibPQ.CopyIn -> False
+    LibPQ.CopyBoth -> False -- CopyBoth is only used for streaming replication, so should not occur in ordinary applications
+    LibPQ.BadResponse -> False
     LibPQ.NonfatalError -> False -- NonfatalError never returned from LibPQ query execution functions. It passes them to the notice processor instead.
-    LibPQ.FatalError    -> False
+    LibPQ.FatalError -> False
 
-{-|
+{- |
   Packages a bytestring parameter value (which is assumed to be a value encoded
   as text that the database can use) as a parameter for executing a query.
   This uses Oid 0 to cause the database to infer the type of the paremeter and
@@ -234,47 +225,41 @@ mkInferredTextParam mbValue =
   case mbValue of
     Nothing ->
       Nothing
-
     Just value ->
       Just (LibPQ.Oid 0, value, LibPQ.Text)
 
-data ConnectionError =
-  ConnectionError
-    { connectionErrorMessage      :: String
-    , connectionErrorLibPQMessage :: Maybe BS.ByteString
-    }
+data ConnectionError = ConnectionError
+  { connectionErrorMessage :: String
+  , connectionErrorLibPQMessage :: Maybe BS.ByteString
+  }
 
 instance Show ConnectionError where
   show err =
-    let
-      libPQErrorMsg =
-        case connectionErrorLibPQMessage err of
-          Nothing ->
-            "<no underying error available>"
-
-          Just libPQMsg ->
-            case Enc.decodeUtf8' libPQMsg of
-              Right decoded ->
-                T.unpack decoded
-
-              Left decodingErr ->
-                "Error decoding libPQ messages as utf8: " <> show decodingErr
-     in
-      connectionErrorMessage err <> ": " <> libPQErrorMsg
+    let libPQErrorMsg =
+          case connectionErrorLibPQMessage err of
+            Nothing ->
+              "<no underying error available>"
+            Just libPQMsg ->
+              case Enc.decodeUtf8' libPQMsg of
+                Right decoded ->
+                  T.unpack decoded
+                Left decodingErr ->
+                  "Error decoding libPQ messages as utf8: " <> show decodingErr
+     in connectionErrorMessage err <> ": " <> libPQErrorMsg
 
 instance Exception ConnectionError
 
-data SqlExecutionError =
-  SqlExecutionError
-    { sqlExecutionErrorExecStatus :: LibPQ.ExecStatus
-    , sqlExecutionErrorMessage    :: BS.ByteString
-    , sqlExecutionErrorSqlState   :: Maybe BS.ByteString
-    } deriving (Show)
+data SqlExecutionError = SqlExecutionError
+  { sqlExecutionErrorExecStatus :: LibPQ.ExecStatus
+  , sqlExecutionErrorMessage :: BS.ByteString
+  , sqlExecutionErrorSqlState :: Maybe BS.ByteString
+  }
+  deriving (Show)
 
 instance Exception SqlExecutionError
 
-data ConnectionUsedAfterCloseError =
-  ConnectionUsedAfterCloseError
+data ConnectionUsedAfterCloseError
+  = ConnectionUsedAfterCloseError
   deriving (Show)
 
 instance Exception ConnectionUsedAfterCloseError

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/ExecutionResult.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/ExecutionResult.hs
@@ -1,43 +1,45 @@
-{-|
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+{- |
 Module    : Database.Orville.PostgreSQL.SqlType
 Copyright : Flipstone Technology Partners 2016-2021
 License   : MIT
 -}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Database.Orville.PostgreSQL.Internal.ExecutionResult
-  ( ExecutionResult(..)
-  , Column(..)
-  , Row(..)
-  , FakeLibPQResult
-  , mkFakeLibPQResult
-  , decodeRows
-  , readRows
-  ) where
+  ( ExecutionResult (..),
+    Column (..),
+    Row (..),
+    FakeLibPQResult,
+    mkFakeLibPQResult,
+    decodeRows,
+    readRows,
+  )
+where
 
 import qualified Data.ByteString as BS
-import           Data.Foldable (foldl')
+import Data.Foldable (foldl')
 import qualified Data.Map.Strict as Map
 import qualified Database.PostgreSQL.LibPQ as LibPQ
 
-import           Database.Orville.PostgreSQL.Internal.SqlType (SqlType(sqlTypeFromSql))
-import           Database.Orville.PostgreSQL.Internal.SqlValue (SqlValue)
+import Database.Orville.PostgreSQL.Internal.SqlType (SqlType (sqlTypeFromSql))
+import Database.Orville.PostgreSQL.Internal.SqlValue (SqlValue)
 import qualified Database.Orville.PostgreSQL.Internal.SqlValue as SqlValue
 
-{-|
+{- |
   A trivial wrapper for `Int` to help keep track of column vs row number
 -}
-newtype Column =
-  Column Int
+newtype Column
+  = Column Int
   deriving (Eq, Ord, Enum)
 
-{-|
+{- |
   A trivial wrapper for `Int` to help keep track of column vs row number
 -}
-newtype Row =
-  Row Int
+newtype Row
+  = Row Int
   deriving (Eq, Ord, Enum)
 
-{-|
+{- |
   `ExecutionResult` is a common interface for types that represent a result
   set returned from the database. For real, live database interactions this
   the concrete type will be a `LibPQ.Result`, but the `FakeLibPQResult`
@@ -46,93 +48,82 @@ newtype Row =
   database.
 -}
 class ExecutionResult result where
-  maxRowNumber    :: result -> IO (Maybe Row)
+  maxRowNumber :: result -> IO (Maybe Row)
   maxColumnNumber :: result -> IO (Maybe Column)
-  columnName      :: result -> Column -> IO (Maybe BS.ByteString)
-  getValue        :: result -> Row -> Column -> IO SqlValue
+  columnName :: result -> Column -> IO (Maybe BS.ByteString)
+  getValue :: result -> Row -> Column -> IO SqlValue
 
 instance ExecutionResult LibPQ.Result where
   maxRowNumber result = do
     rowCount <- fmap fromEnum (LibPQ.ntuples result)
     pure $
-      if
-        rowCount > 0
-      then
-        Just $ Row (rowCount - 1)
-      else
-        Nothing
+      if rowCount > 0
+        then Just $ Row (rowCount - 1)
+        else Nothing
 
   maxColumnNumber result = do
     columnCount <- fmap fromEnum (LibPQ.nfields result)
     pure $
-      if
-        columnCount > 0
-      then
-        Just $ Column (columnCount - 1)
-      else
-        Nothing
-
+      if columnCount > 0
+        then Just $ Column (columnCount - 1)
+        else Nothing
 
   columnName result =
     LibPQ.fname result . LibPQ.toColumn . fromEnum
 
   getValue result (Row row) (Column column) =
-    SqlValue.fromRawBytesNullable <$>
-      LibPQ.getvalue' result (LibPQ.toRow row) (LibPQ.toColumn column)
+    SqlValue.fromRawBytesNullable
+      <$> LibPQ.getvalue' result (LibPQ.toRow row) (LibPQ.toColumn column)
 
-{-|
+{- |
   `FakeLibPQResult` provides a fake, in memory implementation of
   `ExecutionResult`.  This is mostly useful for writing automated tests that
   can assume a result set has been loaded and just need to test decoding the
   results.
 -}
-data FakeLibPQResult =
-  FakeLibPQResult
-    { fakeLibPQColumns     :: Map.Map Column BS.ByteString
-    , fakeLibPQMaxColumn   :: Maybe Column
-    , fakeLibPQMaxRow      :: Maybe Row
-    , fakeLibPQValues      :: Map.Map (Row, Column) SqlValue
-    }
+data FakeLibPQResult = FakeLibPQResult
+  { fakeLibPQColumns :: Map.Map Column BS.ByteString
+  , fakeLibPQMaxColumn :: Maybe Column
+  , fakeLibPQMaxRow :: Maybe Row
+  , fakeLibPQValues :: Map.Map (Row, Column) SqlValue
+  }
 
-{-|
+{- |
   Constructs a `FakeLibPQResult`. The column names given as associated with
   the values for each row by their position in list. Any missing values (e.g.
   because a row is shorter than the heeader list) are treated as a SQL Null
   value.
 -}
-mkFakeLibPQResult :: [BS.ByteString] -- ^ The column names for the result set
-                  -> [[SqlValue]] -- ^ The row data for the result set
-                  -> FakeLibPQResult
+mkFakeLibPQResult ::
+  -- | The column names for the result set
+  [BS.ByteString] ->
+  -- | The row data for the result set
+  [[SqlValue]] ->
+  FakeLibPQResult
 mkFakeLibPQResult columnList valuesList =
-  let
-    indexedValues = do
-      (rowNumber, row) <- zip [Row 0..] valuesList
-      (columnNumber, value) <- zip [Column 0..] row
-      pure ((rowNumber, columnNumber), value)
+  let indexedValues = do
+        (rowNumber, row) <- zip [Row 0 ..] valuesList
+        (columnNumber, value) <- zip [Column 0 ..] row
+        pure ((rowNumber, columnNumber), value)
 
-    maxIndex :: (Row, Column) -> (Row, Column) -> (Row, Column)
-    maxIndex (rowA, columnA) (rowB, columnB) =
-      (max rowA rowB, max columnA columnB)
+      maxIndex :: (Row, Column) -> (Row, Column) -> (Row, Column)
+      maxIndex (rowA, columnA) (rowB, columnB) =
+        (max rowA rowB, max columnA columnB)
 
-    (maxRow, maxColumn) =
-      case map fst indexedValues of
-        [] ->
-          (Nothing, Nothing)
-
-        firstIndex : rest ->
-          let
-            (row, column) =
-              foldl' maxIndex firstIndex rest
-          in
-            (Just row, Just column)
-
-  in
-    FakeLibPQResult
-      { fakeLibPQColumns     = Map.fromList (zip [Column 0..] columnList)
-      , fakeLibPQValues      = Map.fromList indexedValues
-      , fakeLibPQMaxRow      = maxRow
-      , fakeLibPQMaxColumn   = maxColumn
-      }
+      (maxRow, maxColumn) =
+        case map fst indexedValues of
+          [] ->
+            (Nothing, Nothing)
+          firstIndex : rest ->
+            let (row, column) =
+                  foldl' maxIndex firstIndex rest
+             in (Just row, Just column)
+   in FakeLibPQResult
+        { fakeLibPQColumns = Map.fromList (zip [Column 0 ..] columnList)
+        , fakeLibPQValues = Map.fromList indexedValues
+        , fakeLibPQMaxRow = maxRow
+        , fakeLibPQMaxColumn = maxColumn
+        }
 
 instance ExecutionResult FakeLibPQResult where
   maxRowNumber = pure . fakeLibPQMaxRow
@@ -151,44 +142,38 @@ fakeLibPQGetValue result rowNumber columnNumber =
     (rowNumber, columnNumber)
     (fakeLibPQValues result)
 
-
 readRows :: LibPQ.Result -> IO [[(Maybe BS.ByteString, SqlValue)]]
 readRows res = do
   nrows <- LibPQ.ntuples res
   nfields <- LibPQ.nfields res
 
-  let
-    rowIndices =
-      listOfIndicesByCount nrows
+  let rowIndices =
+        listOfIndicesByCount nrows
 
-    fieldIndices =
-      listOfIndicesByCount nfields
+      fieldIndices =
+        listOfIndicesByCount nfields
 
-    -- N.B. the usage of `getvalue'` here is important as this version returns a
-    -- _copy_ of the data in the `Result` rather than a _reference_.
-    -- This allows the `Result` to be garbage collected instead of being held onto indefinitely.
-    readValue rowIndex fieldIndex = do
-      name <- LibPQ.fname res fieldIndex
-      rawValue <- LibPQ.getvalue' res rowIndex fieldIndex
-      pure $
-        ( name
-        , SqlValue.fromRawBytesNullable rawValue
-        )
+      -- N.B. the usage of `getvalue'` here is important as this version returns a
+      -- _copy_ of the data in the `Result` rather than a _reference_.
+      -- This allows the `Result` to be garbage collected instead of being held onto indefinitely.
+      readValue rowIndex fieldIndex = do
+        name <- LibPQ.fname res fieldIndex
+        rawValue <- LibPQ.getvalue' res rowIndex fieldIndex
+        pure $
+          ( name
+          , SqlValue.fromRawBytesNullable rawValue
+          )
 
-    readRow rowIndex =
-      traverse (readValue rowIndex) fieldIndices
+      readRow rowIndex =
+        traverse (readValue rowIndex) fieldIndices
 
   traverse readRow rowIndices
 
 listOfIndicesByCount :: (Num n, Ord n, Enum n) => n -> [n]
 listOfIndicesByCount n =
-  if
-    n > 0
-  then
-    [0..(n - 1)]
-  else
-    []
-
+  if n > 0
+    then [0 .. (n - 1)]
+    else []
 
 -- N.B. This only works for the first column of a table currently.
 -- If there are no results in the given `Result` then we return an empty list
@@ -203,6 +188,5 @@ decodeSingleValue sqlType row =
   case row of
     [] ->
       Nothing
-
     (_, sqlValue) : _ ->
       sqlTypeFromSql sqlType sqlValue

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr.hs
@@ -1,67 +1,68 @@
-{-|
+{-# OPTIONS_GHC -Wno-missing-import-lists #-}
+
+{- |
 Module    : Database.Orville.PostgreSQL.Expr
 Copyright : Flipstone Technology Partners 2016-2021
 License   : MIT
 -}
-{-# OPTIONS_GHC -Wno-missing-import-lists #-}
-
 module Database.Orville.PostgreSQL.Internal.Expr
-  ( QueryExpr
-  , queryExpr
-  , queryExprToSql
-  , SelectList
-  , selectStar
-  , selectColumns
-  , TableExpr
-  , tableExpr
-  , TableName
-  , tableNameToSql
-  , rawTableName
-  , ColumnName
-  , rawColumnName
-  , columnNameToSql
-  , sqlToColumnName
-  , WhereClause
-  , whereClause
-  , BooleanExpr
-  , orExpr
-  , andExpr
-  , parenthesized
-  , comparison
-  , columnEquals
-  , columnGreaterThan
-  , columnLessThan
-  , columnGreaterThanOrEqualTo
-  , columnLessThanOrEqualTo
-  , InsertExpr
-  , insertExpr
-  , insertExprToSql
-  , InsertSource
-  , insertSqlValues
-  , DataType
-  , timestampWithZone
-  , date
-  , tsvector
-  , varchar
-  , char
-  , text
-  , boolean
-  , doublePrecision
-  , bigSerial
-  , bigInt
-  , serial
-  , int
-  , ColumnDefinition
-  , columnDefinition
-  , columnDefinitionToSql
-  , OrderByClause
-  , orderByClauseToSql
-  , orderByClause
-  , appendOrderBy
-  , ascendingOrder
-  , descendingOrder
-  , orderByExpr
-  ) where
+  ( QueryExpr,
+    queryExpr,
+    queryExprToSql,
+    SelectList,
+    selectStar,
+    selectColumns,
+    TableExpr,
+    tableExpr,
+    TableName,
+    tableNameToSql,
+    rawTableName,
+    ColumnName,
+    rawColumnName,
+    columnNameToSql,
+    sqlToColumnName,
+    WhereClause,
+    whereClause,
+    BooleanExpr,
+    orExpr,
+    andExpr,
+    parenthesized,
+    comparison,
+    columnEquals,
+    columnGreaterThan,
+    columnLessThan,
+    columnGreaterThanOrEqualTo,
+    columnLessThanOrEqualTo,
+    InsertExpr,
+    insertExpr,
+    insertExprToSql,
+    InsertSource,
+    insertSqlValues,
+    DataType,
+    timestampWithZone,
+    date,
+    tsvector,
+    varchar,
+    char,
+    text,
+    boolean,
+    doublePrecision,
+    bigSerial,
+    bigInt,
+    serial,
+    int,
+    ColumnDefinition,
+    columnDefinition,
+    columnDefinitionToSql,
+    OrderByClause,
+    orderByClauseToSql,
+    orderByClause,
+    appendOrderBy,
+    ascendingOrder,
+    descendingOrder,
+    orderByExpr,
+  )
+where
 
 import Database.Orville.PostgreSQL.Internal.Expr.ColumnDefinition
 import Database.Orville.PostgreSQL.Internal.Expr.InsertExpr

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/ColumnDefinition.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/ColumnDefinition.hs
@@ -1,33 +1,33 @@
-{-|
+{- |
 Module    : Database.Orville.PostgreSQL.Expr.ColumnDefinition
 Copyright : Flipstone Technology Partners 2016-2021
 License   : MIT
 -}
-
 module Database.Orville.PostgreSQL.Internal.Expr.ColumnDefinition
-  ( ColumnDefinition
-  , columnDefinition
-  , columnDefinitionToSql
-  , DataType
-  , timestampWithZone
-  , date
-  , tsvector
-  , varchar
-  , char
-  , text
-  , boolean
-  , doublePrecision
-  , bigSerial
-  , bigInt
-  , serial
-  , int
-  ) where
+  ( ColumnDefinition,
+    columnDefinition,
+    columnDefinitionToSql,
+    DataType,
+    timestampWithZone,
+    date,
+    tsvector,
+    varchar,
+    char,
+    text,
+    boolean,
+    doublePrecision,
+    bigSerial,
+    bigInt,
+    serial,
+    int,
+  )
+where
 
-import           Database.Orville.PostgreSQL.Internal.Expr.Name (ColumnName, columnNameToSql)
-import qualified Database.Orville.PostgreSQL.Internal.RawSql    as RawSql
+import Database.Orville.PostgreSQL.Internal.Expr.Name (ColumnName, columnNameToSql)
+import qualified Database.Orville.PostgreSQL.Internal.RawSql as RawSql
 
-newtype ColumnDefinition =
-  ColumnDefinition RawSql.RawSql
+newtype ColumnDefinition
+  = ColumnDefinition RawSql.RawSql
 
 columnDefinitionToSql :: ColumnDefinition -> RawSql.RawSql
 columnDefinitionToSql (ColumnDefinition sql) = sql
@@ -36,11 +36,11 @@ columnDefinition :: ColumnName -> DataType -> ColumnDefinition
 columnDefinition columnName dataType =
   ColumnDefinition $
     columnNameToSql columnName
-    <> RawSql.fromString " "
-    <> dataTypeToSql dataType
+      <> RawSql.fromString " "
+      <> dataTypeToSql dataType
 
-newtype DataType =
-  DataType RawSql.RawSql
+newtype DataType
+  = DataType RawSql.RawSql
 
 dataTypeToSql :: DataType -> RawSql.RawSql
 dataTypeToSql (DataType sql) = sql
@@ -65,8 +65,8 @@ varchar len =
   --  STATEMENT:  CREATE TABLE field_definition_test(foo VARCHAR($1))
   DataType $
     RawSql.fromString "VARCHAR("
-    <> RawSql.fromString (show len)
-    <> RawSql.fromString ")"
+      <> RawSql.fromString (show len)
+      <> RawSql.fromString ")"
 
 char :: Int -> DataType
 char len =
@@ -76,8 +76,8 @@ char len =
   --  STATEMENT:  CREATE TABLE field_definition_test(foo CHAR($1))
   DataType $
     RawSql.fromString "CHAR("
-    <> RawSql.fromString (show len)
-    <> RawSql.fromString ")"
+      <> RawSql.fromString (show len)
+      <> RawSql.fromString ")"
 
 text :: DataType
 text =

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/InsertExpr.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/InsertExpr.hs
@@ -1,23 +1,23 @@
-{-|
+{- |
 Module    : Database.Orville.PostgreSQL.Expr.InsertExpr
 Copyright : Flipstone Technology Partners 2016-2021
 License   : MIT
 -}
-
 module Database.Orville.PostgreSQL.Internal.Expr.InsertExpr
-  ( InsertExpr
-  , insertExpr
-  , insertExprToSql
-  , InsertSource
-  , insertSqlValues
-  ) where
+  ( InsertExpr,
+    insertExpr,
+    insertExprToSql,
+    InsertSource,
+    insertSqlValues,
+  )
+where
 
-import           Database.Orville.PostgreSQL.Internal.Expr.Name (TableName, tableNameToSql)
-import qualified Database.Orville.PostgreSQL.Internal.RawSql    as RawSql
-import           Database.Orville.PostgreSQL.Internal.SqlValue  (SqlValue)
+import Database.Orville.PostgreSQL.Internal.Expr.Name (TableName, tableNameToSql)
+import qualified Database.Orville.PostgreSQL.Internal.RawSql as RawSql
+import Database.Orville.PostgreSQL.Internal.SqlValue (SqlValue)
 
-newtype InsertExpr =
-  InsertExpr RawSql.RawSql
+newtype InsertExpr
+  = InsertExpr RawSql.RawSql
 
 insertExprToSql :: InsertExpr -> RawSql.RawSql
 insertExprToSql (InsertExpr sql) = sql
@@ -32,8 +32,8 @@ insertExpr target source =
       , insertSourceToSql source
       ]
 
-newtype InsertSource =
-  InsertSource RawSql.RawSql
+newtype InsertSource
+  = InsertSource RawSql.RawSql
 
 insertSourceToSql :: InsertSource -> RawSql.RawSql
 insertSourceToSql (InsertSource sql) = sql
@@ -42,14 +42,14 @@ insertRowValues :: [RowValues] -> InsertSource
 insertRowValues rows =
   InsertSource $
     RawSql.fromString "VALUES "
-    <> RawSql.intercalate (RawSql.fromString ",") (fmap rowValuesToSql rows)
+      <> RawSql.intercalate (RawSql.fromString ",") (fmap rowValuesToSql rows)
 
 insertSqlValues :: [[SqlValue]] -> InsertSource
 insertSqlValues rows =
   insertRowValues (fmap rowValues rows)
 
-newtype RowValues =
-  RowValues RawSql.RawSql
+newtype RowValues
+  = RowValues RawSql.RawSql
 
 rowValuesToSql :: RowValues -> RawSql.RawSql
 rowValuesToSql (RowValues sql) = sql

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/Name.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/Name.hs
@@ -1,12 +1,14 @@
-{-|
+{-# OPTIONS_GHC -Wno-missing-import-lists #-}
+
+{- |
 Module    : Database.Orville.PostgreSQL.Expr.Name
 Copyright : Flipstone Technology Partners 2016-2021
 License   : MIT
 -}
-{-# OPTIONS_GHC -Wno-missing-import-lists #-}
 module Database.Orville.PostgreSQL.Internal.Expr.Name
-  ( module Export
-  ) where
+  ( module Export,
+  )
+where
 
 import Database.Orville.PostgreSQL.Internal.Expr.Name.ColumnName as Export
-import Database.Orville.PostgreSQL.Internal.Expr.Name.TableName  as Export
+import Database.Orville.PostgreSQL.Internal.Expr.Name.TableName as Export

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/Name/ColumnName.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/Name/ColumnName.hs
@@ -1,15 +1,15 @@
-{-|
+{- |
 Module    : Database.Orville.PostgreSQL.Expr.Name.ColumnName
 Copyright : Flipstone Technology Partners 2016-2021
 License   : MIT
 -}
-
 module Database.Orville.PostgreSQL.Internal.Expr.Name.ColumnName
-  ( ColumnName
-  , rawColumnName
-  , columnNameToSql
-  , sqlToColumnName
-  ) where
+  ( ColumnName,
+    rawColumnName,
+    columnNameToSql,
+    sqlToColumnName,
+  )
+where
 
 import qualified Database.Orville.PostgreSQL.Internal.RawSql as RawSql
 

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/Name/TableName.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/Name/TableName.hs
@@ -1,19 +1,19 @@
-{-|
+{- |
 Module    : Database.Orville.PostgreSQL.Expr.Name.TableName
 Copyright : Flipstone Technology Partners 2016-2021
 License   : MIT
 -}
-
 module Database.Orville.PostgreSQL.Internal.Expr.Name.TableName
-  ( TableName
-  , tableNameToSql
-  , rawTableName
-  ) where
+  ( TableName,
+    tableNameToSql,
+    rawTableName,
+  )
+where
 
 import qualified Database.Orville.PostgreSQL.Internal.RawSql as RawSql
 
-newtype TableName =
-  TableName RawSql.RawSql
+newtype TableName
+  = TableName RawSql.RawSql
 
 tableNameToSql :: TableName -> RawSql.RawSql
 tableNameToSql (TableName sql) = sql

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/OrderBy.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/OrderBy.hs
@@ -1,13 +1,15 @@
-{-|
+{-# OPTIONS_GHC -Wno-missing-import-lists #-}
+
+{- |
 Module    : Database.Orville.PostgreSQL.Expr.OrderBy
 Copyright : Flipstone Technology Partners 2016-2021
 License   : MIT
 -}
-{-# OPTIONS_GHC -Wno-missing-import-lists #-}
 module Database.Orville.PostgreSQL.Internal.Expr.OrderBy
-  ( module Export
-  ) where
+  ( module Export,
+  )
+where
 
-import Database.Orville.PostgreSQL.Internal.Expr.OrderBy.OrderByClause    as Export
+import Database.Orville.PostgreSQL.Internal.Expr.OrderBy.OrderByClause as Export
 import Database.Orville.PostgreSQL.Internal.Expr.OrderBy.OrderByDirection as Export
-import Database.Orville.PostgreSQL.Internal.Expr.OrderBy.OrderByExpr      as Export
+import Database.Orville.PostgreSQL.Internal.Expr.OrderBy.OrderByExpr as Export

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/OrderBy/OrderByClause.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/OrderBy/OrderByClause.hs
@@ -1,20 +1,20 @@
-{-|
+{- |
 Module    : Database.Orville.PostgreSQL.Expr.OrderBy.OrderByClause
 Copyright : Flipstone Technology Partners 2016-2021
 License   : MIT
 -}
-
 module Database.Orville.PostgreSQL.Internal.Expr.OrderBy.OrderByClause
-  ( OrderByClause
-  , orderByClauseToSql
-  , orderByClause
-  ) where
+  ( OrderByClause,
+    orderByClauseToSql,
+    orderByClause,
+  )
+where
 
-import           Database.Orville.PostgreSQL.Internal.Expr.OrderBy.OrderByExpr (OrderByExpr, orderByExprToSql)
-import qualified Database.Orville.PostgreSQL.Internal.RawSql                   as RawSql
+import Database.Orville.PostgreSQL.Internal.Expr.OrderBy.OrderByExpr (OrderByExpr, orderByExprToSql)
+import qualified Database.Orville.PostgreSQL.Internal.RawSql as RawSql
 
-newtype OrderByClause =
-  OrderByClause RawSql.RawSql
+newtype OrderByClause
+  = OrderByClause RawSql.RawSql
 
 orderByClauseToSql :: OrderByClause -> RawSql.RawSql
 orderByClauseToSql (OrderByClause sql) = sql

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/OrderBy/OrderByDirection.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/OrderBy/OrderByDirection.hs
@@ -1,15 +1,15 @@
-{-|
+{- |
 Module    : Database.Orville.PostgreSQL.Expr.OrderBy.OrderByDirection
 Copyright : Flipstone Technology Partners 2016-2021
 License   : MIT
 -}
-
 module Database.Orville.PostgreSQL.Internal.Expr.OrderBy.OrderByDirection
-  ( OrderByDirection
-  , ascendingOrder
-  , descendingOrder
-  , orderByDirectionToSql
-  ) where
+  ( OrderByDirection,
+    ascendingOrder,
+    descendingOrder,
+    orderByDirectionToSql,
+  )
+where
 
 import qualified Database.Orville.PostgreSQL.Internal.RawSql as RawSql
 

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/OrderBy/OrderByExpr.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/OrderBy/OrderByExpr.hs
@@ -1,18 +1,18 @@
-{-|
+{- |
 Module    : Database.Orville.PostgreSQL.Expr.OrderBy.OrderByExpr
 Copyright : Flipstone Technology Partners 2016-2021
 License   : MIT
 -}
-
 module Database.Orville.PostgreSQL.Internal.Expr.OrderBy.OrderByExpr
-  ( OrderByExpr
-  , orderByExprToSql
-  , appendOrderBy
-  , orderByExpr
-  ) where
+  ( OrderByExpr,
+    orderByExprToSql,
+    appendOrderBy,
+    orderByExpr,
+  )
+where
 
-import           Database.Orville.PostgreSQL.Internal.Expr.OrderBy.OrderByDirection (OrderByDirection, orderByDirectionToSql)
-import qualified Database.Orville.PostgreSQL.Internal.RawSql                        as RawSql
+import Database.Orville.PostgreSQL.Internal.Expr.OrderBy.OrderByDirection (OrderByDirection, orderByDirectionToSql)
+import qualified Database.Orville.PostgreSQL.Internal.RawSql as RawSql
 
 newtype OrderByExpr = OrderByExpr RawSql.RawSql
 

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/Query.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/Query.hs
@@ -1,13 +1,15 @@
-{-|
+{-# OPTIONS_GHC -Wno-missing-import-lists #-}
+
+{- |
 Module    : Database.Orville.PostgreSQL.Expr.Query
 Copyright : Flipstone Technology Partners 2016-2021
 License   : MIT
 -}
-{-# OPTIONS_GHC -Wno-missing-import-lists #-}
 module Database.Orville.PostgreSQL.Internal.Expr.Query
-  ( module Export
-  ) where
+  ( module Export,
+  )
+where
 
-import Database.Orville.PostgreSQL.Internal.Expr.Query.QueryExpr  as Export
+import Database.Orville.PostgreSQL.Internal.Expr.Query.QueryExpr as Export
 import Database.Orville.PostgreSQL.Internal.Expr.Query.SelectList as Export
-import Database.Orville.PostgreSQL.Internal.Expr.Query.TableExpr  as Export
+import Database.Orville.PostgreSQL.Internal.Expr.Query.TableExpr as Export

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/Query/QueryExpr.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/Query/QueryExpr.hs
@@ -1,22 +1,22 @@
-{-|
+{- |
 Module    : Database.Orville.PostgreSQL.Expr.Query.QueryExpr
 Copyright : Flipstone Technology Partners 2016-2021
 License   : MIT
 -}
-
 module Database.Orville.PostgreSQL.Internal.Expr.Query.QueryExpr
-  ( QueryExpr
-  , queryExprToSql
-  , queryExpr
-  ) where
+  ( QueryExpr,
+    queryExprToSql,
+    queryExpr,
+  )
+where
 
-import           Database.Orville.PostgreSQL.Internal.Expr.Query.SelectList (SelectList, selectListToSql)
-import           Database.Orville.PostgreSQL.Internal.Expr.Query.TableExpr  (TableExpr, tableExprToSql)
-import qualified Database.Orville.PostgreSQL.Internal.RawSql                as RawSql
+import Database.Orville.PostgreSQL.Internal.Expr.Query.SelectList (SelectList, selectListToSql)
+import Database.Orville.PostgreSQL.Internal.Expr.Query.TableExpr (TableExpr, tableExprToSql)
+import qualified Database.Orville.PostgreSQL.Internal.RawSql as RawSql
 
 -- This is a rough model of "query specification" see https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#_7_16_query_specification for more detail than you probably want
-newtype QueryExpr =
-  QueryExpr RawSql.RawSql
+newtype QueryExpr
+  = QueryExpr RawSql.RawSql
 
 queryExpr :: SelectList -> TableExpr -> QueryExpr
 queryExpr selectList table =

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/Query/SelectList.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/Query/SelectList.hs
@@ -1,18 +1,18 @@
-{-|
+{- |
 Module    : Database.Orville.PostgreSQL.Expr.Query.SelectList
 Copyright : Flipstone Technology Partners 2016-2021
 License   : MIT
 -}
-
 module Database.Orville.PostgreSQL.Internal.Expr.Query.SelectList
-  ( SelectList
-  , selectListToSql
-  , selectColumns
-  , selectStar
-  ) where
+  ( SelectList,
+    selectListToSql,
+    selectColumns,
+    selectStar,
+  )
+where
 
-import           Database.Orville.PostgreSQL.Internal.Expr.Name (ColumnName, columnNameToSql)
-import qualified Database.Orville.PostgreSQL.Internal.RawSql    as RawSql
+import Database.Orville.PostgreSQL.Internal.Expr.Name (ColumnName, columnNameToSql)
+import qualified Database.Orville.PostgreSQL.Internal.RawSql as RawSql
 
 newtype SelectList = SelectList RawSql.RawSql
 

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/Query/TableExpr.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/Query/TableExpr.hs
@@ -1,22 +1,22 @@
-{-|
+{- |
 Module    : Database.Orville.PostgreSQL.Expr.Query.TableExpr
 Copyright : Flipstone Technology Partners 2016-2021
 License   : MIT
 -}
-
 module Database.Orville.PostgreSQL.Internal.Expr.Query.TableExpr
-  ( TableExpr
-  , tableExpr
-  , tableExprToSql
-  ) where
+  ( TableExpr,
+    tableExpr,
+    tableExprToSql,
+  )
+where
 
-import           Database.Orville.PostgreSQL.Internal.Expr.Name              (TableName, tableNameToSql)
-import           Database.Orville.PostgreSQL.Internal.Expr.OrderBy           (OrderByClause, orderByClauseToSql)
-import           Database.Orville.PostgreSQL.Internal.Expr.Where.WhereClause (WhereClause, whereClauseToSql)
-import qualified Database.Orville.PostgreSQL.Internal.RawSql                 as RawSql
+import Database.Orville.PostgreSQL.Internal.Expr.Name (TableName, tableNameToSql)
+import Database.Orville.PostgreSQL.Internal.Expr.OrderBy (OrderByClause, orderByClauseToSql)
+import Database.Orville.PostgreSQL.Internal.Expr.Where.WhereClause (WhereClause, whereClauseToSql)
+import qualified Database.Orville.PostgreSQL.Internal.RawSql as RawSql
 
-newtype TableExpr =
-  TableExpr RawSql.RawSql
+newtype TableExpr
+  = TableExpr RawSql.RawSql
 
 tableExprToSql :: TableExpr -> RawSql.RawSql
 tableExprToSql (TableExpr sql) = sql
@@ -25,6 +25,6 @@ tableExpr :: TableName -> Maybe WhereClause -> Maybe OrderByClause -> TableExpr
 tableExpr tableName mbWhereClause maybeOrderByClause =
   TableExpr $
     tableNameToSql tableName
-    <> RawSql.fromString " "
-    <> maybe mempty whereClauseToSql mbWhereClause
-    <> maybe mempty orderByClauseToSql maybeOrderByClause
+      <> RawSql.fromString " "
+      <> maybe mempty whereClauseToSql mbWhereClause
+      <> maybe mempty orderByClauseToSql maybeOrderByClause

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/Where.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/Where.hs
@@ -1,13 +1,15 @@
-{-|
+{-# OPTIONS_GHC -Wno-missing-import-lists #-}
+
+{- |
 Module    : Database.Orville.PostgreSQL.Expr.Where
 Copyright : Flipstone Technology Partners 2016-2021
 License   : MIT
 -}
-{-# OPTIONS_GHC -Wno-missing-import-lists #-}
 module Database.Orville.PostgreSQL.Internal.Expr.Where
-  ( module Export
-  ) where
+  ( module Export,
+  )
+where
 
-import Database.Orville.PostgreSQL.Internal.Expr.Where.BooleanExpr        as Export
+import Database.Orville.PostgreSQL.Internal.Expr.Where.BooleanExpr as Export
 import Database.Orville.PostgreSQL.Internal.Expr.Where.ComparisonOperator as Export
-import Database.Orville.PostgreSQL.Internal.Expr.Where.WhereClause        as Export
+import Database.Orville.PostgreSQL.Internal.Expr.Where.WhereClause as Export

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/Where/BooleanExpr.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/Where/BooleanExpr.hs
@@ -1,28 +1,28 @@
-{-|
+{- |
 Module    : Database.Orville.PostgreSQL.Expr.Where.BooleanExpr
 Copyright : Flipstone Technology Partners 2016-2021
 License   : MIT
 -}
-
 module Database.Orville.PostgreSQL.Internal.Expr.Where.BooleanExpr
-  ( BooleanExpr
-  , booleanExprToSql
-  , orExpr
-  , andExpr
-  , parenthesized
-  , comparison
-  , columnEquals
-  , columnGreaterThan
-  , columnLessThan
-  , columnGreaterThanOrEqualTo
-  , columnLessThanOrEqualTo
-  ) where
+  ( BooleanExpr,
+    booleanExprToSql,
+    orExpr,
+    andExpr,
+    parenthesized,
+    comparison,
+    columnEquals,
+    columnGreaterThan,
+    columnLessThan,
+    columnGreaterThanOrEqualTo,
+    columnLessThanOrEqualTo,
+  )
+where
 
-import           Database.Orville.PostgreSQL.Internal.Expr.Name                     (ColumnName)
-import           Database.Orville.PostgreSQL.Internal.Expr.Where.ComparisonOperator (ComparisonOperator, comparisonOperatorToSql, equalsOp, greaterThanOp, greaterThanOrEqualsOp, lessThanOp, lessThanOrEqualsOp)
-import           Database.Orville.PostgreSQL.Internal.Expr.Where.RowValuePredicand  (RowValuePredicand, columnReference, comparisonValue, rowValuePredicandToSql)
-import qualified Database.Orville.PostgreSQL.Internal.RawSql                        as RawSql
-import           Database.Orville.PostgreSQL.Internal.SqlValue                      (SqlValue)
+import Database.Orville.PostgreSQL.Internal.Expr.Name (ColumnName)
+import Database.Orville.PostgreSQL.Internal.Expr.Where.ComparisonOperator (ComparisonOperator, comparisonOperatorToSql, equalsOp, greaterThanOp, greaterThanOrEqualsOp, lessThanOp, lessThanOrEqualsOp)
+import Database.Orville.PostgreSQL.Internal.Expr.Where.RowValuePredicand (RowValuePredicand, columnReference, comparisonValue, rowValuePredicandToSql)
+import qualified Database.Orville.PostgreSQL.Internal.RawSql as RawSql
+import Database.Orville.PostgreSQL.Internal.SqlValue (SqlValue)
 
 newtype BooleanExpr = BooleanExpr RawSql.RawSql
 
@@ -33,32 +33,33 @@ orExpr :: BooleanExpr -> BooleanExpr -> BooleanExpr
 orExpr left right =
   BooleanExpr $
     booleanExprToSql left
-    <> RawSql.fromString " OR "
-    <> booleanExprToSql right
+      <> RawSql.fromString " OR "
+      <> booleanExprToSql right
 
 andExpr :: BooleanExpr -> BooleanExpr -> BooleanExpr
 andExpr left right =
   BooleanExpr $
     booleanExprToSql left
-    <> RawSql.fromString " AND "
-    <> booleanExprToSql right
+      <> RawSql.fromString " AND "
+      <> booleanExprToSql right
 
 parenthesized :: BooleanExpr -> BooleanExpr
 parenthesized expr =
   BooleanExpr $
     RawSql.fromString "(" <> booleanExprToSql expr <> RawSql.fromString ")"
 
-comparison :: RowValuePredicand
-           -> ComparisonOperator
-           -> RowValuePredicand
-           -> BooleanExpr
+comparison ::
+  RowValuePredicand ->
+  ComparisonOperator ->
+  RowValuePredicand ->
+  BooleanExpr
 comparison left op right =
   BooleanExpr $
     rowValuePredicandToSql left
-    <> RawSql.fromString " "
-    <> comparisonOperatorToSql op
-    <> RawSql.fromString " "
-    <> rowValuePredicandToSql right
+      <> RawSql.fromString " "
+      <> comparisonOperatorToSql op
+      <> RawSql.fromString " "
+      <> rowValuePredicandToSql right
 
 columnEquals :: ColumnName -> SqlValue -> BooleanExpr
 columnEquals name value =

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/Where/ComparisonOperator.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/Where/ComparisonOperator.hs
@@ -1,24 +1,24 @@
-{-|
+{- |
 Module    : Database.Orville.PostgreSQL.Expr.Where.ComparisonOperator
 Copyright : Flipstone Technology Partners 2016-2021
 License   : MIT
 -}
-
 module Database.Orville.PostgreSQL.Internal.Expr.Where.ComparisonOperator
-  ( ComparisonOperator
-  , comparisonOperatorToSql
-  , equalsOp
-  , notEqualsOp
-  , greaterThanOp
-  , lessThanOp
-  , greaterThanOrEqualsOp
-  , lessThanOrEqualsOp
-  ) where
+  ( ComparisonOperator,
+    comparisonOperatorToSql,
+    equalsOp,
+    notEqualsOp,
+    greaterThanOp,
+    lessThanOp,
+    greaterThanOrEqualsOp,
+    lessThanOrEqualsOp,
+  )
+where
 
 import qualified Database.Orville.PostgreSQL.Internal.RawSql as RawSql
 
-newtype ComparisonOperator =
-  ComparisonOperator RawSql.RawSql
+newtype ComparisonOperator
+  = ComparisonOperator RawSql.RawSql
 
 comparisonOperatorToSql :: ComparisonOperator -> RawSql.RawSql
 comparisonOperatorToSql (ComparisonOperator sql) = sql

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/Where/RowValuePredicand.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/Where/RowValuePredicand.hs
@@ -1,19 +1,19 @@
-{-|
+{- |
 Module    : Database.Orville.PostgreSQL.Expr.Where.RowValuePredicand
 Copyright : Flipstone Technology Partners 2016-2021
 License   : MIT
 -}
-
 module Database.Orville.PostgreSQL.Internal.Expr.Where.RowValuePredicand
-  ( RowValuePredicand
-  , columnReference
-  , comparisonValue
-  , rowValuePredicandToSql
-  ) where
+  ( RowValuePredicand,
+    columnReference,
+    comparisonValue,
+    rowValuePredicandToSql,
+  )
+where
 
-import           Database.Orville.PostgreSQL.Internal.Expr.Name (ColumnName, columnNameToSql)
-import qualified Database.Orville.PostgreSQL.Internal.RawSql    as RawSql
-import           Database.Orville.PostgreSQL.Internal.SqlValue  (SqlValue)
+import Database.Orville.PostgreSQL.Internal.Expr.Name (ColumnName, columnNameToSql)
+import qualified Database.Orville.PostgreSQL.Internal.RawSql as RawSql
+import Database.Orville.PostgreSQL.Internal.SqlValue (SqlValue)
 
 newtype RowValuePredicand = RowValuePredicand RawSql.RawSql
 

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/Where/WhereClause.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/Where/WhereClause.hs
@@ -1,20 +1,20 @@
-{-|
+{- |
 Module    : Database.Orville.PostgreSQL.Expr.Where.WhereClause
 Copyright : Flipstone Technology Partners 2016-2021
 License   : MIT
 -}
-
 module Database.Orville.PostgreSQL.Internal.Expr.Where.WhereClause
-  ( WhereClause
-  , whereClauseToSql
-  , whereClause
-  ) where
+  ( WhereClause,
+    whereClauseToSql,
+    whereClause,
+  )
+where
 
-import           Database.Orville.PostgreSQL.Internal.Expr.Where.BooleanExpr (BooleanExpr, booleanExprToSql)
-import qualified Database.Orville.PostgreSQL.Internal.RawSql                 as RawSql
+import Database.Orville.PostgreSQL.Internal.Expr.Where.BooleanExpr (BooleanExpr, booleanExprToSql)
+import qualified Database.Orville.PostgreSQL.Internal.RawSql as RawSql
 
-newtype WhereClause =
-  WhereClause RawSql.RawSql
+newtype WhereClause
+  = WhereClause RawSql.RawSql
 
 whereClauseToSql :: WhereClause -> RawSql.RawSql
 whereClauseToSql (WhereClause sql) = sql

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/FieldDefinition.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/FieldDefinition.hs
@@ -1,53 +1,55 @@
-{-|
+{-# LANGUAGE GADTs #-}
+
+{- |
 Module    : Database.Orville.PostgreSQL.Internal.FieldDefinition
 Copyright : Flipstone Technology Partners 2016-2021
 License   : MIT
 -}
-{-# LANGUAGE GADTs #-}
 module Database.Orville.PostgreSQL.Internal.FieldDefinition
-  ( FieldDefinition
-  , fieldName
-  , fieldType
-  , fieldNullability
-  , fieldValueToSqlValue
-  , fieldValueFromSqlValue
-  , fieldColumnName
-  , FieldName
-  , stringToFieldName
-  , fieldNameToColumnName
-  , fieldNameToByteString
-  , toSqlExpr
-  , NotNull
-  , Nullable
-  , Nullability(..)
-  , integerField
-  , serialField
-  , bigIntegerField
-  , bigSerialField
-  , doubleField
-  , booleanField
-  , unboundedTextField
-  , boundedTextField
-  , fixedTextField
-  , textSearchVectorField
-  , dateField
-  , timestampField
-  , fieldOfType
-  ) where
+  ( FieldDefinition,
+    fieldName,
+    fieldType,
+    fieldNullability,
+    fieldValueToSqlValue,
+    fieldValueFromSqlValue,
+    fieldColumnName,
+    FieldName,
+    stringToFieldName,
+    fieldNameToColumnName,
+    fieldNameToByteString,
+    toSqlExpr,
+    NotNull,
+    Nullable,
+    Nullability (..),
+    integerField,
+    serialField,
+    bigIntegerField,
+    bigSerialField,
+    doubleField,
+    booleanField,
+    unboundedTextField,
+    boundedTextField,
+    fixedTextField,
+    textSearchVectorField,
+    dateField,
+    timestampField,
+    fieldOfType,
+  )
+where
 
 import qualified Data.ByteString.Char8 as B8
-import           Data.Int (Int32, Int64)
+import Data.Int (Int32, Int64)
 import qualified Data.Text as T
 import qualified Data.Time as Time
 
 import qualified Database.Orville.PostgreSQL.Internal.Expr as Expr
 import qualified Database.Orville.PostgreSQL.Internal.RawSql as RawSql
-import           Database.Orville.PostgreSQL.Internal.SqlType (SqlType)
+import Database.Orville.PostgreSQL.Internal.SqlType (SqlType)
 import qualified Database.Orville.PostgreSQL.Internal.SqlType as SqlType
-import           Database.Orville.PostgreSQL.Internal.SqlValue (SqlValue)
+import Database.Orville.PostgreSQL.Internal.SqlValue (SqlValue)
 
-newtype FieldName =
-  FieldName B8.ByteString
+newtype FieldName
+  = FieldName B8.ByteString
   deriving (Eq, Show)
 
 fieldNameToColumnName :: FieldName -> Expr.ColumnName
@@ -62,27 +64,26 @@ fieldNameToByteString :: FieldName -> B8.ByteString
 fieldNameToByteString (FieldName name) =
   name
 
-{-|
+{- |
   'FieldDefinition' determines the SQL constsruction of a column in the
   database, comprising the name, SQL type and whether the field is nullable.
   A 'FieldDefinition' is matched to a particular Haskell type, which it knows
   how to marshall to and from the database representation of SQL type for
   the field.
 -}
-data FieldDefinition nullability a =
-  FieldDefinition
-    { _fieldName        :: FieldName
-    , _fieldType        :: SqlType a
-    , _fieldNullability :: Nullability nullability
-    }
+data FieldDefinition nullability a = FieldDefinition
+  { _fieldName :: FieldName
+  , _fieldType :: SqlType a
+  , _fieldNullability :: Nullability nullability
+  }
 
-{-|
+{- |
   The name used in database queries to reference the field.
 -}
 fieldName :: FieldDefinition nullability a -> FieldName
 fieldName = _fieldName
 
-{-|
+{- |
   The 'SqlType' for the 'FieldDefinition' determines the PostgreSQL data type
   used to define the field as well as how to mashall Haskell values to and
   from the database.
@@ -90,7 +91,7 @@ fieldName = _fieldName
 fieldType :: FieldDefinition nullability a -> SqlType a
 fieldType = _fieldType
 
-{-|
+{- |
   The 'Nullability' for a field indicates whether the column is marked nullable
   in the database.
 
@@ -100,7 +101,7 @@ fieldType = _fieldType
 fieldNullability :: FieldDefinition nullability a -> Nullability nullability
 fieldNullability = _fieldNullability
 
-{-|
+{- |
   Mashalls a Haskell value to be stored in the field to its 'SqlValue'
   representation.
 -}
@@ -108,7 +109,7 @@ fieldValueToSqlValue :: FieldDefinition nullability a -> a -> SqlValue
 fieldValueToSqlValue =
   SqlType.sqlTypeToSql . fieldType
 
-{-|
+{- |
   Marshalls a 'SqlValue' from the database into the Haskell value that represents it.
   This may fail, in which case 'Nothing' is returned.
 -}
@@ -116,7 +117,7 @@ fieldValueFromSqlValue :: FieldDefinition nullability a -> SqlValue -> Maybe a
 fieldValueFromSqlValue =
   SqlType.sqlTypeFromSql . fieldType
 
-{-|
+{- |
   Constructs the 'Expr.ColumnName' for a field for use in SQL expressions
   from the 'Expr' module.
 -}
@@ -124,7 +125,7 @@ fieldColumnName :: FieldDefinition nullability a -> Expr.ColumnName
 fieldColumnName =
   fieldNameToColumnName . fieldName
 
-{-|
+{- |
   Constructions the equivalant 'Expr.FieldDefinition' as a SQL expression,
   generally for use in DDL for creating column in a table.
 
@@ -137,7 +138,7 @@ toSqlExpr fieldDef =
     (fieldColumnName fieldDef)
     (SqlType.sqlTypeExpr $ fieldType fieldDef)
 
-{-|
+{- |
   'Nullability' represents whether a field will be marked as 'NULL' or 'NOT
   NULL' in the database schema. It is a GADT so that the value constructors
   can be used to record this knowledge in the type system as well. This allows
@@ -146,94 +147,111 @@ toSqlExpr fieldDef =
 -}
 data Nullability nullability where
   Nullable :: Nullability Nullable
-  NotNull  :: Nullability NotNull
+  NotNull :: Nullability NotNull
 
-{-|
+{- |
   'NotNull' is a values-less type used to track that a 'FieldDefinition'
   represents a field that is marked not-null in the database schema.  See the
   'Nullability' type for the value-level representation of field nullability.
 -}
 data NotNull
 
-{-|
+{- |
   'Nullable' is a values-less type used to track that a 'FieldDefinition'
   represents a field that is marked nullable in the database schema. See the
   'Nullability' type for the value-level representation of field nullability.
 -}
 data Nullable
 
-{-|
+{- |
   Builds a 'FieldDefinition' that stores Haskell 'Int32' values as the
   PostgreSQL "INT" type.
 -}
-integerField :: String -- ^ Name of the field in the database
-             -> FieldDefinition NotNull Int32
+integerField ::
+  -- | Name of the field in the database
+  String ->
+  FieldDefinition NotNull Int32
 integerField = fieldOfType SqlType.integer
 
-{-|
+{- |
   Builds a 'FieldDefinition' that stores an 'Int32' value as the "SERIAL"
   type. This can be used to create auto-incrementing columns.
 -}
-serialField :: String -- ^ Name of the field in the database
-            -> FieldDefinition NotNull Int32
+serialField ::
+  -- | Name of the field in the database
+  String ->
+  FieldDefinition NotNull Int32
 serialField = fieldOfType SqlType.serial
 
-{-|
+{- |
   Builds a 'FieldDefinition' that stores Haskell 'Int64' values as the
   PostgreSQL "BIGINT" type.
 -}
-bigIntegerField :: String -- ^ Name of the field in the database
-                -> FieldDefinition NotNull Int64
+bigIntegerField ::
+  -- | Name of the field in the database
+  String ->
+  FieldDefinition NotNull Int64
 bigIntegerField = fieldOfType SqlType.bigInteger
 
-{-|
+{- |
   Builds a 'FieldDefinition' that stores an 'Int64' value as the "BIGSERIAL"
   type. This can be used to create auto-incrementing columns.
 -}
-bigSerialField :: String -- ^ Name of the field in the database
-               -> FieldDefinition NotNull Int64
+bigSerialField ::
+  -- | Name of the field in the database
+  String ->
+  FieldDefinition NotNull Int64
 bigSerialField = fieldOfType SqlType.bigSerial
 
-{-|
+{- |
   Builds a 'FieldDefinition' that stores a 'Double' value as the "DOUBLE
   PRECISION" type. Note: PostgreSQL's "DOUBLE PRECISION" type only allows for
   up to 15 digits of precision, so some rounding may occur when values are
   stored in the database.
 -}
-doubleField :: String -- ^ Name of the field in the database
-            -> FieldDefinition NotNull Double
+doubleField ::
+  -- | Name of the field in the database
+  String ->
+  FieldDefinition NotNull Double
 doubleField = fieldOfType SqlType.double
 
-{-|
+{- |
   Builds a 'FieldDefinition' that stores Haskell 'Bool' values as the
   PostgreSQL "BOOLEAN" type.
 -}
-booleanField :: String -- ^ Name of the field in the database
-             -> FieldDefinition NotNull Bool
+booleanField ::
+  -- | Name of the field in the database
+  String ->
+  FieldDefinition NotNull Bool
 booleanField = fieldOfType SqlType.boolean
 
-{-|
+{- |
   Builds a 'FieldDefinition' that stores Haskell 'T.Text' values as the
   PostgreSQL "TEXT" type. Note that this PostgreSQL has no particular
   limit on the length of text stored.
 -}
-unboundedTextField :: String -- ^ Name of the field in the database
-                   -> FieldDefinition NotNull T.Text
+unboundedTextField ::
+  -- | Name of the field in the database
+  String ->
+  FieldDefinition NotNull T.Text
 unboundedTextField = fieldOfType SqlType.unboundedText
 
-{-|
+{- |
   Builds a 'FieldDefinition' that stores Haskell 'T.Text' values as the
   PostgreSQL "VARCHAR" type. Attempting to store a value beyond the length
   specified will cause an error.
 
   -- TODO: We should have a test for this.
 -}
-boundedTextField :: String -- ^ Name of the field in the database
-                 -> Int -- ^ Maximum length of text in the field
-                 -> FieldDefinition NotNull T.Text
+boundedTextField ::
+  -- | Name of the field in the database
+  String ->
+  -- | Maximum length of text in the field
+  Int ->
+  FieldDefinition NotNull T.Text
 boundedTextField name len = fieldOfType (SqlType.boundedText len) name
 
-{-|
+{- |
   Builds a 'FieldDefinition' that stores Haskell 'T.Text' values as the
   PostgreSQL "CHAR" type. Attempting to store a value beyond the length
   specified will cause an error. Storing a value that is not the full
@@ -241,47 +259,56 @@ boundedTextField name len = fieldOfType (SqlType.boundedText len) name
 
   -- TODO: We should have a test for this.
 -}
-fixedTextField :: String -- ^ Name of the field in the database
-               -> Int -- ^ Maximum length of text in the field
-               -> FieldDefinition NotNull T.Text
+fixedTextField ::
+  -- | Name of the field in the database
+  String ->
+  -- | Maximum length of text in the field
+  Int ->
+  FieldDefinition NotNull T.Text
 fixedTextField name len = fieldOfType (SqlType.fixedText len) name
 
-
-{-|
+{- |
   TODO: write meaningful docs for this when we build a better Haskell
   definition for representing text search vectors.
 -}
 textSearchVectorField :: String -> FieldDefinition NotNull T.Text
 textSearchVectorField = fieldOfType SqlType.textSearchVector
 
-{-|
+{- |
   Builds a 'FieldDefinition' that stores Haskell 'Time.Day' values as the
   PostgreSQL "DATE" type.
 -}
-dateField :: String -- ^ Name of the field in the database
-          -> FieldDefinition NotNull Time.Day
+dateField ::
+  -- | Name of the field in the database
+  String ->
+  FieldDefinition NotNull Time.Day
 dateField = fieldOfType SqlType.date
 
-{-|
+{- |
   Builds a 'FieldDefinition' that stores Haskell 'Time.UTCTime values as the
   PostgreSQL "TIMESTAMP with time zone" type.
 
   TODO: discuss "TIMESTAMP with zone" to avoid confusion?
 -}
-timestampField :: String -- ^ Name of the field in the database
-               -> FieldDefinition NotNull Time.UTCTime
+timestampField ::
+  -- | Name of the field in the database
+  String ->
+  FieldDefinition NotNull Time.UTCTime
 timestampField = fieldOfType SqlType.timestamp
 
-{-|
+{- |
   Builds a 'FieldDefinition' for will use the given 'SqlType' to determine
   the database representation of the field. If you have created a custom
   'SqlType', you can use this function to construct a helper like the
   other functions in this module for creating 'FieldDefinition's for your
   custom type.
 -}
-fieldOfType :: SqlType a -- ^ 'SqlType' that represents the PostgreSQL data type for the field.
-            -> String -- ^ Name of the field in the database
-            -> FieldDefinition NotNull a
+fieldOfType ::
+  -- | 'SqlType' that represents the PostgreSQL data type for the field.
+  SqlType a ->
+  -- | Name of the field in the database
+  String ->
+  FieldDefinition NotNull a
 fieldOfType sqlType name =
   FieldDefinition
     (stringToFieldName name)

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/PGTextFormatValue.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/PGTextFormatValue.hs
@@ -1,16 +1,17 @@
 module Database.Orville.PostgreSQL.Internal.PGTextFormatValue
-  ( PGTextFormatValue
-  , NULByteFoundError(NULByteFoundError)
-  , unsafeFromByteString
-  , fromByteString
-  , toByteString
-  , toBytesForLibPQ
-  ) where
+  ( PGTextFormatValue,
+    NULByteFoundError (NULByteFoundError),
+    unsafeFromByteString,
+    fromByteString,
+    toByteString,
+    toBytesForLibPQ,
+  )
+where
 
-import           Control.Exception (Exception)
+import Control.Exception (Exception)
 import qualified Data.ByteString as BS
 
-{-|
+{- |
   A 'PGTextFormatValue' represents raw bytes that will be passed to postgresql
   via libpq. These bytes must conform to the TEXT format of values that
   postgresql expects. In all cases postgresql will be allowed to infer the type
@@ -36,13 +37,13 @@ instance Eq PGTextFormatValue where
   left == right =
     toBytesForLibPQ left == toBytesForLibPQ right
 
-data NULByteFoundError =
-  NULByteFoundError
+data NULByteFoundError
+  = NULByteFoundError
   deriving (Show, Eq)
 
-instance Exception NULByteFoundError where
+instance Exception NULByteFoundError
 
-{-|
+{- |
   Constructs a 'PGTextFormatValue' from the given bytes directly, without checking
   whether any of the bytes are '\NUL' or not. If a 'BS.ByteString' containing
   a '\NUL' byte is given, the value will be truncated at the '\NUL' when it
@@ -56,7 +57,7 @@ unsafeFromByteString :: BS.ByteString -> PGTextFormatValue
 unsafeFromByteString =
   AssumedToHaveNoNULValues
 
-{-|
+{- |
   Constructs a 'PGTextFormatValue' from the given bytes, which will be checked
   to ensure none of them are '\NUL' before being passed to libpq. If a '\NUL'
   byte is found an error will be raised.
@@ -65,7 +66,7 @@ fromByteString :: BS.ByteString -> PGTextFormatValue
 fromByteString =
   NoAssumptionsMade
 
-{-|
+{- |
   Converts the 'PGTextFormatValue' to bytes intended to be passed to libpq.
   If any '\NUL' bytes are found, 'NULByteErrorFound' will be returned (unless
   'unsafeFromByteString' was used to construct the value).
@@ -75,16 +76,12 @@ toBytesForLibPQ value =
   case value of
     AssumedToHaveNoNULValues noNULBytes ->
       Right noNULBytes
-
     NoAssumptionsMade anyBytes ->
-      if
-        BS.elem 0 anyBytes
-      then
-        Left NULByteFoundError
-      else
-        Right anyBytes
+      if BS.elem 0 anyBytes
+        then Left NULByteFoundError
+        else Right anyBytes
 
-{-|
+{- |
   Convents the 'PGTextFormatValue' back to the bytes that were used to
   construct it, losing the information about whether it would be checked
   for '\NUL' bytes or not.
@@ -94,6 +91,5 @@ toByteString value =
   case value of
     AssumedToHaveNoNULValues bytes ->
       bytes
-
     NoAssumptionsMade bytes ->
       bytes

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/RawSql.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/RawSql.hs
@@ -1,4 +1,4 @@
-{-|
+{- |
 
 Module    : Database.Orville.PostgreSQL.Internal.RawSql
 Copyright : Flipstone Technology Partners 2016-2021
@@ -6,34 +6,34 @@ License   : MIT
 
 The funtions in this module are named with the intent that it is imported
 qualified as 'RawSql'.
-
 -}
 module Database.Orville.PostgreSQL.Internal.RawSql
-  ( RawSql
-  , parameter
-  , fromString
-  , fromBytes
-  , toBytesAndParams
-  , intercalate
-  , execute
-  , executeVoid
-  ) where
+  ( RawSql,
+    parameter,
+    fromString,
+    fromBytes,
+    toBytesAndParams,
+    intercalate,
+    execute,
+    executeVoid,
+  )
+where
 
 import qualified Data.ByteString as BS
-import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString.Builder as BSB
-import           Data.DList (DList)
+import qualified Data.ByteString.Lazy as LBS
+import Data.DList (DList)
 import qualified Data.DList as DList
 import qualified Data.List as List
 import qualified Database.PostgreSQL.LibPQ as LibPQ
 
-import           Database.Orville.PostgreSQL.Connection (Connection, Pool)
+import Database.Orville.PostgreSQL.Connection (Connection, Pool)
 import qualified Database.Orville.PostgreSQL.Connection as Conn
-import           Database.Orville.PostgreSQL.Internal.PGTextFormatValue (PGTextFormatValue)
-import           Database.Orville.PostgreSQL.Internal.SqlValue (SqlValue)
+import Database.Orville.PostgreSQL.Internal.PGTextFormatValue (PGTextFormatValue)
+import Database.Orville.PostgreSQL.Internal.SqlValue (SqlValue)
 import qualified Database.Orville.PostgreSQL.Internal.SqlValue as SqlValue
 
-{-|
+{- |
   'RawSql' provides a type for efficiently constructing raw sql statements
   from smaller parts and then executing them. It also supports using placeholder
   values to pass parameters with a query without having to interpolate them
@@ -47,39 +47,35 @@ data RawSql
 instance Semigroup RawSql where
   (SqlSection builderA) <> (SqlSection builderB) =
     SqlSection (builderA <> builderB)
-
   otherA <> otherB =
     Append otherA otherB
 
 instance Monoid RawSql where
   mempty = SqlSection mempty
 
-{-|
+{- |
   Constructs the actual sql bytestring and parameter values that will be
   passed to the database to execute a 'RawSql' query.
 -}
 toBytesAndParams :: RawSql -> (BS.ByteString, [Maybe PGTextFormatValue])
 toBytesAndParams rawSql =
-  let
-    (byteBuilder, finalProgress) =
-      buildSqlWithProgress startingProgress rawSql
-  in
-    ( LBS.toStrict (BSB.toLazyByteString byteBuilder)
-    , DList.toList (paramValues finalProgress)
-    )
+  let (byteBuilder, finalProgress) =
+        buildSqlWithProgress startingProgress rawSql
+   in ( LBS.toStrict (BSB.toLazyByteString byteBuilder)
+      , DList.toList (paramValues finalProgress)
+      )
 
-{-|
+{- |
   This is an internal datatype used during the sql building process to track
   how many params have been seen so that placeholder indices (e.g. '$1', etc)
   can be generated to include in the sql.
 -}
-data ParamsProgress =
-  ParamsProgress
-    { paramCount :: Int
-    , paramValues :: DList (Maybe PGTextFormatValue)
-    }
+data ParamsProgress = ParamsProgress
+  { paramCount :: Int
+  , paramValues :: DList (Maybe PGTextFormatValue)
+  }
 
-{-|
+{- |
   An initial value for 'ParamsProgress' that indicates no params have been been
   encountered yet.
 -}
@@ -90,7 +86,7 @@ startingProgress =
     , paramValues = DList.empty
     }
 
-{-|
+{- |
   Adds a parameter value to the end of the params list, tracking the count
   of parameters as it does so.
 -}
@@ -101,36 +97,31 @@ snocParam (ParamsProgress count values) newValue =
     , paramValues = DList.snoc values newValue
     }
 
-{-|
+{- |
   Constructs a bytestring builder that can be executed to get the bytes for a
   section of 'RawSql'. This function takes and returns a 'ParamsProgress' so
   that placeholder indices (e.g. '$1') and their corresponding parameter values
   can be tracked across multiple sections of raw sql.
 -}
-buildSqlWithProgress :: ParamsProgress
-                     -> RawSql
-                     -> (BSB.Builder, ParamsProgress)
+buildSqlWithProgress ::
+  ParamsProgress ->
+  RawSql ->
+  (BSB.Builder, ParamsProgress)
 buildSqlWithProgress progress rawSql =
   case rawSql of
     SqlSection builder ->
       (builder, progress)
-
     Parameter value ->
-      let
-        newProgress = snocParam progress (SqlValue.toPGValue value)
-      in
-        ( BSB.stringUtf8 "$" <> BSB.intDec (paramCount newProgress)
-        , newProgress
-        )
-
+      let newProgress = snocParam progress (SqlValue.toPGValue value)
+       in ( BSB.stringUtf8 "$" <> BSB.intDec (paramCount newProgress)
+          , newProgress
+          )
     Append first second ->
-      let
-        (firstBuilder, nextProgress) = buildSqlWithProgress progress first
-        (secondBuilder, finalProgress) = buildSqlWithProgress nextProgress second
-      in
-        (firstBuilder <> secondBuilder, finalProgress)
+      let (firstBuilder, nextProgress) = buildSqlWithProgress progress first
+          (secondBuilder, finalProgress) = buildSqlWithProgress nextProgress second
+       in (firstBuilder <> secondBuilder, finalProgress)
 
-{-|
+{- |
   Constructs a 'RawSql' from a 'String' value using utf8 encoding.
 
   Note that because the string is treated as raw sql it completely up to the
@@ -141,7 +132,7 @@ fromString :: String -> RawSql
 fromString =
   SqlSection . BSB.stringUtf8
 
-{-|
+{- |
   Constructs a 'RawSql' from a 'ByteString' value, which is assumed to be
   encoded sensibly for the database to handle.
 
@@ -153,7 +144,7 @@ fromBytes :: BS.ByteString -> RawSql
 fromBytes =
   SqlSection . BSB.byteString
 
-{-|
+{- |
   Includes an input parameter in the 'RawSql' statement that will be passed
   using placeholders (e.g. '$1') rather than being included directly in the sql
   statement. This is the correct way to include input from untrusted sources as
@@ -165,7 +156,7 @@ parameter :: SqlValue -> RawSql
 parameter =
   Parameter
 
-{-|
+{- |
   Concatenates a list of 'RawSql' values using another 'RawSql' value as
   the a separator between the items.
 -}
@@ -173,28 +164,24 @@ intercalate :: RawSql -> [RawSql] -> RawSql
 intercalate separator parts =
   mconcat (List.intersperse separator parts)
 
-{-|
+{- |
   Executes a 'RawSql' value using the 'Conn.executeRaw' function. Make sure
   to read the documentation of 'Conn.executeRaw' for caveats and warnings.
   Use with caution.
 -}
 execute :: Pool Connection -> RawSql -> IO LibPQ.Result
 execute conn rawSql =
-  let
-    (sqlBytes, params) =
-      toBytesAndParams rawSql
-  in
-    Conn.executeRaw conn sqlBytes params
+  let (sqlBytes, params) =
+        toBytesAndParams rawSql
+   in Conn.executeRaw conn sqlBytes params
 
-{-|
+{- |
   Executes a 'RawSql' value using the 'Conn.executeRawVoid' function. Make sure
   to read the documentation of 'Conn.executeRawVoid' for caveats and warnings.
   Use with caution.
 -}
 executeVoid :: Pool Connection -> RawSql -> IO ()
 executeVoid conn rawSql =
-  let
-    (sqlBytes, params) =
-      toBytesAndParams rawSql
-  in
-    Conn.executeRawVoid conn sqlBytes params
+  let (sqlBytes, params) =
+        toBytesAndParams rawSql
+   in Conn.executeRawVoid conn sqlBytes params

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/SqlMarshaller.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/SqlMarshaller.hs
@@ -1,35 +1,37 @@
-{-|
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE GADTs #-}
+
+{- |
 Module    : Database.Orville.PostgreSQL.Internal.SqlMarshaller
 Copyright : Flipstone Technology Partners 2016-2021
 License   : MIT
 -}
-{-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE GADTs #-}
 module Database.Orville.PostgreSQL.Internal.SqlMarshaller
-  ( SqlMarshaller
-  , MarshallError(..)
-  , marshallEntityToSql
-  , marshallResultFromSql
-  , marshallRowFromSql
-  , marshallField
-  , mkRowSource
-  , RowSource
-  , mapRowSource
-  , applyRowSource
-  , constRowSource
-  , failRowSource
-  ) where
+  ( SqlMarshaller,
+    MarshallError (..),
+    marshallEntityToSql,
+    marshallResultFromSql,
+    marshallRowFromSql,
+    marshallField,
+    mkRowSource,
+    RowSource,
+    mapRowSource,
+    applyRowSource,
+    constRowSource,
+    failRowSource,
+  )
+where
 
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Map.Strict as Map
-import           Data.Maybe (catMaybes)
+import Data.Maybe (catMaybes)
 
-import           Database.Orville.PostgreSQL.Internal.ExecutionResult (ExecutionResult, Column(Column), Row(Row))
+import Database.Orville.PostgreSQL.Internal.ExecutionResult (Column (Column), ExecutionResult, Row (Row))
 import qualified Database.Orville.PostgreSQL.Internal.ExecutionResult as Result
-import           Database.Orville.PostgreSQL.Internal.FieldDefinition (FieldDefinition, FieldName, fieldName, fieldNameToByteString, fieldValueFromSqlValue, fieldValueToSqlValue)
-import           Database.Orville.PostgreSQL.Internal.SqlValue (SqlValue)
+import Database.Orville.PostgreSQL.Internal.FieldDefinition (FieldDefinition, FieldName, fieldName, fieldNameToByteString, fieldValueFromSqlValue, fieldValueToSqlValue)
+import Database.Orville.PostgreSQL.Internal.SqlValue (SqlValue)
 
-{-|
+{- |
   'SqlMarshaller' is how we group the lowest level translation of single fields
   into a higher level marshalling of full sql records into Haskell records.
   This is a flexible abstraction that allows us to ultimately model SQL tables
@@ -38,13 +40,11 @@ import           Database.Orville.PostgreSQL.Internal.SqlValue (SqlValue)
 -}
 data SqlMarshaller a b where
   -- | Our representation of `pure` in the `Applicative` sense
-  MarshallPure  :: b -> SqlMarshaller a b
+  MarshallPure :: b -> SqlMarshaller a b
   -- | Representation of application like `<*>` from `Applicative`
   MarshallApply :: SqlMarshaller a (b -> c) -> SqlMarshaller a b -> SqlMarshaller a c
-
   -- | Nest an arbitrary function, this is used when modeling a SQL table as nested Haskell records
   MarshallNest :: (a -> b) -> SqlMarshaller b c -> SqlMarshaller a c
-
   -- | Mashall a SQL column using the given 'FieldDefinition'
   MarshallField :: FieldDefinition nullability a -> SqlMarshaller a a
 
@@ -55,40 +55,36 @@ instance Applicative (SqlMarshaller a) where
   pure = MarshallPure
   (<*>) = MarshallApply
 
-{-|
+{- |
   Encodes an Haskell entity to the `FieldName`/`SqlValue` pairs that are
   described by a `SqlMarshaller`. Each pair is passed to the result-building
   function to allow to caller to construct the `result` type as desired.
   The `result` is built in a right-associative manner, much like a `foldr`
   operation.
 -}
-marshallEntityToSql :: SqlMarshaller writeEntity readEntity
-                    -> result
-                    -> (FieldName -> SqlValue -> result -> result)
-                    -> writeEntity
-                    -> result
+marshallEntityToSql ::
+  SqlMarshaller writeEntity readEntity ->
+  result ->
+  (FieldName -> SqlValue -> result -> result) ->
+  writeEntity ->
+  result
 marshallEntityToSql marshaller currentResult addToResult entity =
   case marshaller of
     MarshallPure _ ->
       currentResult
-
     MarshallApply submarshallerA submarshallerB ->
-      let
-        subresultB =
-          marshallEntityToSql submarshallerB currentResult addToResult entity
-      in
-        marshallEntityToSql submarshallerA subresultB addToResult entity
-
+      let subresultB =
+            marshallEntityToSql submarshallerB currentResult addToResult entity
+       in marshallEntityToSql submarshallerA subresultB addToResult entity
     MarshallNest nestingFunction submarshaller ->
       marshallEntityToSql submarshaller currentResult addToResult (nestingFunction entity)
-
     MarshallField fieldDefinition ->
       addToResult
         (fieldName fieldDefinition)
         (fieldValueToSqlValue fieldDefinition entity)
         currentResult
 
-{-|
+{- |
   A 'MarshallError' may be returned from 'marshallFromSql' if the result set
   being decoded from the database doesn't meet the expectations of the
   'SqlMarshaller' that is decoding it.
@@ -96,9 +92,9 @@ marshallEntityToSql marshaller currentResult addToResult entity =
 data MarshallError
   = -- | Indicates that a particular value in a column could not be decoded
     FailedToDecodeValue
-    -- | Indicates that an expected column was not found in the result set
-  | FieldNotFoundInResultSet
-  deriving Eq
+  | -- | Indicates that an expected column was not found in the result set
+    FieldNotFoundInResultSet
+  deriving (Eq)
 
 -- NOTE: We want to be sure that the 'Show' instance of Marshall error does
 -- not expose any values read from the database, so we implement it explicitly
@@ -106,10 +102,10 @@ data MarshallError
 instance Show MarshallError where
   show err =
     case err of
-      FailedToDecodeValue      -> "FailedToDecodeValue"
+      FailedToDecodeValue -> "FailedToDecodeValue"
       FieldNotFoundInResultSet -> "FieldNotFoundInResultSet"
 
-{-|
+{- |
   Decodes all the rows found in a execution result at once. The first row that
   fails to decode will return the `MarshallError` that results, otherwise all
   decoded rows will be returned.
@@ -117,17 +113,17 @@ instance Show MarshallError where
   Note that this function loads are decoded rows into memory at once, so it
   should only be used with result sets that you know will fit into memory.
 -}
-marshallResultFromSql :: ExecutionResult result
-                      => SqlMarshaller writeEntity readEntity
-                      -> result
-                      -> IO (Either MarshallError [readEntity])
+marshallResultFromSql ::
+  ExecutionResult result =>
+  SqlMarshaller writeEntity readEntity ->
+  result ->
+  IO (Either MarshallError [readEntity])
 marshallResultFromSql marshaller result = do
   mbMaxRow <- Result.maxRowNumber result
 
   case mbMaxRow of
     Nothing ->
       pure (Right [])
-
     Just maxRow -> do
       rowSource <- mkRowSource marshaller result
       traverseSequence (decodeRow rowSource) [Row 0 .. maxRow]
@@ -135,29 +131,25 @@ marshallResultFromSql marshaller result = do
 traverseSequence :: (a -> IO (Either err b)) -> [a] -> IO (Either err [b])
 traverseSequence f =
   go
-    where
-      go as =
-        case as of
-          [] ->
-            pure (Right [])
+  where
+    go as =
+      case as of
+        [] ->
+          pure (Right [])
+        a : rest -> do
+          eitherB <- f a
+          case eitherB of
+            Left err ->
+              pure (Left err)
+            Right b -> do
+              eitherBS <- go rest
+              case eitherBS of
+                Left err ->
+                  pure (Left err)
+                Right bs ->
+                  pure (Right (b : bs))
 
-          a : rest -> do
-            eitherB <- f a
-            case eitherB of
-              Left err ->
-                pure (Left err)
-
-              Right b -> do
-                eitherBS <- go rest
-                case eitherBS of
-                  Left err ->
-                    pure (Left err)
-
-                  Right bs ->
-                    pure (Right (b:bs))
-
-
-{-|
+{- |
   A `RowSource` can fetch and decode rows from a database result set. Using
   a `RowSource` gives random access to the rows in the result set, only
   attempting to decode them when they are requested by the use via `decodeRow`.
@@ -168,8 +160,8 @@ traverseSequence f =
   As such, you can't use `RowSource` (alone) to achieve any form of streaming
   or pagination of rows between the database server and the client.
 -}
-newtype RowSource readEntity =
-  RowSource (Row -> IO (Either MarshallError readEntity))
+newtype RowSource readEntity
+  = RowSource (Row -> IO (Either MarshallError readEntity))
 
 instance Functor RowSource where
   fmap = mapRowSource
@@ -178,7 +170,7 @@ instance Applicative RowSource where
   pure = constRowSource
   (<*>) = applyRowSource
 
-{-|
+{- |
   Attempts to decode a result set row that has already been fetched from the
   database server into a Haskell value. If the decoding fails, a `MarshallError`
   will be returned.
@@ -187,7 +179,7 @@ decodeRow :: RowSource readEntity -> Row -> IO (Either MarshallError readEntity)
 decodeRow (RowSource source) =
   source
 
-{-|
+{- |
   Adds a function to the decoding proocess to transform the value returned
   by a `RowSource`.
 -}
@@ -195,7 +187,7 @@ mapRowSource :: (a -> b) -> RowSource a -> RowSource b
 mapRowSource f (RowSource decodeA) =
   RowSource $ \row -> fmap (fmap f) (decodeA row)
 
-{-|
+{- |
   Creates a `RowSource` that always returns the value given, rather than
   attempting to access the result set and decoding anything.
 -}
@@ -203,7 +195,7 @@ constRowSource :: readEntity -> RowSource readEntity
 constRowSource =
   RowSource . const . pure . Right
 
-{-|
+{- |
   Applies a function that will be decoded from the result set to another
   value decode from the result set.
 -}
@@ -215,12 +207,11 @@ applyRowSource (RowSource decodeAtoB) (RowSource decodeA) =
     case eitherAToB of
       Left err ->
         pure (Left err)
-
       Right aToB -> do
         eitherA <- decodeA row
         pure (fmap aToB eitherA)
 
-{-|
+{- |
   Creates a `RowSource` that will always fail to decode by returning the
   provided error. This can be used in cases where a `RowSource` must
   be provided but it is already known at run time that decoding is impossible.
@@ -231,51 +222,45 @@ failRowSource :: MarshallError -> RowSource a
 failRowSource =
   RowSource . const . pure . Left
 
-{-|
+{- |
   Uses the `SqlMarshaller` given to build a `RowSource` that will decode
   from the given result set. The returned `RowSource` can then be used to
   decode rows as desired by the user. Note that the entire result set is
   held in memory for potential decoding until the `RowSource` is garbage
   collected.
 -}
-mkRowSource :: ExecutionResult result
-            => SqlMarshaller writeEntity readEntity
-            -> result
-            -> IO (RowSource readEntity)
+mkRowSource ::
+  ExecutionResult result =>
+  SqlMarshaller writeEntity readEntity ->
+  result ->
+  IO (RowSource readEntity)
 mkRowSource marshaller result = do
   columnMap <- prepareColumnMap result
 
-  let
-    mkSource :: SqlMarshaller a b -> RowSource b
-    mkSource marshallerPart =
-      -- Note, this case statement is evaluated before the row argument is
-      -- ever passed to a `RowSource` to ensure that a single `RowSource`
-      -- operation is build and re-used when decoding many rows.
-      case marshallerPart of
-        MarshallPure readEntity ->
-          constRowSource readEntity
-
-        MarshallApply marshallAToB marshallA ->
-          mkSource marshallAToB <*> mkSource marshallA
-
-        MarshallNest _ someMarshaller ->
-          mkSource someMarshaller
-
-        MarshallField fieldDef ->
-          let
-            fieldNameBytes =
-              fieldNameToByteString (fieldName fieldDef)
-          in
-            case Map.lookup fieldNameBytes columnMap of
-              Just columnNumber ->
-                mkColumnRowSource fieldDef result columnNumber
-
-              Nothing ->
-                failRowSource FieldNotFoundInResultSet
+  let mkSource :: SqlMarshaller a b -> RowSource b
+      mkSource marshallerPart =
+        -- Note, this case statement is evaluated before the row argument is
+        -- ever passed to a `RowSource` to ensure that a single `RowSource`
+        -- operation is build and re-used when decoding many rows.
+        case marshallerPart of
+          MarshallPure readEntity ->
+            constRowSource readEntity
+          MarshallApply marshallAToB marshallA ->
+            mkSource marshallAToB <*> mkSource marshallA
+          MarshallNest _ someMarshaller ->
+            mkSource someMarshaller
+          MarshallField fieldDef ->
+            let fieldNameBytes =
+                  fieldNameToByteString (fieldName fieldDef)
+             in case Map.lookup fieldNameBytes columnMap of
+                  Just columnNumber ->
+                    mkColumnRowSource fieldDef result columnNumber
+                  Nothing ->
+                    failRowSource FieldNotFoundInResultSet
 
   pure . mkSource $ marshaller
 
-{-|
+{- |
   Decodes a result set row from the database using the given 'SqlMarshaller'.
   This will lookup the values in the result set based on the field names in all
   the 'FieldDefinition's used in the 'SqlMarshaller' and attempt to convert the
@@ -283,54 +268,57 @@ mkRowSource marshaller result = do
   process will cause the entire row to fail to decode and return a
   'MarshallError' in the result.
 -}
-marshallRowFromSql :: ExecutionResult result
-                   => SqlMarshaller writeEntity readEntity -- ^ 'SqlMarshaller' to use for decoding
-                   -> Row -- ^ A row number to decode
-                   -> result -- ^ result set to decode from
-                   -> IO (Either MarshallError readEntity)
+marshallRowFromSql ::
+  ExecutionResult result =>
+  -- | 'SqlMarshaller' to use for decoding
+  SqlMarshaller writeEntity readEntity ->
+  -- | A row number to decode
+  Row ->
+  -- | result set to decode from
+  result ->
+  IO (Either MarshallError readEntity)
 marshallRowFromSql marshaller rowNumber result = do
   rowSource <- mkRowSource marshaller result
   decodeRow rowSource rowNumber
 
-{-|
+{- |
   An internal helper function that finds all the column names in a result set
   and associates them with the respective column numbers for easier lookup.
 -}
-prepareColumnMap :: ExecutionResult result
-                 => result
-                 -> IO (Map.Map B8.ByteString Column)
+prepareColumnMap ::
+  ExecutionResult result =>
+  result ->
+  IO (Map.Map B8.ByteString Column)
 prepareColumnMap result = do
   mbMaxColumn <- Result.maxColumnNumber result
 
-  let
-    mkNameEntry columnNumber = do
-      mbColumnName <- Result.columnName result columnNumber
+  let mkNameEntry columnNumber = do
+        mbColumnName <- Result.columnName result columnNumber
 
-      pure $
-        case mbColumnName of
-          Just name ->
-            Just (name, columnNumber)
-
-          Nothing ->
-            Nothing
+        pure $
+          case mbColumnName of
+            Just name ->
+              Just (name, columnNumber)
+            Nothing ->
+              Nothing
 
   case mbMaxColumn of
     Nothing ->
       pure Map.empty
-
     Just maxColumn -> do
       entries <- traverse mkNameEntry [Column 0 .. maxColumn]
       pure $ Map.fromList (catMaybes entries)
 
-{-|
+{- |
   A internal helper function for to build a `RowSource` that retrieves and
   decodes a single column value form the result set.
 -}
-mkColumnRowSource :: ExecutionResult result
-                  => FieldDefinition nullability a
-                  -> result
-                  -> Column
-                  -> RowSource a
+mkColumnRowSource ::
+  ExecutionResult result =>
+  FieldDefinition nullability a ->
+  result ->
+  Column ->
+  RowSource a
 mkColumnRowSource fieldDef result column =
   RowSource $ \row -> do
     sqlValue <- Result.getValue result row column
@@ -338,12 +326,10 @@ mkColumnRowSource fieldDef result column =
     case fieldValueFromSqlValue fieldDef sqlValue of
       Just value ->
         pure (Right value)
-
       Nothing ->
         pure (Left FailedToDecodeValue)
 
-
-{-|
+{- |
   Builds a 'SqlMarshaller' that maps a single field of a Haskell entity to
   a single column in the database. That value to store in the database will
   be retried from the entity using provided accessor function. This function
@@ -363,8 +349,9 @@ mkColumnRowSource fieldDef result column =
 
   @
 -}
-marshallField :: (writeEntity -> fieldValue)
-             -> FieldDefinition nullability fieldValue
-             -> SqlMarshaller writeEntity fieldValue
+marshallField ::
+  (writeEntity -> fieldValue) ->
+  FieldDefinition nullability fieldValue ->
+  SqlMarshaller writeEntity fieldValue
 marshallField accessor fieldDef =
   MarshallNest accessor (MarshallField fieldDef)

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/SqlValue.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/SqlValue.hs
@@ -1,4 +1,4 @@
-{-|
+{- |
 
 Module    : Database.Orville.PostgreSQL.Internal.SqlValue
 Copyright : Flipstone Technology Partners 2016-2021
@@ -6,45 +6,45 @@ License   : MIT
 
 The funtions in this module are named with the intent that it is imported
 qualified as 'SqlValue.
-
 -}
 module Database.Orville.PostgreSQL.Internal.SqlValue
-  ( SqlValue
-  , isSqlNull
-  , sqlNull
-  , fromInt32
-  , toInt32
-  , fromInt64
-  , toInt64
-  , fromInt
-  , toInt
-  , fromDouble
-  , toDouble
-  , fromBool
-  , toBool
-  , fromText
-  , toText
-  , fromDay
-  , toDay
-  , fromUTCTime
-  , toUTCTime
-  , fromRawBytes
-  , fromRawBytesNullable
-  , toPGValue
-  ) where
+  ( SqlValue,
+    isSqlNull,
+    sqlNull,
+    fromInt32,
+    toInt32,
+    fromInt64,
+    toInt64,
+    fromInt,
+    toInt,
+    fromDouble,
+    toDouble,
+    fromBool,
+    toBool,
+    fromText,
+    toText,
+    fromDay,
+    toDay,
+    fromUTCTime,
+    toUTCTime,
+    fromRawBytes,
+    fromRawBytesNullable,
+    toPGValue,
+  )
+where
 
 import qualified Data.Attoparsec.ByteString as AttoBS
 import qualified Data.Attoparsec.ByteString.Char8 as AttoB8
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Builder as BSB
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.ByteString.Lazy as LBS
-import qualified Data.ByteString.Builder as BSB
-import           Data.Int (Int32, Int64)
+import Data.Int (Int32, Int64)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TextEnc
 import qualified Data.Time as Time
 
-import           Database.Orville.PostgreSQL.Internal.PGTextFormatValue (PGTextFormatValue)
+import Database.Orville.PostgreSQL.Internal.PGTextFormatValue (PGTextFormatValue)
 import qualified Database.Orville.PostgreSQL.Internal.PGTextFormatValue as PGTextFormatValue
 
 data SqlValue
@@ -52,16 +52,16 @@ data SqlValue
   | SqlNull
   deriving (Show, Eq)
 
-{-|
+{- |
   Checks whether the 'SqlValue' represents a sql NULL value in the database.
 -}
 isSqlNull :: SqlValue -> Bool
 isSqlNull sqlValue =
   case sqlValue of
     SqlValue _ -> False
-    SqlNull    -> True
+    SqlNull -> True
 
-{-|
+{- |
   A value of 'SqlValue' that will be interpreted as a sql NULL value when
   pasesed to the database.
 -}
@@ -69,7 +69,7 @@ sqlNull :: SqlValue
 sqlNull =
   SqlNull
 
-{-|
+{- |
   Converts a 'SqlValue' to its underlying raw bytes as it will be represented
   when sent to the database. The output should be recognizable as similar to
   to values you would write in query. If the value represents a sql NULL
@@ -80,11 +80,10 @@ toPGValue sqlValue =
   case sqlValue of
     SqlValue value ->
       Just value
-
     SqlNull ->
       Nothing
 
-{-|
+{- |
   Creates a 'SqlValue' from a raw byte string as if the bytes had returned
   by the database. This function does not interpret the bytes in any way,
   but the using decode functions on them might fail depending on whether the
@@ -98,7 +97,7 @@ fromRawBytes :: BS.ByteString -> SqlValue
 fromRawBytes =
   SqlValue . PGTextFormatValue.fromByteString
 
-{-|
+{- |
   Creates a 'SqlValue' from a raw byte string. If 'Nothing' is specified as the
   input parameter then the resulting 'SqlValue' will represent a NULL value in
   sql. Otherwise the bytes given are used in the same way as 'fromRawBytes'
@@ -107,14 +106,14 @@ fromRawBytesNullable :: Maybe BS.ByteString -> SqlValue
 fromRawBytesNullable =
   maybe sqlNull fromRawBytes
 
-{-|
+{- |
   Encodes an 'Int32' value for usage with database
 -}
 fromInt32 :: Int32 -> SqlValue
 fromInt32 =
   fromBSBuilderWithNoNULs BSB.int32Dec
 
-{-|
+{- |
   Attempts to decode a 'SqlValue' a Haskell 'Int32' value. If decoding fails
   'Nothing' is returned.
 -}
@@ -122,21 +121,21 @@ toInt32 :: SqlValue -> Maybe Int32
 toInt32 =
   toParsedValue (AttoB8.signed AttoB8.decimal)
 
-{-|
+{- |
   Encodes an 'Int64' value for usage with database
 -}
 fromInt64 :: Int64 -> SqlValue
 fromInt64 =
   fromBSBuilderWithNoNULs BSB.int64Dec
 
-{-|
+{- |
   Encodes an 'Int32' value for usage with database
 -}
 fromInt :: Int -> SqlValue
 fromInt =
   fromBSBuilderWithNoNULs BSB.intDec
 
-{-|
+{- |
   Attempts to decode a 'SqlValue' a Haskell 'Int' value. If decoding fails
   'Nothing' is returned.
 -}
@@ -144,7 +143,7 @@ toInt :: SqlValue -> Maybe Int
 toInt =
   toParsedValue (AttoB8.signed AttoB8.decimal)
 
-{-|
+{- |
   Attempts to decode a 'SqlValue' a Haskell 'Int' value. If decoding fails
   'Nothing' is returned.
 -}
@@ -152,14 +151,14 @@ toInt64 :: SqlValue -> Maybe Int64
 toInt64 =
   toParsedValue (AttoB8.signed AttoB8.decimal)
 
-{-|
+{- |
   Encodes a 'Double' value for usage with database
 -}
 fromDouble :: Double -> SqlValue
 fromDouble =
   fromBSBuilderWithNoNULs BSB.doubleDec
 
-{-|
+{- |
   Attempts to decode a 'SqlValue' a Haskell 'Double' value. If decoding fails
   'Nothing' is returned.
 -}
@@ -167,7 +166,7 @@ toDouble :: SqlValue -> Maybe Double
 toDouble =
   toParsedValue (AttoB8.signed AttoB8.double)
 
-{-|
+{- |
   Encodes a 'Bool' value for usage with database
 -}
 fromBool :: Bool -> SqlValue
@@ -177,7 +176,7 @@ fromBool =
       True -> BSB.char8 't'
       False -> BSB.char8 'f'
 
-{-|
+{- |
   Attempts to decode a 'SqlValue' a Haskell 'Bool' value. If decoding fails
   'Nothing' is returned.
 -}
@@ -188,16 +187,16 @@ toBool =
     case char of
       't' -> pure True
       'f' -> pure False
-      _   -> fail "Invalid boolean character value"
+      _ -> fail "Invalid boolean character value"
 
-{-|
+{- |
   Encodes a 'T.Text' value as utf8 so that it can be used with the database.
 -}
 fromText :: T.Text -> SqlValue
 fromText =
   SqlValue . PGTextFormatValue.fromByteString . TextEnc.encodeUtf8
 
-{-|
+{- |
   Attempts to decode a 'SqlValue' as UTF-8 text. If the decoding fails,
   'Nothing' is returned.
 
@@ -209,9 +208,9 @@ toText =
   toBytesValue $ \bytes ->
     case TextEnc.decodeUtf8' bytes of
       Right t -> Just t
-      Left _  -> Nothing
+      Left _ -> Nothing
 
-{-|
+{- |
   Encodes a 'Time.Day' value as text in YYYY-MM-DD format so that it can be
   used with the database.
 -}
@@ -219,7 +218,7 @@ fromDay :: Time.Day -> SqlValue
 fromDay =
   SqlValue . PGTextFormatValue.unsafeFromByteString . B8.pack . Time.showGregorian
 
-{-|
+{- |
   Attempts to decode a 'SqlValue' as into a 'Time.Day' value by parsing it
   from YYYY-MM-DD format. If the decoding fails 'Nothing' is returned.
 -}
@@ -232,17 +231,17 @@ toDay sqlValue = do
     (Time.iso8601DateFormat Nothing)
     (T.unpack txt)
 
-{-|
+{- |
   Encodes a 'Time.UTCTime' in ISO 8601 format for usage with the database.
 -}
 fromUTCTime :: Time.UTCTime -> SqlValue
 fromUTCTime =
   SqlValue
-  . PGTextFormatValue.unsafeFromByteString
-  . B8.pack
-  . Time.formatTime Time.defaultTimeLocale "%0Y-%m-%dT%H:%M:%S"
+    . PGTextFormatValue.unsafeFromByteString
+    . B8.pack
+    . Time.formatTime Time.defaultTimeLocale "%0Y-%m-%dT%H:%M:%S"
 
-{-|
+{- |
   Attempts to decode a 'SqlValue' as a 'Time.UTCTime' formatted in iso8601
   format. If the decoding fails, 'Nothing' is returned.
 -}
@@ -255,28 +254,28 @@ toUTCTime sqlValue = do
   txt <- toText sqlValue
   Time.parseTimeM False Time.defaultTimeLocale "%F %T%Q%Z" (T.unpack txt <> "00")
 
-{-|
+{- |
   A internal helper function that constructs a 'SqlValue' via a byte string builder
 -}
 fromBSBuilderWithNoNULs :: (a -> BSB.Builder) -> a -> SqlValue
 fromBSBuilderWithNoNULs builder =
   SqlValue
-  . PGTextFormatValue.unsafeFromByteString
-  . LBS.toStrict
-  . BSB.toLazyByteString
-  . builder
+    . PGTextFormatValue.unsafeFromByteString
+    . LBS.toStrict
+    . BSB.toLazyByteString
+    . builder
 
-{-|
+{- |
   A internal helper function that parses 'SqlValue' via an Attoparsec parser.
 -}
 toParsedValue :: AttoB8.Parser a -> SqlValue -> Maybe a
 toParsedValue parser =
   toBytesValue $ \bytes ->
     case AttoBS.parseOnly parser bytes of
-      Left _  -> Nothing
+      Left _ -> Nothing
       Right i -> Just i
 
-{-|
+{- |
   An internal helper function that parses the bytes from a 'SqlValue'
   with the given parsing function. If the 'SqlValue' is NULL, 'Nothing'
   is returned. If the parsing function fails (by returning 'Nothing'), then
@@ -287,6 +286,5 @@ toBytesValue byteParser sqlValue =
   case sqlValue of
     SqlNull ->
       Nothing
-
     SqlValue bytes ->
       byteParser (PGTextFormatValue.toByteString bytes)

--- a/orville-postgresql-libpq/test/Main.hs
+++ b/orville-postgresql-libpq/test/Main.hs
@@ -1,6 +1,7 @@
 module Main
-  ( main
-  ) where
+  ( main,
+  )
+where
 
 import qualified Data.ByteString.Char8 as B8
 import Test.Tasty (defaultMain, testGroup)
@@ -11,8 +12,8 @@ import Test.Connection (connectionTree)
 import Test.Expr (exprSpecs)
 import Test.FieldDefinition (fieldDefinitionTree)
 import Test.RawSql (rawSqlSpecs)
-import Test.SqlType (sqlTypeSpecs)
 import Test.SqlMarshaller (sqlMarshallerTree)
+import Test.SqlType (sqlTypeSpecs)
 
 main :: IO ()
 main = do
@@ -26,7 +27,8 @@ main = do
       sqlTypeSpecs pool
 
   defaultMain $
-    testGroup "Tests"
+    testGroup
+      "Tests"
       [ connectionTree pool
       , specTree
       , sqlMarshallerTree

--- a/orville-postgresql-libpq/test/Test/FieldDefinition.hs
+++ b/orville-postgresql-libpq/test/Test/FieldDefinition.hs
@@ -1,20 +1,21 @@
 module Test.FieldDefinition
-  ( fieldDefinitionTree
-  ) where
+  ( fieldDefinitionTree,
+  )
+where
 
-import           Control.Monad.IO.Class (liftIO)
-import           Data.Pool (Pool)
+import Control.Monad.IO.Class (liftIO)
+import Data.Pool (Pool)
 import qualified Data.Text as T
 import qualified Data.Time as Time
-import           Hedgehog ((===))
+import Hedgehog ((===))
 import qualified Hedgehog as HH
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
-import           Test.Tasty (TestTree, testGroup)
-import           Test.Tasty.Hedgehog (testProperty)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Hedgehog (testProperty)
 
-import           Database.Orville.PostgreSQL.Connection (Connection)
-import           Database.Orville.PostgreSQL.Internal.ExecutionResult (readRows)
+import Database.Orville.PostgreSQL.Connection (Connection)
+import Database.Orville.PostgreSQL.Internal.ExecutionResult (readRows)
 import qualified Database.Orville.PostgreSQL.Internal.Expr as Expr
 import qualified Database.Orville.PostgreSQL.Internal.FieldDefinition as FieldDef
 import qualified Database.Orville.PostgreSQL.Internal.RawSql as RawSql
@@ -23,76 +24,68 @@ import qualified Test.PGGen as PGGen
 
 fieldDefinitionTree :: Pool Connection -> TestTree
 fieldDefinitionTree pool =
-  testGroup "FieldDefinition"
+  testGroup
+    "FieldDefinition"
     [ testProperty "can round trip an integer field" . HH.property $ do
-      runRoundTripTest pool $
-        RoundTripTest
-          { roundTripFieldDef = FieldDef.integerField "foo"
-          , roundTripGen = Gen.integral (Range.linearFrom 0 minBound maxBound)
-          }
-
+        runRoundTripTest pool $
+          RoundTripTest
+            { roundTripFieldDef = FieldDef.integerField "foo"
+            , roundTripGen = Gen.integral (Range.linearFrom 0 minBound maxBound)
+            }
     , testProperty "can round trip a bigIntegerField" . HH.property $ do
-      runRoundTripTest pool $
-        RoundTripTest
-          { roundTripFieldDef = FieldDef.bigIntegerField "foo"
-          , roundTripGen = Gen.integral (Range.linearFrom 0 minBound maxBound)
-          }
-
+        runRoundTripTest pool $
+          RoundTripTest
+            { roundTripFieldDef = FieldDef.bigIntegerField "foo"
+            , roundTripGen = Gen.integral (Range.linearFrom 0 minBound maxBound)
+            }
     , testProperty "can round trip a doubleField" . HH.property $ do
-      runRoundTripTest pool $
-        RoundTripTest
-          { roundTripFieldDef = FieldDef.doubleField "foo"
-          , roundTripGen = PGGen.pgDouble
-          }
-
+        runRoundTripTest pool $
+          RoundTripTest
+            { roundTripFieldDef = FieldDef.doubleField "foo"
+            , roundTripGen = PGGen.pgDouble
+            }
     , testProperty "can round trip a booleanField" . HH.property $ do
-      runRoundTripTest pool $
-        RoundTripTest
-          { roundTripFieldDef = FieldDef.booleanField "foo"
-          , roundTripGen = Gen.bool
-          }
-
+        runRoundTripTest pool $
+          RoundTripTest
+            { roundTripFieldDef = FieldDef.booleanField "foo"
+            , roundTripGen = Gen.bool
+            }
     , testProperty "can round trip an unboundedTextField" . HH.property $ do
-      runRoundTripTest pool $
-        RoundTripTest
-          { roundTripFieldDef = FieldDef.unboundedTextField "foo"
-          , roundTripGen = PGGen.pgText (Range.constant 0 1024)
-          }
-
+        runRoundTripTest pool $
+          RoundTripTest
+            { roundTripFieldDef = FieldDef.unboundedTextField "foo"
+            , roundTripGen = PGGen.pgText (Range.constant 0 1024)
+            }
     , testProperty "can round trip a boundedTextField" . HH.property $ do
-      runRoundTripTest pool $
-        RoundTripTest
-          { roundTripFieldDef = FieldDef.boundedTextField "foo" 4
-          , roundTripGen = PGGen.pgText (Range.constant 0 4)
-          }
-
+        runRoundTripTest pool $
+          RoundTripTest
+            { roundTripFieldDef = FieldDef.boundedTextField "foo" 4
+            , roundTripGen = PGGen.pgText (Range.constant 0 4)
+            }
     , testProperty "can round trip a fixedTextField" . HH.property $ do
-      runRoundTripTest pool $
-        RoundTripTest
-          { roundTripFieldDef = FieldDef.fixedTextField "foo" 4
-          , roundTripGen = PGGen.pgText (Range.constant 4 4)
-          }
-
+        runRoundTripTest pool $
+          RoundTripTest
+            { roundTripFieldDef = FieldDef.fixedTextField "foo" 4
+            , roundTripGen = PGGen.pgText (Range.constant 4 4)
+            }
     , testProperty "can round trip a textSearchVectorField" . HH.property $ do
-      runRoundTripTest pool $
-        RoundTripTest
-          { roundTripFieldDef = FieldDef.textSearchVectorField "foo"
-          , roundTripGen = tsVectorGen
-          }
-
+        runRoundTripTest pool $
+          RoundTripTest
+            { roundTripFieldDef = FieldDef.textSearchVectorField "foo"
+            , roundTripGen = tsVectorGen
+            }
     , testProperty "can round trip a dateField" . HH.property $ do
-      runRoundTripTest pool $
-        RoundTripTest
-          { roundTripFieldDef = FieldDef.dateField "foo"
-          , roundTripGen = dayGen
-          }
-
+        runRoundTripTest pool $
+          RoundTripTest
+            { roundTripFieldDef = FieldDef.dateField "foo"
+            , roundTripGen = dayGen
+            }
     , testProperty "can round trip a timestampField" . HH.property $ do
-      runRoundTripTest pool $
-        RoundTripTest
-          { roundTripFieldDef = FieldDef.timestampField "foo"
-          , roundTripGen = utcTimeGen
-          }
+        runRoundTripTest pool $
+          RoundTripTest
+            { roundTripFieldDef = FieldDef.timestampField "foo"
+            , roundTripGen = utcTimeGen
+            }
     ]
 
 -- This generator generates alphanumeric values currently because of syntax
@@ -120,16 +113,14 @@ timeOfDayGen :: HH.Gen Time.DiffTime
 timeOfDayGen =
   Time.secondsToDiffTime <$> Gen.integral (Range.constant 0 85399)
 
-data RoundTripTest a =
-  RoundTripTest
-    { roundTripFieldDef :: FieldDef.FieldDefinition FieldDef.NotNull a
-    , roundTripGen :: HH.Gen a
-    }
+data RoundTripTest a = RoundTripTest
+  { roundTripFieldDef :: FieldDef.FieldDefinition FieldDef.NotNull a
+  , roundTripGen :: HH.Gen a
+  }
 
 runRoundTripTest :: (Show a, Eq a) => Pool Connection -> RoundTripTest a -> HH.PropertyT IO ()
 runRoundTripTest pool testCase = do
-  let
-    fieldDef = roundTripFieldDef testCase
+  let fieldDef = roundTripFieldDef testCase
 
   value <- HH.forAll (roundTripGen testCase)
 
@@ -151,14 +142,12 @@ runRoundTripTest pool testCase = do
 
     readRows result
 
-  let
-    roundTripResult =
-      case rows of
-        [[(_, sqlValue)]] ->
-          Right (FieldDef.fieldValueFromSqlValue fieldDef sqlValue)
-
-        _ ->
-          Left ("Expected one row with one value in results, but got: " ++ show rows)
+  let roundTripResult =
+        case rows of
+          [[(_, sqlValue)]] ->
+            Right (FieldDef.fieldValueFromSqlValue fieldDef sqlValue)
+          _ ->
+            Left ("Expected one row with one value in results, but got: " ++ show rows)
 
   roundTripResult === Right (Just value)
 
@@ -172,7 +161,7 @@ dropAndRecreateTestTable fieldDef pool = do
 
   RawSql.executeVoid pool $
     RawSql.fromString "CREATE TABLE "
-    <> Expr.tableNameToSql testTable
-    <> RawSql.fromString "("
-    <> Expr.columnDefinitionToSql (FieldDef.toSqlExpr fieldDef)
-    <> RawSql.fromString ")"
+      <> Expr.tableNameToSql testTable
+      <> RawSql.fromString "("
+      <> Expr.columnDefinitionToSql (FieldDef.toSqlExpr fieldDef)
+      <> RawSql.fromString ")"

--- a/orville-postgresql-libpq/test/Test/PGGen.hs
+++ b/orville-postgresql-libpq/test/Test/PGGen.hs
@@ -1,7 +1,8 @@
 module Test.PGGen
-  ( pgText
-  , pgDouble
-  ) where
+  ( pgText,
+    pgDouble,
+  )
+where
 
 import qualified Data.Text as T
 import qualified Hedgehog as HH
@@ -15,10 +16,8 @@ pgText range =
 
 pgDouble :: HH.Gen Double
 pgDouble =
-  let
-    -- Necessary because PostgreSQL only stores up to 15 digits of precision
-    -- With a 3-digit range, this gives us 12 places after the decimal
-    truncateLongDouble :: Double -> Double
-    truncateLongDouble = (/1e12) . (fromIntegral :: Int -> Double) . round . (*1e12)
-  in
-    flip Gen.subterm truncateLongDouble . Gen.double $ Range.linearFracFrom 0 (-1000) 1000
+  let -- Necessary because PostgreSQL only stores up to 15 digits of precision
+      -- With a 3-digit range, this gives us 12 places after the decimal
+      truncateLongDouble :: Double -> Double
+      truncateLongDouble = (/ 1e12) . (fromIntegral :: Int -> Double) . round . (* 1e12)
+   in flip Gen.subterm truncateLongDouble . Gen.double $ Range.linearFracFrom 0 (-1000) 1000

--- a/orville-postgresql-libpq/test/Test/RawSql.hs
+++ b/orville-postgresql-libpq/test/Test/RawSql.hs
@@ -1,6 +1,7 @@
 module Test.RawSql
-  ( rawSqlSpecs
-  ) where
+  ( rawSqlSpecs,
+  )
+where
 
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Text as T
@@ -8,57 +9,55 @@ import qualified Data.Text as T
 import qualified Database.Orville.PostgreSQL.Internal.PGTextFormatValue as PGTextFormatValue
 import qualified Database.Orville.PostgreSQL.Internal.RawSql as RawSql
 import qualified Database.Orville.PostgreSQL.Internal.SqlValue as SqlValue
-import           Test.Tasty.Hspec (Spec, describe, it, shouldBe)
+import Test.Tasty.Hspec (Spec, describe, it, shouldBe)
 
 rawSqlSpecs :: Spec
 rawSqlSpecs =
   describe "RawSql Tests" $ do
     it "Builds concatenated sql from strings" $ do
-      let
-        rawSql =
-          RawSql.fromString "SELECT * "
-          <> RawSql.fromString "FROM foo "
-          <> RawSql.fromString "WHERE id = 1"
+      let rawSql =
+            RawSql.fromString "SELECT * "
+              <> RawSql.fromString "FROM foo "
+              <> RawSql.fromString "WHERE id = 1"
 
-        expectedBytes =
-          B8.pack "SELECT * FROM foo WHERE id = 1"
+          expectedBytes =
+            B8.pack "SELECT * FROM foo WHERE id = 1"
 
-        (actualBytes, actualParams) =
-          RawSql.toBytesAndParams rawSql
+          (actualBytes, actualParams) =
+            RawSql.toBytesAndParams rawSql
 
       actualBytes `shouldBe` expectedBytes
       actualParams `shouldBe` []
 
     it "Tracks value placeholders in concatenated order" $ do
-      let
-        rawSql =
-          RawSql.fromString "SELECT * "
-          <> RawSql.fromString "FROM foo "
-          <> RawSql.fromString "WHERE id = "
-          <> RawSql.parameter (SqlValue.fromInt32 1)
-          <> RawSql.fromString " AND "
-          <> RawSql.fromString "bar IN ("
-          <> RawSql.intercalate (RawSql.fromString ",") bars
-          <> RawSql.fromString ")"
+      let rawSql =
+            RawSql.fromString "SELECT * "
+              <> RawSql.fromString "FROM foo "
+              <> RawSql.fromString "WHERE id = "
+              <> RawSql.parameter (SqlValue.fromInt32 1)
+              <> RawSql.fromString " AND "
+              <> RawSql.fromString "bar IN ("
+              <> RawSql.intercalate (RawSql.fromString ",") bars
+              <> RawSql.fromString ")"
 
-        bars =
-          map RawSql.parameter
-            [ SqlValue.fromText (T.pack "pants")
-            , SqlValue.fromText (T.pack "cheese")
+          bars =
+            map
+              RawSql.parameter
+              [ SqlValue.fromText (T.pack "pants")
+              , SqlValue.fromText (T.pack "cheese")
+              ]
+
+          expectedBytes =
+            B8.pack "SELECT * FROM foo WHERE id = $1 AND bar IN ($2,$3)"
+
+          expectedParams =
+            [ Just . PGTextFormatValue.fromByteString . B8.pack $ "1"
+            , Just . PGTextFormatValue.fromByteString . B8.pack $ "pants"
+            , Just . PGTextFormatValue.fromByteString . B8.pack $ "cheese"
             ]
 
-        expectedBytes =
-          B8.pack "SELECT * FROM foo WHERE id = $1 AND bar IN ($2,$3)"
-
-        expectedParams =
-          [ Just . PGTextFormatValue.fromByteString . B8.pack $ "1"
-          , Just . PGTextFormatValue.fromByteString . B8.pack $ "pants"
-          , Just . PGTextFormatValue.fromByteString . B8.pack $ "cheese"
-          ]
-
-        (actualBytes, actualParams) =
-          RawSql.toBytesAndParams rawSql
+          (actualBytes, actualParams) =
+            RawSql.toBytesAndParams rawSql
 
       actualBytes `shouldBe` expectedBytes
       actualParams `shouldBe` expectedParams
-

--- a/orville-postgresql-libpq/test/Test/SqlMarshaller.hs
+++ b/orville-postgresql-libpq/test/Test/SqlMarshaller.hs
@@ -1,136 +1,126 @@
 module Test.SqlMarshaller
-  ( sqlMarshallerTree
-  ) where
+  ( sqlMarshallerTree,
+  )
+where
 
+import Control.Monad.IO.Class (liftIO)
 import qualified Data.ByteString.Char8 as B8
-import           Data.Int (Int32)
+import Data.Int (Int32)
 import qualified Data.Text as T
-import           Control.Monad.IO.Class (liftIO)
-import           Hedgehog ((===))
+import Hedgehog ((===))
 import qualified Hedgehog as HH
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
-import           Test.Tasty.Hedgehog (testProperty)
-import           Test.Tasty (TestTree, testGroup)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Hedgehog (testProperty)
 
-import           Database.Orville.PostgreSQL.Internal.ExecutionResult (Row(..))
+import Database.Orville.PostgreSQL.Internal.ExecutionResult (Row (..))
 import qualified Database.Orville.PostgreSQL.Internal.ExecutionResult as Result
-import           Database.Orville.PostgreSQL.Internal.FieldDefinition (integerField, unboundedTextField, stringToFieldName)
-import           Database.Orville.PostgreSQL.Internal.SqlMarshaller (SqlMarshaller, marshallEntityToSql, marshallRowFromSql, marshallResultFromSql, marshallField, MarshallError(..))
+import Database.Orville.PostgreSQL.Internal.FieldDefinition (integerField, stringToFieldName, unboundedTextField)
+import Database.Orville.PostgreSQL.Internal.SqlMarshaller (MarshallError (..), SqlMarshaller, marshallEntityToSql, marshallField, marshallResultFromSql, marshallRowFromSql)
 import qualified Database.Orville.PostgreSQL.Internal.SqlValue as SqlValue
 
 import qualified Test.PGGen as PGGen
 
 sqlMarshallerTree :: TestTree
 sqlMarshallerTree =
-  testGroup "SqlMarshaller properties"
+  testGroup
+    "SqlMarshaller properties"
     [ testProperty "Can round read a pure Int via SqlMarshaller" . HH.property $ do
         someInt <- HH.forAll generateInt
         result <- liftIO $ marshallRowFromSql (pure someInt) (Row 0) (Result.mkFakeLibPQResult [] [])
         result === Right someInt
-
     , testProperty "Can combine SqlMarshallers with <*>" . HH.property $ do
         firstInt <- HH.forAll generateInt
         secondInt <- HH.forAll generateInt
         result <- liftIO $ marshallRowFromSql ((pure (+ firstInt)) <*> (pure secondInt)) (Row 0) (Result.mkFakeLibPQResult [] [])
         result === Right (firstInt + secondInt)
-
     , testProperty "Read a single field from a result row using marshallField" . HH.property $ do
-        targetName  <- HH.forAll generateName
+        targetName <- HH.forAll generateName
         targetValue <- HH.forAll generateInt32
 
         namesBefore <- HH.forAll (generateNamesOtherThan targetName)
-        namesAfter  <- HH.forAll (generateNamesOtherThan targetName)
+        namesAfter <- HH.forAll (generateNamesOtherThan targetName)
 
-        valuesBefore  <- HH.forAll (generateAssociatedValues namesBefore generateInt32)
-        valuesAfter   <- HH.forAll (generateAssociatedValues namesAfter generateInt32)
+        valuesBefore <- HH.forAll (generateAssociatedValues namesBefore generateInt32)
+        valuesAfter <- HH.forAll (generateAssociatedValues namesAfter generateInt32)
 
-        let
-          fieldDef = integerField targetName
-          marshaller = marshallField id fieldDef
-          input =
-            Result.mkFakeLibPQResult
-              (map B8.pack (namesBefore ++ (targetName : namesAfter)))
-              [map SqlValue.fromInt32 (valuesBefore ++ (targetValue : valuesAfter))]
+        let fieldDef = integerField targetName
+            marshaller = marshallField id fieldDef
+            input =
+              Result.mkFakeLibPQResult
+                (map B8.pack (namesBefore ++ (targetName : namesAfter)))
+                [map SqlValue.fromInt32 (valuesBefore ++ (targetValue : valuesAfter))]
 
         result <- liftIO $ marshallRowFromSql marshaller (Row 0) input
         result === Right targetValue
-
     , testProperty "marshallField fails gracefully when decoding a non-existent column" . HH.property $ do
-        targetName  <- HH.forAll generateName
-        otherNames  <- HH.forAll (generateNamesOtherThan targetName)
+        targetName <- HH.forAll generateName
+        otherNames <- HH.forAll (generateNamesOtherThan targetName)
         otherValues <- HH.forAll (generateAssociatedValues otherNames generateInt32)
 
-        let
-          fieldDef = integerField targetName
-          marshaller = marshallField id fieldDef
-          input =
-            Result.mkFakeLibPQResult
-              (map B8.pack otherNames)
-              [map SqlValue.fromInt32 otherValues]
+        let fieldDef = integerField targetName
+            marshaller = marshallField id fieldDef
+            input =
+              Result.mkFakeLibPQResult
+                (map B8.pack otherNames)
+                [map SqlValue.fromInt32 otherValues]
 
         result <- liftIO $ marshallRowFromSql marshaller (Row 0) input
         result === Left FieldNotFoundInResultSet
-
     , testProperty "marshallField fails gracefully when decoding a bad value" . HH.property $ do
-        targetName     <- HH.forAll generateName
+        targetName <- HH.forAll generateName
         nonIntegerText <- HH.forAll (Gen.text (Range.linear 0 10) Gen.alpha)
 
-        let
-          fieldDef = integerField targetName
-          marshaller = marshallField id fieldDef
-          input =
-            Result.mkFakeLibPQResult
-              [B8.pack targetName]
-              [[SqlValue.fromText nonIntegerText]]
+        let fieldDef = integerField targetName
+            marshaller = marshallField id fieldDef
+            input =
+              Result.mkFakeLibPQResult
+                [B8.pack targetName]
+                [[SqlValue.fromText nonIntegerText]]
 
         result <- liftIO $ marshallRowFromSql marshaller (Row 0) input
         result === Left FailedToDecodeValue
-
     , testProperty "marshallResultFromSql decodes all rows in result set" . HH.property $ do
         foos <- HH.forAll $ Gen.list (Range.linear 0 10) generateFoo
 
-        let
-          mkRowValues foo =
-            [SqlValue.fromText (fooName foo), SqlValue.fromInt32 (fooSize foo)]
+        let mkRowValues foo =
+              [SqlValue.fromText (fooName foo), SqlValue.fromInt32 (fooSize foo)]
 
-          input =
-            Result.mkFakeLibPQResult
-              [B8.pack "name", B8.pack "size"]
-              (map mkRowValues foos)
-
+            input =
+              Result.mkFakeLibPQResult
+                [B8.pack "name", B8.pack "size"]
+                (map mkRowValues foos)
 
         result <- liftIO $ marshallResultFromSql fooMarshaller input
         result === Right foos
-
     , testProperty "marshallEntityToSql collects all fields as their sql values" . HH.property $ do
         foo <- HH.forAll generateFoo
 
-        let
-          addField :: a -> b -> [(a, b)] -> [(a, b)]
-          addField name sqlValue fields =
-            (name, sqlValue) : fields
+        let addField :: a -> b -> [(a, b)] -> [(a, b)]
+            addField name sqlValue fields =
+              (name, sqlValue) : fields
 
-          actualFooRow =
-            marshallEntityToSql
-              fooMarshaller
-              []
-              addField
-              foo
+            actualFooRow =
+              marshallEntityToSql
+                fooMarshaller
+                []
+                addField
+                foo
 
-          expectedFooRow =
-            [ (stringToFieldName "name", SqlValue.fromText $ fooName foo)
-            , (stringToFieldName "size", SqlValue.fromInt32 $ fooSize foo)
-            ]
+            expectedFooRow =
+              [ (stringToFieldName "name", SqlValue.fromText $ fooName foo)
+              , (stringToFieldName "size", SqlValue.fromInt32 $ fooSize foo)
+              ]
 
         actualFooRow === expectedFooRow
     ]
 
-data Foo =
-  Foo
-    { fooName :: T.Text
-    , fooSize :: Int32
-    } deriving (Eq, Show)
+data Foo = Foo
+  { fooName :: T.Text
+  , fooSize :: Int32
+  }
+  deriving (Eq, Show)
 
 fooMarshaller :: SqlMarshaller Foo Foo
 fooMarshaller =

--- a/orville-postgresql-libpq/test/Test/SqlType.hs
+++ b/orville-postgresql-libpq/test/Test/SqlType.hs
@@ -1,40 +1,35 @@
 module Test.SqlType
-  ( sqlTypeSpecs
-  ) where
+  ( sqlTypeSpecs,
+  )
+where
 
-import Data.Pool (Pool)
 import qualified Data.ByteString.Char8 as B8
 import Data.Int (Int64)
+import Data.Pool (Pool)
 import qualified Data.Text as T
 import qualified Data.Time as Time
 import Test.Tasty.Hspec (Spec, describe, it, shouldBe)
 
 import Database.Orville.PostgreSQL.Connection (Connection, executeRawVoid)
 import Database.Orville.PostgreSQL.Internal.ExecutionResult (decodeRows)
-import Database.Orville.PostgreSQL.Internal.SqlType (SqlType
-                                                     -- numeric types
-                                                    , integer
-                                                    , serial
-                                                    , bigInteger
-                                                    , bigSerial
-                                                    , double
-
-                                                    -- textual-ish types
-                                                    , boolean
-                                                    , unboundedText
-                                                    , fixedText
-                                                    , boundedText
-                                                    , textSearchVector
-
-                                                    -- date types
-                                                    , date
-                                                    , timestamp
-
-                                                    -- type conversions
-                                                    , nullableType
-                                                    )
 import qualified Database.Orville.PostgreSQL.Internal.Expr as Expr
 import qualified Database.Orville.PostgreSQL.Internal.RawSql as RawSql
+import Database.Orville.PostgreSQL.Internal.SqlType
+  ( SqlType,
+    bigInteger,
+    bigSerial,
+    boolean,
+    boundedText,
+    date,
+    double,
+    fixedText,
+    integer,
+    nullableType,
+    serial,
+    textSearchVector,
+    timestamp,
+    unboundedText,
+  )
 import qualified Database.Orville.PostgreSQL.Internal.SqlValue as SqlValue
 
 sqlTypeSpecs :: Pool Connection -> Spec
@@ -323,20 +318,18 @@ nullableSpecs pool = do
         , expectedValue = Nothing
         }
 
-data DecodingTest a =
-  DecodingTest
-    { sqlTypeDDL :: String
-    , rawSqlValue :: Maybe B8.ByteString
-    , sqlType :: SqlType a
-    , expectedValue :: a
-    }
+data DecodingTest a = DecodingTest
+  { sqlTypeDDL :: String
+  , rawSqlValue :: Maybe B8.ByteString
+  , sqlType :: SqlType a
+  , expectedValue :: a
+  }
 
 runDecodingTest :: (Show a, Eq a) => Pool Connection -> DecodingTest a -> IO ()
 runDecodingTest pool test = do
   dropAndRecreateTable pool "decoding_test" (sqlTypeDDL test)
 
-  let
-    tableName = Expr.rawTableName "decoding_test"
+  let tableName = Expr.rawTableName "decoding_test"
 
   RawSql.executeVoid pool $
     Expr.insertExprToSql $
@@ -349,7 +342,7 @@ runDecodingTest pool test = do
       Expr.queryExprToSql $
         Expr.queryExpr Expr.selectStar (Expr.tableExpr tableName Nothing Nothing)
 
-  (maybeA:_) <- decodeRows result (sqlType test)
+  (maybeA : _) <- decodeRows result (sqlType test)
   shouldBe maybeA (Just (expectedValue test))
 
 dropAndRecreateTable :: Pool Connection -> String -> String -> IO ()


### PR DESCRIPTION
Running the formatter is scripted and depends only on POSIX, `stack`(to install fourmolu), and the `-P` extension to xargs which seems reasonably available and is used to run formatting in parallel.
For example it can run done with `docker-compose run --rm dev sh -c ./scripts/format-repo.sh`.

Some more details:
- Adds a fourmolu configuration file.
- Adds helper script for running the fourmolu during development (that will format all the .hs files found)
- Adds a CI job to check that formatting was done, which can be expanded for more tooling later if desired
  - This also uses a helper script, both placed in a orville-postgresql-libpq/scripts directory
- Adds a docker-compose file for running tools in CI and caching the build of them as the build of fourmolu was otherwise taking >2x the runtime of the other jobs
- Runs the formatting on the entire LibPQ codebase.