### PR TITLE
Add deleteEntity and deleteExpr

### DIFF
--- a/orville-postgresql-libpq/orville-postgresql-libpq.cabal
+++ b/orville-postgresql-libpq/orville-postgresql-libpq.cabal
@@ -63,6 +63,7 @@ library
       Orville.PostgreSQL.Internal.Expr.Query.TableExpr
       Orville.PostgreSQL.Internal.Expr.TableDefinition
       Orville.PostgreSQL.Internal.Expr.Update
+      Orville.PostgreSQL.Internal.Expr.Delete
       Orville.PostgreSQL.Internal.Expr.Where
       Orville.PostgreSQL.Internal.Expr.Where.BooleanExpr
       Orville.PostgreSQL.Internal.Expr.Where.ComparisonOperator

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
@@ -7,6 +7,7 @@ module Orville.PostgreSQL
   ( EntityOperations.insertEntity,
     EntityOperations.insertEntities,
     EntityOperations.updateEntity,
+    EntityOperations.deleteEntity,
     EntityOperations.findEntitiesBy,
     EntityOperations.findFirstEntityBy,
     EntityOperations.findEntity,

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/EntityOperations.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/EntityOperations.hs
@@ -2,6 +2,7 @@ module Orville.PostgreSQL.Internal.EntityOperations
   ( insertEntity,
     insertEntities,
     updateEntity,
+    deleteEntity,
     findEntitiesBy,
     findFirstEntityBy,
     findEntity,
@@ -64,6 +65,21 @@ updateEntity tableDef key writeEntity =
       RawSql.executeVoid
         connection
         (TableDef.mkUpdateExpr tableDef key writeEntity)
+
+{- |
+  Deletes the row with the given key
+-}
+deleteEntity ::
+  MonadOrville.MonadOrville m =>
+  TableDef.TableDefinition key writeEntity readEntity ->
+  key ->
+  m ()
+deleteEntity tableDef key =
+  MonadOrville.withConnection $ \connection ->
+    liftIO $
+      RawSql.executeVoid
+        connection
+        (TableDef.mkDeleteExpr tableDef key)
 
 {- |
   Finds all the entities in the given table according to the specified

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr.hs
@@ -36,6 +36,8 @@ module Orville.PostgreSQL.Internal.Expr
     groupByExpr,
     LimitExpr,
     limitExpr,
+    DeleteExpr,
+    deleteExpr,
     InsertExpr,
     insertExpr,
     InsertColumnList,
@@ -80,6 +82,7 @@ module Orville.PostgreSQL.Internal.Expr
 where
 
 import Orville.PostgreSQL.Internal.Expr.ColumnDefinition
+import Orville.PostgreSQL.Internal.Expr.Delete
 import Orville.PostgreSQL.Internal.Expr.GroupBy
 import Orville.PostgreSQL.Internal.Expr.InsertExpr
 import Orville.PostgreSQL.Internal.Expr.LimitExpr

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/Delete.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/Delete.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Orville.PostgreSQL.Internal.Expr.Delete
+  ( DeleteExpr,
+    deleteExpr,
+  )
+where
+
+import Data.Maybe (maybeToList)
+
+import Orville.PostgreSQL.Internal.Expr.Name (TableName)
+import Orville.PostgreSQL.Internal.Expr.Where (WhereClause)
+import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+
+newtype DeleteExpr
+  = DeleteExpr RawSql.RawSql
+  deriving (RawSql.SqlExpression)
+
+deleteExpr ::
+  TableName ->
+  Maybe WhereClause ->
+  DeleteExpr
+deleteExpr tableName maybeWhereClause =
+  DeleteExpr $
+    RawSql.intercalate
+      RawSql.space
+      ( RawSql.fromString "DELETE FROM" :
+        RawSql.toRawSql tableName :
+        maybeToList (RawSql.toRawSql <$> maybeWhereClause)
+      )

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/TableDefinition.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/TableDefinition.hs
@@ -12,6 +12,7 @@ module Orville.PostgreSQL.Internal.TableDefinition
     mkInsertSource,
     mkQueryExpr,
     mkUpdateExpr,
+    mkDeleteExpr,
   )
 where
 
@@ -180,6 +181,22 @@ mkUpdateExpr tableDef key writeEntity =
    in Expr.updateExpr
         (tableName tableDef)
         (Expr.setClauseList setClauses)
+        (Just (Expr.whereClause isEntityKey))
+
+{- |
+  Builds an 'Expr.DeleteExpr' that will delete the entity with the given 'key'.
+-}
+mkDeleteExpr ::
+  TableDefinition key writeEntity readEntity ->
+  key ->
+  Expr.DeleteExpr
+mkDeleteExpr tableDef key =
+  let isEntityKey =
+        primaryKeyEqualsExpr
+          (tablePrimaryKey tableDef)
+          key
+   in Expr.deleteExpr
+        (tableName tableDef)
         (Just (Expr.whereClause isEntityKey))
 
 {- |


### PR DESCRIPTION
Adds `deleteEntity`, rough sql equivalent:

```sql
DELETE FROM someTable WHERE id = someId;
```

Also adds `deleteExpr`:
```sql
DELETE FROM someTable [WHERE someOptionalWhereClause];
```