### PR TITLE
Adds table definition for querying information_schema.columns

### DIFF
--- a/orville-postgresql-libpq/orville-postgresql-libpq.cabal
+++ b/orville-postgresql-libpq/orville-postgresql-libpq.cabal
@@ -45,7 +45,12 @@ library
       Orville.PostgreSQL.Internal.SqlValue
       Orville.PostgreSQL.Internal.TableDefinition
   other-modules:
+      Orville.PostgreSQL.InformationSchema.ColumnName
+      Orville.PostgreSQL.InformationSchema.InformationSchemaColumn
       Orville.PostgreSQL.InformationSchema.InformationSchemaTable
+      Orville.PostgreSQL.InformationSchema.TableCatalog
+      Orville.PostgreSQL.InformationSchema.TableName
+      Orville.PostgreSQL.InformationSchema.TableSchema
       Orville.PostgreSQL.Internal.EntityOperations
       Orville.PostgreSQL.Internal.Execute
       Orville.PostgreSQL.Internal.Expr.ColumnDefinition

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/InformationSchema.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/InformationSchema.hs
@@ -5,4 +5,9 @@ module Orville.PostgreSQL.InformationSchema
   )
 where
 
+import Orville.PostgreSQL.InformationSchema.ColumnName as Export
+import Orville.PostgreSQL.InformationSchema.InformationSchemaColumn as Export
 import Orville.PostgreSQL.InformationSchema.InformationSchemaTable as Export
+import Orville.PostgreSQL.InformationSchema.TableCatalog as Export
+import Orville.PostgreSQL.InformationSchema.TableName as Export
+import Orville.PostgreSQL.InformationSchema.TableSchema as Export

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/InformationSchema/ColumnName.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/InformationSchema/ColumnName.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Orville.PostgreSQL.InformationSchema.ColumnName
+  ( ColumnName (..),
+    columnNameFromText,
+    columnNameField,
+  )
+where
+
+import qualified Data.String as String
+import qualified Data.Text as T
+
+import qualified Orville.PostgreSQL as Orville
+
+{- |
+  The @column_name@ field of the @information_schema@ tables.
+-}
+columnNameField :: Orville.FieldDefinition Orville.NotNull ColumnName
+columnNameField =
+  Orville.coerceField
+    (Orville.unboundedTextField "column_name")
+
+{- |
+  Represents a column name as data retrieved from @information_schema@ tables,
+  not as it would be used in a SQL expression.
+-}
+newtype ColumnName
+  = ColumnName T.Text
+  deriving (Show, Eq, Ord, String.IsString)
+
+{- |
+  Create a 'ColumnName' from a 'T.Text' value
+-}
+columnNameFromText :: T.Text -> ColumnName
+columnNameFromText = ColumnName

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/InformationSchema/InformationSchemaColumn.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/InformationSchema/InformationSchemaColumn.hs
@@ -1,0 +1,43 @@
+module Orville.PostgreSQL.InformationSchema.InformationSchemaColumn
+  ( InformationSchemaColumn (..),
+    informationSchemaColumnsTable,
+  )
+where
+
+import qualified Orville.PostgreSQL as Orville
+import Orville.PostgreSQL.InformationSchema.ColumnName (ColumnName, columnNameField)
+import Orville.PostgreSQL.InformationSchema.TableCatalog (CatalogName, tableCatalogField)
+import Orville.PostgreSQL.InformationSchema.TableName (TableName, tableNameField)
+import Orville.PostgreSQL.InformationSchema.TableSchema (SchemaName, tableSchemaField)
+
+{- |
+  Contains metadata about a column collected from the @information_schema.columns@ table in
+  the database.
+-}
+data InformationSchemaColumn = InformationSchemaColumn
+  { columnTableCatalog :: CatalogName
+  , columnTableSchema :: SchemaName
+  , columnTableName :: TableName
+  , columnName :: ColumnName
+  }
+  deriving (Show, Eq)
+
+{- |
+  An Orville 'Orville.TableDefinition' that can be used to query the
+  @information_schema.column@ table to gather metadata about the tables in the
+  database.
+-}
+informationSchemaColumnsTable :: Orville.TableDefinition Orville.NoKey InformationSchemaColumn InformationSchemaColumn
+informationSchemaColumnsTable =
+  Orville.setTableSchema "information_schema" $
+    Orville.mkTableDefinitionWithoutKey
+      "columns"
+      informationSchemaColumnMarshaller
+
+informationSchemaColumnMarshaller :: Orville.SqlMarshaller InformationSchemaColumn InformationSchemaColumn
+informationSchemaColumnMarshaller =
+  InformationSchemaColumn
+    <$> Orville.marshallField columnTableCatalog tableCatalogField
+    <*> Orville.marshallField columnTableSchema tableSchemaField
+    <*> Orville.marshallField columnTableName tableNameField
+    <*> Orville.marshallField columnName columnNameField

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/InformationSchema/InformationSchemaTable.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/InformationSchema/InformationSchemaTable.hs
@@ -1,27 +1,16 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-
 module Orville.PostgreSQL.InformationSchema.InformationSchemaTable
   ( InformationSchemaTable (..),
     informationSchemaTablesTable,
-    CatalogName (..),
-    catalogNameFromText,
-    tableCatalogField,
-    SchemaName (..),
-    schemaNameFromText,
-    tableSchemaField,
-    TableName (..),
-    tableNameFromText,
-    tableNameField,
   )
 where
 
-import qualified Data.String as String
-import qualified Data.Text as T
-
 import qualified Orville.PostgreSQL as Orville
+import Orville.PostgreSQL.InformationSchema.TableCatalog (CatalogName, tableCatalogField)
+import Orville.PostgreSQL.InformationSchema.TableName (TableName, tableNameField)
+import Orville.PostgreSQL.InformationSchema.TableSchema (SchemaName, tableSchemaField)
 
 {- |
-  Contains metadata about a table collected from the @information_schema@ table in
+  Contains metadata about a table collected from the @information_schema.tables@ table in
   the database.
 -}
 data InformationSchemaTable = InformationSchemaTable
@@ -49,69 +38,3 @@ informationSchemaTableMarshaller =
     <$> Orville.marshallField tableCatalog tableCatalogField
     <*> Orville.marshallField tableSchema tableSchemaField
     <*> Orville.marshallField tableName tableNameField
-
-{- |
-  The @table_catalog@ field of the @information_schema.tables@ table.
--}
-tableCatalogField :: Orville.FieldDefinition Orville.NotNull CatalogName
-tableCatalogField =
-  Orville.coerceField
-    (Orville.unboundedTextField "table_catalog")
-
-{- |
-  Represents a schema name as data retrieved from @information_schema@ tables,
-  not as it would be used in a SQL expression.
--}
-newtype CatalogName
-  = CatalogName T.Text
-  deriving (Show, Eq, Ord, String.IsString)
-
-{- |
-  Create a 'CatalogName' from a 'T.Text' value
--}
-catalogNameFromText :: T.Text -> CatalogName
-catalogNameFromText = CatalogName
-
-{- |
-  The @table_schema@ field of the @information_schema.tables@ table.
--}
-tableSchemaField :: Orville.FieldDefinition Orville.NotNull SchemaName
-tableSchemaField =
-  Orville.coerceField
-    (Orville.unboundedTextField "table_schema")
-
-{- |
-  Represents a schema name as data retrieved from @information_schema@ tables,
-  not as it would be used in a SQL expression.
--}
-newtype SchemaName
-  = SchemaName T.Text
-  deriving (Show, Eq, Ord, String.IsString)
-
-{- |
-  Create a 'SchemaName' from a 'T.Text' value
--}
-schemaNameFromText :: T.Text -> SchemaName
-schemaNameFromText = SchemaName
-
-{- |
-  The @table_name@ field of the @information_schema.tables@ table.
--}
-tableNameField :: Orville.FieldDefinition Orville.NotNull TableName
-tableNameField =
-  Orville.coerceField
-    (Orville.unboundedTextField "table_name")
-
-{- |
-  Represents a table name as data retrieved from @information_schema@ tables,
-  not as it would be used in a SQL expression.
--}
-newtype TableName
-  = TableName T.Text
-  deriving (Show, Eq, Ord, String.IsString)
-
-{- |
-  Create a 'TableName' from a 'T.Text' value
--}
-tableNameFromText :: T.Text -> TableName
-tableNameFromText = TableName

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/InformationSchema/TableCatalog.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/InformationSchema/TableCatalog.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Orville.PostgreSQL.InformationSchema.TableCatalog
+  ( CatalogName (..),
+    catalogNameFromText,
+    tableCatalogField,
+  )
+where
+
+import qualified Data.String as String
+import qualified Data.Text as T
+
+import qualified Orville.PostgreSQL as Orville
+
+{- |
+  The @table_catalog@ field of the @information_schema@ tables.
+-}
+tableCatalogField :: Orville.FieldDefinition Orville.NotNull CatalogName
+tableCatalogField =
+  Orville.coerceField
+    (Orville.unboundedTextField "table_catalog")
+
+{- |
+  Represents a schema name as data retrieved from @information_schema@ tables,
+  not as it would be used in a SQL expression.
+-}
+newtype CatalogName
+  = CatalogName T.Text
+  deriving (Show, Eq, Ord, String.IsString)
+
+{- |
+  Create a 'CatalogName' from a 'T.Text' value
+-}
+catalogNameFromText :: T.Text -> CatalogName
+catalogNameFromText = CatalogName

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/InformationSchema/TableName.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/InformationSchema/TableName.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Orville.PostgreSQL.InformationSchema.TableName
+  ( TableName (..),
+    tableNameFromText,
+    tableNameField,
+  )
+where
+
+import qualified Data.String as String
+import qualified Data.Text as T
+
+import qualified Orville.PostgreSQL as Orville
+
+{- |
+  The @table_name@ field of the @information_schema@ tables.
+-}
+tableNameField :: Orville.FieldDefinition Orville.NotNull TableName
+tableNameField =
+  Orville.coerceField
+    (Orville.unboundedTextField "table_name")
+
+{- |
+  Represents a table name as data retrieved from @information_schema@ tables,
+  not as it would be used in a SQL expression.
+-}
+newtype TableName
+  = TableName T.Text
+  deriving (Show, Eq, Ord, String.IsString)
+
+{- |
+  Create a 'TableName' from a 'T.Text' value
+-}
+tableNameFromText :: T.Text -> TableName
+tableNameFromText = TableName

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/InformationSchema/TableSchema.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/InformationSchema/TableSchema.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Orville.PostgreSQL.InformationSchema.TableSchema
+  ( SchemaName (..),
+    schemaNameFromText,
+    tableSchemaField,
+  )
+where
+
+import qualified Data.String as String
+import qualified Data.Text as T
+
+import qualified Orville.PostgreSQL as Orville
+
+{- |
+  The @table_schema@ field of the @information_schema@ tables.
+-}
+tableSchemaField :: Orville.FieldDefinition Orville.NotNull SchemaName
+tableSchemaField =
+  Orville.coerceField
+    (Orville.unboundedTextField "table_schema")
+
+{- |
+  Represents a schema name as data retrieved from @information_schema@ tables,
+  not as it would be used in a SQL expression.
+-}
+newtype SchemaName
+  = SchemaName T.Text
+  deriving (Show, Eq, Ord, String.IsString)
+
+{- |
+  Create a 'SchemaName' from a 'T.Text' value
+-}
+schemaNameFromText :: T.Text -> SchemaName
+schemaNameFromText = SchemaName


### PR DESCRIPTION
This expands to `InformationSchema` module with minimal support of the
`columns` table -- just enough that we'll be able to tell whether to add
a column for the purposes of migration.