### PR TITLE
Removes top-level foralls from Plan functions

### DIFF
--- a/orville-postgresql/Dockerfile
+++ b/orville-postgresql/Dockerfile
@@ -9,8 +9,7 @@ FROM flipstone/stack:v2-1.9.3
 # redirect. Since we expect the `0.9_development` branch to replace master, I've
 # simply removed the offending file from the apt sources below.
 
-RUN rm /etc/apt/sources.list.d/fpco.list &&\
-    apt-get update &&\
+RUN apt-get update &&\
     apt-get install -y --no-install-recommends libpq5 libpq-dev &&\
     apt-get clean
 

--- a/orville-postgresql/scripts/up.sh
+++ b/orville-postgresql/scripts/up.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# dev is specified here so that docker-compose up will only attached to the dev
+# container and not the db container. A number of the tests produce errors logs
+# in the database container which are expected for negative testing (e.g.
+# primary key violations, not null violations). These logs end up interspersed
+# throughout the test results, which is annoying. If you need to see the logs
+# for debugging, you can run `docker-compose logs testdb`, or just run
+# `docker-compose up` directly.
+docker-compose up dev

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Plan/Operation.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Plan/Operation.hs
@@ -376,8 +376,8 @@ runSelectOne selectOp param =
 
 
 {-|
-  'runSelectMany is an internal helper function that executes a
-  'SelectOperation' on a miltple input parameters.
+  'runSelectMany' is an internal helper function that executes a
+  'SelectOperation' on multiple input parameters.
 -}
 runSelectMany :: (Ord param, Core.MonadOrville conn m)
               => SelectOperation param row result


### PR DESCRIPTION
This removes the `forall` on some top level plan functions to avoid
triggering the simplying-subsumption eta-expansion requirement in user
code on GHC 9.

I have left the `forall` on `PlanMany` to avoid letting a `Planned`
value containing a `Many` from escaping the plan scope. If such values
can escape escape the user can pass them directly to a new planning
scope, leading to very surprising results.