### PR TITLE
LibPQ: Adds SelectOptions with WhereCondition

### DIFF
--- a/orville-postgresql-libpq/orville-postgresql-libpq.cabal
+++ b/orville-postgresql-libpq/orville-postgresql-libpq.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: f01c660c8806d3d6a9cae7ec8e93ae903084eb286faa431db51bf20e905071b9
+-- hash: 9add8aabc0da78d0ae39ac3b1feb0880f1f024d2031b911ea1411537137ad1aa
 
 name:           orville-postgresql-libpq
 version:        0.10.0.0
@@ -39,6 +39,7 @@ library
       Database.Orville.PostgreSQL.Internal.PGTextFormatValue
       Database.Orville.PostgreSQL.Internal.PrimaryKey
       Database.Orville.PostgreSQL.Internal.RawSql
+      Database.Orville.PostgreSQL.Internal.SelectOptions
       Database.Orville.PostgreSQL.Internal.SqlMarshaller
       Database.Orville.PostgreSQL.Internal.SqlType
       Database.Orville.PostgreSQL.Internal.SqlValue
@@ -66,6 +67,8 @@ library
       Database.Orville.PostgreSQL.Internal.MonadOrville
       Database.Orville.PostgreSQL.Internal.Orville
       Database.Orville.PostgreSQL.Internal.RecordOperations
+      Database.Orville.PostgreSQL.Internal.SelectOptions.SelectOptions
+      Database.Orville.PostgreSQL.Internal.SelectOptions.WhereCondition
       Paths_orville_postgresql_libpq
   hs-source-dirs:
       src
@@ -95,8 +98,10 @@ test-suite spec
       Test.Expr
       Test.FieldDefinition
       Test.PGGen
+      Test.PropertyHelpers
       Test.RawSql
       Test.RecordOperations
+      Test.SelectOptions
       Test.SqlMarshaller
       Test.SqlType
       Test.TableDefinition

--- a/orville-postgresql-libpq/package.yaml
+++ b/orville-postgresql-libpq/package.yaml
@@ -29,6 +29,7 @@ library:
     - Database.Orville.PostgreSQL.Internal.PGTextFormatValue
     - Database.Orville.PostgreSQL.Internal.PrimaryKey
     - Database.Orville.PostgreSQL.Internal.RawSql
+    - Database.Orville.PostgreSQL.Internal.SelectOptions
     - Database.Orville.PostgreSQL.Internal.SqlMarshaller
     - Database.Orville.PostgreSQL.Internal.SqlType
     - Database.Orville.PostgreSQL.Internal.SqlValue
@@ -81,8 +82,10 @@ tests:
       - Test.Expr
       - Test.FieldDefinition
       - Test.PGGen
+      - Test.PropertyHelpers
       - Test.RawSql
       - Test.RecordOperations
+      - Test.SelectOptions
       - Test.SqlMarshaller
       - Test.SqlType
       - Test.TableDefinition

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL.hs
@@ -14,6 +14,20 @@ module Database.Orville.PostgreSQL
     MonadOrville.MonadOrvilleControl (liftWithConnection),
     MonadOrville.HasOrvilleState (askOrvilleState, localOrvilleState),
     MonadOrville.OrvilleState,
+    SelectOptions.SelectOptions,
+    SelectOptions.where_,
+    SelectOptions.emptySelectOptions,
+    SelectOptions.appendSelectOptions,
+    SelectOptions.WhereCondition,
+    SelectOptions.whereEquals,
+    SelectOptions.whereNotEquals,
+    SelectOptions.whereGreaterThan,
+    SelectOptions.whereLessThan,
+    SelectOptions.whereGreaterThanOrEqualTo,
+    SelectOptions.whereLessThanOrEqualTo,
+    SelectOptions.whereBooleanExpr,
+    SelectOptions.whereAnd,
+    SelectOptions.whereOr,
     SqlType.SqlType
       ( SqlType.SqlType,
         SqlType.sqlTypeExpr,
@@ -56,5 +70,6 @@ import qualified Database.Orville.PostgreSQL.Internal.Expr as Expr
 import qualified Database.Orville.PostgreSQL.Internal.MonadOrville as MonadOrville
 import qualified Database.Orville.PostgreSQL.Internal.Orville as Orville
 import qualified Database.Orville.PostgreSQL.Internal.RecordOperations as RecordOperations
+import qualified Database.Orville.PostgreSQL.Internal.SelectOptions as SelectOptions
 import qualified Database.Orville.PostgreSQL.Internal.SqlType as SqlType
 import qualified Database.Orville.PostgreSQL.Internal.TableDefinition as TableDefinition

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr.hs
@@ -29,6 +29,7 @@ module Database.Orville.PostgreSQL.Internal.Expr
     parenthesized,
     comparison,
     columnEquals,
+    columnNotEquals,
     columnGreaterThan,
     columnLessThan,
     columnGreaterThanOrEqualTo,

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/Where/BooleanExpr.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/Where/BooleanExpr.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {- |
 Module    : Database.Orville.PostgreSQL.Expr.Where.BooleanExpr
 Copyright : Flipstone Technology Partners 2016-2021
@@ -11,6 +12,7 @@ module Database.Orville.PostgreSQL.Internal.Expr.Where.BooleanExpr
     parenthesized,
     comparison,
     columnEquals,
+    columnNotEquals,
     columnGreaterThan,
     columnLessThan,
     columnGreaterThanOrEqualTo,
@@ -19,12 +21,14 @@ module Database.Orville.PostgreSQL.Internal.Expr.Where.BooleanExpr
 where
 
 import Database.Orville.PostgreSQL.Internal.Expr.Name (ColumnName)
-import Database.Orville.PostgreSQL.Internal.Expr.Where.ComparisonOperator (ComparisonOperator, comparisonOperatorToSql, equalsOp, greaterThanOp, greaterThanOrEqualsOp, lessThanOp, lessThanOrEqualsOp)
+import Database.Orville.PostgreSQL.Internal.Expr.Where.ComparisonOperator (ComparisonOperator, comparisonOperatorToSql, equalsOp, greaterThanOp, greaterThanOrEqualsOp, lessThanOp, lessThanOrEqualsOp, notEqualsOp)
 import Database.Orville.PostgreSQL.Internal.Expr.Where.RowValuePredicand (RowValuePredicand, columnReference, comparisonValue, rowValuePredicandToSql)
 import qualified Database.Orville.PostgreSQL.Internal.RawSql as RawSql
 import Database.Orville.PostgreSQL.Internal.SqlValue (SqlValue)
 
-newtype BooleanExpr = BooleanExpr RawSql.RawSql
+newtype BooleanExpr =
+  BooleanExpr RawSql.RawSql
+  deriving (RawSql.ToRawSql)
 
 booleanExprToSql :: BooleanExpr -> RawSql.RawSql
 booleanExprToSql (BooleanExpr sql) = sql
@@ -64,6 +68,10 @@ comparison left op right =
 columnEquals :: ColumnName -> SqlValue -> BooleanExpr
 columnEquals name value =
   comparison (columnReference name) equalsOp (comparisonValue value)
+
+columnNotEquals :: ColumnName -> SqlValue -> BooleanExpr
+columnNotEquals name value =
+  comparison (columnReference name) notEqualsOp (comparisonValue value)
 
 columnGreaterThan :: ColumnName -> SqlValue -> BooleanExpr
 columnGreaterThan name value =

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/Where/WhereClause.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/Expr/Where/WhereClause.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {- |
 Module    : Database.Orville.PostgreSQL.Expr.Where.WhereClause
 Copyright : Flipstone Technology Partners 2016-2021
@@ -15,6 +16,7 @@ import qualified Database.Orville.PostgreSQL.Internal.RawSql as RawSql
 
 newtype WhereClause
   = WhereClause RawSql.RawSql
+  deriving (RawSql.ToRawSql)
 
 whereClauseToSql :: WhereClause -> RawSql.RawSql
 whereClauseToSql (WhereClause sql) = sql

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/RawSql.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/RawSql.hs
@@ -12,7 +12,6 @@ module Database.Orville.PostgreSQL.Internal.RawSql
     parameter,
     fromString,
     fromBytes,
-    toBytesAndParams,
     intercalate,
     execute,
     executeVoid,
@@ -22,6 +21,11 @@ module Database.Orville.PostgreSQL.Internal.RawSql
     comma,
     leftParen,
     rightParen,
+
+    -- * Generic interface for generating sql
+    ToRawSql(toRawSql),
+    toBytesAndParams,
+    toBytes,
   )
 where
 
@@ -59,17 +63,32 @@ instance Semigroup RawSql where
 instance Monoid RawSql where
   mempty = SqlSection mempty
 
+class ToRawSql a where
+  toRawSql :: a -> RawSql
+
+instance ToRawSql RawSql where
+  toRawSql = id
+
 {- |
   Constructs the actual sql bytestring and parameter values that will be
   passed to the database to execute a 'RawSql' query.
 -}
-toBytesAndParams :: RawSql -> (BS.ByteString, [Maybe PGTextFormatValue])
-toBytesAndParams rawSql =
+toBytesAndParams :: ToRawSql sql => sql -> (BS.ByteString, [Maybe PGTextFormatValue])
+toBytesAndParams sql =
   let (byteBuilder, finalProgress) =
-        buildSqlWithProgress startingProgress rawSql
+        buildSqlWithProgress startingProgress (toRawSql sql)
    in ( LBS.toStrict (BSB.toLazyByteString byteBuilder)
       , DList.toList (paramValues finalProgress)
       )
+
+{- |
+  Builds te bytes that represent the raw sql. These bytes may not be executable
+  on their own, because they may contain placeholders that must be filled in,
+  but can be useful for inspecting sql queries.
+-}
+toBytes :: ToRawSql sql => sql -> BS.ByteString
+toBytes =
+  fst . toBytesAndParams
 
 {- |
   This is an internal datatype used during the sql building process to track
@@ -175,10 +194,10 @@ intercalate separator parts =
   to read the documentation of 'Conn.executeRaw' for caveats and warnings.
   Use with caution.
 -}
-execute :: Connection -> RawSql -> IO LibPQ.Result
-execute connection rawSql =
+execute :: ToRawSql sql => Connection -> sql -> IO LibPQ.Result
+execute connection sql =
   let (sqlBytes, params) =
-        toBytesAndParams rawSql
+        toBytesAndParams sql
    in Conn.executeRaw connection sqlBytes params
 
 {- |
@@ -186,10 +205,10 @@ execute connection rawSql =
   to read the documentation of 'Conn.executeRawVoid' for caveats and warnings.
   Use with caution.
 -}
-executeVoid :: Connection -> RawSql -> IO ()
-executeVoid connection rawSql =
+executeVoid :: ToRawSql sql => Connection -> sql -> IO ()
+executeVoid connection sql =
   let (sqlBytes, params) =
-        toBytesAndParams rawSql
+        toBytesAndParams sql
    in Conn.executeRawVoid connection sqlBytes params
 
 -- | Just a plain old space, provided for convenience

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/SelectOptions.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/SelectOptions.hs
@@ -1,0 +1,9 @@
+{-# OPTIONS_GHC -Wno-missing-import-lists #-}
+
+module Database.Orville.PostgreSQL.Internal.SelectOptions
+  ( module Export,
+  )
+where
+
+import Database.Orville.PostgreSQL.Internal.SelectOptions.SelectOptions as Export
+import Database.Orville.PostgreSQL.Internal.SelectOptions.WhereCondition as Export

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/SelectOptions/SelectOptions.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/SelectOptions/SelectOptions.hs
@@ -1,0 +1,70 @@
+module Database.Orville.PostgreSQL.Internal.SelectOptions.SelectOptions
+  ( SelectOptions,
+    emptySelectOptions,
+    appendSelectOptions,
+    selectWhereClause,
+    where_,
+  )
+where
+
+import Data.List.NonEmpty (NonEmpty ((:|)))
+
+import qualified Database.Orville.PostgreSQL.Internal.Expr as Expr
+import Database.Orville.PostgreSQL.Internal.SelectOptions.WhereCondition (WhereCondition, whereAnd, whereConditionToBooleanExpr)
+
+{-|
+   A 'SelectOptions' is a set of options that can be used to change the way
+   a basic query function works by adding 'WHERE', 'ORDER BY', 'GROUP BY', etc.
+   Functions are provided to construct 'SelectOptions' for individual options,
+   which may then be combined via '<>' (also exposed as 'appendSelectOptions').
+-}
+data SelectOptions = SelectOptions
+  { i_whereConditions :: [WhereCondition]
+  }
+
+instance Semigroup SelectOptions where
+  (<>) = appendSelectOptions
+
+instance Monoid SelectOptions where
+  mempty = emptySelectOptions
+
+{-|
+  A set of empty 'SelectOptions' that will not change how a query is run.
+-}
+emptySelectOptions :: SelectOptions
+emptySelectOptions =
+  SelectOptions
+    { i_whereConditions = []
+    }
+
+{-|
+  Combines multple select options together, unioning the options together where
+  possible. For options where this is not possible, (e.g. 'LIMIT'), the one
+  on the left is preferred.
+-}
+appendSelectOptions :: SelectOptions -> SelectOptions -> SelectOptions
+appendSelectOptions left right =
+  SelectOptions
+    (i_whereConditions left <> i_whereConditions right)
+
+{-|
+  Builds the 'Expr.WhereClause' that should be used to include the
+  'WhereCondition's from the 'SelectOptions' on a query. This will be 'Nothing'
+  where no 'WhereCondition's have been specified.
+-}
+selectWhereClause :: SelectOptions -> Maybe Expr.WhereClause
+selectWhereClause selectOptions =
+  case i_whereConditions selectOptions of
+    [] ->
+      Nothing
+    (first : rest) ->
+      Just . Expr.whereClause . whereConditionToBooleanExpr $ whereAnd (first :| rest)
+
+{-|
+  Constructs a 'SelectOptions' with just the given 'WhereCondition'.
+-}
+where_ :: WhereCondition -> SelectOptions
+where_ condition =
+  emptySelectOptions
+    { i_whereConditions = [condition]
+    }

--- a/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/SelectOptions/WhereCondition.hs
+++ b/orville-postgresql-libpq/src/Database/Orville/PostgreSQL/Internal/SelectOptions/WhereCondition.hs
@@ -1,0 +1,134 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+module Database.Orville.PostgreSQL.Internal.SelectOptions.WhereCondition
+  ( WhereCondition,
+    whereEquals,
+    whereNotEquals,
+    whereGreaterThan,
+    whereLessThan,
+    whereGreaterThanOrEqualTo,
+    whereLessThanOrEqualTo,
+    whereAnd,
+    whereOr,
+    whereBooleanExpr,
+    whereConditionToBooleanExpr,
+  )
+where
+
+import Data.List.NonEmpty (NonEmpty ((:|)))
+
+import qualified Database.Orville.PostgreSQL.Internal.Expr as Expr
+import qualified Database.Orville.PostgreSQL.Internal.FieldDefinition as FieldDef
+import qualified Database.Orville.PostgreSQL.Internal.RawSql as RawSql
+import qualified Database.Orville.PostgreSQL.Internal.SqlValue as SqlValue
+
+{- |
+  A 'WhereCondition' represents a SQL expression that can be added to SELECT
+  statements to restrict the rows returned by a query. Various functions
+  are provided below to construct conditions.
+-}
+newtype WhereCondition
+  = WhereCondition Expr.BooleanExpr
+  deriving (RawSql.ToRawSql)
+
+{- |
+  Constructs a 'WhereCondition' from a 'Expr.BooleanExpr'. You can use this
+  to together with the 'RawSql.RawSql' related functions in the 'Expr' module
+  to use SQL expressions Orville does not have direct support for in your
+  queries.
+-}
+whereBooleanExpr :: Expr.BooleanExpr -> WhereCondition
+whereBooleanExpr =
+  WhereCondition
+
+{- |
+  Converts a 'WhereCondition' into a 'Expr.BooleanExpr' so that you can use it
+  with the functions from the 'Expr' module if you are building SQL expressions
+  yourself.
+-}
+whereConditionToBooleanExpr :: WhereCondition -> Expr.BooleanExpr
+whereConditionToBooleanExpr (WhereCondition expr) =
+  expr
+
+{- |
+  Checks that the value in a field equals a particular value.
+-}
+whereEquals :: FieldDef.FieldDefinition nullability a -> a -> WhereCondition
+whereEquals =
+  whereColumnComparison Expr.columnEquals
+
+{- |
+  Checks that the value in a field does not equal a particular value.
+-}
+whereNotEquals :: FieldDef.FieldDefinition nullability a -> a -> WhereCondition
+whereNotEquals =
+  whereColumnComparison Expr.columnNotEquals
+
+{- |
+  Checks that the value in a field is greater than a particular value.
+-}
+whereGreaterThan :: FieldDef.FieldDefinition nullability a -> a -> WhereCondition
+whereGreaterThan =
+  whereColumnComparison Expr.columnGreaterThan
+
+{- |
+  Checks that the value in a field is less than a particular value.
+-}
+whereLessThan :: FieldDef.FieldDefinition nullability a -> a -> WhereCondition
+whereLessThan =
+  whereColumnComparison Expr.columnLessThan
+
+{- |
+  Checks that the value in a field is greater than or equal to a particular value.
+-}
+whereGreaterThanOrEqualTo :: FieldDef.FieldDefinition nullability a -> a -> WhereCondition
+whereGreaterThanOrEqualTo =
+  whereColumnComparison Expr.columnGreaterThanOrEqualTo
+
+{- |
+  Checks that the value in a field is less than or equal to a particular value.
+-}
+whereLessThanOrEqualTo :: FieldDef.FieldDefinition nullability a -> a -> WhereCondition
+whereLessThanOrEqualTo =
+  whereColumnComparison Expr.columnLessThanOrEqualTo
+
+{- |
+  INTERNAL: Constructs a field-based 'WhereCondition' using a function that
+  builds a 'Expr.BooleanExpr'
+-}
+whereColumnComparison ::
+  (Expr.ColumnName -> SqlValue.SqlValue -> Expr.BooleanExpr) ->
+  (FieldDef.FieldDefinition nullability a -> a -> WhereCondition)
+whereColumnComparison columnComparison fieldDef a =
+  WhereCondition $
+    columnComparison
+      (FieldDef.fieldColumnName fieldDef)
+      (FieldDef.fieldValueToSqlValue fieldDef a)
+
+{- |
+  Combines multiple 'WhereCondition's together using 'AND'.
+-}
+whereAnd :: NonEmpty WhereCondition -> WhereCondition
+whereAnd =
+  foldParenthenizedExprs Expr.andExpr
+
+{- |
+  Combines multiple 'WhereCondition's together using 'OR.
+-}
+whereOr :: NonEmpty WhereCondition -> WhereCondition
+whereOr =
+  foldParenthenizedExprs Expr.orExpr
+
+{- |
+  INTERNAL: Combines a (non-empty) list of 'WhereCondition's together using
+  the provided function to combine each pair.
+-}
+foldParenthenizedExprs ::
+  (Expr.BooleanExpr -> Expr.BooleanExpr -> Expr.BooleanExpr) ->
+  NonEmpty WhereCondition ->
+  WhereCondition
+foldParenthenizedExprs foldExpr conditions =
+  let (first :| rest) =
+        fmap
+          (Expr.parenthesized . whereConditionToBooleanExpr)
+          conditions
+       in WhereCondition $ foldr (flip foldExpr) first rest

--- a/orville-postgresql-libpq/test/Main.hs
+++ b/orville-postgresql-libpq/test/Main.hs
@@ -13,6 +13,7 @@ import Test.Expr (exprSpecs)
 import Test.FieldDefinition (fieldDefinitionTree)
 import Test.RawSql (rawSqlSpecs)
 import Test.RecordOperations (recordOperationsTree)
+import Test.SelectOptions (selectOptionsTree)
 import Test.SqlMarshaller (sqlMarshallerTree)
 import Test.SqlType (sqlTypeSpecs)
 import Test.TableDefinition (tableDefinitionTree)
@@ -36,5 +37,6 @@ main = do
       , sqlMarshallerTree
       , fieldDefinitionTree pool
       , tableDefinitionTree pool
+      , selectOptionsTree
       , recordOperationsTree pool
       ]

--- a/orville-postgresql-libpq/test/Test/Connection.hs
+++ b/orville-postgresql-libpq/test/Test/Connection.hs
@@ -22,6 +22,7 @@ import qualified Database.Orville.PostgreSQL.Connection as Connection
 import qualified Database.Orville.PostgreSQL.Internal.PGTextFormatValue as PGTextFormatValue
 
 import qualified Test.PGGen as PGGen
+import           Test.PropertyHelpers (testPropertyOnce)
 
 connectionTree :: Pool Connection -> TestTree
 connectionTree pool =
@@ -99,7 +100,7 @@ connectionTree pool =
         value === Just bytesBefore
     , -- Note: we only run this test once to cut down on the number of errors
       -- printed out by the database server when running tests repeatedly.
-      testProperty "executeRaw returns error if invalid sql is given" . HH.withTests 1 . HH.property $ do
+      testPropertyOnce "executeRaw returns error if invalid sql is given" . HH.property $ do
         -- We generate non-empty queries here becaues libpq returns different
         -- error details when an empty string is passed
         randomText <- HH.forAll $ PGGen.pgText (Range.constant 1 16)

--- a/orville-postgresql-libpq/test/Test/FieldDefinition.hs
+++ b/orville-postgresql-libpq/test/Test/FieldDefinition.hs
@@ -26,6 +26,7 @@ import qualified Database.Orville.PostgreSQL.Internal.RawSql as RawSql
 import qualified Database.Orville.PostgreSQL.Internal.SqlValue as SqlValue
 
 import qualified Test.PGGen as PGGen
+import Test.PropertyHelpers (testPropertyOnce)
 
 fieldDefinitionTree :: Pool Connection -> TestTree
 fieldDefinitionTree pool =
@@ -91,7 +92,7 @@ testFieldProperties pool fieldDefName roundTripTest =
         runRoundTripTest pool roundTripTest
     , testProperty "can round trip values (nullable)" . HH.property $ do
         runNullableRoundTripTest pool roundTripTest
-    , testProperty "cannot insert null values into a not null field" . HH.withTests 1 . HH.property $ do
+    , testPropertyOnce "cannot insert null values into a not null field" . HH.property $ do
         runNullCounterExampleTest pool roundTripTest
     ]
 

--- a/orville-postgresql-libpq/test/Test/PropertyHelpers.hs
+++ b/orville-postgresql-libpq/test/Test/PropertyHelpers.hs
@@ -1,0 +1,11 @@
+module Test.PropertyHelpers
+  ( testPropertyOnce
+  ) where
+
+import Test.Tasty (TestName, TestTree)
+import qualified Hedgehog as HH
+import Test.Tasty.Hedgehog (testProperty)
+
+testPropertyOnce :: TestName -> HH.Property -> TestTree
+testPropertyOnce description =
+  testProperty description . HH.withTests 1

--- a/orville-postgresql-libpq/test/Test/SelectOptions.hs
+++ b/orville-postgresql-libpq/test/Test/SelectOptions.hs
@@ -1,0 +1,84 @@
+module Test.SelectOptions
+  ( selectOptionsTree
+  ) where
+
+import qualified Data.ByteString.Char8 as B8
+import Data.Int (Int32)
+import qualified Hedgehog as HH
+import Hedgehog ((===))
+import Data.List.NonEmpty (NonEmpty((:|)))
+import Test.Tasty (TestTree, testGroup)
+
+import qualified Database.Orville.PostgreSQL.Internal.SelectOptions as SO
+import qualified Database.Orville.PostgreSQL.Internal.FieldDefinition as FieldDef
+import qualified Database.Orville.PostgreSQL.Internal.RawSql as RawSql
+
+import Test.PropertyHelpers (testPropertyOnce)
+
+selectOptionsTree :: TestTree
+selectOptionsTree =
+  testGroup
+    "SelectOptions"
+    [ testPropertyOnce "emptySelectOptions yields no whereClause" . HH.property $
+        assertWhereClauseEquals
+          Nothing
+          SO.emptySelectOptions
+
+    , testPropertyOnce "whereEquals generates expected sql" . HH.property $
+        assertWhereClauseEquals
+          (Just "WHERE (foo = $1)")
+          (SO.where_ $ SO.whereEquals fooField 0)
+
+    , testPropertyOnce "whereNotEquals generates expected sql" . HH.property $
+        assertWhereClauseEquals
+          (Just "WHERE (foo <> $1)")
+          (SO.where_ $ SO.whereNotEquals fooField 0)
+
+    , testPropertyOnce "whereLessThan generates expected sql" . HH.property $
+        assertWhereClauseEquals
+          (Just "WHERE (foo < $1)")
+          (SO.where_ $ SO.whereLessThan fooField 0)
+
+    , testPropertyOnce "whereGreaterThan generates expected sql" . HH.property $
+        assertWhereClauseEquals
+          (Just "WHERE (foo > $1)")
+          (SO.where_ $ SO.whereGreaterThan fooField 0)
+
+    , testPropertyOnce "whereLessThanOrEqualTo generates expected sql" . HH.property $
+        assertWhereClauseEquals
+          (Just "WHERE (foo <= $1)")
+          (SO.where_ $ SO.whereLessThanOrEqualTo fooField 0)
+
+    , testPropertyOnce "whereGreaterThanOrEqualTo generates expected sql" . HH.property $
+        assertWhereClauseEquals
+          (Just "WHERE (foo >= $1)")
+          (SO.where_ $ SO.whereGreaterThanOrEqualTo fooField 0)
+
+    , testPropertyOnce "whereAnd generates expected sql" . HH.property $
+        assertWhereClauseEquals
+          (Just "WHERE ((foo = $1) AND (bar = $2))")
+          (SO.where_ $ SO.whereAnd (SO.whereEquals fooField 10 :| [SO.whereEquals barField 20]))
+
+    , testPropertyOnce "whereOr generates expected sql" . HH.property $
+        assertWhereClauseEquals
+          (Just "WHERE ((foo = $1) OR (bar = $2))")
+          (SO.where_ $ SO.whereOr (SO.whereEquals fooField 10 :| [SO.whereEquals barField 20]))
+
+    , testPropertyOnce "combining SelectOptions ANDs the where clauses together" . HH.property $
+        assertWhereClauseEquals
+          (Just "WHERE (foo = $1) AND (bar = $2)")
+          (SO.where_ (SO.whereEquals fooField 10)
+          <> SO.where_ (SO.whereEquals barField 20))
+    ]
+
+assertWhereClauseEquals :: HH.MonadTest m => Maybe String -> SO.SelectOptions -> m ()
+assertWhereClauseEquals mbWhereClause selectOptions =
+  fmap RawSql.toBytes (SO.selectWhereClause selectOptions) === fmap B8.pack mbWhereClause
+
+fooField :: FieldDef.FieldDefinition FieldDef.NotNull Int32
+fooField =
+  FieldDef.integerField "foo"
+
+barField :: FieldDef.FieldDefinition FieldDef.NotNull Int32
+barField =
+  FieldDef.integerField "bar"

--- a/orville-postgresql-libpq/test/Test/TableDefinition.hs
+++ b/orville-postgresql-libpq/test/Test/TableDefinition.hs
@@ -20,6 +20,7 @@ import Database.Orville.PostgreSQL.Internal.SqlMarshaller (marshallResultFromSql
 import Database.Orville.PostgreSQL.Internal.TableDefinition (mkInsertExpr, mkQueryExpr, tableMarshaller)
 
 import qualified Test.Entities.Foo as Foo
+import Test.PropertyHelpers (testPropertyOnce)
 import qualified Test.TestTable as TestTable
 
 tableDefinitionTree :: Pool Connection -> TestTree
@@ -43,7 +44,7 @@ tableDefinitionTree pool =
             marshallResultFromSql (tableMarshaller Foo.table) result
 
         foosFromDB === Right [originalFoo]
-    , testProperty "Creates a primary key that rejects duplicate records" . HH.withTests 1 . HH.property $ do
+    , testPropertyOnce "Creates a primary key that rejects duplicate records" . HH.property $ do
         originalFoo <- HH.forAll Foo.generate
 
         let insertFoo =


### PR DESCRIPTION
This begins porting the `SelectOptions` type, only supporting
`WhereCondition`s for the moment.

I opted to forego the old version `WhereCondition` that modeled where
conditions explicity in Haskell in favor of just a newtype wrapper
around `BooleanExpr`. This made it much easier to implement and provided
an obvious and natural interface for incorporated expression that
Orville does not support directly into the higher-level API.

I also introduced a `ToRawSql` class that I think can help us make some
function more re-useable. I only added it in a few places for the
moment, but if we like this direction then we can adjust the rest of the
`Expr` interface to orient around it.