### PR TITLE
[0.9] Add functions from Where/SelectOptions to (String, [SqlValue])

### DIFF
--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Core.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Core.hs
@@ -131,6 +131,7 @@ module Database.Orville.PostgreSQL.Core
   , whereNotIn
   , whereQualified
   , whereRaw
+  , whereToSql
   , isNull
   , isNotNull
   , (.==)
@@ -148,6 +149,7 @@ module Database.Orville.PostgreSQL.Core
   , limit
   , offset
   , groupBy
+  , selectOptionsToSql
   , (<>)
   , FieldUpdate
   , fieldUpdate

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/SelectOptions.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/SelectOptions.hs
@@ -140,3 +140,7 @@ offset n = SelectOptions mempty mempty mempty mempty (First $ Just n) mempty
 groupBy :: ToGroupBy a => a -> SelectOptions
 groupBy groupable =
   SelectOptions mempty mempty mempty mempty mempty [toGroupBy groupable]
+
+selectOptionsToSql :: SelectOptions -> (String, [SqlValue])
+selectOptionsToSql opts =
+  (selectOptClause opts, selectOptValues opts)

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/Where.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/Where.hs
@@ -29,6 +29,7 @@ module Database.Orville.PostgreSQL.Internal.Where
   , isNotNull
   , whereClause
   , whereValues
+  , whereToSql
   ) where
 
 import qualified Data.List as List
@@ -199,3 +200,6 @@ whereClause conds = "WHERE " ++ whereConditionSql (whereAnd conds)
 
 whereValues :: [WhereCondition] -> [SqlValue]
 whereValues = List.concatMap whereConditionValues
+
+whereToSql :: [WhereCondition] -> (String, [SqlValue])
+whereToSql conds = (whereClause conds, whereValues conds)


### PR DESCRIPTION
These functions allow for sharing WhereConditions and SelectOptions between queries executed with higher-level primitives like `selectQueryTable` and lower-level ones like `selectQueryRawRows`.

The user is responsible for passing the obtained `SqlValue`s back into Orville in the right order.

The tests are failing because CircleCI doesn't seem to be configured for the 0.9 branch which this is for.