### PR TITLE
Make SqlValue more opaque by removing Show, Eq

### DIFF
--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/SqlValue.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/SqlValue.hs
@@ -50,7 +50,6 @@ import qualified Orville.PostgreSQL.Internal.PGTextFormatValue as PGTextFormatVa
 data SqlValue
   = SqlValue PGTextFormatValue
   | SqlNull
-  deriving (Show, Eq)
 
 {- |
   Checks whether the 'SqlValue' represents a sql NULL value in the database.

--- a/orville-postgresql-libpq/test/Test/Expr/GroupBy.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/GroupBy.hs
@@ -17,6 +17,7 @@ import qualified Orville.PostgreSQL.Internal.Expr as Expr
 import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
 import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
 
+import Test.Expr.TestSchema (sqlValuesToText)
 import qualified Test.Property as Property
 
 data FooBar = FooBar
@@ -84,7 +85,7 @@ runGroupByTest pool test = Property.singletonProperty $
             (Expr.tableExpr exprTestTable Nothing Nothing (groupByClause test) Nothing)
 
     rows <- MIO.liftIO $ ExecResult.readRows result
-    rows HH.=== mkGroupByTestExpectedRows test
+    sqlValuesToText rows HH.=== sqlValuesToText (mkGroupByTestExpectedRows test)
 
 testTable :: Expr.TableName
 testTable =

--- a/orville-postgresql-libpq/test/Test/Expr/GroupBy.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/GroupBy.hs
@@ -17,7 +17,7 @@ import qualified Orville.PostgreSQL.Internal.Expr as Expr
 import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
 import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
 
-import Test.Expr.TestSchema (sqlValuesToText)
+import Test.Expr.TestSchema (assertEqualSqlRows)
 import qualified Test.Property as Property
 
 data FooBar = FooBar
@@ -85,7 +85,7 @@ runGroupByTest pool test = Property.singletonProperty $
             (Expr.tableExpr exprTestTable Nothing Nothing (groupByClause test) Nothing)
 
     rows <- MIO.liftIO $ ExecResult.readRows result
-    sqlValuesToText rows HH.=== sqlValuesToText (mkGroupByTestExpectedRows test)
+    rows `assertEqualSqlRows` mkGroupByTestExpectedRows test
 
 testTable :: Expr.TableName
 testTable =

--- a/orville-postgresql-libpq/test/Test/Expr/InsertUpdate.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/InsertUpdate.hs
@@ -45,7 +45,7 @@ insertUpdateTests pool =
 
                   ExecResult.readRows result
 
-            rows === map encodeFooBar fooBars
+            sqlValuesToText rows === sqlValuesToText (map encodeFooBar fooBars)
         )
       ,
         ( String.fromString "updateExpr updates rows in the db"
@@ -78,7 +78,7 @@ insertUpdateTests pool =
 
                   ExecResult.readRows result
 
-            rows === map encodeFooBar newFooBars
+            sqlValuesToText rows === sqlValuesToText (map encodeFooBar newFooBars)
         )
       ,
         ( String.fromString "updateExpr uses a where clause when given"
@@ -111,6 +111,6 @@ insertUpdateTests pool =
 
                   ExecResult.readRows result
 
-            rows === map encodeFooBar newFooBars
+            sqlValuesToText rows === sqlValuesToText (map encodeFooBar newFooBars)
         )
       ]

--- a/orville-postgresql-libpq/test/Test/Expr/InsertUpdate.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/InsertUpdate.hs
@@ -7,7 +7,6 @@ import qualified Control.Monad.IO.Class as MIO
 import qualified Data.Pool as Pool
 import qualified Data.String as String
 import qualified Data.Text as T
-import Hedgehog ((===))
 import qualified Hedgehog as HH
 
 import qualified Orville.PostgreSQL.Connection as Conn
@@ -16,7 +15,7 @@ import qualified Orville.PostgreSQL.Internal.Expr as Expr
 import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
 import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
 
-import Test.Expr.TestSchema (FooBar (..), barColumn, dropAndRecreateTestTable, encodeFooBar, fooBarTable, fooColumn, insertFooBarSource, orderByFoo)
+import Test.Expr.TestSchema (FooBar (..), assertEqualSqlRows, barColumn, dropAndRecreateTestTable, encodeFooBar, fooBarTable, fooColumn, insertFooBarSource, orderByFoo)
 import qualified Test.Property as Property
 
 insertUpdateTests :: Pool.Pool Conn.Connection -> IO Bool
@@ -45,7 +44,7 @@ insertUpdateTests pool =
 
                   ExecResult.readRows result
 
-            sqlValuesToText rows === sqlValuesToText (map encodeFooBar fooBars)
+            rows `assertEqualSqlRows` map encodeFooBar fooBars
         )
       ,
         ( String.fromString "updateExpr updates rows in the db"
@@ -78,7 +77,7 @@ insertUpdateTests pool =
 
                   ExecResult.readRows result
 
-            sqlValuesToText rows === sqlValuesToText (map encodeFooBar newFooBars)
+            rows `assertEqualSqlRows` map encodeFooBar newFooBars
         )
       ,
         ( String.fromString "updateExpr uses a where clause when given"
@@ -111,6 +110,6 @@ insertUpdateTests pool =
 
                   ExecResult.readRows result
 
-            sqlValuesToText rows === sqlValuesToText (map encodeFooBar newFooBars)
+            rows `assertEqualSqlRows` map encodeFooBar newFooBars
         )
       ]

--- a/orville-postgresql-libpq/test/Test/Expr/OrderBy.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/OrderBy.hs
@@ -13,7 +13,7 @@ import qualified Orville.PostgreSQL.Internal.ExecutionResult as ExecResult
 import qualified Orville.PostgreSQL.Internal.Expr as Expr
 import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
 
-import Test.Expr.TestSchema (FooBar (..), barColumn, dropAndRecreateTestTable, encodeFooBar, fooBarTable, fooColumn, insertFooBarSource, sqlValuesToText)
+import Test.Expr.TestSchema (FooBar (..), assertEqualSqlRows, barColumn, dropAndRecreateTestTable, encodeFooBar, fooBarTable, fooColumn, insertFooBarSource)
 import qualified Test.Property as Property
 
 orderByTests :: Pool.Pool Conn.Connection -> IO Bool
@@ -87,4 +87,4 @@ runOrderByTest pool test =
 
           ExecResult.readRows result
 
-    sqlValuesToText rows HH.=== sqlValuesToText (map encodeFooBar (orderByExpectedQueryResults test))
+    rows `assertEqualSqlRows` map encodeFooBar (orderByExpectedQueryResults test)

--- a/orville-postgresql-libpq/test/Test/Expr/OrderBy.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/OrderBy.hs
@@ -13,7 +13,7 @@ import qualified Orville.PostgreSQL.Internal.ExecutionResult as ExecResult
 import qualified Orville.PostgreSQL.Internal.Expr as Expr
 import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
 
-import Test.Expr.TestSchema (FooBar (..), barColumn, dropAndRecreateTestTable, encodeFooBar, fooBarTable, fooColumn, insertFooBarSource)
+import Test.Expr.TestSchema (FooBar (..), barColumn, dropAndRecreateTestTable, encodeFooBar, fooBarTable, fooColumn, insertFooBarSource, sqlValuesToText)
 import qualified Test.Property as Property
 
 orderByTests :: Pool.Pool Conn.Connection -> IO Bool
@@ -87,4 +87,4 @@ runOrderByTest pool test =
 
           ExecResult.readRows result
 
-    rows HH.=== map encodeFooBar (orderByExpectedQueryResults test)
+    sqlValuesToText rows HH.=== sqlValuesToText (map encodeFooBar (orderByExpectedQueryResults test))

--- a/orville-postgresql-libpq/test/Test/Expr/TestSchema.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/TestSchema.hs
@@ -7,6 +7,7 @@ module Test.Expr.TestSchema
     orderByFoo,
     insertFooBarSource,
     dropAndRecreateTestTable,
+    sqlValuesToText,
   )
 where
 
@@ -61,3 +62,7 @@ dropAndRecreateTestTable :: Connection.Connection -> IO ()
 dropAndRecreateTestTable connection = do
   RawSql.executeVoid connection (RawSql.fromString "DROP TABLE IF EXISTS " <> RawSql.toRawSql fooBarTable)
   RawSql.executeVoid connection (RawSql.fromString "CREATE TABLE " <> RawSql.toRawSql fooBarTable <> RawSql.fromString "(foo INTEGER, bar TEXT)")
+
+-- SqlValue doesn't have Show or Eq, so use this to compare them in tests
+sqlValuesToText :: [[(a, SqlValue.SqlValue)]] -> [[(a, Maybe T.Text)]]
+sqlValuesToText = fmap (fmap (\(a, b) -> (a, SqlValue.toText b)))

--- a/orville-postgresql-libpq/test/Test/Expr/TestSchema.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/TestSchema.hs
@@ -7,13 +7,15 @@ module Test.Expr.TestSchema
     orderByFoo,
     insertFooBarSource,
     dropAndRecreateTestTable,
-    sqlValuesToText,
+    assertEqualSqlRows,
+    sqlRowsToText,
   )
 where
 
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Int as Int
 import qualified Data.Text as T
+import qualified Hedgehog as HH
 
 import qualified Orville.PostgreSQL.Connection as Connection
 import qualified Orville.PostgreSQL.Internal.Expr as Expr
@@ -64,5 +66,12 @@ dropAndRecreateTestTable connection = do
   RawSql.executeVoid connection (RawSql.fromString "CREATE TABLE " <> RawSql.toRawSql fooBarTable <> RawSql.fromString "(foo INTEGER, bar TEXT)")
 
 -- SqlValue doesn't have Show or Eq, so use this to compare them in tests
-sqlValuesToText :: [[(a, SqlValue.SqlValue)]] -> [[(a, Maybe T.Text)]]
-sqlValuesToText = fmap (fmap (\(a, b) -> (a, SqlValue.toText b)))
+assertEqualSqlRows ::
+  (Show a, Eq a, HH.MonadTest m) =>
+  [[(a, SqlValue.SqlValue)]] ->
+  [[(a, SqlValue.SqlValue)]] ->
+  m ()
+assertEqualSqlRows l r = sqlRowsToText l HH.=== sqlRowsToText r
+
+sqlRowsToText :: [[(a, SqlValue.SqlValue)]] -> [[(a, Maybe T.Text)]]
+sqlRowsToText = fmap (fmap (\(a, b) -> (a, SqlValue.toText b)))

--- a/orville-postgresql-libpq/test/Test/Expr/Where.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/Where.hs
@@ -15,7 +15,7 @@ import qualified Orville.PostgreSQL.Internal.Expr as Expr
 import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
 import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
 
-import Test.Expr.TestSchema (FooBar (..), barColumn, dropAndRecreateTestTable, encodeFooBar, fooBarTable, fooColumn, insertFooBarSource)
+import Test.Expr.TestSchema (FooBar (..), barColumn, dropAndRecreateTestTable, encodeFooBar, fooBarTable, fooColumn, insertFooBarSource, sqlValuesToText)
 import qualified Test.Property as Property
 
 whereTests :: Pool.Pool Connection.Connection -> IO Bool
@@ -140,4 +140,4 @@ runWhereConditionTest pool test =
 
           ExecResult.readRows result
 
-    rows HH.=== map encodeFooBar (whereExpectedQueryResults test)
+    sqlValuesToText rows HH.=== sqlValuesToText (map encodeFooBar (whereExpectedQueryResults test))

--- a/orville-postgresql-libpq/test/Test/Expr/Where.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/Where.hs
@@ -15,7 +15,7 @@ import qualified Orville.PostgreSQL.Internal.Expr as Expr
 import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
 import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
 
-import Test.Expr.TestSchema (FooBar (..), barColumn, dropAndRecreateTestTable, encodeFooBar, fooBarTable, fooColumn, insertFooBarSource, sqlValuesToText)
+import Test.Expr.TestSchema (FooBar (..), assertEqualSqlRows, barColumn, dropAndRecreateTestTable, encodeFooBar, fooBarTable, fooColumn, insertFooBarSource)
 import qualified Test.Property as Property
 
 whereTests :: Pool.Pool Connection.Connection -> IO Bool
@@ -140,4 +140,4 @@ runWhereConditionTest pool test =
 
           ExecResult.readRows result
 
-    sqlValuesToText rows HH.=== sqlValuesToText (map encodeFooBar (whereExpectedQueryResults test))
+    rows `assertEqualSqlRows` map encodeFooBar (whereExpectedQueryResults test)

--- a/orville-postgresql-libpq/test/Test/FieldDefinition.hs
+++ b/orville-postgresql-libpq/test/Test/FieldDefinition.hs
@@ -22,6 +22,7 @@ import qualified Orville.PostgreSQL.Internal.FieldDefinition as FieldDef
 import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
 import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
 
+import Test.Expr.TestSchema (sqlValuesToText)
 import qualified Test.PGGen as PGGen
 import qualified Test.Property as Property
 
@@ -199,7 +200,7 @@ runRoundTripTest pool testCase =
             [[(_, sqlValue)]] ->
               Right (FieldDef.fieldValueFromSqlValue fieldDef sqlValue)
             _ ->
-              Left ("Expected one row with one value in results, but got: " ++ show rows)
+              Left ("Expected one row with one value in results, but got: " ++ show (sqlValuesToText rows))
 
     roundTripResult HH.=== Right (Just value)
 
@@ -235,7 +236,7 @@ runNullableRoundTripTest pool testCase =
             [[(_, sqlValue)]] ->
               Right (FieldDef.fieldValueFromSqlValue fieldDef sqlValue)
             _ ->
-              Left ("Expected one row with one value in results, but got: " ++ show rows)
+              Left ("Expected one row with one value in results, but got: " ++ show (sqlValuesToText rows))
 
     roundTripResult HH.=== Right (Just value)
 

--- a/orville-postgresql-libpq/test/Test/FieldDefinition.hs
+++ b/orville-postgresql-libpq/test/Test/FieldDefinition.hs
@@ -22,7 +22,7 @@ import qualified Orville.PostgreSQL.Internal.FieldDefinition as FieldDef
 import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
 import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
 
-import Test.Expr.TestSchema (sqlValuesToText)
+import Test.Expr.TestSchema (sqlRowsToText)
 import qualified Test.PGGen as PGGen
 import qualified Test.Property as Property
 
@@ -200,7 +200,7 @@ runRoundTripTest pool testCase =
             [[(_, sqlValue)]] ->
               Right (FieldDef.fieldValueFromSqlValue fieldDef sqlValue)
             _ ->
-              Left ("Expected one row with one value in results, but got: " ++ show (sqlValuesToText rows))
+              Left ("Expected one row with one value in results, but got: " ++ show (sqlRowsToText rows))
 
     roundTripResult HH.=== Right (Just value)
 
@@ -236,7 +236,7 @@ runNullableRoundTripTest pool testCase =
             [[(_, sqlValue)]] ->
               Right (FieldDef.fieldValueFromSqlValue fieldDef sqlValue)
             _ ->
-              Left ("Expected one row with one value in results, but got: " ++ show (sqlValuesToText rows))
+              Left ("Expected one row with one value in results, but got: " ++ show (sqlRowsToText rows))
 
     roundTripResult HH.=== Right (Just value)
 

--- a/orville-postgresql-libpq/test/Test/SqlMarshaller.hs
+++ b/orville-postgresql-libpq/test/Test/SqlMarshaller.hs
@@ -17,6 +17,7 @@ import qualified Orville.PostgreSQL.Internal.FieldDefinition as FieldDefinition
 import qualified Orville.PostgreSQL.Internal.SqlMarshaller as SqlMarshaller
 import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
 
+import Test.Expr.TestSchema (sqlValuesToText)
 import qualified Test.PGGen as PGGen
 
 sqlMarshallerTests :: IO Bool
@@ -130,7 +131,7 @@ sqlMarshallerTests =
                   , (FieldDefinition.stringToFieldName "size", SqlValue.fromInt32 $ fooSize foo)
                   ]
 
-            actualFooRow HH.=== expectedFooRow
+            sqlValuesToText [actualFooRow] HH.=== sqlValuesToText [expectedFooRow]
         )
       ]
 

--- a/orville-postgresql-libpq/test/Test/SqlMarshaller.hs
+++ b/orville-postgresql-libpq/test/Test/SqlMarshaller.hs
@@ -17,7 +17,7 @@ import qualified Orville.PostgreSQL.Internal.FieldDefinition as FieldDefinition
 import qualified Orville.PostgreSQL.Internal.SqlMarshaller as SqlMarshaller
 import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
 
-import Test.Expr.TestSchema (sqlValuesToText)
+import Test.Expr.TestSchema (assertEqualSqlRows)
 import qualified Test.PGGen as PGGen
 
 sqlMarshallerTests :: IO Bool
@@ -131,7 +131,7 @@ sqlMarshallerTests =
                   , (FieldDefinition.stringToFieldName "size", SqlValue.fromInt32 $ fooSize foo)
                   ]
 
-            sqlValuesToText [actualFooRow] HH.=== sqlValuesToText [expectedFooRow]
+            [actualFooRow] `assertEqualSqlRows` [expectedFooRow]
         )
       ]
 


### PR DESCRIPTION
Remove these instances on `SqlValue`, but keep tests running by passing`SqlValue`s through `toText` first. If needed in the future, we could further process those `Text`s

It's pretty likely there's a better place for the `sqlValuesToText` helper to live, happy to move it.