### PR TITLE
LibPQ: Exposes `withConnection`

### DIFF
--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL.hs
@@ -10,6 +10,7 @@ module Database.Orville.PostgreSQL
     Orville.Orville,
     Orville.runOrville,
     MonadOrville.MonadOrville,
+    MonadOrville.withConnection,
     MonadOrville.MonadOrvilleControl (liftWithConnection),
     MonadOrville.HasOrvilleState (askOrvilleState, localOrvilleState),
     MonadOrville.OrvilleState,


### PR DESCRIPTION
I missed exposing this when I added `MonadOrville`