### PR TITLE
LibPQ: Retabs build.sh

### DIFF
--- a/orville-postgresql-libpq/docker-compose.yml
+++ b/orville-postgresql-libpq/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     environment:
       TEST_CONN_STRING: "host=testdb user=orville_test"
     command:
-      - ./test-loop
+      - ./scripts/test-loop
       - stack-lts-17.3.yml
     # A TTY is required for the test-loop script to use
     # stack test. stdin_open would be sufficient, but

--- a/orville-postgresql-libpq/scripts/build.sh
+++ b/orville-postgresql-libpq/scripts/build.sh
@@ -6,25 +6,25 @@ SHOULD_SKIP_IMAGE_BUILD=0
 # Process arguments at the beginning to influence verbosity as early as possible.
 for arg in "$@"
 do
-    case ${arg} in
-        -v|--verbose)
-            SHOULD_BE_VERBOSE=1
-	    shift
-            ;;
-	--skip-image-build)
-	    SHOULD_SKIP_IMAGE_BUILD=1
-	    shift
-	    ;;
-	-h|--help)
-	    printf "Usage: build.sh [--verbose] [--skip-image-build]"
-	    exit 0;
-	    ;;
-        *)
-            if [ "$#" -gt 0 ]; then
-		shift; # shift only if possible
-	    fi
-        ;;
-    esac
+  case ${arg} in
+    -v|--verbose)
+      SHOULD_BE_VERBOSE=1
+      shift
+      ;;
+    --skip-image-build)
+      SHOULD_SKIP_IMAGE_BUILD=1
+      shift
+      ;;
+    -h|--help)
+      printf "Usage: build.sh [--verbose] [--skip-image-build]"
+      exit 0;
+      ;;
+    *)
+      if [ "$#" -gt 0 ]; then
+        shift; # shift only if possible
+      fi
+      ;;
+  esac
 done
 
 
@@ -32,25 +32,22 @@ done
 
 ## echo only on verbose mode
 echo_when_verbose() {
-    if [ "$SHOULD_BE_VERBOSE" -eq 1 ]; then
-	echo "$1"
-    fi
+  if [ "$SHOULD_BE_VERBOSE" -eq 1 ]; then
+    echo "$1"
+  fi
 }
 
 if ! command -v docker-compose 2>/dev/null 1>/dev/null; then
-    printf "docker-compose is used to build, but wasn't found!";
-    exit 1;
+  printf "docker-compose is used to build, but wasn't found!";
+  exit 1;
 else
-    # the actual logic of what "build" means
+  # the actual logic of what "build" means
 
-    if [ ! "$SHOULD_SKIP_IMAGE_BUILD" ]; then
-	echo_when_verbose "We start by ensuring the docker image is up to date\n"
-	docker-compose build
-    fi
+  if [ ! "$SHOULD_SKIP_IMAGE_BUILD" ]; then
+    echo_when_verbose "We start by ensuring the docker image is up to date\n"
+    docker-compose build
+  fi
 
-    echo_when_verbose "Now running the tests against the supported stack resolvers.\n"
-    docker-compose run --rm dev sh ./scripts/test-all
-
-    echo_when_verbose "Going to run formatting against the codebase.\n"
-    docker-compose run --rm dev sh ./scripts/format-repo.sh
+  echo_when_verbose "Now running the tests against the supported stack resolvers.\n"
+  docker-compose run --rm dev sh ./scripts/test-all
 fi


### PR DESCRIPTION
The `build.sh` file seemed to have a mix of tabs and spaces, based on
inconsistent indentation when I loaded it in vim. I retabbed it so the
indentation is consistent.

Edit: I tagged a second commit related to local builds that fixes the `docker-compose.yml` file onto this PR as well.