### PR TITLE
LibPQ: Adds MonadOrville and friends

### DIFF
--- a/orville-postgresql-libpq/orville-postgresql-libpq.cabal
+++ b/orville-postgresql-libpq/orville-postgresql-libpq.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 9f28feaa7c0b043db21c37372118622c0c998806a733e20dc81847877b32963d
+-- hash: f01c660c8806d3d6a9cae7ec8e93ae903084eb286faa431db51bf20e905071b9
 
 name:           orville-postgresql-libpq
 version:        0.10.0.0
@@ -63,6 +63,9 @@ library
       Database.Orville.PostgreSQL.Internal.Expr.Where.ComparisonOperator
       Database.Orville.PostgreSQL.Internal.Expr.Where.RowValuePredicand
       Database.Orville.PostgreSQL.Internal.Expr.Where.WhereClause
+      Database.Orville.PostgreSQL.Internal.MonadOrville
+      Database.Orville.PostgreSQL.Internal.Orville
+      Database.Orville.PostgreSQL.Internal.RecordOperations
       Paths_orville_postgresql_libpq
   hs-source-dirs:
       src
@@ -76,6 +79,7 @@ library
     , resource-pool
     , text
     , time >=1.5
+    , transformers ==0.5.*
   if flag(ci)
     ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-patterns -Wincomplete-record-updates -Wmissing-local-signatures -Wmissing-export-lists -Wmissing-import-lists -Wnoncanonical-monad-instances -Wredundant-constraints -Wpartial-fields -Wmissed-specialisations -Wno-implicit-prelude -Wno-safe -Wno-unsafe
   else
@@ -87,13 +91,16 @@ test-suite spec
   main-is: Main.hs
   other-modules:
       Test.Connection
+      Test.Entities.Foo
       Test.Expr
       Test.FieldDefinition
       Test.PGGen
       Test.RawSql
+      Test.RecordOperations
       Test.SqlMarshaller
       Test.SqlType
       Test.TableDefinition
+      Test.TestTable
   hs-source-dirs:
       test
   ghc-options: -j -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wmissing-local-signatures -Wmissing-export-lists -Wno-implicit-prelude -Wno-safe -Wno-unsafe -Wnoncanonical-monad-instances -Wredundant-constraints -Wpartial-fields -Wmissed-specialisations

--- a/orville-postgresql-libpq/package.yaml
+++ b/orville-postgresql-libpq/package.yaml
@@ -69,6 +69,7 @@ library:
     - resource-pool
     - text
     - time >=1.5
+    - transformers >= 0.5 && < 0.6
 
 tests:
   spec:
@@ -76,13 +77,16 @@ tests:
     main: Main.hs
     other-modules:
       - Test.Connection
+      - Test.Entities.Foo
       - Test.Expr
       - Test.FieldDefinition
       - Test.PGGen
       - Test.RawSql
+      - Test.RecordOperations
       - Test.SqlMarshaller
       - Test.SqlType
       - Test.TableDefinition
+      - Test.TestTable
     dependencies:
       - base
       - bytestring

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL.hs
@@ -4,68 +4,56 @@ Copyright : Flipstone Technology Partners 2020-2021
 License   : MIT
 -}
 module Database.Orville.PostgreSQL
-  ( createConnectionPool,
-    SqlType
-      ( SqlType,
-        sqlTypeExpr,
-        sqlTypeReferenceExpr,
-        sqlTypeNullable,
-        sqlTypeId,
-        sqlTypeSqlSize,
-        sqlTypeToSql,
-        sqlTypeFromSql
+  ( RecordOperations.insertRecord,
+    Connection.createConnectionPool,
+    TableDefinition.TableDefinition,
+    Orville.Orville,
+    Orville.runOrville,
+    MonadOrville.MonadOrville,
+    MonadOrville.MonadOrvilleControl (liftWithConnection),
+    MonadOrville.HasOrvilleState (askOrvilleState, localOrvilleState),
+    MonadOrville.OrvilleState,
+    SqlType.SqlType
+      ( SqlType.SqlType,
+        SqlType.sqlTypeExpr,
+        SqlType.sqlTypeReferenceExpr,
+        SqlType.sqlTypeNullable,
+        SqlType.sqlTypeId,
+        SqlType.sqlTypeSqlSize,
+        SqlType.sqlTypeToSql,
+        SqlType.sqlTypeFromSql
       ),
-    -- numeric types
-    integer,
-    serial,
-    bigInteger,
-    bigSerial,
-    double,
-    -- textual-ish types
-    boolean,
-    unboundedText,
-    fixedText,
-    boundedText,
-    textSearchVector,
-    -- date types
-    date,
-    timestamp,
+
+    -- * numeric types
+    SqlType.integer,
+    SqlType.serial,
+    SqlType.bigInteger,
+    SqlType.bigSerial,
+    SqlType.double,
+
+    -- * textual-ish types
+    SqlType.boolean,
+    SqlType.unboundedText,
+    SqlType.fixedText,
+    SqlType.boundedText,
+    SqlType.textSearchVector,
+
+    -- * date types
+    SqlType.date,
+    SqlType.timestamp,
     -- type conversions
-    nullableType,
-    foreignRefType,
-    convertSqlType,
-    maybeConvertSqlType,
+    SqlType.nullableType,
+    SqlType.foreignRefType,
+    SqlType.convertSqlType,
+    SqlType.maybeConvertSqlType,
     Expr.QueryExpr,
   )
 where
 
-import Database.Orville.PostgreSQL.Connection (createConnectionPool)
+import qualified Database.Orville.PostgreSQL.Connection as Connection
 import qualified Database.Orville.PostgreSQL.Internal.Expr as Expr
-import Database.Orville.PostgreSQL.Internal.SqlType
-  ( SqlType
-      ( SqlType,
-        sqlTypeExpr,
-        sqlTypeFromSql,
-        sqlTypeId,
-        sqlTypeNullable,
-        sqlTypeReferenceExpr,
-        sqlTypeSqlSize,
-        sqlTypeToSql
-      ),
-    bigInteger,
-    bigSerial,
-    boolean,
-    boundedText,
-    convertSqlType,
-    date,
-    double,
-    fixedText,
-    foreignRefType,
-    integer,
-    maybeConvertSqlType,
-    nullableType,
-    serial,
-    textSearchVector,
-    timestamp,
-    unboundedText,
-  )
+import qualified Database.Orville.PostgreSQL.Internal.MonadOrville as MonadOrville
+import qualified Database.Orville.PostgreSQL.Internal.Orville as Orville
+import qualified Database.Orville.PostgreSQL.Internal.RecordOperations as RecordOperations
+import qualified Database.Orville.PostgreSQL.Internal.SqlType as SqlType
+import qualified Database.Orville.PostgreSQL.Internal.TableDefinition as TableDefinition

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Connection.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Connection.hs
@@ -22,7 +22,7 @@ import Control.Monad (void)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
 import Data.Maybe (fromMaybe)
-import Data.Pool (Pool, createPool, withResource)
+import Data.Pool (Pool, createPool)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as Enc
 import Data.Time (NominalDiffTime)
@@ -55,25 +55,25 @@ createConnectionPool stripes linger maxRes connectionString =
  Use with caution.
 -}
 executeRaw ::
-  Pool Connection ->
+  Connection ->
   BS.ByteString ->
   [Maybe PGTextFormatValue] ->
   IO LibPQ.Result
-executeRaw pool bs params =
+executeRaw connection bs params =
   case traverse (traverse toBytesForLibPQ) params of
     Left NULByteFoundError ->
       throwIO NULByteFoundError
     Right paramBytes ->
-      withResource pool (underlyingExecute bs paramBytes)
+      underlyingExecute bs paramBytes connection
 
 {- |
  'executeRawVoid' a version of 'executeRaw' that completely ignores the result.
  If an error occurs it is raised as an exception.
  Use with caution.
 -}
-executeRawVoid :: Pool Connection -> BS.ByteString -> [Maybe PGTextFormatValue] -> IO ()
-executeRawVoid pool bs params =
-  void $ executeRaw pool bs params
+executeRawVoid :: Connection -> BS.ByteString -> [Maybe PGTextFormatValue] -> IO ()
+executeRawVoid connection bs params =
+  void $ executeRaw connection bs params
 
 {- |
  The basic connection interface.

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/MonadOrville.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/MonadOrville.hs
@@ -13,7 +13,7 @@ module Database.Orville.PostgreSQL.Internal.MonadOrville
 where
 
 import Control.Monad.IO.Class (MonadIO)
-import Control.Monad.Trans.Reader (ReaderT (ReaderT), runReaderT, ask, local)
+import Control.Monad.Trans.Reader (ReaderT (ReaderT), ask, local, runReaderT)
 import Data.Pool (Pool, withResource)
 
 import Database.Orville.PostgreSQL.Connection (Connection)
@@ -59,7 +59,6 @@ class
     newtype MyApplicationMonad a =
       MyApplicationMonad (ReaderT MyApplicationState IO) a
 
-
     instance HasOrvilleState MyApplicationMonad where
       askOrvilleState =
         MyApplicationMonad (asks appOrvilleState)
@@ -75,14 +74,13 @@ class
   the case that your application has no extra context to track.
 -}
 class HasOrvilleState m where
-  {- |
+  {-
     Fetches the current 'OrvilleState' from the host Monad context. The
     equivalent of 'ask' for 'ReaderT OrvilleState'
   -}
   askOrvilleState :: m OrvilleState
 
-
-  {- |
+  {-
     Applies a modification to the 'OrvilleState' that is local to the given
     monad operation. Calls to 'askOrvilleState' made within the 'm a' provided
     must return the modified state. The modified state must only apply to
@@ -90,11 +88,11 @@ class HasOrvilleState m where
     for 'ReaderT OrvilleState'
   -}
   localOrvilleState ::
-                       (OrvilleState -> OrvilleState)
-                       -- ^ The function to modify the 'OrvilleState'
-                    -> m a
-                       -- ^ The monad operation to execute with the modified state
-                    -> m a
+    -- | The function to modify the 'OrvilleState'
+    (OrvilleState -> OrvilleState) ->
+    -- | The monad operation to execute with the modified state
+    m a ->
+    m a
 
 instance Monad m => HasOrvilleState (ReaderT OrvilleState m) where
   askOrvilleState = ask
@@ -172,7 +170,7 @@ data ConnectionState
   before release, we just haven't gotten quite there yet.
 -}
 class MonadOrvilleControl m where
-  {- |
+  {-
     Orville will use this function to lift the acquisition of connections
     from the resource pool into the application monad.
   -}

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/MonadOrville.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/MonadOrville.hs
@@ -1,0 +1,213 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Database.Orville.PostgreSQL.Internal.MonadOrville
+  ( MonadOrville,
+    HasOrvilleState (askOrvilleState, localOrvilleState),
+    OrvilleState (OrvilleState),
+    newOrvilleState,
+    resetOrvilleState,
+    MonadOrvilleControl (liftWithConnection),
+    withConnection,
+  )
+where
+
+import Control.Monad.IO.Class (MonadIO)
+import Control.Monad.Trans.Reader (ReaderT (ReaderT), runReaderT, ask, local)
+import Data.Pool (Pool, withResource)
+
+import Database.Orville.PostgreSQL.Connection (Connection)
+
+{- |
+  'MonadOrville' is the typeclass that most Orville operations require to
+  do anything that connects to the database. 'MonadOrville' itself is empty,
+  but it lists all the required typeclasses as superclass contraints so that
+  it can be used instead of listing all the constraints on every function.
+
+  If you want to be able to run Orville operations directly in your own
+  application's Monad stack, a good starting place is to add
+
+  @
+    instance MonadOrville MyApplicationMonad
+  @
+
+  to your module and then let the compiler tell you what instances you
+  are missing from the superclasses.
+-}
+class
+  ( HasOrvilleState m
+  , MonadOrvilleControl m
+  , MonadIO m
+  ) =>
+  MonadOrville m
+
+{- |
+  'HasOrvilleState' is the typeclass that Orville uses to access and manange
+  the connection pool and state tracking when it is being executed inside an
+  unknown Monad. It is a specialized version of the Reader interface so that it
+  can easily implemented by application Monads that already have a Reader
+  context and want to simply add 'OrvilleState' as an attribute to that
+  context, like so
+
+  @
+    data MyApplicationState =
+      MyApplicationState
+        { appConfig :: MyAppConfig
+        , appOrvilleState :: OrvilleState
+        }
+
+    newtype MyApplicationMonad a =
+      MyApplicationMonad (ReaderT MyApplicationState IO) a
+
+
+    instance HasOrvilleState MyApplicationMonad where
+      askOrvilleState =
+        MyApplicationMonad (asks appOrvilleState)
+
+      localOrvilleState f (MyApplicationMonad reader) =
+        MyApplicationMonad $
+          local
+            (\state -> state { appOrvilleState = f (appOrvilleState state))
+            reader
+  @
+
+  An instance for 'ReaderT OrvilleState m' is provided as a convenience in
+  the case that your application has no extra context to track.
+-}
+class HasOrvilleState m where
+  {- |
+    Fetches the current 'OrvilleState' from the host Monad context. The
+    equivalent of 'ask' for 'ReaderT OrvilleState'
+  -}
+  askOrvilleState :: m OrvilleState
+
+
+  {- |
+    Applies a modification to the 'OrvilleState' that is local to the given
+    monad operation. Calls to 'askOrvilleState' made within the 'm a' provided
+    must return the modified state. The modified state must only apply to
+    the given 'm a' and not persisted beyond it. The equivalent of 'local'
+    for 'ReaderT OrvilleState'
+  -}
+  localOrvilleState ::
+                       (OrvilleState -> OrvilleState)
+                       -- ^ The function to modify the 'OrvilleState'
+                    -> m a
+                       -- ^ The monad operation to execute with the modified state
+                    -> m a
+
+instance Monad m => HasOrvilleState (ReaderT OrvilleState m) where
+  askOrvilleState = ask
+  localOrvilleState = local
+
+{- |
+  'OrvilleState' is used to manange opening connections to the database,
+  transactions, etc. 'newOrvilleState should be used to create an appopriate
+  initial state for your monad's context.
+-}
+data OrvilleState = OrvilleState
+  { orvilleConnectionPool :: Pool Connection
+  , orvilleConnectionState :: ConnectionState
+  }
+
+{- |
+  Creates a appropriate initial 'OrvilleState' that will use the connection
+  pool given to initiate connections to the database.
+-}
+newOrvilleState :: Pool Connection -> OrvilleState
+newOrvilleState pool =
+  OrvilleState
+    { orvilleConnectionPool = pool
+    , orvilleConnectionState = NotConnected
+    }
+
+{- |
+  Creates a new initial 'OrvilleState' using the connection pool from the
+  provide state. You might need to use this if you are spawning one Orville
+  monad from another and they should not share the same connection and
+  transaction state.
+-}
+resetOrvilleState :: OrvilleState -> OrvilleState
+resetOrvilleState =
+  newOrvilleState . orvilleConnectionPool
+
+{- |
+  INTERNAL: Transitions the 'OrvilleState' into "connected" status, storing
+  the given 'Connection' as the database connection to be used to execute
+  all queries. This is used by 'withConnection' to track the connection it
+  retrieves from the pool.
+-}
+connectState :: Connection -> OrvilleState -> OrvilleState
+connectState conn context =
+  context
+    { orvilleConnectionState = Connected conn
+    }
+
+{- |
+  INTERNAL: This type is used to signal whether a database connection has
+  been retrieved from the pool for the current operation or not. The
+  value is tracked in the 'OrvilleState' for the host monad, and is checked
+  by 'withConnection' to avoid checking out two separate connections for a
+  multiple operations that needs to be run on the same connection (e.g.
+  multiple operations inside a transaction).
+-}
+data ConnectionState
+  = NotConnected
+  | Connected Connection
+
+{- |
+  'MonadOrvilleControl' presents the interface that Orville will used to
+  lift low-level IO operations that cannot be lifted via 'liftIO' (i.e.
+  those where the IO parameter is contravriant rather than covariant).
+
+  For application monads built using only 'ReaderT' and 'IO', this can be
+  trivially implemented (or derived), using the 'ReaderT' instance that is
+  provided here. If you monad stack is sufficiently complicated, you may
+  need to use the 'unliftio' package as a stepping stone to implementing
+  'MonadOrvilleControl'. If your monad uses features that 'unliftio' cannot
+  support (e.g. the State monad or continuations), then you may need to
+  use 'monad-control' instead.
+
+  TODO: Orville will provide helpers for using 'unliftio' and 'monad-control',
+  before release, we just haven't gotten quite there yet.
+-}
+class MonadOrvilleControl m where
+  {- |
+    Orville will use this function to lift the acquisition of connections
+    from the resource pool into the application monad.
+  -}
+  liftWithConnection ::
+    (forall a. (Connection -> IO a) -> IO a) -> (Connection -> m b) -> m b
+
+instance MonadOrvilleControl IO where
+  liftWithConnection ioWithConn =
+    ioWithConn
+
+instance MonadOrvilleControl m => MonadOrvilleControl (ReaderT context m) where
+  liftWithConnection ioWithConn action = do
+    ReaderT $ \env ->
+      liftWithConnection ioWithConn (flip runReaderT env . action)
+
+{- |
+  'withConnection' should be used to receive a 'Connection' handle for
+  executing queries against the database from within an application monad using
+  Orville.  For the "outermost" call of 'withConnection', a connection will be
+  acquired from the resource pool. Additional calls to 'withConnection' that
+  happen inside the 'm a' that uses the connection with return the same
+  'Connection' the same connection. When the 'm a' finishes the connection
+  will be returned to the pool. If 'm a' throws an exception the pool's
+  exception handling will take effect, generally destroying the connection in
+  case it was the source of the error.
+-}
+withConnection :: MonadOrville m => (Connection -> m a) -> m a
+withConnection connectedAction = do
+  context <- askOrvilleState
+
+  case orvilleConnectionState context of
+    Connected conn ->
+      connectedAction conn
+    NotConnected -> do
+      let pool = orvilleConnectionPool context
+      liftWithConnection (withResource pool) $ \conn ->
+        localOrvilleState (connectState conn) $
+          connectedAction conn

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Orville.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Orville.hs
@@ -1,0 +1,62 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Database.Orville.PostgreSQL.Internal.Orville
+  ( Orville,
+    runOrville,
+    runOrvilleWithState,
+  )
+where
+
+import Control.Monad.IO.Class (MonadIO)
+import Control.Monad.Trans.Reader (ReaderT, runReaderT)
+import Data.Pool (Pool)
+
+import Database.Orville.PostgreSQL.Connection (Connection)
+import qualified Database.Orville.PostgreSQL.Internal.MonadOrville as MonadOrville
+
+{- |
+  The 'Orville' Monad provides a easy starter implementation of 'MonadOrville'
+  when you don't have a monad specific to your application that you need to
+  use.
+
+  If you want add Orville capabilities to your own monad, take a look at
+  'MonadOrville' to learn what needs to be done.
+-}
+newtype Orville a = Orville
+  { unwrapOrville :: ReaderT MonadOrville.OrvilleState IO a
+  }
+  deriving
+    ( Functor
+    , Applicative
+    , Monad
+    , MonadIO
+    , MonadOrville.MonadOrvilleControl
+    , MonadOrville.HasOrvilleState
+    )
+
+instance MonadOrville.MonadOrville Orville
+
+{- |
+  Runs an 'Orville' operation in the 'IO' monad using the given connection
+  pool.
+-}
+runOrville :: Pool Connection -> Orville a -> IO a
+runOrville pool =
+  runOrvilleWithState (MonadOrville.newOrvilleState pool)
+
+{- |
+  Runs an 'Orville' operation in the 'IO' monad, starting from the provided
+  'OrvilleState'.
+
+  Caution: If you harvest an 'OrvilleState' from inside a
+  'MonadOrville.MonadOrville' monad using 'MonadOrville.askOrvilleState',
+  you may pick up connection tracking state that you didn't intend to. You
+  may want to use 'MonadOrville.resetOrvilleState' in this situation to get
+  a new initial state before passing it to 'runOrvilleWithState'.
+
+  On the other hand, if you know that you want to pass the existing connection
+  state from another monad into the 'Orville' monad, this is how you do it.
+-}
+runOrvilleWithState :: MonadOrville.OrvilleState -> Orville a -> IO a
+runOrvilleWithState state orville =
+  runReaderT (unwrapOrville orville) state

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/RawSql.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/RawSql.hs
@@ -33,7 +33,7 @@ import qualified Data.DList as DList
 import qualified Data.List as List
 import qualified Database.PostgreSQL.LibPQ as LibPQ
 
-import Database.Orville.PostgreSQL.Connection (Connection, Pool)
+import Database.Orville.PostgreSQL.Connection (Connection)
 import qualified Database.Orville.PostgreSQL.Connection as Conn
 import Database.Orville.PostgreSQL.Internal.PGTextFormatValue (PGTextFormatValue)
 import Database.Orville.PostgreSQL.Internal.SqlValue (SqlValue)
@@ -175,22 +175,22 @@ intercalate separator parts =
   to read the documentation of 'Conn.executeRaw' for caveats and warnings.
   Use with caution.
 -}
-execute :: Pool Connection -> RawSql -> IO LibPQ.Result
-execute conn rawSql =
+execute :: Connection -> RawSql -> IO LibPQ.Result
+execute connection rawSql =
   let (sqlBytes, params) =
         toBytesAndParams rawSql
-   in Conn.executeRaw conn sqlBytes params
+   in Conn.executeRaw connection sqlBytes params
 
 {- |
   Executes a 'RawSql' value using the 'Conn.executeRawVoid' function. Make sure
   to read the documentation of 'Conn.executeRawVoid' for caveats and warnings.
   Use with caution.
 -}
-executeVoid :: Pool Connection -> RawSql -> IO ()
-executeVoid conn rawSql =
+executeVoid :: Connection -> RawSql -> IO ()
+executeVoid connection rawSql =
   let (sqlBytes, params) =
         toBytesAndParams rawSql
-   in Conn.executeRawVoid conn sqlBytes params
+   in Conn.executeRawVoid connection sqlBytes params
 
 -- | Just a plain old space, provided for convenience
 space :: RawSql

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/RecordOperations.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/RecordOperations.hs
@@ -1,0 +1,29 @@
+module Database.Orville.PostgreSQL.Internal.RecordOperations
+  ( insertRecord,
+  )
+where
+
+import Control.Monad.IO.Class (MonadIO (liftIO))
+import Data.List.NonEmpty (NonEmpty ((:|)))
+
+import qualified Database.Orville.PostgreSQL.Internal.Expr as Expr
+import qualified Database.Orville.PostgreSQL.Internal.MonadOrville as MonadOrville
+import qualified Database.Orville.PostgreSQL.Internal.RawSql as RawSql
+import Database.Orville.PostgreSQL.Internal.TableDefinition (TableDefinition, mkInsertExpr)
+
+{- |
+  Inserts a record into the specified table.
+
+  TODO: This should return the 'readEntity' type using using the psql RETURNING
+  clause and decoding the result set.
+-}
+insertRecord ::
+  MonadOrville.MonadOrville m =>
+  TableDefinition key writeEntity readEntity ->
+  writeEntity ->
+  m ()
+insertRecord entityTable entity = do
+  let insertEntity = mkInsertExpr entityTable (entity :| [])
+  MonadOrville.withConnection $ \connection ->
+    liftIO $
+      RawSql.executeVoid connection (Expr.insertExprToSql insertEntity)

--- a/orville-postgresql-libpq/test/Main.hs
+++ b/orville-postgresql-libpq/test/Main.hs
@@ -12,6 +12,7 @@ import Test.Connection (connectionTree)
 import Test.Expr (exprSpecs)
 import Test.FieldDefinition (fieldDefinitionTree)
 import Test.RawSql (rawSqlSpecs)
+import Test.RecordOperations (recordOperationsTree)
 import Test.SqlMarshaller (sqlMarshallerTree)
 import Test.SqlType (sqlTypeSpecs)
 import Test.TableDefinition (tableDefinitionTree)
@@ -35,4 +36,5 @@ main = do
       , sqlMarshallerTree
       , fieldDefinitionTree pool
       , tableDefinitionTree pool
+      , recordOperationsTree pool
       ]

--- a/orville-postgresql-libpq/test/Test/Entities/Foo.hs
+++ b/orville-postgresql-libpq/test/Test/Entities/Foo.hs
@@ -1,0 +1,56 @@
+module Test.Entities.Foo
+  ( Foo (..),
+    table,
+    generate,
+  )
+where
+
+import Data.Int (Int32)
+import qualified Data.Text as T
+import qualified Hedgehog as HH
+import qualified Hedgehog.Range as Range
+
+import qualified Database.Orville.PostgreSQL.Internal.Expr as Expr
+import Database.Orville.PostgreSQL.Internal.FieldDefinition (FieldDefinition, NotNull, integerField, unboundedTextField)
+import Database.Orville.PostgreSQL.Internal.PrimaryKey (primaryKey)
+import Database.Orville.PostgreSQL.Internal.SqlMarshaller (SqlMarshaller, marshallField)
+import Database.Orville.PostgreSQL.Internal.TableDefinition (TableDefinition (..))
+
+import qualified Test.PGGen as PGGen
+
+type FooId = Int32
+type FooName = T.Text
+
+data Foo = Foo
+  { fooId :: FooId
+  , fooName :: FooName
+  }
+  deriving (Eq, Show)
+
+table :: TableDefinition FooId Foo Foo
+table =
+  TableDefinition
+    { tableName = Expr.rawTableName "foo"
+    , tablePrimaryKey = primaryKey fooIdField
+    , tableMarshaller = fooMarshaller
+    }
+
+fooMarshaller :: SqlMarshaller Foo Foo
+fooMarshaller =
+  Foo
+    <$> marshallField fooId fooIdField
+    <*> marshallField fooName fooNameField
+
+fooIdField :: FieldDefinition NotNull FooId
+fooIdField =
+  integerField "id"
+
+fooNameField :: FieldDefinition NotNull FooName
+fooNameField =
+  unboundedTextField "name"
+
+generate :: HH.Gen Foo
+generate =
+  Foo
+    <$> PGGen.pgInt32
+    <*> PGGen.pgText (Range.constant 0 10)

--- a/orville-postgresql-libpq/test/Test/RecordOperations.hs
+++ b/orville-postgresql-libpq/test/Test/RecordOperations.hs
@@ -1,0 +1,29 @@
+module Test.RecordOperations
+  ( recordOperationsTree,
+  )
+where
+
+import Control.Monad.IO.Class (liftIO)
+import Data.Pool (Pool, withResource)
+import qualified Hedgehog as HH
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Hedgehog (testProperty)
+
+import Database.Orville.PostgreSQL (insertRecord, runOrville)
+import Database.Orville.PostgreSQL.Connection (Connection)
+
+import qualified Test.Entities.Foo as Foo
+import qualified Test.TestTable as TestTable
+
+recordOperationsTree :: Pool Connection -> TestTree
+recordOperationsTree pool =
+  testGroup
+    "RecordOperations"
+    [ testProperty "insertRecord does not raise an error" . HH.property $ do
+        foo <- HH.forAll Foo.generate
+
+        liftIO $ do
+          withResource pool $ \connection ->
+            TestTable.dropAndRecreateTableDef connection Foo.table
+          runOrville pool $ insertRecord Foo.table foo
+    ]

--- a/orville-postgresql-libpq/test/Test/TestTable.hs
+++ b/orville-postgresql-libpq/test/Test/TestTable.hs
@@ -1,0 +1,17 @@
+module Test.TestTable
+  ( dropAndRecreateTableDef,
+  )
+where
+
+import Database.Orville.PostgreSQL.Connection (Connection)
+import qualified Database.Orville.PostgreSQL.Internal.Expr as Expr
+import qualified Database.Orville.PostgreSQL.Internal.RawSql as RawSql
+import Database.Orville.PostgreSQL.Internal.TableDefinition (TableDefinition (tableName), mkCreateTableExpr)
+
+dropAndRecreateTableDef ::
+  Connection ->
+  TableDefinition key writeEntity readEntity ->
+  IO ()
+dropAndRecreateTableDef connection tableDef = do
+  RawSql.executeVoid connection (RawSql.fromString "DROP TABLE IF EXISTS " <> Expr.tableNameToSql (tableName tableDef))
+  RawSql.executeVoid connection (Expr.createTableExprToSql $ mkCreateTableExpr tableDef)


### PR DESCRIPTION
This adds `MonadOrville`, `MonadOrvilleControl` and `HasOrvilleState` in
their basic forms so that libpq orville can be used from an application
monad. Currently `insertRecord` is provided as an example to test this.