### PR TITLE
LibPQ: Adds minimal port of TableDefinition

### DIFF
--- a/orville-postgresql-libpq/orville-postgresql-libpq.cabal
+++ b/orville-postgresql-libpq/orville-postgresql-libpq.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: dd505d0ebcd3f0682de30095297baf85c56855258fbaa6e9112593806abfff44
+-- hash: 9f28feaa7c0b043db21c37372118622c0c998806a733e20dc81847877b32963d
 
 name:           orville-postgresql-libpq
 version:        0.10.0.0
@@ -14,7 +14,8 @@ category:       Database
 author:         Flipstone Technology Partners
 maintainer:     development@flipstone.com
 license:        MIT
-tested-with:    GHC == 8.6.5
+tested-with:
+    GHC == 8.6.5
 build-type:     Simple
 extra-source-files:
     README.md
@@ -36,10 +37,12 @@ library
       Database.Orville.PostgreSQL.Internal.Expr
       Database.Orville.PostgreSQL.Internal.FieldDefinition
       Database.Orville.PostgreSQL.Internal.PGTextFormatValue
+      Database.Orville.PostgreSQL.Internal.PrimaryKey
       Database.Orville.PostgreSQL.Internal.RawSql
       Database.Orville.PostgreSQL.Internal.SqlMarshaller
       Database.Orville.PostgreSQL.Internal.SqlType
       Database.Orville.PostgreSQL.Internal.SqlValue
+      Database.Orville.PostgreSQL.Internal.TableDefinition
   other-modules:
       Database.Orville.PostgreSQL.Internal.Expr.ColumnDefinition
       Database.Orville.PostgreSQL.Internal.Expr.InsertExpr
@@ -54,6 +57,7 @@ library
       Database.Orville.PostgreSQL.Internal.Expr.Query.QueryExpr
       Database.Orville.PostgreSQL.Internal.Expr.Query.SelectList
       Database.Orville.PostgreSQL.Internal.Expr.Query.TableExpr
+      Database.Orville.PostgreSQL.Internal.Expr.TableDefinition
       Database.Orville.PostgreSQL.Internal.Expr.Where
       Database.Orville.PostgreSQL.Internal.Expr.Where.BooleanExpr
       Database.Orville.PostgreSQL.Internal.Expr.Where.ComparisonOperator
@@ -66,8 +70,8 @@ library
       attoparsec
     , base >=4.8 && <5
     , bytestring
-    , containers >=0.6 && <0.7
-    , dlist >=0.8 && <0.9
+    , containers ==0.6.*
+    , dlist ==0.8.*
     , postgresql-libpq >=0.9.4.2 && <0.10
     , resource-pool
     , text
@@ -89,6 +93,7 @@ test-suite spec
       Test.RawSql
       Test.SqlMarshaller
       Test.SqlType
+      Test.TableDefinition
   hs-source-dirs:
       test
   ghc-options: -j -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wmissing-local-signatures -Wmissing-export-lists -Wno-implicit-prelude -Wno-safe -Wno-unsafe -Wnoncanonical-monad-instances -Wredundant-constraints -Wpartial-fields -Wmissed-specialisations

--- a/orville-postgresql-libpq/package.yaml
+++ b/orville-postgresql-libpq/package.yaml
@@ -27,10 +27,12 @@ library:
     - Database.Orville.PostgreSQL.Internal.Expr
     - Database.Orville.PostgreSQL.Internal.FieldDefinition
     - Database.Orville.PostgreSQL.Internal.PGTextFormatValue
+    - Database.Orville.PostgreSQL.Internal.PrimaryKey
     - Database.Orville.PostgreSQL.Internal.RawSql
     - Database.Orville.PostgreSQL.Internal.SqlMarshaller
     - Database.Orville.PostgreSQL.Internal.SqlType
     - Database.Orville.PostgreSQL.Internal.SqlValue
+    - Database.Orville.PostgreSQL.Internal.TableDefinition
   when:
     - condition: flag(ci)
       then:
@@ -80,6 +82,7 @@ tests:
       - Test.RawSql
       - Test.SqlMarshaller
       - Test.SqlType
+      - Test.TableDefinition
     dependencies:
       - base
       - bytestring

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr.hs
@@ -36,6 +36,8 @@ module Database.Orville.PostgreSQL.Internal.Expr
     InsertExpr,
     insertExpr,
     insertExprToSql,
+    InsertColumnList,
+    insertColumnList,
     InsertSource,
     insertSqlValues,
     DataType,
@@ -61,6 +63,12 @@ module Database.Orville.PostgreSQL.Internal.Expr
     ascendingOrder,
     descendingOrder,
     orderByExpr,
+    CreateTableExpr,
+    createTableExpr,
+    createTableExprToSql,
+    PrimaryKeyExpr,
+    primaryKeyExpr,
+    primaryKeyToSql,
   )
 where
 
@@ -69,4 +77,5 @@ import Database.Orville.PostgreSQL.Internal.Expr.InsertExpr
 import Database.Orville.PostgreSQL.Internal.Expr.Name
 import Database.Orville.PostgreSQL.Internal.Expr.OrderBy
 import Database.Orville.PostgreSQL.Internal.Expr.Query
+import Database.Orville.PostgreSQL.Internal.Expr.TableDefinition
 import Database.Orville.PostgreSQL.Internal.Expr.Where

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/ColumnDefinition.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/ColumnDefinition.hs
@@ -36,7 +36,7 @@ columnDefinition :: ColumnName -> DataType -> ColumnDefinition
 columnDefinition columnName dataType =
   ColumnDefinition $
     columnNameToSql columnName
-      <> RawSql.fromString " "
+      <> RawSql.space
       <> dataTypeToSql dataType
 
 newtype DataType

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/OrderBy/OrderByExpr.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/OrderBy/OrderByExpr.hs
@@ -21,8 +21,8 @@ orderByExprToSql (OrderByExpr sql) = sql
 
 appendOrderBy :: OrderByExpr -> OrderByExpr -> OrderByExpr
 appendOrderBy (OrderByExpr a) (OrderByExpr b) =
-  OrderByExpr (a <> RawSql.fromString ", " <> b)
+  OrderByExpr (a <> RawSql.comma <> b)
 
 orderByExpr :: RawSql.RawSql -> OrderByDirection -> OrderByExpr
 orderByExpr sql orderSql =
-  OrderByExpr $ sql <> RawSql.fromString " " <> orderByDirectionToSql orderSql
+  OrderByExpr $ sql <> RawSql.space <> orderByDirectionToSql orderSql

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/Query/SelectList.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/Query/SelectList.hs
@@ -24,7 +24,7 @@ selectColumns :: [ColumnName] -> SelectList
 selectColumns columnNames =
   SelectList $
     RawSql.intercalate
-      (RawSql.fromString ",")
+      RawSql.comma
       (fmap columnNameToSql columnNames)
 
 selectListToSql :: SelectList -> RawSql.RawSql

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/Query/TableExpr.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/Query/TableExpr.hs
@@ -25,6 +25,6 @@ tableExpr :: TableName -> Maybe WhereClause -> Maybe OrderByClause -> TableExpr
 tableExpr tableName mbWhereClause maybeOrderByClause =
   TableExpr $
     tableNameToSql tableName
-      <> RawSql.fromString " "
+      <> RawSql.space
       <> maybe mempty whereClauseToSql mbWhereClause
       <> maybe mempty orderByClauseToSql maybeOrderByClause

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/TableDefinition.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/TableDefinition.hs
@@ -1,0 +1,59 @@
+module Database.Orville.PostgreSQL.Internal.Expr.TableDefinition
+  ( CreateTableExpr,
+    createTableExpr,
+    createTableExprToSql,
+    PrimaryKeyExpr,
+    primaryKeyExpr,
+    primaryKeyToSql,
+  )
+where
+
+import Database.Orville.PostgreSQL.Internal.Expr.ColumnDefinition (ColumnDefinition, columnDefinitionToSql)
+import Database.Orville.PostgreSQL.Internal.Expr.Name (ColumnName, TableName, columnNameToSql, tableNameToSql)
+import qualified Database.Orville.PostgreSQL.Internal.RawSql as RawSql
+
+newtype CreateTableExpr
+  = CreateTableExpr RawSql.RawSql
+
+createTableExpr ::
+  TableName ->
+  [ColumnDefinition] ->
+  Maybe PrimaryKeyExpr ->
+  CreateTableExpr
+createTableExpr tableName columnDefs mbPrimaryKey =
+  let columnDefsSql =
+        map columnDefinitionToSql columnDefs
+
+      tableElementsSql =
+        case mbPrimaryKey of
+          Nothing ->
+            columnDefsSql
+          Just primaryKey ->
+            primaryKeyToSql primaryKey : columnDefsSql
+   in CreateTableExpr $
+        mconcat
+          [ RawSql.fromString "CREATE TABLE "
+          , tableNameToSql tableName
+          , RawSql.leftParen
+          , RawSql.intercalate RawSql.comma tableElementsSql
+          , RawSql.rightParen
+          ]
+
+createTableExprToSql :: CreateTableExpr -> RawSql.RawSql
+createTableExprToSql (CreateTableExpr sql) = sql
+
+newtype PrimaryKeyExpr
+  = PrimaryKeyExpr RawSql.RawSql
+
+primaryKeyToSql :: PrimaryKeyExpr -> RawSql.RawSql
+primaryKeyToSql (PrimaryKeyExpr sql) = sql
+
+primaryKeyExpr :: [ColumnName] -> PrimaryKeyExpr
+primaryKeyExpr columnNames =
+  PrimaryKeyExpr $
+    mconcat
+      [ RawSql.fromString "PRIMARY KEY "
+      , RawSql.leftParen
+      , RawSql.intercalate RawSql.comma (map columnNameToSql columnNames)
+      , RawSql.rightParen
+      ]

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/Where/BooleanExpr.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/Where/BooleanExpr.hs
@@ -46,7 +46,7 @@ andExpr left right =
 parenthesized :: BooleanExpr -> BooleanExpr
 parenthesized expr =
   BooleanExpr $
-    RawSql.fromString "(" <> booleanExprToSql expr <> RawSql.fromString ")"
+    RawSql.leftParen <> booleanExprToSql expr <> RawSql.rightParen
 
 comparison ::
   RowValuePredicand ->
@@ -56,9 +56,9 @@ comparison ::
 comparison left op right =
   BooleanExpr $
     rowValuePredicandToSql left
-      <> RawSql.fromString " "
+      <> RawSql.space
       <> comparisonOperatorToSql op
-      <> RawSql.fromString " "
+      <> RawSql.space
       <> rowValuePredicandToSql right
 
 columnEquals :: ColumnName -> SqlValue -> BooleanExpr

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/FieldDefinition.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/FieldDefinition.hs
@@ -13,11 +13,12 @@ module Database.Orville.PostgreSQL.Internal.FieldDefinition
     fieldValueToSqlValue,
     fieldValueFromSqlValue,
     fieldColumnName,
+    fieldColumnDefinition,
     FieldName,
     stringToFieldName,
+    fieldNameToString,
     fieldNameToColumnName,
     fieldNameToByteString,
-    toSqlExpr,
     NotNull,
     Nullable,
     Nullability (..),
@@ -59,6 +60,10 @@ fieldNameToColumnName (FieldName name) =
 stringToFieldName :: String -> FieldName
 stringToFieldName =
   FieldName . B8.pack
+
+fieldNameToString :: FieldName -> String
+fieldNameToString =
+  B8.unpack . fieldNameToByteString
 
 fieldNameToByteString :: FieldName -> B8.ByteString
 fieldNameToByteString (FieldName name) =
@@ -129,11 +134,10 @@ fieldColumnName =
   Constructions the equivalant 'Expr.FieldDefinition' as a SQL expression,
   generally for use in DDL for creating column in a table.
 
-  TODO: this is NotNull at the momentbecause I haven't made it handle adding the
-  NULL modifier to the DDL yet
+  TODO: Handle nullable fields here when we finish porting nullability.
 -}
-toSqlExpr :: FieldDefinition NotNull a -> Expr.ColumnDefinition
-toSqlExpr fieldDef =
+fieldColumnDefinition :: FieldDefinition nullability a -> Expr.ColumnDefinition
+fieldColumnDefinition fieldDef =
   Expr.columnDefinition
     (fieldColumnName fieldDef)
     (SqlType.sqlTypeExpr $ fieldType fieldDef)

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/PrimaryKey.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/PrimaryKey.hs
@@ -91,11 +91,11 @@ compositePrimaryKey =
   PrimaryKey
 
 {- |
-  'primaryKeyPart' builds building block for a composite primary key based a
-  'FieldDefinition' and an accessor function to extract the value for that
-  field from the Haskell 'key' type that represents the overall composite key.
-  'PrimaryKeyPart' values built using this function are usually then passed
-  in a list to 'compositePrimaryKey' to build a 'PrimaryKey'.
+  'primaryKeyPart' constructs a building block for a composite primary key
+  based a 'FieldDefinition' and an accessor function to extract the value for
+  that field from the Haskell 'key' type that represents the overall composite
+  key.  'PrimaryKeyPart' values built using this function are usually then
+  passed in a list to 'compositePrimaryKey' to build a 'PrimaryKey'.
 -}
 primaryKeyPart ::
   (key -> part) ->

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/PrimaryKey.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/PrimaryKey.hs
@@ -1,0 +1,131 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Database.Orville.PostgreSQL.Internal.PrimaryKey
+  ( PrimaryKey,
+    primaryKeyDescription,
+    primaryKeyToSql,
+    primaryKey,
+    compositePrimaryKey,
+    primaryKeyPart,
+    mapPrimaryKeyParts,
+    mkPrimaryKeyExpr,
+  )
+where
+
+import qualified Data.List as List
+
+import qualified Database.Orville.PostgreSQL.Internal.Expr as Expr
+import Database.Orville.PostgreSQL.Internal.FieldDefinition (FieldDefinition, NotNull, fieldColumnName, fieldName, fieldNameToString, fieldValueToSqlValue)
+import qualified Database.Orville.PostgreSQL.Internal.SqlValue as SqlValue
+
+{- |
+  A Haskell description of the 'FieldDefinition's that make up the primary
+  key of a SQL table. This type supports composite primary keys as well
+  as singular ones.
+-}
+data PrimaryKey key
+  = PrimaryKey (PrimaryKeyPart key) [PrimaryKeyPart key]
+
+{- |
+  An internal helper type representing a single part of a composite primary
+  key. This is not export in part to hide the use of GADTs, and also simply
+  to avoid leaking implementation details.
+-}
+data PrimaryKeyPart key
+  = forall part. PrimaryKeyPart (key -> part) (FieldDefinition NotNull part)
+
+{- |
+  'primaryKeyDescription' builds a user-readable representation of the
+  primary key for use in error messages and such. It is a comma-delimited
+  list of the names of the fields that make up the primary key.
+-}
+primaryKeyDescription :: PrimaryKey key -> String
+primaryKeyDescription keyDef =
+  let partName :: (part -> key) -> FieldDefinition NotNull a -> String
+      partName _ field =
+        fieldNameToString (fieldName field)
+   in List.intercalate ", " (mapPrimaryKeyParts partName keyDef)
+
+{- |
+  'primaryKeyToSql' converts a Haskell value for a primary key into the
+  (possibly multiple) sql values that represent the primary key in the
+  database.
+-}
+primaryKeyToSql :: PrimaryKey key -> key -> [SqlValue.SqlValue]
+primaryKeyToSql keyDef key =
+  mapPrimaryKeyParts (partSqlValue key) keyDef
+
+{- |
+  'partSqlValue' is an internal helper function that builds the 'SqlValue'
+  for one part of a (possible composite) primary key.
+-}
+partSqlValue :: key -> (key -> part) -> FieldDefinition NotNull part -> SqlValue.SqlValue
+partSqlValue key getPart partField =
+  fieldValueToSqlValue partField (getPart key)
+
+{- |
+  'primaryKey' constructs a single-field primary key from the 'FieldDefinition'
+  that corresponds to the primary key's column. This is generally used while
+  building a 'TableDefinition'.
+-}
+primaryKey :: FieldDefinition NotNull key -> PrimaryKey key
+primaryKey fieldDef =
+  PrimaryKey (PrimaryKeyPart id fieldDef) []
+
+{- |
+  'compositePrimaryKey' constructs a multi-field primary key from the given
+  parts, each of which corresponds to one field in the primary key.  You should
+  use this while building a 'TableDefinition' for a table that you want to have
+  a multi-column primary key. See 'primaryKeyPart' for how to build the parts
+  to be passed as parameters. Note: there is no special significance to the
+  first argument other than requiring that there is at least one field in the
+  primary key.
+-}
+compositePrimaryKey ::
+  PrimaryKeyPart key ->
+  [PrimaryKeyPart key] ->
+  PrimaryKey key
+compositePrimaryKey =
+  PrimaryKey
+
+{- |
+  'primaryKeyPart' builds on section of a composite primary key based on the
+  field definition that corresponds to that column of the primary key. The
+  function given is used to decompose the Haskell value for the composite key
+  into the individual parts so they can be converted to sql for things like
+  building 'WhereCondition'
+-}
+primaryKeyPart ::
+  (key -> part) ->
+  FieldDefinition NotNull part ->
+  PrimaryKeyPart key
+primaryKeyPart =
+  PrimaryKeyPart
+
+{- |
+  'mapPrimaryKeyParts' provides a way to access the innards of a 'PrimaryKey'
+  definition to extract information. The given function will be called on
+  each part of the primary key in order and the list of results is returned.
+  Note that single-field and multi-field primary keys are treated the same by
+  this function, with the single-field case simply behaving as composite key
+  with just one part.
+-}
+mapPrimaryKeyParts ::
+  ( forall part.
+    (key -> part) ->
+    FieldDefinition NotNull part ->
+    a
+  ) ->
+  PrimaryKey key ->
+  [a]
+mapPrimaryKeyParts f (PrimaryKey first rest) =
+  let doPart (PrimaryKeyPart getPart field) =
+        f getPart field
+   in map doPart (first : rest)
+
+mkPrimaryKeyExpr :: PrimaryKey key -> Expr.PrimaryKeyExpr
+mkPrimaryKeyExpr keyDef =
+  let names =
+        mapPrimaryKeyParts (\_ field -> fieldColumnName field) keyDef
+   in Expr.primaryKeyExpr names

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/RawSql.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/RawSql.hs
@@ -16,6 +16,12 @@ module Database.Orville.PostgreSQL.Internal.RawSql
     intercalate,
     execute,
     executeVoid,
+
+    -- * Fragmants provided for convenience
+    space,
+    comma,
+    leftParen,
+    rightParen,
   )
 where
 
@@ -185,3 +191,19 @@ executeVoid conn rawSql =
   let (sqlBytes, params) =
         toBytesAndParams rawSql
    in Conn.executeRawVoid conn sqlBytes params
+
+-- | Just a plain old space, provided for convenience
+space :: RawSql
+space = fromString " "
+
+-- | Just a plain old comma, provided for convenience
+comma :: RawSql
+comma = fromString ","
+
+-- | Just a plain old left paren, provided for convenience
+leftParen :: RawSql
+leftParen = fromString "("
+
+-- | Just a plain old right paren, provided for convenience
+rightParen :: RawSql
+rightParen = fromString ")"

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/TableDefinition.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/TableDefinition.hs
@@ -15,7 +15,7 @@ import Data.List.NonEmpty (NonEmpty, toList)
 import qualified Database.Orville.PostgreSQL.Internal.Expr as Expr
 import Database.Orville.PostgreSQL.Internal.FieldDefinition (FieldDefinition, fieldColumnDefinition, fieldColumnName, fieldValueToSqlValue)
 import Database.Orville.PostgreSQL.Internal.PrimaryKey (PrimaryKey, mkPrimaryKeyExpr)
-import Database.Orville.PostgreSQL.Internal.SqlMarshaller (SqlMarshaller, foldMarshallerFields)
+import Database.Orville.PostgreSQL.Internal.SqlMarshaller (FieldFold, SqlMarshaller, foldMarshallerFields)
 import Database.Orville.PostgreSQL.Internal.SqlValue (SqlValue)
 
 {- |
@@ -109,11 +109,7 @@ mkInsertSource marshaller entities =
   field from a Haskell entity, adding it a list of 'SqlValue's that is being
   built.
 -}
-collectSqlValue ::
-  FieldDefinition nullability a ->
-  (entity -> a) ->
-  (entity -> [SqlValue]) ->
-  (entity -> [SqlValue])
+collectSqlValue :: FieldFold entity (entity -> [SqlValue])
 collectSqlValue fieldDef accessor encodeRest entity =
   fieldValueToSqlValue fieldDef (accessor entity) : (encodeRest entity)
 
@@ -148,10 +144,7 @@ marshallerColumnNames marshaller =
   list of values being built.
 -}
 collectFromField ::
-  (FieldDefinition nullability a -> result) ->
-  FieldDefinition nullability a ->
-  (writeEntity -> a) ->
-  [result] ->
-  [result]
+  (forall nullability a. FieldDefinition nullability a -> result) ->
+  FieldFold entity [result]
 collectFromField fromField fieldDef _ results =
   fromField fieldDef : results

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/TableDefinition.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/TableDefinition.hs
@@ -1,0 +1,157 @@
+{-# LANGUAGE RankNTypes #-}
+
+module Database.Orville.PostgreSQL.Internal.TableDefinition
+  ( TableDefinition (..),
+    mkInsertExpr,
+    mkCreateTableExpr,
+    mkInsertColumnList,
+    mkInsertSource,
+    mkQueryExpr,
+  )
+where
+
+import Data.List.NonEmpty (NonEmpty, toList)
+
+import qualified Database.Orville.PostgreSQL.Internal.Expr as Expr
+import Database.Orville.PostgreSQL.Internal.FieldDefinition (FieldDefinition, fieldColumnDefinition, fieldColumnName, fieldValueToSqlValue)
+import Database.Orville.PostgreSQL.Internal.PrimaryKey (PrimaryKey, mkPrimaryKeyExpr)
+import Database.Orville.PostgreSQL.Internal.SqlMarshaller (SqlMarshaller, foldMarshallerFields)
+import Database.Orville.PostgreSQL.Internal.SqlValue (SqlValue)
+
+{- |
+  Contains the definition of a SQL table for Orville to use for generating
+  queries and marshalling Haskell values to and from the database.
+
+  * 'key' is the Haskell type used to store values of the primary
+    key for the table.
+
+  * 'writeEntity' is the Haskell type for values that Orville will write
+    to the database for you (i.e. both inserts and updates)
+
+  * 'readEntity' is the Haskell type for values that Orville will decode
+    from the result set when entities are queried from this table.
+-}
+data TableDefinition key writeEntity readEntity = TableDefinition
+  { tableName :: Expr.TableName
+  , tablePrimaryKey :: PrimaryKey key
+  , tableMarshaller :: SqlMarshaller writeEntity readEntity
+  }
+
+{- |
+  Builds a 'Expr.CreateTableExpr' that will create a SQL table matching the
+  given 'TableDefinition' when it is executed.
+-}
+mkCreateTableExpr ::
+  TableDefinition key writeEntity readEntity ->
+  Expr.CreateTableExpr
+mkCreateTableExpr tableDef =
+  let columnDefinitions =
+        foldMarshallerFields
+          (tableMarshaller tableDef)
+          []
+          (collectFromField fieldColumnDefinition)
+   in Expr.createTableExpr
+        (tableName tableDef)
+        columnDefinitions
+        (Just . mkPrimaryKeyExpr . tablePrimaryKey $ tableDef)
+
+{- |
+  Builds an 'Expr.InsertExpr' that will insert the given entities into the
+  SQL table when it is executed.
+-}
+mkInsertExpr ::
+  TableDefinition key writeEntity readEntity ->
+  NonEmpty writeEntity ->
+  Expr.InsertExpr
+mkInsertExpr tableDef entities =
+  let columnList =
+        mkInsertColumnList . tableMarshaller $ tableDef
+
+      insertSource =
+        mkInsertSource (tableMarshaller tableDef) entities
+   in Expr.insertExpr (tableName tableDef) (Just columnList) insertSource
+
+{- |
+  Builds an 'Expr.InsertColumnList' that specifies the columns for an
+  insert statement in the order that they appear in the given 'SqlMarshaller'.
+
+  In normal circumstances you will want to build the complete insert statement
+  via 'mkInsertExpr', but this is exported in case you are a composing SQL
+  yourself and need the column list of an insert as a fragment.
+-}
+mkInsertColumnList ::
+  SqlMarshaller writeEntity readEntity ->
+  Expr.InsertColumnList
+mkInsertColumnList =
+  Expr.insertColumnList . marshallerColumnNames
+
+{- |
+  Builds an 'Expr.InsertSource' that will insert the given entities with their
+  values specified in the order that the fields appear in the given
+  'SqlMarshaller' (which matches the order of column names produced by
+  'mkInsertColumnColumnsList').
+
+  In normal circumstances you will want to build the complete insert statement
+  via 'mkInsertExpr', but this is exported in case you are a composing SQL
+  yourself and need the column list of an insert as a fragment.
+-}
+mkInsertSource ::
+  SqlMarshaller writeEntity readEntity ->
+  NonEmpty writeEntity ->
+  Expr.InsertSource
+mkInsertSource marshaller entities =
+  let encodeRow =
+        foldMarshallerFields marshaller (const []) collectSqlValue
+   in Expr.insertSqlValues $ map encodeRow (toList entities)
+
+{- |
+  An internal helper function that collects the 'SqlValue' encoded value for a
+  field from a Haskell entity, adding it a list of 'SqlValue's that is being
+  built.
+-}
+collectSqlValue ::
+  FieldDefinition nullability a ->
+  (entity -> a) ->
+  (entity -> [SqlValue]) ->
+  (entity -> [SqlValue])
+collectSqlValue fieldDef accessor encodeRest entity =
+  fieldValueToSqlValue fieldDef (accessor entity) : (encodeRest entity)
+
+{- |
+  Builds a 'Expr.QueryExpr' that will do a select from the SQL table described
+  by the table definiton, selecting all the columns found in the table's
+  'SqlMarshaller'.
+-}
+mkQueryExpr ::
+  TableDefinition key writeEntity readEntity ->
+  Maybe Expr.WhereClause ->
+  Maybe Expr.OrderByClause ->
+  Expr.QueryExpr
+mkQueryExpr tableDef whereClause orderByClause =
+  let columns =
+        marshallerColumnNames . tableMarshaller $ tableDef
+   in Expr.queryExpr
+        (Expr.selectColumns columns)
+        (Expr.tableExpr (tableName tableDef) whereClause orderByClause)
+
+{- |
+  An internal helper function that collects the column names for all the
+  'FieldDefinition's that are referenced by the given 'SqlMarshaller'.
+-}
+marshallerColumnNames :: SqlMarshaller writeEntity readEntity -> [Expr.ColumnName]
+marshallerColumnNames marshaller =
+  foldMarshallerFields marshaller [] (collectFromField fieldColumnName)
+
+{- |
+  An internal helper function that collects a value derived from a
+  'FieldDefinition' via the given function. The derived value is added to the
+  list of values being built.
+-}
+collectFromField ::
+  (FieldDefinition nullability a -> result) ->
+  FieldDefinition nullability a ->
+  (writeEntity -> a) ->
+  [result] ->
+  [result]
+collectFromField fromField fieldDef _ results =
+  fromField fieldDef : results

--- a/orville-postgresql-libpq/test/Main.hs
+++ b/orville-postgresql-libpq/test/Main.hs
@@ -14,6 +14,7 @@ import Test.FieldDefinition (fieldDefinitionTree)
 import Test.RawSql (rawSqlSpecs)
 import Test.SqlMarshaller (sqlMarshallerTree)
 import Test.SqlType (sqlTypeSpecs)
+import Test.TableDefinition (tableDefinitionTree)
 
 main :: IO ()
 main = do
@@ -33,4 +34,5 @@ main = do
       , specTree
       , sqlMarshallerTree
       , fieldDefinitionTree pool
+      , tableDefinitionTree pool
       ]

--- a/orville-postgresql-libpq/test/Test/Connection.hs
+++ b/orville-postgresql-libpq/test/Test/Connection.hs
@@ -69,7 +69,7 @@ connectionTree pool =
           Left PGTextFormatValue.NULByteFoundError ->
             HH.success
           Right _ -> do
-            HH.footnote "Expected 'executeRow' to return failure, but it did not"
+            HH.footnote "Expected 'executeRaw' to return failure, but it did not"
             HH.failure
     , testProperty "executeRaw truncates values at the nul byte given using unsafe constructor" . HH.property $ do
         textBefore <- HH.forAll $ PGGen.pgText (Range.linear 0 32)

--- a/orville-postgresql-libpq/test/Test/Expr.hs
+++ b/orville-postgresql-libpq/test/Test/Expr.hs
@@ -181,7 +181,7 @@ runOrderByTest pool test = do
 
   RawSql.executeVoid pool
     . Expr.insertExprToSql
-    $ Expr.insertExpr exprTestTable (mkOrderByTestInsertSource test)
+    $ Expr.insertExpr exprTestTable Nothing (mkOrderByTestInsertSource test)
 
   result <-
     RawSql.execute pool
@@ -223,7 +223,7 @@ runWhereConditionTest pool test = do
 
   RawSql.executeVoid pool $
     Expr.insertExprToSql $
-      Expr.insertExpr exprTestTable (mkTestInsertSource test)
+      Expr.insertExpr exprTestTable Nothing (mkTestInsertSource test)
 
   result <-
     RawSql.execute pool $

--- a/orville-postgresql-libpq/test/Test/PGGen.hs
+++ b/orville-postgresql-libpq/test/Test/PGGen.hs
@@ -1,9 +1,11 @@
 module Test.PGGen
   ( pgText,
     pgDouble,
+    pgInt32,
   )
 where
 
+import Data.Int (Int32)
 import qualified Data.Text as T
 import qualified Hedgehog as HH
 import qualified Hedgehog.Gen as Gen
@@ -13,6 +15,10 @@ pgText :: HH.Range Int -> HH.Gen T.Text
 pgText range =
   Gen.text range $
     Gen.filter (/= '\NUL') Gen.unicode
+
+pgInt32 :: HH.Gen Int32
+pgInt32 =
+  Gen.integral (Range.linearFrom 0 minBound maxBound)
 
 pgDouble :: HH.Gen Double
 pgDouble =

--- a/orville-postgresql-libpq/test/Test/RawSql.hs
+++ b/orville-postgresql-libpq/test/Test/RawSql.hs
@@ -37,7 +37,7 @@ rawSqlSpecs =
               <> RawSql.parameter (SqlValue.fromInt32 1)
               <> RawSql.fromString " AND "
               <> RawSql.fromString "bar IN ("
-              <> RawSql.intercalate (RawSql.fromString ",") bars
+              <> RawSql.intercalate RawSql.comma bars
               <> RawSql.fromString ")"
 
           bars =

--- a/orville-postgresql-libpq/test/Test/SqlMarshaller.hs
+++ b/orville-postgresql-libpq/test/Test/SqlMarshaller.hs
@@ -16,8 +16,8 @@ import Test.Tasty.Hedgehog (testProperty)
 
 import Database.Orville.PostgreSQL.Internal.ExecutionResult (Row (..))
 import qualified Database.Orville.PostgreSQL.Internal.ExecutionResult as Result
-import Database.Orville.PostgreSQL.Internal.FieldDefinition (FieldDefinition, FieldName, fieldName, fieldValueToSqlValue, integerField, stringToFieldName, unboundedTextField)
-import Database.Orville.PostgreSQL.Internal.SqlMarshaller (MarshallError (..), SqlMarshaller, foldMarshallerFields, marshallField, marshallResultFromSql, marshallRowFromSql)
+import Database.Orville.PostgreSQL.Internal.FieldDefinition (FieldName, fieldName, fieldValueToSqlValue, integerField, stringToFieldName, unboundedTextField)
+import Database.Orville.PostgreSQL.Internal.SqlMarshaller (FieldFold, MarshallError (..), SqlMarshaller, foldMarshallerFields, marshallField, marshallResultFromSql, marshallRowFromSql)
 import qualified Database.Orville.PostgreSQL.Internal.SqlValue as SqlValue
 
 import qualified Test.PGGen as PGGen
@@ -97,11 +97,7 @@ sqlMarshallerTree =
     , testProperty "foldMarhallerFields collects all fields as their sql values" . HH.property $ do
         foo <- HH.forAll generateFoo
 
-        let addField ::
-              FieldDefinition nullability a ->
-              (Foo -> a) ->
-              [(FieldName, SqlValue.SqlValue)] ->
-              [(FieldName, SqlValue.SqlValue)]
+        let addField :: FieldFold Foo [(FieldName, SqlValue.SqlValue)]
             addField fieldDef getValue fields =
               (fieldName fieldDef, fieldValueToSqlValue fieldDef (getValue foo)) : fields
 

--- a/orville-postgresql-libpq/test/Test/SqlType.hs
+++ b/orville-postgresql-libpq/test/Test/SqlType.hs
@@ -335,6 +335,7 @@ runDecodingTest pool test = do
     Expr.insertExprToSql $
       Expr.insertExpr
         tableName
+        Nothing
         (Expr.insertSqlValues [[SqlValue.fromRawBytesNullable (rawSqlValue test)]])
 
   result <-

--- a/orville-postgresql-libpq/test/Test/TableDefinition.hs
+++ b/orville-postgresql-libpq/test/Test/TableDefinition.hs
@@ -1,0 +1,112 @@
+module Test.TableDefinition
+  ( tableDefinitionTree,
+  )
+where
+
+import Control.Exception (try)
+import Control.Monad.IO.Class (liftIO)
+import qualified Data.ByteString.Char8 as B8
+import Data.Int (Int32)
+import Data.List.NonEmpty (NonEmpty ((:|)))
+import Data.Pool (Pool)
+import qualified Data.Text as T
+import Hedgehog ((===))
+import qualified Hedgehog as HH
+import qualified Hedgehog.Range as Range
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Hedgehog (testProperty)
+
+import Database.Orville.PostgreSQL.Connection (Connection, SqlExecutionError (sqlExecutionErrorSqlState))
+import qualified Database.Orville.PostgreSQL.Internal.Expr as Expr
+import Database.Orville.PostgreSQL.Internal.FieldDefinition (FieldDefinition, NotNull, integerField, unboundedTextField)
+import Database.Orville.PostgreSQL.Internal.PrimaryKey (primaryKey)
+import qualified Database.Orville.PostgreSQL.Internal.RawSql as RawSql
+import Database.Orville.PostgreSQL.Internal.SqlMarshaller (SqlMarshaller, marshallField, marshallResultFromSql)
+import Database.Orville.PostgreSQL.Internal.TableDefinition (TableDefinition (..), mkCreateTableExpr, mkInsertExpr, mkQueryExpr)
+
+import qualified Test.PGGen as PGGen
+
+tableDefinitionTree :: Pool Connection -> TestTree
+tableDefinitionTree pool =
+  testGroup
+    "TableDefinition"
+    [ testProperty "Creates a table than can round trip an entity through it" . HH.property $ do
+        originalFoo <- HH.forAll generateFoo
+
+        let insertFoo =
+              mkInsertExpr fooTable (originalFoo :| [])
+
+            selectFoos =
+              mkQueryExpr fooTable Nothing Nothing
+
+        foosFromDB <-
+          liftIO $ do
+            dropAndRecreateTestTable pool fooTable
+            RawSql.executeVoid pool (Expr.insertExprToSql insertFoo)
+            result <- RawSql.execute pool (Expr.queryExprToSql selectFoos)
+            marshallResultFromSql (tableMarshaller fooTable) result
+
+        foosFromDB === Right [originalFoo]
+    , testProperty "Creates a primary key that rejects duplicate records" . HH.withTests 1 . HH.property $ do
+        originalFoo <- HH.forAll generateFoo
+
+        let insertFoo =
+              mkInsertExpr fooTable (originalFoo :| [])
+
+        result <- liftIO . try $ do
+          dropAndRecreateTestTable pool fooTable
+          RawSql.executeVoid pool (Expr.insertExprToSql insertFoo)
+          RawSql.executeVoid pool (Expr.insertExprToSql insertFoo)
+
+        case result of
+          Right () -> do
+            HH.footnote "Expected 'executeVoid' to return failure, but it did not"
+            HH.failure
+          Left err ->
+            sqlExecutionErrorSqlState err === Just (B8.pack "23505")
+    ]
+
+fooTable :: TableDefinition FooId Foo Foo
+fooTable =
+  TableDefinition
+    { tableName = Expr.rawTableName "foo"
+    , tablePrimaryKey = primaryKey fooIdField
+    , tableMarshaller = fooMarshaller
+    }
+
+fooMarshaller :: SqlMarshaller Foo Foo
+fooMarshaller =
+  Foo
+    <$> marshallField fooId fooIdField
+    <*> marshallField fooName fooNameField
+
+fooIdField :: FieldDefinition NotNull FooId
+fooIdField =
+  integerField "id"
+
+fooNameField :: FieldDefinition NotNull FooName
+fooNameField =
+  unboundedTextField "name"
+
+type FooId = Int32
+type FooName = T.Text
+
+data Foo = Foo
+  { fooId :: FooId
+  , fooName :: FooName
+  }
+  deriving (Eq, Show)
+
+generateFoo :: HH.Gen Foo
+generateFoo =
+  Foo
+    <$> PGGen.pgInt32
+    <*> PGGen.pgText (Range.constant 0 10)
+
+dropAndRecreateTestTable ::
+  Pool Connection ->
+  TableDefinition key writeEntity readEntity ->
+  IO ()
+dropAndRecreateTestTable pool tableDef = do
+  RawSql.executeVoid pool (RawSql.fromString "DROP TABLE IF EXISTS " <> Expr.tableNameToSql (tableName tableDef))
+  RawSql.executeVoid pool (Expr.createTableExprToSql $ mkCreateTableExpr tableDef)


### PR DESCRIPTION
This adds a minimal port of `TableDefinition`, containing just the table
name, marshaller and primary key. It includes functions to generate SQL
expressions for table creation, record insertion and querying.

`SqlMarshaller` needed some API tuning to get everything that
`TableDefinition` needed for its job. The "marshall to sql" function
became simply a fold over the fields in the `SqlMarshaller`, which is
used in a couple of different ways for building the queries to support
table operations.

We may decide that we don't want to export the `TableDefinition`
constructor (so that we can add record fields without it being a
breaking api change), but I deferred that decision for the moment in
favor of getting this basic functionality working.