### PR TITLE
GHC 9 compatibility

### DIFF
--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/Execute.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/Execute.hs
@@ -12,7 +12,9 @@ import Database.Orville.PostgreSQL.Internal.Monad
 
 executingSql :: MonadOrville conn m => QueryType -> String -> IO a -> m a
 executingSql queryType sql action = do
-  runningQuery <- ormEnvRunningQuery <$> getOrvilleEnv
+  runningQuery <-
+    (\queryType -> ormEnvRunningQuery queryType)
+      <$> getOrvilleEnv
   liftIO $ runningQuery queryType sql (catchSqlErr sql action)
 
 catchSqlErr :: String -> IO a -> IO a

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/Monad.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/Monad.hs
@@ -235,8 +235,8 @@ class ( Monad m
 
 
 instance MonadOrvilleControl IO where
-  liftWithConnection = id
-  liftFinally = id
+  liftWithConnection ioWithConn = ioWithConn
+  liftFinally ioFinally = ioFinally
 
 {-|
    defaultLiftWithConnection provides a simple definition of


### PR DESCRIPTION
The code is not building with GHC 9, which is already out and used by some people.
Some people may already potentially be using GHC 9, no need to exclude them.

The fix is of this commit is called "manual eta-expansion" and is
mentioned in the "Simplify Subsumption" proposal.

It still works with GHC 8.6.

https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0287-simplify-subsumption.rst