### PR TITLE
LibPQ: Hides the TableDefinition constructor

### DIFF
--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/TableDefinition.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/TableDefinition.hs
@@ -1,7 +1,11 @@
 {-# LANGUAGE RankNTypes #-}
 
 module Database.Orville.PostgreSQL.Internal.TableDefinition
-  ( TableDefinition (..),
+  ( TableDefinition,
+    mkTableDefiniton,
+    tableName,
+    tablePrimaryKey,
+    tableMarshaller,
     mkInsertExpr,
     mkCreateTableExpr,
     mkInsertColumnList,
@@ -32,10 +36,48 @@ import Database.Orville.PostgreSQL.Internal.SqlValue (SqlValue)
     from the result set when entities are queried from this table.
 -}
 data TableDefinition key writeEntity readEntity = TableDefinition
-  { tableName :: Expr.TableName
-  , tablePrimaryKey :: PrimaryKey key
-  , tableMarshaller :: SqlMarshaller writeEntity readEntity
+  { _tableName :: Expr.TableName
+  , _tablePrimaryKey :: PrimaryKey key
+  , _tableMarshaller :: SqlMarshaller writeEntity readEntity
   }
+
+{- |
+  Constructs a new 'TableDefinition' with the minimal fields required for
+  operation.
+-}
+mkTableDefiniton ::
+  -- | The name of the table
+  String ->
+  -- | Definition of the table's primary key
+  PrimaryKey key ->
+  -- | A 'SqlMarshaller' to marshall table entities to and from the database
+  SqlMarshaller writeEntity readEntity ->
+  TableDefinition key writeEntity readEntity
+mkTableDefiniton name primaryKey marshaller =
+  TableDefinition
+    { _tableName = Expr.rawTableName name
+    , _tablePrimaryKey = primaryKey
+    , _tableMarshaller = marshaller
+    }
+
+{- |
+  Returns the tables name in as an expression that can be used to build SQL
+  statements.
+-}
+tableName :: TableDefinition key writeEntity readEntity -> Expr.TableName
+tableName = _tableName
+
+{- |
+  Returns the primary key for the table, as defined at construction via 'mkTableDefinition'.
+-}
+tablePrimaryKey :: TableDefinition key writeEntity readEntity -> PrimaryKey key
+tablePrimaryKey = _tablePrimaryKey
+
+{- |
+  Returns the marshaller for the table, as defined at construction via 'mkTableDefinition'.
+-}
+tableMarshaller :: TableDefinition key writeEntity readEntity -> SqlMarshaller writeEntity readEntity
+tableMarshaller = _tableMarshaller
 
 {- |
   Builds a 'Expr.CreateTableExpr' that will create a SQL table matching the

--- a/orville-postgresql-libpq/test/Test/Entities/Foo.hs
+++ b/orville-postgresql-libpq/test/Test/Entities/Foo.hs
@@ -10,11 +10,10 @@ import qualified Data.Text as T
 import qualified Hedgehog as HH
 import qualified Hedgehog.Range as Range
 
-import qualified Database.Orville.PostgreSQL.Internal.Expr as Expr
 import Database.Orville.PostgreSQL.Internal.FieldDefinition (FieldDefinition, NotNull, integerField, unboundedTextField)
 import Database.Orville.PostgreSQL.Internal.PrimaryKey (primaryKey)
 import Database.Orville.PostgreSQL.Internal.SqlMarshaller (SqlMarshaller, marshallField)
-import Database.Orville.PostgreSQL.Internal.TableDefinition (TableDefinition (..))
+import Database.Orville.PostgreSQL.Internal.TableDefinition (TableDefinition, mkTableDefiniton)
 
 import qualified Test.PGGen as PGGen
 
@@ -29,11 +28,7 @@ data Foo = Foo
 
 table :: TableDefinition FooId Foo Foo
 table =
-  TableDefinition
-    { tableName = Expr.rawTableName "foo"
-    , tablePrimaryKey = primaryKey fooIdField
-    , tableMarshaller = fooMarshaller
-    }
+  mkTableDefiniton "foo" (primaryKey fooIdField) fooMarshaller
 
 fooMarshaller :: SqlMarshaller Foo Foo
 fooMarshaller =

--- a/orville-postgresql-libpq/test/Test/TableDefinition.hs
+++ b/orville-postgresql-libpq/test/Test/TableDefinition.hs
@@ -17,7 +17,7 @@ import Database.Orville.PostgreSQL.Connection (Connection, SqlExecutionError (sq
 import qualified Database.Orville.PostgreSQL.Internal.Expr as Expr
 import qualified Database.Orville.PostgreSQL.Internal.RawSql as RawSql
 import Database.Orville.PostgreSQL.Internal.SqlMarshaller (marshallResultFromSql)
-import Database.Orville.PostgreSQL.Internal.TableDefinition (TableDefinition (tableMarshaller), mkInsertExpr, mkQueryExpr)
+import Database.Orville.PostgreSQL.Internal.TableDefinition (mkInsertExpr, mkQueryExpr, tableMarshaller)
 
 import qualified Test.Entities.Foo as Foo
 import qualified Test.TestTable as TestTable

--- a/orville-postgresql-libpq/test/Test/TestTable.hs
+++ b/orville-postgresql-libpq/test/Test/TestTable.hs
@@ -6,7 +6,7 @@ where
 import Database.Orville.PostgreSQL.Connection (Connection)
 import qualified Database.Orville.PostgreSQL.Internal.Expr as Expr
 import qualified Database.Orville.PostgreSQL.Internal.RawSql as RawSql
-import Database.Orville.PostgreSQL.Internal.TableDefinition (TableDefinition (tableName), mkCreateTableExpr)
+import Database.Orville.PostgreSQL.Internal.TableDefinition (TableDefinition, mkCreateTableExpr, tableName)
 
 dropAndRecreateTableDef ::
   Connection ->


### PR DESCRIPTION
If we expose the constructor adding new fields to the record to support
features we may not have thought of yet becomes a breaking API change.
Instead, we'll provide a way to set optional fields after the initial
construction as an alternative instead so that we can add new fields
without a breaking change to the exposed API.