### PR TITLE
HDBC: Drop Index only if it exists during migration.

### DIFF
--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/MigrateIndex.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/MigrateIndex.hs
@@ -39,4 +39,6 @@ createIndexPlan indexDef schemaState = do
 dropIndexPlan :: String -> SchemaState -> Maybe MigrationPlan
 dropIndexPlan name schemaState = do
   guard (schemaStateIndexExists name schemaState)
-  pure $ migrationDDLForItem (DropIndex name) ("DROP INDEX " ++ name)
+  -- Here we drop the index only if it exists so that during the migration plan
+  -- should something else prior cause the index to be dropped we will not cause an error.
+  pure $ migrationDDLForItem (DropIndex name) ("DROP INDEX IF EXISTS" ++ name)

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/MigrateIndex.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/MigrateIndex.hs
@@ -41,4 +41,4 @@ dropIndexPlan name schemaState = do
   guard (schemaStateIndexExists name schemaState)
   -- Here we drop the index only if it exists so that during the migration plan
   -- should something else prior cause the index to be dropped we will not cause an error.
-  pure $ migrationDDLForItem (DropIndex name) ("DROP INDEX IF EXISTS" ++ name)
+  pure $ migrationDDLForItem (DropIndex name) ("DROP INDEX IF EXISTS " ++ name)


### PR DESCRIPTION
This fixes #141