### PR TITLE
Prints test details only for failures

### DIFF
--- a/orville-postgresql-libpq/test/Main.hs
+++ b/orville-postgresql-libpq/test/Main.hs
@@ -17,6 +17,7 @@ import qualified Test.Expr.TableDefinition as ExprTableDefinition
 import qualified Test.Expr.Where as ExprWhere
 import qualified Test.FieldDefinition as FieldDefinition
 import qualified Test.InformationSchema as InformationSchema
+import qualified Test.Property as Property
 import qualified Test.RawSql as RawSql
 import qualified Test.ReservedWords as ReservedWords
 import qualified Test.SelectOptions as SelectOptions
@@ -29,8 +30,8 @@ main = do
   let connBStr = B8.pack "host=testdb user=orville_test password=orville"
   pool <- Connection.createConnectionPool 1 10 1 connBStr
 
-  results <-
-    sequence
+  summary <-
+    Property.checkGroups
       [ Connection.connectionTests pool
       , RawSql.rawSqlTests
       , TableDefinition.tableDefinitionTests pool
@@ -48,4 +49,4 @@ main = do
       , ReservedWords.reservedWordsTests pool
       ]
 
-  Monad.unless (and results) SE.exitFailure
+  Monad.unless (Property.allPassed summary) SE.exitFailure

--- a/orville-postgresql-libpq/test/Test/Connection.hs
+++ b/orville-postgresql-libpq/test/Test/Connection.hs
@@ -21,115 +21,113 @@ import qualified Orville.PostgreSQL.Internal.PGTextFormatValue as PGTextFormatVa
 import qualified Test.PGGen as PGGen
 import qualified Test.Property as Property
 
-connectionTests :: Pool.Pool Connection.Connection -> IO Bool
+connectionTests :: Pool.Pool Connection.Connection -> Property.Group
 connectionTests pool =
-  HH.checkSequential $
-    HH.Group
-      (String.fromString "Connection")
-      [
-        ( String.fromString "executeRaw can pass non-null bytes equivalents whether checked for NUL or not"
-        , HH.property $ do
-            text <- HH.forAll $ PGGen.pgText (Range.linear 0 256)
+  Property.Group "Connection" $
+    [
+      ( String.fromString "executeRaw can pass non-null bytes equivalents whether checked for NUL or not"
+      , HH.property $ do
+          text <- HH.forAll $ PGGen.pgText (Range.linear 0 256)
 
-            let notNulBytes =
-                  Enc.encodeUtf8 text
+          let notNulBytes =
+                Enc.encodeUtf8 text
 
-            value <-
-              MIO.liftIO . Pool.withResource pool $ \connection -> do
-                result <-
-                  Connection.executeRaw
-                    connection
-                    (B8.pack "SELECT $1::text = $2::text")
-                    [ Just $ PGTextFormatValue.fromByteString notNulBytes
-                    , Just $ PGTextFormatValue.unsafeFromByteString notNulBytes
-                    ]
+          value <-
+            MIO.liftIO . Pool.withResource pool $ \connection -> do
+              result <-
+                Connection.executeRaw
+                  connection
+                  (B8.pack "SELECT $1::text = $2::text")
+                  [ Just $ PGTextFormatValue.fromByteString notNulBytes
+                  , Just $ PGTextFormatValue.unsafeFromByteString notNulBytes
+                  ]
 
-                LibPQ.getvalue' result 0 0
+              LibPQ.getvalue' result 0 0
 
-            value HH.=== Just (B8.pack "t")
-        )
-      ,
-        ( String.fromString "executeRaw returns error if nul byte is given using safe constructor"
-        , HH.property $ do
-            textBefore <- HH.forAll $ PGGen.pgText (Range.linear 0 32)
-            textAfter <- HH.forAll $ PGGen.pgText (Range.linear 0 32)
+          value HH.=== Just (B8.pack "t")
+      )
+    ,
+      ( String.fromString "executeRaw returns error if nul byte is given using safe constructor"
+      , HH.property $ do
+          textBefore <- HH.forAll $ PGGen.pgText (Range.linear 0 32)
+          textAfter <- HH.forAll $ PGGen.pgText (Range.linear 0 32)
 
-            let bytesWithNul =
-                  B8.concat
-                    [ Enc.encodeUtf8 textBefore
-                    , B8.pack "\NUL"
-                    , Enc.encodeUtf8 textAfter
-                    ]
+          let bytesWithNul =
+                B8.concat
+                  [ Enc.encodeUtf8 textBefore
+                  , B8.pack "\NUL"
+                  , Enc.encodeUtf8 textAfter
+                  ]
 
-            result <-
-              MIO.liftIO . E.try . Pool.withResource pool $ \connection ->
+          result <-
+            MIO.liftIO . E.try . Pool.withResource pool $ \connection ->
+              Connection.executeRaw
+                connection
+                (B8.pack "SELECT $1::text")
+                [ Just $ PGTextFormatValue.fromByteString bytesWithNul
+                ]
+
+          case result of
+            Left PGTextFormatValue.NULByteFoundError ->
+              HH.success
+            Right _ -> do
+              HH.footnote "Expected 'executeRaw' to return failure, but it did not"
+              HH.failure
+      )
+    ,
+      ( String.fromString "executeRaw truncates values at the nul byte given using unsafe constructor"
+      , HH.property $ do
+          textBefore <- HH.forAll $ PGGen.pgText (Range.linear 0 32)
+          textAfter <- HH.forAll $ PGGen.pgText (Range.linear 0 32)
+
+          let bytesBefore =
+                Enc.encodeUtf8 textBefore
+
+              bytesWithNul =
+                B8.concat
+                  [ bytesBefore
+                  , B8.pack "\NUL"
+                  , Enc.encodeUtf8 textAfter
+                  ]
+
+          value <-
+            MIO.liftIO . Pool.withResource pool $ \connection -> do
+              result <-
                 Connection.executeRaw
                   connection
                   (B8.pack "SELECT $1::text")
-                  [ Just $ PGTextFormatValue.fromByteString bytesWithNul
+                  [ Just $ PGTextFormatValue.unsafeFromByteString bytesWithNul
                   ]
 
-            case result of
-              Left PGTextFormatValue.NULByteFoundError ->
-                HH.success
-              Right _ -> do
-                HH.footnote "Expected 'executeRaw' to return failure, but it did not"
-                HH.failure
-        )
-      ,
-        ( String.fromString "executeRaw truncates values at the nul byte given using unsafe constructor"
-        , HH.property $ do
-            textBefore <- HH.forAll $ PGGen.pgText (Range.linear 0 32)
-            textAfter <- HH.forAll $ PGGen.pgText (Range.linear 0 32)
+              LibPQ.getvalue' result 0 0
 
-            let bytesBefore =
-                  Enc.encodeUtf8 textBefore
+          value HH.=== Just bytesBefore
+      )
+    , -- Note: we only run this test once to cut down on the number of errors
+      -- printed out by the database server when running tests repeatedly.
 
-                bytesWithNul =
-                  B8.concat
-                    [ bytesBefore
-                    , B8.pack "\NUL"
-                    , Enc.encodeUtf8 textAfter
-                    ]
+      ( String.fromString "executeRaw returns error if invalid sql is given"
+      , Property.singletonProperty $ do
+          -- We generate non-empty queries here becaues libpq returns different
+          -- error details when an empty string is passed
+          randomText <- HH.forAll $ PGGen.pgText (Range.constant 1 16)
 
-            value <-
-              MIO.liftIO . Pool.withResource pool $ \connection -> do
-                result <-
-                  Connection.executeRaw
-                    connection
-                    (B8.pack "SELECT $1::text")
-                    [ Just $ PGTextFormatValue.unsafeFromByteString bytesWithNul
-                    ]
+          result <-
+            MIO.liftIO . E.try . Pool.withResource pool $ \connection ->
+              Connection.executeRaw
+                connection
+                (Enc.encodeUtf8 randomText)
+                []
 
-                LibPQ.getvalue' result 0 0
+          case result of
+            Left err -> do
+              Connection.sqlExecutionErrorExecStatus err HH.=== LibPQ.FatalError
 
-            value HH.=== Just bytesBefore
-        )
-      , -- Note: we only run this test once to cut down on the number of errors
-        -- printed out by the database server when running tests repeatedly.
+              let syntaxErrorState = B8.pack "42601"
 
-        ( String.fromString "executeRaw returns error if invalid sql is given"
-        , Property.singletonProperty $ do
-            -- We generate non-empty queries here becaues libpq returns different
-            -- error details when an empty string is passed
-            randomText <- HH.forAll $ PGGen.pgText (Range.constant 1 16)
-
-            result <-
-              MIO.liftIO . E.try . Pool.withResource pool $ \connection ->
-                Connection.executeRaw
-                  connection
-                  (Enc.encodeUtf8 randomText)
-                  []
-
-            case result of
-              Left err -> do
-                Connection.sqlExecutionErrorExecStatus err HH.=== LibPQ.FatalError
-
-                let syntaxErrorState = B8.pack "42601"
-
-                Connection.sqlExecutionErrorSqlState err HH.=== Just syntaxErrorState
-              Right _ -> do
-                HH.footnote "Expected 'executeRow' to return failure, but it did not"
-                HH.failure
-        )
-      ]
+              Connection.sqlExecutionErrorSqlState err HH.=== Just syntaxErrorState
+            Right _ -> do
+              HH.footnote "Expected 'executeRow' to return failure, but it did not"
+              HH.failure
+      )
+    ]

--- a/orville-postgresql-libpq/test/Test/EntityOperations.hs
+++ b/orville-postgresql-libpq/test/Test/EntityOperations.hs
@@ -16,119 +16,118 @@ import qualified Orville.PostgreSQL as Orville
 import qualified Orville.PostgreSQL.Connection as Connection
 
 import qualified Test.Entities.Foo as Foo
+import qualified Test.Property as Property
 
-entityOperationsTests :: Pool.Pool Connection.Connection -> IO Bool
+entityOperationsTests :: Pool.Pool Connection.Connection -> Property.Group
 entityOperationsTests pool =
-  HH.checkSequential $
-    HH.Group
-      (String.fromString "EntityOperations")
-      [
-        ( String.fromString "insertEntity/findEntitiesBy forms a round trip"
-        , HH.property $ do
-            originalFoo <- HH.forAll Foo.generate
+  Property.group "EntityOperations" $
+    [
+      ( String.fromString "insertEntity/findEntitiesBy forms a round trip"
+      , HH.property $ do
+          originalFoo <- HH.forAll Foo.generate
 
-            retrievedFoos <-
-              Foo.withTable pool $ do
-                Orville.insertEntity Foo.table originalFoo
-                Orville.findEntitiesBy Foo.table mempty
+          retrievedFoos <-
+            Foo.withTable pool $ do
+              Orville.insertEntity Foo.table originalFoo
+              Orville.findEntitiesBy Foo.table mempty
 
-            retrievedFoos === [originalFoo]
-        )
-      ,
-        ( String.fromString "insertEntities/findFirstEntityBy only return 1"
-        , HH.property $ do
-            originalFoos <- HH.forAll $ Foo.generateList (Range.linear 0 10)
+          retrievedFoos === [originalFoo]
+      )
+    ,
+      ( String.fromString "insertEntities/findFirstEntityBy only return 1"
+      , HH.property $ do
+          originalFoos <- HH.forAll $ Foo.generateList (Range.linear 0 10)
 
-            HH.cover 1 (String.fromString "empty list") (null originalFoos)
-            HH.cover 20 (String.fromString "non-empty list") (not (null originalFoos))
+          HH.cover 1 (String.fromString "empty list") (null originalFoos)
+          HH.cover 20 (String.fromString "non-empty list") (not (null originalFoos))
 
-            mbRetrievedFoo <-
-              Foo.withTable pool $ do
-                mapM_ (Orville.insertEntities Foo.table) (NEL.nonEmpty originalFoos)
-                Orville.findFirstEntityBy Foo.table mempty
+          mbRetrievedFoo <-
+            Foo.withTable pool $ do
+              mapM_ (Orville.insertEntities Foo.table) (NEL.nonEmpty originalFoos)
+              Orville.findFirstEntityBy Foo.table mempty
 
-            let expectedLength =
-                  case originalFoos of
-                    [] -> 0
-                    _ -> 1
+          let expectedLength =
+                case originalFoos of
+                  [] -> 0
+                  _ -> 1
 
-            -- Once we add order by to 'SelectOptions' we can order by something here
-            -- and assert which item is returned.
-            length (Maybe.maybeToList mbRetrievedFoo) === expectedLength
-        )
-      ,
-        ( String.fromString "insertEntity/findEntity forms a round trip"
-        , HH.property $ do
-            originalFoo <- HH.forAll Foo.generate
+          -- Once we add order by to 'SelectOptions' we can order by something here
+          -- and assert which item is returned.
+          length (Maybe.maybeToList mbRetrievedFoo) === expectedLength
+      )
+    ,
+      ( String.fromString "insertEntity/findEntity forms a round trip"
+      , HH.property $ do
+          originalFoo <- HH.forAll Foo.generate
 
-            mbRetrievedFoo <-
-              Foo.withTable pool $ do
-                Orville.insertEntity Foo.table originalFoo
-                Orville.findEntity Foo.table (Foo.fooId originalFoo)
+          mbRetrievedFoo <-
+            Foo.withTable pool $ do
+              Orville.insertEntity Foo.table originalFoo
+              Orville.findEntity Foo.table (Foo.fooId originalFoo)
 
-            mbRetrievedFoo === Just originalFoo
-        )
-      ,
-        ( String.fromString "updateEntity updates row at the given key"
-        , HH.property $ do
-            originalFoo <- HH.forAll Foo.generate
-            newFoo <- HH.forAll Foo.generate
+          mbRetrievedFoo === Just originalFoo
+      )
+    ,
+      ( String.fromString "updateEntity updates row at the given key"
+      , HH.property $ do
+          originalFoo <- HH.forAll Foo.generate
+          newFoo <- HH.forAll Foo.generate
 
-            retrievedFoos <-
-              Foo.withTable pool $ do
-                Orville.insertEntity Foo.table originalFoo
-                Orville.updateEntity Foo.table (Foo.fooId originalFoo) newFoo
-                Orville.findEntitiesBy Foo.table mempty
+          retrievedFoos <-
+            Foo.withTable pool $ do
+              Orville.insertEntity Foo.table originalFoo
+              Orville.updateEntity Foo.table (Foo.fooId originalFoo) newFoo
+              Orville.findEntitiesBy Foo.table mempty
 
-            retrievedFoos === [newFoo]
-        )
-      ,
-        ( String.fromString "updateEntity updates no rows when key does not match"
-        , HH.property $ do
-            originalFoo <- HH.forAll Foo.generate
-            newFoo <- HH.forAll Foo.generate
+          retrievedFoos === [newFoo]
+      )
+    ,
+      ( String.fromString "updateEntity updates no rows when key does not match"
+      , HH.property $ do
+          originalFoo <- HH.forAll Foo.generate
+          newFoo <- HH.forAll Foo.generate
 
-            let mismatchFooId =
-                  1 + Foo.fooId originalFoo
+          let mismatchFooId =
+                1 + Foo.fooId originalFoo
 
-            retrievedFoos <-
-              Foo.withTable pool $ do
-                Orville.insertEntity Foo.table originalFoo
-                Orville.updateEntity Foo.table mismatchFooId newFoo
-                Orville.findEntitiesBy Foo.table mempty
+          retrievedFoos <-
+            Foo.withTable pool $ do
+              Orville.insertEntity Foo.table originalFoo
+              Orville.updateEntity Foo.table mismatchFooId newFoo
+              Orville.findEntitiesBy Foo.table mempty
 
-            retrievedFoos === [originalFoo]
-        )
-      ,
-        ( String.fromString "deleteEntity deletes row at the given key"
-        , HH.property $ do
-            originalFoo <- HH.forAll Foo.generate
-            let withDifferentKey = Gen.filter $ (Foo.fooId originalFoo /=) . Foo.fooId
-            anotherFoo <- HH.forAll . withDifferentKey $ Foo.generate
+          retrievedFoos === [originalFoo]
+      )
+    ,
+      ( String.fromString "deleteEntity deletes row at the given key"
+      , HH.property $ do
+          originalFoo <- HH.forAll Foo.generate
+          let withDifferentKey = Gen.filter $ (Foo.fooId originalFoo /=) . Foo.fooId
+          anotherFoo <- HH.forAll . withDifferentKey $ Foo.generate
 
-            retrievedFoos <-
-              Foo.withTable pool $ do
-                Orville.insertEntity Foo.table originalFoo
-                Orville.insertEntity Foo.table anotherFoo
-                Orville.deleteEntity Foo.table (Foo.fooId originalFoo)
-                Orville.findEntitiesBy Foo.table mempty
+          retrievedFoos <-
+            Foo.withTable pool $ do
+              Orville.insertEntity Foo.table originalFoo
+              Orville.insertEntity Foo.table anotherFoo
+              Orville.deleteEntity Foo.table (Foo.fooId originalFoo)
+              Orville.findEntitiesBy Foo.table mempty
 
-            retrievedFoos === [anotherFoo]
-        )
-      ,
-        ( String.fromString "deleteEntity deletes no rows when key doesn't match"
-        , HH.property $ do
-            originalFoo <- HH.forAll Foo.generate
+          retrievedFoos === [anotherFoo]
+      )
+    ,
+      ( String.fromString "deleteEntity deletes no rows when key doesn't match"
+      , HH.property $ do
+          originalFoo <- HH.forAll Foo.generate
 
-            let mismatchFooId =
-                  1 + Foo.fooId originalFoo
+          let mismatchFooId =
+                1 + Foo.fooId originalFoo
 
-            retrievedFoos <-
-              Foo.withTable pool $ do
-                Orville.insertEntity Foo.table originalFoo
-                Orville.deleteEntity Foo.table mismatchFooId
-                Orville.findEntitiesBy Foo.table mempty
+          retrievedFoos <-
+            Foo.withTable pool $ do
+              Orville.insertEntity Foo.table originalFoo
+              Orville.deleteEntity Foo.table mismatchFooId
+              Orville.findEntitiesBy Foo.table mempty
 
-            retrievedFoos === [originalFoo]
-        )
-      ]
+          retrievedFoos === [originalFoo]
+      )
+    ]

--- a/orville-postgresql-libpq/test/Test/Expr/GroupBy.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/GroupBy.hs
@@ -26,37 +26,36 @@ data FooBar = FooBar
   , bar :: String
   }
 
-groupByTests :: Pool.Pool Conn.Connection -> IO Bool
+groupByTests :: Pool.Pool Conn.Connection -> Property.Group
 groupByTests pool =
-  HH.checkSequential $
-    HH.Group
-      (String.fromString "Expr - GroupBy")
-      [
-        ( String.fromString "appendGroupBy causes grouping on both clauses"
-        , runGroupByTest pool $
-            GroupByTest
-              { groupByValuesToInsert = [FooBar 1 "dog", FooBar 2 "dingo", FooBar 1 "dog", FooBar 3 "dingo", FooBar 1 "dog", FooBar 2 "dingo"]
-              , groupByExpectedQueryResults = [FooBar 1 "dog", FooBar 3 "dingo", FooBar 2 "dingo"]
-              , groupByClause =
-                  Just . Expr.groupByClause $
-                    Expr.appendGroupBy
-                      (Expr.groupByExpr $ RawSql.toRawSql barColumn)
-                      (Expr.groupByExpr $ RawSql.toRawSql fooColumn)
-              }
-        )
-      ,
-        ( String.fromString "groupByColumnsExpr groups by columns"
-        , runGroupByTest pool $
-            GroupByTest
-              { groupByValuesToInsert = [FooBar 1 "dog", FooBar 2 "dingo", FooBar 3 "dog"]
-              , groupByExpectedQueryResults = [FooBar 2 "dingo", FooBar 3 "dog", FooBar 1 "dog"]
-              , groupByClause =
-                  Just . Expr.groupByClause $
-                    Expr.groupByColumnsExpr $
-                      barColumn NE.:| [fooColumn]
-              }
-        )
-      ]
+  Property.group
+    "Expr - GroupBy"
+    [
+      ( String.fromString "appendGroupBy causes grouping on both clauses"
+      , runGroupByTest pool $
+          GroupByTest
+            { groupByValuesToInsert = [FooBar 1 "dog", FooBar 2 "dingo", FooBar 1 "dog", FooBar 3 "dingo", FooBar 1 "dog", FooBar 2 "dingo"]
+            , groupByExpectedQueryResults = [FooBar 1 "dog", FooBar 3 "dingo", FooBar 2 "dingo"]
+            , groupByClause =
+                Just . Expr.groupByClause $
+                  Expr.appendGroupBy
+                    (Expr.groupByExpr $ RawSql.toRawSql barColumn)
+                    (Expr.groupByExpr $ RawSql.toRawSql fooColumn)
+            }
+      )
+    ,
+      ( String.fromString "groupByColumnsExpr groups by columns"
+      , runGroupByTest pool $
+          GroupByTest
+            { groupByValuesToInsert = [FooBar 1 "dog", FooBar 2 "dingo", FooBar 3 "dog"]
+            , groupByExpectedQueryResults = [FooBar 2 "dingo", FooBar 3 "dog", FooBar 1 "dog"]
+            , groupByClause =
+                Just . Expr.groupByClause $
+                  Expr.groupByColumnsExpr $
+                    barColumn NE.:| [fooColumn]
+            }
+      )
+    ]
 
 data GroupByTest = GroupByTest
   { groupByValuesToInsert :: [FooBar]

--- a/orville-postgresql-libpq/test/Test/Expr/InsertUpdate.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/InsertUpdate.hs
@@ -7,7 +7,6 @@ import qualified Control.Monad.IO.Class as MIO
 import qualified Data.Pool as Pool
 import qualified Data.String as String
 import qualified Data.Text as T
-import qualified Hedgehog as HH
 
 import qualified Orville.PostgreSQL.Connection as Conn
 import qualified Orville.PostgreSQL.Internal.ExecutionResult as ExecResult
@@ -18,101 +17,100 @@ import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
 import Test.Expr.TestSchema (FooBar (..), assertEqualSqlRows, barColumn, dropAndRecreateTestTable, encodeFooBar, fooBarTable, fooColumn, insertFooBarSource, orderByFoo)
 import qualified Test.Property as Property
 
-insertUpdateTests :: Pool.Pool Conn.Connection -> IO Bool
+insertUpdateTests :: Pool.Pool Conn.Connection -> Property.Group
 insertUpdateTests pool =
-  HH.checkSequential $
-    HH.Group
-      (String.fromString "Expr - Insert/Update")
-      [
-        ( String.fromString "insertExpr inserts values"
-        , Property.singletonProperty $ do
-            let fooBars = [FooBar 1 "dog", FooBar 2 "cat"]
+  Property.group
+    "Expr - Insert/Update"
+    [
+      ( String.fromString "insertExpr inserts values"
+      , Property.singletonProperty $ do
+          let fooBars = [FooBar 1 "dog", FooBar 2 "cat"]
 
-            rows <-
-              MIO.liftIO $
-                Pool.withResource pool $ \connection -> do
-                  dropAndRecreateTestTable connection
+          rows <-
+            MIO.liftIO $
+              Pool.withResource pool $ \connection -> do
+                dropAndRecreateTestTable connection
 
-                  RawSql.executeVoid connection $
-                    Expr.insertExpr fooBarTable Nothing (insertFooBarSource fooBars)
+                RawSql.executeVoid connection $
+                  Expr.insertExpr fooBarTable Nothing (insertFooBarSource fooBars)
 
-                  result <-
-                    RawSql.execute connection $
-                      Expr.queryExpr
-                        (Expr.selectClause $ Expr.selectExpr Nothing)
-                        (Expr.selectColumns [fooColumn, barColumn])
-                        (Just $ Expr.tableExpr fooBarTable Nothing Nothing Nothing Nothing Nothing)
+                result <-
+                  RawSql.execute connection $
+                    Expr.queryExpr
+                      (Expr.selectClause $ Expr.selectExpr Nothing)
+                      (Expr.selectColumns [fooColumn, barColumn])
+                      (Just $ Expr.tableExpr fooBarTable Nothing Nothing Nothing Nothing Nothing)
 
-                  ExecResult.readRows result
+                ExecResult.readRows result
 
-            rows `assertEqualSqlRows` map encodeFooBar fooBars
-        )
-      ,
-        ( String.fromString "updateExpr updates rows in the db"
-        , Property.singletonProperty $ do
-            let oldFooBars = [FooBar 1 "dog", FooBar 2 "cat"]
-                newFooBars = [FooBar 1 "ferret", FooBar 2 "ferret"]
+          rows `assertEqualSqlRows` map encodeFooBar fooBars
+      )
+    ,
+      ( String.fromString "updateExpr updates rows in the db"
+      , Property.singletonProperty $ do
+          let oldFooBars = [FooBar 1 "dog", FooBar 2 "cat"]
+              newFooBars = [FooBar 1 "ferret", FooBar 2 "ferret"]
 
-                setBarToFerret =
-                  Expr.updateExpr
-                    fooBarTable
-                    (Expr.setClauseList [Expr.setColumn barColumn (SqlValue.fromText (T.pack "ferret"))])
-                    Nothing
+              setBarToFerret =
+                Expr.updateExpr
+                  fooBarTable
+                  (Expr.setClauseList [Expr.setColumn barColumn (SqlValue.fromText (T.pack "ferret"))])
+                  Nothing
 
-            rows <-
-              MIO.liftIO $
-                Pool.withResource pool $ \connection -> do
-                  dropAndRecreateTestTable connection
+          rows <-
+            MIO.liftIO $
+              Pool.withResource pool $ \connection -> do
+                dropAndRecreateTestTable connection
 
-                  RawSql.executeVoid connection $
-                    Expr.insertExpr fooBarTable Nothing (insertFooBarSource oldFooBars)
+                RawSql.executeVoid connection $
+                  Expr.insertExpr fooBarTable Nothing (insertFooBarSource oldFooBars)
 
-                  RawSql.executeVoid connection $
-                    setBarToFerret
+                RawSql.executeVoid connection $
+                  setBarToFerret
 
-                  result <-
-                    RawSql.execute connection $
-                      Expr.queryExpr
-                        (Expr.selectClause $ Expr.selectExpr Nothing)
-                        (Expr.selectColumns [fooColumn, barColumn])
-                        (Just $ Expr.tableExpr fooBarTable Nothing (Just orderByFoo) Nothing Nothing Nothing)
+                result <-
+                  RawSql.execute connection $
+                    Expr.queryExpr
+                      (Expr.selectClause $ Expr.selectExpr Nothing)
+                      (Expr.selectColumns [fooColumn, barColumn])
+                      (Just $ Expr.tableExpr fooBarTable Nothing (Just orderByFoo) Nothing Nothing Nothing)
 
-                  ExecResult.readRows result
+                ExecResult.readRows result
 
-            rows `assertEqualSqlRows` map encodeFooBar newFooBars
-        )
-      ,
-        ( String.fromString "updateExpr uses a where clause when given"
-        , Property.singletonProperty $ do
-            let oldFooBars = [FooBar 1 "dog", FooBar 2 "cat"]
-                newFooBars = [FooBar 1 "ferret", FooBar 2 "cat"]
+          rows `assertEqualSqlRows` map encodeFooBar newFooBars
+      )
+    ,
+      ( String.fromString "updateExpr uses a where clause when given"
+      , Property.singletonProperty $ do
+          let oldFooBars = [FooBar 1 "dog", FooBar 2 "cat"]
+              newFooBars = [FooBar 1 "ferret", FooBar 2 "cat"]
 
-                updateDogToForret =
-                  Expr.updateExpr
-                    fooBarTable
-                    (Expr.setClauseList [Expr.setColumn barColumn (SqlValue.fromText (T.pack "ferret"))])
-                    (Just (Expr.whereClause (Expr.columnEquals barColumn (SqlValue.fromText (T.pack "dog")))))
+              updateDogToForret =
+                Expr.updateExpr
+                  fooBarTable
+                  (Expr.setClauseList [Expr.setColumn barColumn (SqlValue.fromText (T.pack "ferret"))])
+                  (Just (Expr.whereClause (Expr.columnEquals barColumn (SqlValue.fromText (T.pack "dog")))))
 
-            rows <-
-              MIO.liftIO $
-                Pool.withResource pool $ \connection -> do
-                  dropAndRecreateTestTable connection
+          rows <-
+            MIO.liftIO $
+              Pool.withResource pool $ \connection -> do
+                dropAndRecreateTestTable connection
 
-                  RawSql.executeVoid connection $
-                    Expr.insertExpr fooBarTable Nothing (insertFooBarSource oldFooBars)
+                RawSql.executeVoid connection $
+                  Expr.insertExpr fooBarTable Nothing (insertFooBarSource oldFooBars)
 
-                  RawSql.executeVoid connection $
-                    updateDogToForret
+                RawSql.executeVoid connection $
+                  updateDogToForret
 
-                  result <-
-                    RawSql.execute connection $
-                      Expr.queryExpr
-                        (Expr.selectClause $ Expr.selectExpr Nothing)
-                        (Expr.selectColumns [fooColumn, barColumn])
-                        (Just $ Expr.tableExpr fooBarTable Nothing (Just orderByFoo) Nothing Nothing Nothing)
+                result <-
+                  RawSql.execute connection $
+                    Expr.queryExpr
+                      (Expr.selectClause $ Expr.selectExpr Nothing)
+                      (Expr.selectColumns [fooColumn, barColumn])
+                      (Just $ Expr.tableExpr fooBarTable Nothing (Just orderByFoo) Nothing Nothing Nothing)
 
-                  ExecResult.readRows result
+                ExecResult.readRows result
 
-            rows `assertEqualSqlRows` map encodeFooBar newFooBars
-        )
-      ]
+          rows `assertEqualSqlRows` map encodeFooBar newFooBars
+      )
+    ]

--- a/orville-postgresql-libpq/test/Test/Expr/OrderBy.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/OrderBy.hs
@@ -17,64 +17,62 @@ import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
 import Test.Expr.TestSchema (FooBar (..), assertEqualSqlRows, barColumn, dropAndRecreateTestTable, encodeFooBar, fooBarTable, fooColumn, insertFooBarSource)
 import qualified Test.Property as Property
 
-orderByTests :: Pool.Pool Conn.Connection -> IO Bool
+orderByTests :: Pool.Pool Conn.Connection -> Property.Group
 orderByTests pool =
-  HH.checkSequential $
-    HH.Group
-      (String.fromString "Expr - OrderBy")
-      [
-        ( String.fromString "ascendingExpr sorts a text column"
-        , runOrderByTest pool $
-            OrderByTest
-              { orderByValuesToInsert = [FooBar 1 "dog", FooBar 2 "dingo", FooBar 3 "dog"]
-              , orderByExpectedQueryResults = [FooBar 2 "dingo", FooBar 1 "dog", FooBar 3 "dog"]
-              , orderByClause =
-                  Just . Expr.orderByClause $
-                    Expr.orderByExpr
-                      (RawSql.toRawSql barColumn)
-                      Expr.ascendingOrder
-              }
-        )
-      ,
-        ( String.fromString "descendingExpr sorts a text column"
-        , runOrderByTest pool $
-            OrderByTest
-              { orderByValuesToInsert = [FooBar 1 "dog", FooBar 2 "dingo", FooBar 3 "dog"]
-              , orderByExpectedQueryResults = [FooBar 1 "dog", FooBar 3 "dog", FooBar 2 "dingo"]
-              , orderByClause =
-                  Just . Expr.orderByClause $
-                    Expr.orderByExpr
-                      (RawSql.toRawSql barColumn)
-                      Expr.descendingOrder
-              }
-        )
-      ,
-        ( String.fromString "addOrderBy causes ordering on both columns"
-        , runOrderByTest pool $
-            OrderByTest
-              { orderByValuesToInsert = [FooBar 1 "dog", FooBar 2 "dingo", FooBar 3 "dog"]
-              , orderByExpectedQueryResults = [FooBar 2 "dingo", FooBar 3 "dog", FooBar 1 "dog"]
-              , orderByClause =
-                  Just . Expr.orderByClause $
-                    Expr.appendOrderBy
-                      (Expr.orderByExpr (RawSql.toRawSql barColumn) Expr.ascendingOrder)
-                      (Expr.orderByExpr (RawSql.toRawSql fooColumn) Expr.descendingOrder)
-              }
-        )
-      ,
-        ( String.fromString "orderByColumnsExpr orders by columns"
-        , runOrderByTest pool $
-            OrderByTest
-              { orderByValuesToInsert = [FooBar 1 "dog", FooBar 2 "dingo", FooBar 3 "dog"]
-              , orderByExpectedQueryResults = [FooBar 2 "dingo", FooBar 3 "dog", FooBar 1 "dog"]
-              , orderByClause =
-                  Just . Expr.orderByClause $
-                    Expr.orderByColumnsExpr $
-                      (barColumn, Expr.ascendingOrder)
-                        NE.:| [(fooColumn, Expr.descendingOrder)]
-              }
-        )
-      ]
+  Property.group "Expr - OrderBy" $
+    [
+      ( String.fromString "ascendingExpr sorts a text column"
+      , runOrderByTest pool $
+          OrderByTest
+            { orderByValuesToInsert = [FooBar 1 "dog", FooBar 2 "dingo", FooBar 3 "dog"]
+            , orderByExpectedQueryResults = [FooBar 2 "dingo", FooBar 1 "dog", FooBar 3 "dog"]
+            , orderByClause =
+                Just . Expr.orderByClause $
+                  Expr.orderByExpr
+                    (RawSql.toRawSql barColumn)
+                    Expr.ascendingOrder
+            }
+      )
+    ,
+      ( String.fromString "descendingExpr sorts a text column"
+      , runOrderByTest pool $
+          OrderByTest
+            { orderByValuesToInsert = [FooBar 1 "dog", FooBar 2 "dingo", FooBar 3 "dog"]
+            , orderByExpectedQueryResults = [FooBar 1 "dog", FooBar 3 "dog", FooBar 2 "dingo"]
+            , orderByClause =
+                Just . Expr.orderByClause $
+                  Expr.orderByExpr
+                    (RawSql.toRawSql barColumn)
+                    Expr.descendingOrder
+            }
+      )
+    ,
+      ( String.fromString "addOrderBy causes ordering on both columns"
+      , runOrderByTest pool $
+          OrderByTest
+            { orderByValuesToInsert = [FooBar 1 "dog", FooBar 2 "dingo", FooBar 3 "dog"]
+            , orderByExpectedQueryResults = [FooBar 2 "dingo", FooBar 3 "dog", FooBar 1 "dog"]
+            , orderByClause =
+                Just . Expr.orderByClause $
+                  Expr.appendOrderBy
+                    (Expr.orderByExpr (RawSql.toRawSql barColumn) Expr.ascendingOrder)
+                    (Expr.orderByExpr (RawSql.toRawSql fooColumn) Expr.descendingOrder)
+            }
+      )
+    ,
+      ( String.fromString "orderByColumnsExpr orders by columns"
+      , runOrderByTest pool $
+          OrderByTest
+            { orderByValuesToInsert = [FooBar 1 "dog", FooBar 2 "dingo", FooBar 3 "dog"]
+            , orderByExpectedQueryResults = [FooBar 2 "dingo", FooBar 3 "dog", FooBar 1 "dog"]
+            , orderByClause =
+                Just . Expr.orderByClause $
+                  Expr.orderByColumnsExpr $
+                    (barColumn, Expr.ascendingOrder)
+                      NE.:| [(fooColumn, Expr.descendingOrder)]
+            }
+      )
+    ]
 
 data OrderByTest = OrderByTest
   { orderByValuesToInsert :: [FooBar]

--- a/orville-postgresql-libpq/test/Test/Expr/TableDefinition.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/TableDefinition.hs
@@ -17,66 +17,65 @@ import qualified Orville.PostgreSQL.Internal.Expr as Expr
 
 import qualified Test.Property as Property
 
-tableDefinitionTests :: Pool.Pool Conn.Connection -> IO Bool
+tableDefinitionTests :: Pool.Pool Conn.Connection -> Property.Group
 tableDefinitionTests pool =
-  HH.checkSequential $
-    HH.Group
-      (String.fromString "Expr - TableDefinition")
-      [
-        ( String.fromString "Create table creates a table with one column"
-        , Property.singletonProperty $ do
-            MIO.liftIO $
-              Orville.runOrville pool $ do
-                Orville.executeVoid $ Expr.dropTableExpr (Just Expr.ifExists) exprTableName
-                Orville.executeVoid $ Expr.createTableExpr exprTableName [column1Definition] Nothing
+  Property.group
+    "Expr - TableDefinition"
+    [
+      ( String.fromString "Create table creates a table with one column"
+      , Property.singletonProperty $ do
+          MIO.liftIO $
+            Orville.runOrville pool $ do
+              Orville.executeVoid $ Expr.dropTableExpr (Just Expr.ifExists) exprTableName
+              Orville.executeVoid $ Expr.createTableExpr exprTableName [column1Definition] Nothing
 
-            assertColumnNamesEqual
-              pool
-              informationSchemaTableName
-              [informationSchemaColumn1Name]
-        )
-      ,
-        ( String.fromString "Create table creates a table with multiple columns"
-        , Property.singletonProperty $ do
-            MIO.liftIO $
-              Orville.runOrville pool $ do
-                Orville.executeVoid $ Expr.dropTableExpr (Just Expr.ifExists) exprTableName
-                Orville.executeVoid $ Expr.createTableExpr exprTableName [column1Definition, column2Definition] Nothing
+          assertColumnNamesEqual
+            pool
+            informationSchemaTableName
+            [informationSchemaColumn1Name]
+      )
+    ,
+      ( String.fromString "Create table creates a table with multiple columns"
+      , Property.singletonProperty $ do
+          MIO.liftIO $
+            Orville.runOrville pool $ do
+              Orville.executeVoid $ Expr.dropTableExpr (Just Expr.ifExists) exprTableName
+              Orville.executeVoid $ Expr.createTableExpr exprTableName [column1Definition, column2Definition] Nothing
 
-            assertColumnNamesEqual
-              pool
-              informationSchemaTableName
-              [informationSchemaColumn1Name, informationSchemaColumn2Name]
-        )
-      ,
-        ( String.fromString "Alter table adds one column"
-        , Property.singletonProperty $ do
-            MIO.liftIO $
-              Orville.runOrville pool $ do
-                Orville.executeVoid $ Expr.dropTableExpr (Just Expr.ifExists) exprTableName
-                Orville.executeVoid $ Expr.createTableExpr exprTableName [] Nothing
-                Orville.executeVoid $ Expr.alterTableExpr exprTableName (Expr.addColumn column1Definition :| [])
+          assertColumnNamesEqual
+            pool
+            informationSchemaTableName
+            [informationSchemaColumn1Name, informationSchemaColumn2Name]
+      )
+    ,
+      ( String.fromString "Alter table adds one column"
+      , Property.singletonProperty $ do
+          MIO.liftIO $
+            Orville.runOrville pool $ do
+              Orville.executeVoid $ Expr.dropTableExpr (Just Expr.ifExists) exprTableName
+              Orville.executeVoid $ Expr.createTableExpr exprTableName [] Nothing
+              Orville.executeVoid $ Expr.alterTableExpr exprTableName (Expr.addColumn column1Definition :| [])
 
-            assertColumnNamesEqual
-              pool
-              informationSchemaTableName
-              [informationSchemaColumn1Name]
-        )
-      ,
-        ( String.fromString "Alter table adds multiple columns"
-        , Property.singletonProperty $ do
-            MIO.liftIO $
-              Orville.runOrville pool $ do
-                Orville.executeVoid $ Expr.dropTableExpr (Just Expr.ifExists) exprTableName
-                Orville.executeVoid $ Expr.createTableExpr exprTableName [] Nothing
-                Orville.executeVoid $ Expr.alterTableExpr exprTableName (Expr.addColumn column1Definition :| [Expr.addColumn column2Definition])
+          assertColumnNamesEqual
+            pool
+            informationSchemaTableName
+            [informationSchemaColumn1Name]
+      )
+    ,
+      ( String.fromString "Alter table adds multiple columns"
+      , Property.singletonProperty $ do
+          MIO.liftIO $
+            Orville.runOrville pool $ do
+              Orville.executeVoid $ Expr.dropTableExpr (Just Expr.ifExists) exprTableName
+              Orville.executeVoid $ Expr.createTableExpr exprTableName [] Nothing
+              Orville.executeVoid $ Expr.alterTableExpr exprTableName (Expr.addColumn column1Definition :| [Expr.addColumn column2Definition])
 
-            assertColumnNamesEqual
-              pool
-              informationSchemaTableName
-              [informationSchemaColumn1Name, informationSchemaColumn2Name]
-        )
-      ]
+          assertColumnNamesEqual
+            pool
+            informationSchemaTableName
+            [informationSchemaColumn1Name, informationSchemaColumn2Name]
+      )
+    ]
 
 exprTableName :: Expr.QualifiedTableName
 exprTableName =

--- a/orville-postgresql-libpq/test/Test/FieldDefinition.hs
+++ b/orville-postgresql-libpq/test/Test/FieldDefinition.hs
@@ -26,22 +26,20 @@ import Test.Expr.TestSchema (sqlRowsToText)
 import qualified Test.PGGen as PGGen
 import qualified Test.Property as Property
 
-fieldDefinitionTests :: Pool.Pool Connection.Connection -> IO Bool
+fieldDefinitionTests :: Pool.Pool Connection.Connection -> Property.Group
 fieldDefinitionTests pool =
-  HH.checkSequential $
-    HH.Group
-      (String.fromString "FieldDefinition")
-      $ integerField pool
-        <> bigIntegerField pool
-        <> doubleField pool
-        <> booleanField pool
-        <> unboundedTextField pool
-        <> boundedTextField pool
-        <> fixedTextField pool
-        <> textSearchVectorField pool
-        <> dateField pool
-        <> timestampField pool
-        <> timestampWithoutZoneField pool
+  Property.group "FieldDefinition" $
+    integerField pool
+      <> bigIntegerField pool
+      <> doubleField pool
+      <> booleanField pool
+      <> unboundedTextField pool
+      <> boundedTextField pool
+      <> fixedTextField pool
+      <> textSearchVectorField pool
+      <> dateField pool
+      <> timestampField pool
+      <> timestampWithoutZoneField pool
 
 integerField :: Pool.Pool Connection.Connection -> [(HH.PropertyName, HH.Property)]
 integerField pool =

--- a/orville-postgresql-libpq/test/Test/InformationSchema.hs
+++ b/orville-postgresql-libpq/test/Test/InformationSchema.hs
@@ -15,60 +15,59 @@ import qualified Orville.PostgreSQL.InformationSchema as InformationSchema
 
 import qualified Test.Property as Property
 
-informationSchemaTests :: Pool.Pool Conn.Connection -> IO Bool
+informationSchemaTests :: Pool.Pool Conn.Connection -> Property.Group
 informationSchemaTests pool =
-  HH.checkSequential $
-    HH.Group
-      (String.fromString "InformationSchema")
-      [
-        ( String.fromString "Can query information about a table"
-        , Property.singletonProperty $ do
-            result <- MIO.liftIO . Orville.runOrville pool $ do
-              Orville.findFirstEntityBy
-                InformationSchema.informationSchemaTablesTable
-                ( Orville.where_ $
-                    Orville.whereAnd
-                      ( Orville.fieldEquals InformationSchema.tableSchemaField informationSchemaSchemaName
-                          :| [ Orville.fieldEquals InformationSchema.tableNameField tablesTableName
-                             ]
-                      )
-                )
+  Property.group
+    "InformationSchema"
+    [
+      ( String.fromString "Can query information about a table"
+      , Property.singletonProperty $ do
+          result <- MIO.liftIO . Orville.runOrville pool $ do
+            Orville.findFirstEntityBy
+              InformationSchema.informationSchemaTablesTable
+              ( Orville.where_ $
+                  Orville.whereAnd
+                    ( Orville.fieldEquals InformationSchema.tableSchemaField informationSchemaSchemaName
+                        :| [ Orville.fieldEquals InformationSchema.tableNameField tablesTableName
+                           ]
+                    )
+              )
 
-            let expected =
-                  InformationSchema.InformationSchemaTable
-                    { InformationSchema.tableCatalog = orvilleTestCatalogName
-                    , InformationSchema.tableSchema = informationSchemaSchemaName
-                    , InformationSchema.tableName = tablesTableName
-                    }
+          let expected =
+                InformationSchema.InformationSchemaTable
+                  { InformationSchema.tableCatalog = orvilleTestCatalogName
+                  , InformationSchema.tableSchema = informationSchemaSchemaName
+                  , InformationSchema.tableName = tablesTableName
+                  }
 
-            result HH.=== Just expected
-        )
-      ,
-        ( String.fromString "Can query information about a column"
-        , Property.singletonProperty $ do
-            result <- MIO.liftIO . Orville.runOrville pool $ do
-              Orville.findFirstEntityBy
-                InformationSchema.informationSchemaColumnsTable
-                ( Orville.where_ $
-                    Orville.whereAnd
-                      ( Orville.fieldEquals InformationSchema.tableSchemaField informationSchemaSchemaName
-                          :| [ Orville.fieldEquals InformationSchema.tableNameField tablesTableName
-                             , Orville.fieldEquals InformationSchema.columnNameField tableNameColumnName
-                             ]
-                      )
-                )
+          result HH.=== Just expected
+      )
+    ,
+      ( String.fromString "Can query information about a column"
+      , Property.singletonProperty $ do
+          result <- MIO.liftIO . Orville.runOrville pool $ do
+            Orville.findFirstEntityBy
+              InformationSchema.informationSchemaColumnsTable
+              ( Orville.where_ $
+                  Orville.whereAnd
+                    ( Orville.fieldEquals InformationSchema.tableSchemaField informationSchemaSchemaName
+                        :| [ Orville.fieldEquals InformationSchema.tableNameField tablesTableName
+                           , Orville.fieldEquals InformationSchema.columnNameField tableNameColumnName
+                           ]
+                    )
+              )
 
-            let expected =
-                  InformationSchema.InformationSchemaColumn
-                    { InformationSchema.columnTableCatalog = orvilleTestCatalogName
-                    , InformationSchema.columnTableSchema = informationSchemaSchemaName
-                    , InformationSchema.columnTableName = tablesTableName
-                    , InformationSchema.columnName = tableNameColumnName
-                    }
+          let expected =
+                InformationSchema.InformationSchemaColumn
+                  { InformationSchema.columnTableCatalog = orvilleTestCatalogName
+                  , InformationSchema.columnTableSchema = informationSchemaSchemaName
+                  , InformationSchema.columnTableName = tablesTableName
+                  , InformationSchema.columnName = tableNameColumnName
+                  }
 
-            result HH.=== Just expected
-        )
-      ]
+          result HH.=== Just expected
+      )
+    ]
 
 orvilleTestCatalogName :: InformationSchema.CatalogName
 orvilleTestCatalogName =

--- a/orville-postgresql-libpq/test/Test/Property.hs
+++ b/orville-postgresql-libpq/test/Test/Property.hs
@@ -1,10 +1,67 @@
 module Test.Property
   ( singletonProperty,
+    Group (..),
+    group,
+    checkGroups,
+    checkGroup,
+    allPassed,
   )
 where
 
+import qualified Control.Monad as Monad
 import qualified GHC.Stack as CallStack
 import qualified Hedgehog as HH
+import qualified Hedgehog.Internal.Config as Config
+import qualified Hedgehog.Internal.Property as Property
+import qualified Hedgehog.Internal.Report as Report
+import qualified Hedgehog.Internal.Runner as Runner
+import qualified Hedgehog.Internal.Seed as Seed
 
 singletonProperty :: CallStack.HasCallStack => HH.PropertyT IO () -> HH.Property
 singletonProperty = HH.withTests 1 . HH.property
+
+data Group = Group
+  { groupName :: String
+  , groupProperties :: [(HH.PropertyName, HH.Property)]
+  }
+
+group :: String -> [(HH.PropertyName, HH.Property)] -> Group
+group = Group
+
+checkGroups :: Foldable f => f Group -> IO Report.Summary
+checkGroups groups = do
+  useColor <- Config.resolveColor Nothing
+  summary <- foldMap (checkGroup useColor) groups
+  putStrLn =<< Report.renderSummary useColor summary
+  pure summary
+
+checkGroup :: Config.UseColor -> Group -> IO Report.Summary
+checkGroup useColor propGroup = do
+  let name = groupName propGroup
+      properties = groupProperties propGroup
+
+  putStrLn $ "• " <> name <> " : " <> show (length properties) <> " properties"
+  foldMap (checkProperty useColor) properties
+
+checkProperty :: Config.UseColor -> (HH.PropertyName, HH.Property) -> IO Report.Summary
+checkProperty useColor (name, prop) = do
+  seed <- Seed.random
+  report <-
+    Runner.checkReport
+      (Property.propertyConfig prop)
+      0
+      seed
+      (Property.propertyTest prop)
+      (\_ -> pure ())
+
+  let result = Report.reportStatus report
+
+  Monad.when (result /= Report.OK) $ do
+    putStrLn =<< Report.renderResult useColor (Just name) report
+
+  pure $ Report.fromResult result
+
+allPassed :: Report.Summary -> Bool
+allPassed summary =
+  Report.summaryFailed summary == 0
+    && Report.summaryGaveUp summary == 0

--- a/orville-postgresql-libpq/test/Test/RawSql.hs
+++ b/orville-postgresql-libpq/test/Test/RawSql.hs
@@ -14,61 +14,60 @@ import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
 
 import qualified Test.Property as Property
 
-rawSqlTests :: IO Bool
+rawSqlTests :: Property.Group
 rawSqlTests =
-  HH.checkParallel $
-    HH.Group
-      (String.fromString "RawSql Tests")
-      [
-        ( String.fromString "Builds concatenated sql from strings"
-        , Property.singletonProperty $ do
-            let rawSql =
-                  RawSql.fromString "SELECT * "
-                    <> RawSql.fromString "FROM foo "
-                    <> RawSql.fromString "WHERE id = 1"
+  Property.group
+    "RawSql"
+    [
+      ( String.fromString "Builds concatenated sql from strings"
+      , Property.singletonProperty $ do
+          let rawSql =
+                RawSql.fromString "SELECT * "
+                  <> RawSql.fromString "FROM foo "
+                  <> RawSql.fromString "WHERE id = 1"
 
-                expectedBytes =
-                  B8.pack "SELECT * FROM foo WHERE id = 1"
+              expectedBytes =
+                B8.pack "SELECT * FROM foo WHERE id = 1"
 
-                (actualBytes, actualParams) =
-                  RawSql.toBytesAndParams rawSql
+              (actualBytes, actualParams) =
+                RawSql.toBytesAndParams rawSql
 
-            actualBytes HH.=== expectedBytes
-            actualParams HH.=== []
-        )
-      ,
-        ( String.fromString "Tracks value placeholders in concatenated order"
-        , Property.singletonProperty $ do
-            let rawSql =
-                  RawSql.fromString "SELECT * "
-                    <> RawSql.fromString "FROM foo "
-                    <> RawSql.fromString "WHERE id = "
-                    <> RawSql.parameter (SqlValue.fromInt32 1)
-                    <> RawSql.fromString " AND "
-                    <> RawSql.fromString "bar IN ("
-                    <> RawSql.intercalate RawSql.comma bars
-                    <> RawSql.fromString ")"
+          actualBytes HH.=== expectedBytes
+          actualParams HH.=== []
+      )
+    ,
+      ( String.fromString "Tracks value placeholders in concatenated order"
+      , Property.singletonProperty $ do
+          let rawSql =
+                RawSql.fromString "SELECT * "
+                  <> RawSql.fromString "FROM foo "
+                  <> RawSql.fromString "WHERE id = "
+                  <> RawSql.parameter (SqlValue.fromInt32 1)
+                  <> RawSql.fromString " AND "
+                  <> RawSql.fromString "bar IN ("
+                  <> RawSql.intercalate RawSql.comma bars
+                  <> RawSql.fromString ")"
 
-                bars =
-                  map
-                    RawSql.parameter
-                    [ SqlValue.fromText (T.pack "pants")
-                    , SqlValue.fromText (T.pack "cheese")
-                    ]
-
-                expectedBytes =
-                  B8.pack "SELECT * FROM foo WHERE id = $1 AND bar IN ($2,$3)"
-
-                expectedParams =
-                  [ Just . PGTextFormatValue.fromByteString . B8.pack $ "1"
-                  , Just . PGTextFormatValue.fromByteString . B8.pack $ "pants"
-                  , Just . PGTextFormatValue.fromByteString . B8.pack $ "cheese"
+              bars =
+                map
+                  RawSql.parameter
+                  [ SqlValue.fromText (T.pack "pants")
+                  , SqlValue.fromText (T.pack "cheese")
                   ]
 
-                (actualBytes, actualParams) =
-                  RawSql.toBytesAndParams rawSql
+              expectedBytes =
+                B8.pack "SELECT * FROM foo WHERE id = $1 AND bar IN ($2,$3)"
 
-            actualBytes HH.=== expectedBytes
-            actualParams HH.=== expectedParams
-        )
-      ]
+              expectedParams =
+                [ Just . PGTextFormatValue.fromByteString . B8.pack $ "1"
+                , Just . PGTextFormatValue.fromByteString . B8.pack $ "pants"
+                , Just . PGTextFormatValue.fromByteString . B8.pack $ "cheese"
+                ]
+
+              (actualBytes, actualParams) =
+                RawSql.toBytesAndParams rawSql
+
+          actualBytes HH.=== expectedBytes
+          actualParams HH.=== expectedParams
+      )
+    ]

--- a/orville-postgresql-libpq/test/Test/ReservedWords.hs
+++ b/orville-postgresql-libpq/test/Test/ReservedWords.hs
@@ -15,25 +15,23 @@ import qualified Test.Entities.User as User
 import qualified Test.Property as Property
 import qualified Test.TestTable as TestTable
 
-reservedWordsTests :: Pool.Pool Conn.Connection -> IO Bool
+reservedWordsTests :: Pool.Pool Conn.Connection -> Property.Group
 reservedWordsTests pool =
-  HH.checkSequential $
-    HH.Group
-      (String.fromString "ReservedWords")
-      [
-        ( String.fromString "Can insert and select an entity with reserved words in its schema"
-        , Property.singletonProperty $ do
-            originalUser <- HH.forAll User.generate
+  Property.group "ReservedWords" $
+    [
+      ( String.fromString "Can insert and select an entity with reserved words in its schema"
+      , Property.singletonProperty $ do
+          originalUser <- HH.forAll User.generate
 
-            usersFromDB <-
-              MIO.liftIO $ do
-                Pool.withResource pool $ \connection ->
-                  TestTable.dropAndRecreateTableDef connection User.table
+          usersFromDB <-
+            MIO.liftIO $ do
+              Pool.withResource pool $ \connection ->
+                TestTable.dropAndRecreateTableDef connection User.table
 
-                Orville.runOrville pool $ do
-                  Orville.insertEntity User.table originalUser
-                  Orville.findEntitiesBy User.table mempty
+              Orville.runOrville pool $ do
+                Orville.insertEntity User.table originalUser
+                Orville.findEntitiesBy User.table mempty
 
-            usersFromDB HH.=== [originalUser]
-        )
-      ]
+          usersFromDB HH.=== [originalUser]
+      )
+    ]

--- a/orville-postgresql-libpq/test/Test/SelectOptions.hs
+++ b/orville-postgresql-libpq/test/Test/SelectOptions.hs
@@ -15,142 +15,141 @@ import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
 import qualified Orville.PostgreSQL.Internal.SelectOptions as SO
 import qualified Test.Property as Property
 
-selectOptionsTests :: IO Bool
+selectOptionsTests :: Property.Group
 selectOptionsTests =
-  HH.checkParallel $
-    HH.Group
-      (String.fromString "SelectOptions")
-      [
-        ( String.fromString "emptySelectOptions yields no whereClause"
-        , Property.singletonProperty $
-            assertWhereClauseEquals
-              Nothing
-              SO.emptySelectOptions
-        )
-      ,
-        ( String.fromString "fieldEquals generates expected sql"
-        , Property.singletonProperty $
-            assertWhereClauseEquals
-              (Just "WHERE (\"foo\" = $1)")
-              (SO.where_ $ SO.fieldEquals fooField 0)
-        )
-      ,
-        ( String.fromString "fieldNotEquals generates expected sql"
-        , Property.singletonProperty $
-            assertWhereClauseEquals
-              (Just "WHERE (\"foo\" <> $1)")
-              (SO.where_ $ SO.fieldNotEquals fooField 0)
-        )
-      ,
-        ( String.fromString "fieldLessThan generates expected sql"
-        , Property.singletonProperty $
-            assertWhereClauseEquals
-              (Just "WHERE (\"foo\" < $1)")
-              (SO.where_ $ SO.fieldLessThan fooField 0)
-        )
-      ,
-        ( String.fromString "fieldGreaterThan generates expected sql"
-        , Property.singletonProperty $
-            assertWhereClauseEquals
-              (Just "WHERE (\"foo\" > $1)")
-              (SO.where_ $ SO.fieldGreaterThan fooField 0)
-        )
-      ,
-        ( String.fromString "fieldLessThanOrEqualTo generates expected sql"
-        , Property.singletonProperty $
-            assertWhereClauseEquals
-              (Just "WHERE (\"foo\" <= $1)")
-              (SO.where_ $ SO.fieldLessThanOrEqualTo fooField 0)
-        )
-      ,
-        ( String.fromString "fieldGreaterThanOrEqualTo generates expected sql"
-        , Property.singletonProperty $
-            assertWhereClauseEquals
-              (Just "WHERE (\"foo\" >= $1)")
-              (SO.where_ $ SO.fieldGreaterThanOrEqualTo fooField 0)
-        )
-      ,
-        ( String.fromString "whereAnd generates expected sql"
-        , Property.singletonProperty $
-            assertWhereClauseEquals
-              (Just "WHERE ((\"foo\" = $1) AND (\"bar\" = $2))")
-              (SO.where_ $ SO.whereAnd (SO.fieldEquals fooField 10 :| [SO.fieldEquals barField 20]))
-        )
-      ,
-        ( String.fromString "whereOr generates expected sql"
-        , Property.singletonProperty $
-            assertWhereClauseEquals
-              (Just "WHERE ((\"foo\" = $1) OR (\"bar\" = $2))")
-              (SO.where_ $ SO.whereOr (SO.fieldEquals fooField 10 :| [SO.fieldEquals barField 20]))
-        )
-      ,
-        ( String.fromString "combining SelectOptions ANDs the where clauses together"
-        , Property.singletonProperty $
-            assertWhereClauseEquals
-              (Just "WHERE (\"foo\" = $1) AND (\"bar\" = $2)")
-              ( SO.where_ (SO.fieldEquals fooField 10)
-                  <> SO.where_ (SO.fieldEquals barField 20)
-              )
-        )
-      ,
-        ( String.fromString "whereIn generates expected sql"
-        , Property.singletonProperty $
-            assertWhereClauseEquals
-              (Just "WHERE (\"foo\" IN ($1))")
-              (SO.where_ $ SO.whereIn fooField (10 :| []))
-        )
-      ,
-        ( String.fromString "whereNotIn generates expected sql"
-        , Property.singletonProperty $
-            assertWhereClauseEquals
-              (Just "WHERE (\"foo\" NOT IN ($1, $2))")
-              (SO.where_ $ SO.whereNotIn fooField (10 :| [20]))
-        )
-      ,
-        ( String.fromString "distinct generates expected sql"
-        , Property.singletonProperty $
-            assertDistinctEquals
-              ("SELECT DISTINCT ")
-              (SO.distinct)
-        )
-      ,
-        ( String.fromString "orderBy generates expected sql"
-        , Property.singletonProperty $
-            assertOrderByClauseEquals
-              (Just "ORDER BY \"foo\" ASC, \"bar\" DESC")
-              ( SO.orderBy . Expr.orderByColumnsExpr $
-                  (FieldDef.fieldColumnName fooField, Expr.ascendingOrder)
-                    :| [(FieldDef.fieldColumnName barField, Expr.descendingOrder)]
-              )
-        )
-      ,
-        ( String.fromString "orderBy generates expected sql with multiple selectOptions"
-        , Property.singletonProperty $
-            assertOrderByClauseEquals
-              (Just "ORDER BY foo ASC, \"bar\" DESC")
-              ( (SO.orderBy $ Expr.orderByExpr (RawSql.fromString "foo") Expr.ascendingOrder)
-                  <> (SO.orderBy $ Expr.orderByExpr (RawSql.toRawSql $ FieldDef.fieldColumnName barField) Expr.descendingOrder)
-              )
-        )
-      ,
-        ( String.fromString "groupBy generates expected sql"
-        , Property.singletonProperty $
-            assertGroupByClauseEquals
-              (Just "GROUP BY \"foo\", \"bar\"")
-              ( SO.groupBy . Expr.groupByColumnsExpr $
-                  FieldDef.fieldColumnName fooField :| [FieldDef.fieldColumnName barField]
-              )
-        )
-      ,
-        ( String.fromString "groupBy generates expected sql with multiple selectOptions"
-        , Property.singletonProperty $
-            assertGroupByClauseEquals
-              (Just "GROUP BY foo, \"bar\"")
-              ( (SO.groupBy . Expr.groupByExpr $ RawSql.fromString "foo")
-                  <> (SO.groupBy . Expr.groupByExpr . RawSql.toRawSql $ FieldDef.fieldColumnName barField)
-              )
-        )
-      ]
+  Property.group
+    "SelectOptions"
+    [
+      ( String.fromString "emptySelectOptions yields no whereClause"
+      , Property.singletonProperty $
+          assertWhereClauseEquals
+            Nothing
+            SO.emptySelectOptions
+      )
+    ,
+      ( String.fromString "fieldEquals generates expected sql"
+      , Property.singletonProperty $
+          assertWhereClauseEquals
+            (Just "WHERE (\"foo\" = $1)")
+            (SO.where_ $ SO.fieldEquals fooField 0)
+      )
+    ,
+      ( String.fromString "fieldNotEquals generates expected sql"
+      , Property.singletonProperty $
+          assertWhereClauseEquals
+            (Just "WHERE (\"foo\" <> $1)")
+            (SO.where_ $ SO.fieldNotEquals fooField 0)
+      )
+    ,
+      ( String.fromString "fieldLessThan generates expected sql"
+      , Property.singletonProperty $
+          assertWhereClauseEquals
+            (Just "WHERE (\"foo\" < $1)")
+            (SO.where_ $ SO.fieldLessThan fooField 0)
+      )
+    ,
+      ( String.fromString "fieldGreaterThan generates expected sql"
+      , Property.singletonProperty $
+          assertWhereClauseEquals
+            (Just "WHERE (\"foo\" > $1)")
+            (SO.where_ $ SO.fieldGreaterThan fooField 0)
+      )
+    ,
+      ( String.fromString "fieldLessThanOrEqualTo generates expected sql"
+      , Property.singletonProperty $
+          assertWhereClauseEquals
+            (Just "WHERE (\"foo\" <= $1)")
+            (SO.where_ $ SO.fieldLessThanOrEqualTo fooField 0)
+      )
+    ,
+      ( String.fromString "fieldGreaterThanOrEqualTo generates expected sql"
+      , Property.singletonProperty $
+          assertWhereClauseEquals
+            (Just "WHERE (\"foo\" >= $1)")
+            (SO.where_ $ SO.fieldGreaterThanOrEqualTo fooField 0)
+      )
+    ,
+      ( String.fromString "whereAnd generates expected sql"
+      , Property.singletonProperty $
+          assertWhereClauseEquals
+            (Just "WHERE ((\"foo\" = $1) AND (\"bar\" = $2))")
+            (SO.where_ $ SO.whereAnd (SO.fieldEquals fooField 10 :| [SO.fieldEquals barField 20]))
+      )
+    ,
+      ( String.fromString "whereOr generates expected sql"
+      , Property.singletonProperty $
+          assertWhereClauseEquals
+            (Just "WHERE ((\"foo\" = $1) OR (\"bar\" = $2))")
+            (SO.where_ $ SO.whereOr (SO.fieldEquals fooField 10 :| [SO.fieldEquals barField 20]))
+      )
+    ,
+      ( String.fromString "combining SelectOptions ANDs the where clauses together"
+      , Property.singletonProperty $
+          assertWhereClauseEquals
+            (Just "WHERE (\"foo\" = $1) AND (\"bar\" = $2)")
+            ( SO.where_ (SO.fieldEquals fooField 10)
+                <> SO.where_ (SO.fieldEquals barField 20)
+            )
+      )
+    ,
+      ( String.fromString "whereIn generates expected sql"
+      , Property.singletonProperty $
+          assertWhereClauseEquals
+            (Just "WHERE (\"foo\" IN ($1))")
+            (SO.where_ $ SO.whereIn fooField (10 :| []))
+      )
+    ,
+      ( String.fromString "whereNotIn generates expected sql"
+      , Property.singletonProperty $
+          assertWhereClauseEquals
+            (Just "WHERE (\"foo\" NOT IN ($1, $2))")
+            (SO.where_ $ SO.whereNotIn fooField (10 :| [20]))
+      )
+    ,
+      ( String.fromString "distinct generates expected sql"
+      , Property.singletonProperty $
+          assertDistinctEquals
+            ("SELECT DISTINCT ")
+            (SO.distinct)
+      )
+    ,
+      ( String.fromString "orderBy generates expected sql"
+      , Property.singletonProperty $
+          assertOrderByClauseEquals
+            (Just "ORDER BY \"foo\" ASC, \"bar\" DESC")
+            ( SO.orderBy . Expr.orderByColumnsExpr $
+                (FieldDef.fieldColumnName fooField, Expr.ascendingOrder)
+                  :| [(FieldDef.fieldColumnName barField, Expr.descendingOrder)]
+            )
+      )
+    ,
+      ( String.fromString "orderBy generates expected sql with multiple selectOptions"
+      , Property.singletonProperty $
+          assertOrderByClauseEquals
+            (Just "ORDER BY foo ASC, \"bar\" DESC")
+            ( (SO.orderBy $ Expr.orderByExpr (RawSql.fromString "foo") Expr.ascendingOrder)
+                <> (SO.orderBy $ Expr.orderByExpr (RawSql.toRawSql $ FieldDef.fieldColumnName barField) Expr.descendingOrder)
+            )
+      )
+    ,
+      ( String.fromString "groupBy generates expected sql"
+      , Property.singletonProperty $
+          assertGroupByClauseEquals
+            (Just "GROUP BY \"foo\", \"bar\"")
+            ( SO.groupBy . Expr.groupByColumnsExpr $
+                FieldDef.fieldColumnName fooField :| [FieldDef.fieldColumnName barField]
+            )
+      )
+    ,
+      ( String.fromString "groupBy generates expected sql with multiple selectOptions"
+      , Property.singletonProperty $
+          assertGroupByClauseEquals
+            (Just "GROUP BY foo, \"bar\"")
+            ( (SO.groupBy . Expr.groupByExpr $ RawSql.fromString "foo")
+                <> (SO.groupBy . Expr.groupByExpr . RawSql.toRawSql $ FieldDef.fieldColumnName barField)
+            )
+      )
+    ]
 
 assertDistinctEquals :: HH.MonadTest m => String -> SO.SelectOptions -> m ()
 assertDistinctEquals mbDistinct selectOptions =

--- a/orville-postgresql-libpq/test/Test/SqlType.hs
+++ b/orville-postgresql-libpq/test/Test/SqlType.hs
@@ -21,23 +21,21 @@ import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
 
 import qualified Test.Property as Property
 
-sqlTypeTests :: Pool.Pool Connection.Connection -> IO Bool
+sqlTypeTests :: Pool.Pool Connection.Connection -> Property.Group
 sqlTypeTests pool =
-  HH.checkSequential $
-    HH.Group
-      (String.fromString "SqlType decoding tests")
-      $ integerTests pool
-        <> bigIntegerTests pool
-        <> serialTests pool
-        <> bigSerialTests pool
-        <> doubleTests pool
-        <> boolTests pool
-        <> unboundedTextTests pool
-        <> fixedTextTests pool
-        <> boundedTextTests pool
-        <> textSearchVectorTests pool
-        <> dateTests pool
-        <> timestampTests pool
+  Property.group "SqlType" $
+    integerTests pool
+      <> bigIntegerTests pool
+      <> serialTests pool
+      <> bigSerialTests pool
+      <> doubleTests pool
+      <> boolTests pool
+      <> unboundedTextTests pool
+      <> fixedTextTests pool
+      <> boundedTextTests pool
+      <> textSearchVectorTests pool
+      <> dateTests pool
+      <> timestampTests pool
 
 integerTests :: Pool.Pool Connection.Connection -> [(HH.PropertyName, HH.Property)]
 integerTests pool =

--- a/orville-postgresql-libpq/test/Test/TableDefinition.hs
+++ b/orville-postgresql-libpq/test/Test/TableDefinition.hs
@@ -21,56 +21,54 @@ import qualified Test.Entities.Foo as Foo
 import qualified Test.Property as Property
 import qualified Test.TestTable as TestTable
 
-tableDefinitionTests :: Pool.Pool Conn.Connection -> IO Bool
+tableDefinitionTests :: Pool.Pool Conn.Connection -> Property.Group
 tableDefinitionTests pool =
-  HH.checkSequential $
-    HH.Group
-      (String.fromString "TableDefinition")
-      [
-        ( String.fromString "Creates a table than can round trip an entity through it"
-        , HH.property $ do
-            originalFoo <- HH.forAll Foo.generate
+  Property.group "TableDefinition" $
+    [
+      ( String.fromString "Creates a table than can round trip an entity through it"
+      , HH.property $ do
+          originalFoo <- HH.forAll Foo.generate
 
-            let insertFoo =
-                  TableDefinition.mkInsertExpr Foo.table (originalFoo NEL.:| [])
+          let insertFoo =
+                TableDefinition.mkInsertExpr Foo.table (originalFoo NEL.:| [])
 
-                selectFoos =
-                  TableDefinition.mkQueryExpr
-                    Foo.table
-                    (Expr.selectClause $ Expr.selectExpr Nothing)
-                    Nothing
-                    Nothing
-                    Nothing
-                    Nothing
-                    Nothing
+              selectFoos =
+                TableDefinition.mkQueryExpr
+                  Foo.table
+                  (Expr.selectClause $ Expr.selectExpr Nothing)
+                  Nothing
+                  Nothing
+                  Nothing
+                  Nothing
+                  Nothing
 
-            foosFromDB <-
-              MIO.liftIO . Pool.withResource pool $ \connection -> do
-                TestTable.dropAndRecreateTableDef connection Foo.table
-                RawSql.executeVoid connection insertFoo
-                result <- RawSql.execute connection selectFoos
-                SqlMarshaller.marshallResultFromSql (TableDefinition.tableMarshaller Foo.table) result
-
-            foosFromDB HH.=== Right [originalFoo]
-        )
-      ,
-        ( String.fromString "Creates a primary key that rejects duplicate records"
-        , Property.singletonProperty $ do
-            originalFoo <- HH.forAll Foo.generate
-
-            let insertFoo =
-                  TableDefinition.mkInsertExpr Foo.table (originalFoo NEL.:| [])
-
-            result <- MIO.liftIO . E.try . Pool.withResource pool $ \connection -> do
+          foosFromDB <-
+            MIO.liftIO . Pool.withResource pool $ \connection -> do
               TestTable.dropAndRecreateTableDef connection Foo.table
               RawSql.executeVoid connection insertFoo
-              RawSql.executeVoid connection insertFoo
+              result <- RawSql.execute connection selectFoos
+              SqlMarshaller.marshallResultFromSql (TableDefinition.tableMarshaller Foo.table) result
 
-            case result of
-              Right () -> do
-                HH.footnote "Expected 'executeVoid' to return failure, but it did not"
-                HH.failure
-              Left err ->
-                Conn.sqlExecutionErrorSqlState err HH.=== Just (B8.pack "23505")
-        )
-      ]
+          foosFromDB HH.=== Right [originalFoo]
+      )
+    ,
+      ( String.fromString "Creates a primary key that rejects duplicate records"
+      , Property.singletonProperty $ do
+          originalFoo <- HH.forAll Foo.generate
+
+          let insertFoo =
+                TableDefinition.mkInsertExpr Foo.table (originalFoo NEL.:| [])
+
+          result <- MIO.liftIO . E.try . Pool.withResource pool $ \connection -> do
+            TestTable.dropAndRecreateTableDef connection Foo.table
+            RawSql.executeVoid connection insertFoo
+            RawSql.executeVoid connection insertFoo
+
+          case result of
+            Right () -> do
+              HH.footnote "Expected 'executeVoid' to return failure, but it did not"
+              HH.failure
+            Left err ->
+              Conn.sqlExecutionErrorSqlState err HH.=== Just (B8.pack "23505")
+      )
+    ]


### PR DESCRIPTION
This adds a bit of custom runner code for our Hedgehog tests to cut
down on the test noise and make the output nicer when printer through
docker.

This is similar to setting the verbosity level to Quiet in hedgehog,
with a couple of changes that I think are nice for our context:

* It prints a summary for the entire test suite rather than each group
* It shows the number of properties in each group when the group begins
  running
* Doesn't produce weird newlines in output from docker

I did not bother to create our own version of `checkParallel` because
the the tests we were runnning using it are already very fast,
especially compared to the tests that though the database.

The output when running `./scripts/up.sh` now looks like this:

```
dev_1     | • Connection : 4 properties
dev_1     | • RawSql : 2 properties
dev_1     | • TableDefinition : 2 properties
dev_1     | • SqlMarshaller : 11 properties
dev_1     | • FieldDefinition : 33 properties
dev_1     | • EntityOperations : 7 properties
dev_1     | • Expr - Insert/Update : 3 properties
dev_1     | • Expr - WhereClause : 10 properties
dev_1     | • Expr - OrderBy : 4 properties
dev_1     | • Expr - TableDefinition : 4 properties
dev_1     | • SqlType : 27 properties
dev_1     | • SelectOptions : 17 properties
dev_1     | • InformationSchema : 2 properties
dev_1     | • AutoMigration : 2 properties
dev_1     | • ReservedWords : 1 properties
dev_1     |   ✓ 129 succeeded.
```