### PR TITLE
Adds basic `withTransaction`

### DIFF
--- a/orville-postgresql-libpq/orville-postgresql-libpq.cabal
+++ b/orville-postgresql-libpq/orville-postgresql-libpq.cabal
@@ -64,6 +64,7 @@ library
       Orville.PostgreSQL.Internal.Expr.Name.ColumnName
       Orville.PostgreSQL.Internal.Expr.Name.Identifier
       Orville.PostgreSQL.Internal.Expr.Name.QualifiedTableName
+      Orville.PostgreSQL.Internal.Expr.Name.SavepointName
       Orville.PostgreSQL.Internal.Expr.Name.SchemaName
       Orville.PostgreSQL.Internal.Expr.Name.TableName
       Orville.PostgreSQL.Internal.Expr.OffsetExpr
@@ -79,6 +80,7 @@ library
       Orville.PostgreSQL.Internal.Expr.Select.SelectClause
       Orville.PostgreSQL.Internal.Expr.Select.SelectExpr
       Orville.PostgreSQL.Internal.Expr.TableDefinition
+      Orville.PostgreSQL.Internal.Expr.Transaction
       Orville.PostgreSQL.Internal.Expr.Update
       Orville.PostgreSQL.Internal.Expr.Where
       Orville.PostgreSQL.Internal.Expr.Where.BooleanExpr
@@ -87,8 +89,10 @@ library
       Orville.PostgreSQL.Internal.Expr.Where.WhereClause
       Orville.PostgreSQL.Internal.MonadOrville
       Orville.PostgreSQL.Internal.Orville
+      Orville.PostgreSQL.Internal.OrvilleState
       Orville.PostgreSQL.Internal.SelectOptions.SelectOptions
       Orville.PostgreSQL.Internal.SelectOptions.WhereCondition
+      Orville.PostgreSQL.Internal.Transaction
       Paths_orville_postgresql_libpq
   hs-source-dirs:
       src
@@ -100,6 +104,7 @@ library
     , dlist >=0.8 && <1.1
     , postgresql-libpq >=0.9.4.2 && <0.10
     , resource-pool
+    , safe-exceptions >=0.1.7
     , text
     , time >=1.5
     , transformers ==0.5.*
@@ -135,6 +140,7 @@ test-suite spec
       Test.SqlType
       Test.TableDefinition
       Test.TestTable
+      Test.Transaction
       Paths_orville_postgresql_libpq
   hs-source-dirs:
       test
@@ -146,6 +152,7 @@ test-suite spec
     , orville-postgresql-libpq
     , postgresql-libpq
     , resource-pool
+    , safe-exceptions
     , text
     , time
   default-language: Haskell2010

--- a/orville-postgresql-libpq/package.yaml
+++ b/orville-postgresql-libpq/package.yaml
@@ -70,6 +70,7 @@ library:
     - postgresql-libpq >= 0.9.4.2 && <0.10
     - containers >= 0.6 && < 0.7
     - resource-pool
+    - safe-exceptions >=0.1.7
     - text
     - time >=1.5
     - transformers >= 0.5 && < 0.6
@@ -85,6 +86,7 @@ tests:
       - postgresql-libpq
       - orville-postgresql-libpq
       - resource-pool
+      - safe-exceptions
       - text
       - time
     ghc-options:

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
@@ -62,9 +62,12 @@ module Orville.PostgreSQL
     Orville.runOrville,
     MonadOrville.MonadOrville,
     MonadOrville.withConnection,
+    Transaction.withTransaction,
     MonadOrville.MonadOrvilleControl (liftWithConnection),
-    MonadOrville.HasOrvilleState (askOrvilleState, localOrvilleState),
-    MonadOrville.OrvilleState,
+    OrvilleState.HasOrvilleState (askOrvilleState, localOrvilleState),
+    OrvilleState.OrvilleState,
+    OrvilleState.newOrvilleState,
+    OrvilleState.resetOrvilleState,
     SelectOptions.SelectOptions,
     SelectOptions.where_,
     SelectOptions.emptySelectOptions,
@@ -126,8 +129,10 @@ import qualified Orville.PostgreSQL.Internal.Expr as Expr
 import qualified Orville.PostgreSQL.Internal.FieldDefinition as FieldDefinition
 import qualified Orville.PostgreSQL.Internal.MonadOrville as MonadOrville
 import qualified Orville.PostgreSQL.Internal.Orville as Orville
+import qualified Orville.PostgreSQL.Internal.OrvilleState as OrvilleState
 import qualified Orville.PostgreSQL.Internal.PrimaryKey as PrimaryKey
 import qualified Orville.PostgreSQL.Internal.SelectOptions as SelectOptions
 import qualified Orville.PostgreSQL.Internal.SqlMarshaller as SqlMarshaller
 import qualified Orville.PostgreSQL.Internal.SqlType as SqlType
 import qualified Orville.PostgreSQL.Internal.TableDefinition as TableDefinition
+import qualified Orville.PostgreSQL.Internal.Transaction as Transaction

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/AutoMigration.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/AutoMigration.hs
@@ -11,7 +11,7 @@ module Orville.PostgreSQL.AutoMigration
   )
 where
 
-import Control.Exception (Exception, throwIO)
+import Control.Exception.Safe (Exception, throwIO)
 import Control.Monad.IO.Class (liftIO)
 import Data.Foldable (traverse_)
 import Data.List.NonEmpty (NonEmpty ((:|)), nonEmpty)

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr.hs
@@ -35,6 +35,9 @@ module Orville.PostgreSQL.Internal.Expr
     ColumnName,
     columnName,
     columnNameFromIdentifier,
+    SavepointName,
+    savepointName,
+    savepointNameFromIdentifier,
     WhereClause,
     whereClause,
     BooleanExpr,
@@ -112,6 +115,22 @@ module Orville.PostgreSQL.Internal.Expr
     IfExists,
     ifExists,
     Distinct (Distinct),
+    BeginTransactionExpr,
+    beginTransaction,
+    IsolationLevel,
+    serializable,
+    repeatableRead,
+    readCommitted,
+    readUncommitted,
+    CommitExpr,
+    commit,
+    RollbackExpr,
+    rollback,
+    rollbackTo,
+    SavepointExpr,
+    savepoint,
+    ReleaseSavepointExpr,
+    releaseSavepoint,
   )
 where
 
@@ -125,5 +144,6 @@ import Orville.PostgreSQL.Internal.Expr.OffsetExpr
 import Orville.PostgreSQL.Internal.Expr.OrderBy
 import Orville.PostgreSQL.Internal.Expr.Query
 import Orville.PostgreSQL.Internal.Expr.TableDefinition
+import Orville.PostgreSQL.Internal.Expr.Transaction
 import Orville.PostgreSQL.Internal.Expr.Update
 import Orville.PostgreSQL.Internal.Expr.Where

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/Name.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/Name.hs
@@ -13,5 +13,6 @@ where
 import Orville.PostgreSQL.Internal.Expr.Name.ColumnName as Export
 import Orville.PostgreSQL.Internal.Expr.Name.Identifier as Export
 import Orville.PostgreSQL.Internal.Expr.Name.QualifiedTableName as Export
+import Orville.PostgreSQL.Internal.Expr.Name.SavepointName as Export
 import Orville.PostgreSQL.Internal.Expr.Name.SchemaName as Export
 import Orville.PostgreSQL.Internal.Expr.Name.TableName as Export

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/Name/SavepointName.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/Name/SavepointName.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+{- |
+Module    : Orville.PostgreSQL.Expr.Name.SavepointName
+Copyright : Flipstone Technology Partners 2016-2021
+License   : MIT
+-}
+module Orville.PostgreSQL.Internal.Expr.Name.SavepointName
+  ( SavepointName,
+    savepointName,
+    savepointNameFromIdentifier,
+  )
+where
+
+import Orville.PostgreSQL.Internal.Expr.Name.Identifier (Identifier, identifier)
+import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+
+newtype SavepointName
+  = SavepointName Identifier
+  deriving (RawSql.SqlExpression)
+
+savepointName :: String -> SavepointName
+savepointName = SavepointName . identifier
+
+savepointNameFromIdentifier :: Identifier -> SavepointName
+savepointNameFromIdentifier = SavepointName

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/Transaction.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/Transaction.hs
@@ -1,0 +1,97 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Orville.PostgreSQL.Internal.Expr.Transaction
+  ( BeginTransactionExpr,
+    beginTransaction,
+    IsolationLevel,
+    serializable,
+    repeatableRead,
+    readCommitted,
+    readUncommitted,
+    CommitExpr,
+    commit,
+    RollbackExpr,
+    rollback,
+    rollbackTo,
+    SavepointExpr,
+    savepoint,
+    ReleaseSavepointExpr,
+    releaseSavepoint,
+  )
+where
+
+import Data.Maybe (maybeToList)
+
+import qualified Orville.PostgreSQL.Internal.Expr.Name as Name
+import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+
+newtype BeginTransactionExpr
+  = BeginTransactionExpr RawSql.RawSql
+  deriving (RawSql.SqlExpression)
+
+beginTransaction :: Maybe IsolationLevel -> BeginTransactionExpr
+beginTransaction maybeIsolationLevel =
+  BeginTransactionExpr $
+    RawSql.intercalate RawSql.space $
+      ( RawSql.fromString "BEGIN TRANSACTION" :
+        maybeToList (RawSql.toRawSql <$> maybeIsolationLevel)
+      )
+
+newtype IsolationLevel
+  = IsolationLevel RawSql.RawSql
+  deriving (RawSql.SqlExpression)
+
+serializable :: IsolationLevel
+serializable =
+  IsolationLevel (RawSql.fromString "SERIALIZABLE")
+
+repeatableRead :: IsolationLevel
+repeatableRead =
+  IsolationLevel (RawSql.fromString "REPEATABLE READ")
+
+readCommitted :: IsolationLevel
+readCommitted =
+  IsolationLevel (RawSql.fromString "READ COMMITTED")
+
+readUncommitted :: IsolationLevel
+readUncommitted =
+  IsolationLevel (RawSql.fromString "READ UNCOMMITTED")
+
+newtype CommitExpr
+  = CommitExpr RawSql.RawSql
+  deriving (RawSql.SqlExpression)
+
+commit :: CommitExpr
+commit =
+  CommitExpr (RawSql.fromString "COMMIT")
+
+newtype RollbackExpr
+  = RollbackExpr RawSql.RawSql
+  deriving (RawSql.SqlExpression)
+
+rollback :: RollbackExpr
+rollback =
+  RollbackExpr (RawSql.fromString "ROLLBACK")
+
+rollbackTo :: Name.SavepointName -> RollbackExpr
+rollbackTo savepointName =
+  RollbackExpr $
+    RawSql.fromString "ROLLBACK TO SAVEPOINT " <> RawSql.toRawSql savepointName
+
+newtype SavepointExpr
+  = SavepointExpr RawSql.RawSql
+  deriving (RawSql.SqlExpression)
+
+savepoint :: Name.SavepointName -> SavepointExpr
+savepoint savepointName =
+  SavepointExpr $
+    RawSql.fromString "SAVEPOINT " <> RawSql.toRawSql savepointName
+
+newtype ReleaseSavepointExpr
+  = ReleaseSavepontExpr RawSql.RawSql
+  deriving (RawSql.SqlExpression)
+
+releaseSavepoint :: Name.SavepointName -> ReleaseSavepointExpr
+releaseSavepoint savepointName =
+  ReleaseSavepontExpr $
+    RawSql.fromString "RELEASE SAVEPOINT " <> RawSql.toRawSql savepointName

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/MonadOrville.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/MonadOrville.hs
@@ -3,20 +3,25 @@
 
 module Orville.PostgreSQL.Internal.MonadOrville
   ( MonadOrville,
-    HasOrvilleState (askOrvilleState, localOrvilleState),
-    OrvilleState (OrvilleState),
-    newOrvilleState,
-    resetOrvilleState,
-    MonadOrvilleControl (liftWithConnection),
+    MonadOrvilleControl (liftWithConnection, liftFinally),
     withConnection,
+    withConnectedState,
   )
 where
 
 import Control.Monad.IO.Class (MonadIO)
-import Control.Monad.Trans.Reader (ReaderT (ReaderT), ask, local, runReaderT)
-import Data.Pool (Pool, withResource)
+import Control.Monad.Trans.Reader (ReaderT (ReaderT), runReaderT)
+import Data.Pool (withResource)
 
 import Orville.PostgreSQL.Connection (Connection)
+import Orville.PostgreSQL.Internal.OrvilleState
+  ( ConnectedState (ConnectedState, connectedConnection, connectedTransaction),
+    ConnectionState (Connected, NotConnected),
+    HasOrvilleState (askOrvilleState, localOrvilleState),
+    connectState,
+    orvilleConnectionPool,
+    orvilleConnectionState,
+  )
 
 {- |
   'MonadOrville' is the typeclass that most Orville operations require to
@@ -42,118 +47,6 @@ class
   MonadOrville m
 
 {- |
-  'HasOrvilleState' is the typeclass that Orville uses to access and manange
-  the connection pool and state tracking when it is being executed inside an
-  unknown Monad. It is a specialized version of the Reader interface so that it
-  can easily implemented by application Monads that already have a Reader
-  context and want to simply add 'OrvilleState' as an attribute to that
-  context, like so
-
-  @
-    data MyApplicationState =
-      MyApplicationState
-        { appConfig :: MyAppConfig
-        , appOrvilleState :: OrvilleState
-        }
-
-    newtype MyApplicationMonad a =
-      MyApplicationMonad (ReaderT MyApplicationState IO) a
-
-    instance HasOrvilleState MyApplicationMonad where
-      askOrvilleState =
-        MyApplicationMonad (asks appOrvilleState)
-
-      localOrvilleState f (MyApplicationMonad reader) =
-        MyApplicationMonad $
-          local
-            (\state -> state { appOrvilleState = f (appOrvilleState state))
-            reader
-  @
-
-  An instance for 'ReaderT OrvilleState m' is provided as a convenience in
-  the case that your application has no extra context to track.
--}
-class HasOrvilleState m where
-  {-
-    Fetches the current 'OrvilleState' from the host Monad context. The
-    equivalent of 'ask' for 'ReaderT OrvilleState'
-  -}
-  askOrvilleState :: m OrvilleState
-
-  {-
-    Applies a modification to the 'OrvilleState' that is local to the given
-    monad operation. Calls to 'askOrvilleState' made within the 'm a' provided
-    must return the modified state. The modified state must only apply to
-    the given 'm a' and not persisted beyond it. The equivalent of 'local'
-    for 'ReaderT OrvilleState'
-  -}
-  localOrvilleState ::
-    -- | The function to modify the 'OrvilleState'
-    (OrvilleState -> OrvilleState) ->
-    -- | The monad operation to execute with the modified state
-    m a ->
-    m a
-
-instance Monad m => HasOrvilleState (ReaderT OrvilleState m) where
-  askOrvilleState = ask
-  localOrvilleState = local
-
-{- |
-  'OrvilleState' is used to manange opening connections to the database,
-  transactions, etc. 'newOrvilleState should be used to create an appopriate
-  initial state for your monad's context.
--}
-data OrvilleState = OrvilleState
-  { orvilleConnectionPool :: Pool Connection
-  , orvilleConnectionState :: ConnectionState
-  }
-
-{- |
-  Creates a appropriate initial 'OrvilleState' that will use the connection
-  pool given to initiate connections to the database.
--}
-newOrvilleState :: Pool Connection -> OrvilleState
-newOrvilleState pool =
-  OrvilleState
-    { orvilleConnectionPool = pool
-    , orvilleConnectionState = NotConnected
-    }
-
-{- |
-  Creates a new initial 'OrvilleState' using the connection pool from the
-  provide state. You might need to use this if you are spawning one Orville
-  monad from another and they should not share the same connection and
-  transaction state.
--}
-resetOrvilleState :: OrvilleState -> OrvilleState
-resetOrvilleState =
-  newOrvilleState . orvilleConnectionPool
-
-{- |
-  INTERNAL: Transitions the 'OrvilleState' into "connected" status, storing
-  the given 'Connection' as the database connection to be used to execute
-  all queries. This is used by 'withConnection' to track the connection it
-  retrieves from the pool.
--}
-connectState :: Connection -> OrvilleState -> OrvilleState
-connectState conn context =
-  context
-    { orvilleConnectionState = Connected conn
-    }
-
-{- |
-  INTERNAL: This type is used to signal whether a database connection has
-  been retrieved from the pool for the current operation or not. The
-  value is tracked in the 'OrvilleState' for the host monad, and is checked
-  by 'withConnection' to avoid checking out two separate connections for a
-  multiple operations that needs to be run on the same connection (e.g.
-  multiple operations inside a transaction).
--}
-data ConnectionState
-  = NotConnected
-  | Connected Connection
-
-{- |
   'MonadOrvilleControl' presents the interface that Orville will used to
   lift low-level IO operations that cannot be lifted via 'liftIO' (i.e.
   those where the IO parameter is contravriant rather than covariant).
@@ -177,21 +70,37 @@ class MonadOrvilleControl m where
   liftWithConnection ::
     (forall a. (Connection -> IO a) -> IO a) -> (Connection -> m b) -> m b
 
+  {-
+    Orville with use this function to resource cleanup actions from IO
+    into the application monad.
+  -}
+  liftFinally :: (forall a b. IO a -> IO b -> IO a) -> m c -> m d -> m c
+
 instance MonadOrvilleControl IO where
   liftWithConnection ioWithConn =
     ioWithConn
 
-instance MonadOrvilleControl m => MonadOrvilleControl (ReaderT context m) where
+  liftFinally ioFinally =
+    ioFinally
+
+instance MonadOrvilleControl m => MonadOrvilleControl (ReaderT state m) where
   liftWithConnection ioWithConn action = do
     ReaderT $ \env ->
       liftWithConnection ioWithConn (flip runReaderT env . action)
+
+  liftFinally ioFinally action cleanup = do
+    ReaderT $ \env ->
+      liftFinally
+        ioFinally
+        (runReaderT action env)
+        (runReaderT cleanup env)
 
 {- |
   'withConnection' should be used to receive a 'Connection' handle for
   executing queries against the database from within an application monad using
   Orville.  For the "outermost" call of 'withConnection', a connection will be
   acquired from the resource pool. Additional calls to 'withConnection' that
-  happen inside the 'm a' that uses the connection with return the same
+  happen inside the 'm a' that uses the connection will return the same
   'Connection' the same connection. When the 'm a' finishes the connection
   will be returned to the pool. If 'm a' throws an exception the pool's
   exception handling will take effect, generally destroying the connection in
@@ -199,13 +108,26 @@ instance MonadOrvilleControl m => MonadOrvilleControl (ReaderT context m) where
 -}
 withConnection :: MonadOrville m => (Connection -> m a) -> m a
 withConnection connectedAction = do
-  context <- askOrvilleState
+  withConnectedState (connectedAction . connectedConnection)
 
-  case orvilleConnectionState context of
-    Connected conn ->
-      connectedAction conn
-    NotConnected -> do
-      let pool = orvilleConnectionPool context
-      liftWithConnection (withResource pool) $ \conn ->
-        localOrvilleState (connectState conn) $
-          connectedAction conn
+{- |
+  INTERNAL: This in an internal version of 'withConnection' that gives access to
+  the entire 'ConnectedState' value to allow for transaction management.
+-}
+withConnectedState :: MonadOrville m => (ConnectedState -> m a) -> m a
+withConnectedState connectedAction = do
+  state <- askOrvilleState
+
+  case orvilleConnectionState state of
+    Connected connectedState ->
+      connectedAction connectedState
+    NotConnected ->
+      let pool = orvilleConnectionPool state
+       in liftWithConnection (withResource pool) $ \conn ->
+            let connectedState =
+                  ConnectedState
+                    { connectedConnection = conn
+                    , connectedTransaction = Nothing
+                    }
+             in localOrvilleState (connectState connectedState) $
+                  connectedAction connectedState

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/OrvilleState.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/OrvilleState.hs
@@ -1,0 +1,168 @@
+{-# LANGUAGE FlexibleInstances #-}
+
+module Orville.PostgreSQL.Internal.OrvilleState
+  ( OrvilleState,
+    newOrvilleState,
+    resetOrvilleState,
+    orvilleConnectionPool,
+    orvilleConnectionState,
+    HasOrvilleState (askOrvilleState, localOrvilleState),
+    ConnectionState (NotConnected, Connected),
+    ConnectedState (ConnectedState, connectedConnection, connectedTransaction),
+    connectState,
+    TransactionState (OutermostTransaction, SavepointTransaction),
+    newTransaction,
+    Savepoint,
+    savepointNestingLevel,
+  )
+where
+
+import Control.Monad.Trans.Reader (ReaderT, ask, local)
+import Data.Pool (Pool)
+
+import Orville.PostgreSQL.Connection (Connection)
+
+{- |
+  'OrvilleState' is used to manange opening connections to the database,
+  transactions, etc. 'newOrvilleState should be used to create an appopriate
+  initial state for your monad's context.
+-}
+data OrvilleState = OrvilleState
+  { orvilleConnectionPool :: Pool Connection
+  , orvilleConnectionState :: ConnectionState
+  }
+
+{- |
+  'HasOrvilleState' is the typeclass that Orville uses to access and manange
+  the connection pool and state tracking when it is being executed inside an
+  unknown Monad. It is a specialized version of the Reader interface so that it
+  can easily implemented by application Monads that already have a Reader
+  context and want to simply add 'OrvilleState' as an attribute to that
+  context, like so
+
+  @
+    data MyApplicationState =
+      MyApplicationState
+        { appConfig :: MyAppConfig
+        , appOrvilleState :: OrvilleState
+        }
+
+    newtype MyApplicationMonad a =
+      MyApplicationMonad (ReaderT MyApplicationState IO) a
+
+    instance HasOrvilleState MyApplicationMonad where
+      askOrvilleState =
+        MyApplicationMonad (asks appOrvilleState)
+
+      localOrvilleState f (MyApplicationMonad reader) =
+        MyApplicationMonad $
+          local
+            (\state -> state { appOrvilleState = f (appOrvilleState state))
+            reader
+  @
+
+  An instance for 'ReaderT OrvilleState m' is provided as a convenience in
+  the case that your application has no extra context to track.
+-}
+class HasOrvilleState m where
+  {-
+    Fetches the current 'OrvilleState' from the host Monad context. The
+    equivalent of 'ask' for 'ReaderT OrvilleState'
+  -}
+  askOrvilleState :: m OrvilleState
+
+  {-
+    Applies a modification to the 'OrvilleState' that is local to the given
+    monad operation. Calls to 'askOrvilleState' made within the 'm a' provided
+    must return the modified state. The modified state must only apply to
+    the given 'm a' and not persisted beyond it. The equivalent of 'local'
+    for 'ReaderT OrvilleState'
+  -}
+  localOrvilleState ::
+    -- | The function to modify the 'OrvilleState'
+    (OrvilleState -> OrvilleState) ->
+    -- | The monad operation to execute with the modified state
+    m a ->
+    m a
+
+instance Monad m => HasOrvilleState (ReaderT OrvilleState m) where
+  askOrvilleState = ask
+  localOrvilleState = local
+
+{- |
+  Creates a appropriate initial 'OrvilleState' that will use the connection
+  pool given to initiate connections to the database.
+-}
+newOrvilleState :: Pool Connection -> OrvilleState
+newOrvilleState pool =
+  OrvilleState
+    { orvilleConnectionPool = pool
+    , orvilleConnectionState = NotConnected
+    }
+
+{- |
+  Creates a new initial 'OrvilleState' using the connection pool from the
+  provide state. You might need to use this if you are spawning one Orville
+  monad from another and they should not share the same connection and
+  transaction state.
+-}
+resetOrvilleState :: OrvilleState -> OrvilleState
+resetOrvilleState =
+  newOrvilleState . orvilleConnectionPool
+
+{- |
+  INTERNAL: Transitions the 'OrvilleState' into "connected" status, storing
+  the given 'Connection' as the database connection to be used to execute
+  all queries. This is used by 'withConnection' to track the connection it
+  retrieves from the pool.
+-}
+connectState :: ConnectedState -> OrvilleState -> OrvilleState
+connectState connectedState state =
+  state
+    { orvilleConnectionState = Connected connectedState
+    }
+
+{- |
+  INTERNAL: This type is used to signal whether a database connection has
+  been retrieved from the pool for the current operation or not. The
+  value is tracked in the 'OrvilleState' for the host monad, and is checked
+  by 'withConnection' to avoid checking out two separate connections for a
+  multiple operations that needs to be run on the same connection (e.g.
+  multiple operations inside a transaction).
+-}
+data ConnectionState
+  = NotConnected
+  | Connected ConnectedState
+
+data ConnectedState = ConnectedState
+  { connectedConnection :: Connection
+  , connectedTransaction :: Maybe TransactionState
+  }
+
+data TransactionState
+  = OutermostTransaction
+  | SavepointTransaction Savepoint
+
+newTransaction :: Maybe TransactionState -> TransactionState
+newTransaction maybeTransactionState =
+  case maybeTransactionState of
+    Nothing ->
+      OutermostTransaction
+    Just OutermostTransaction ->
+      SavepointTransaction initialSavepoint
+    Just (SavepointTransaction savepoint) ->
+      SavepointTransaction (nextSavepoint savepoint)
+
+newtype Savepoint
+  = Savepoint Int
+
+initialSavepoint :: Savepoint
+initialSavepoint =
+  Savepoint 1
+
+nextSavepoint :: Savepoint -> Savepoint
+nextSavepoint (Savepoint n) =
+  Savepoint (n + 1)
+
+savepointNestingLevel :: Savepoint -> Int
+savepointNestingLevel (Savepoint n) = n

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Transaction.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Transaction.hs
@@ -1,0 +1,103 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Orville.PostgreSQL.Internal.Transaction
+  ( withTransaction,
+  )
+where
+
+import qualified Control.Exception as Exception
+import qualified Control.Monad as Monad
+import Control.Monad.IO.Class (liftIO)
+import qualified Data.IORef as IORef
+
+import qualified Orville.PostgreSQL.Internal.Expr as Expr
+import qualified Orville.PostgreSQL.Internal.MonadOrville as MonadOrville
+import qualified Orville.PostgreSQL.Internal.OrvilleState as OrvilleState
+import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+
+{- |
+  Performs a an action in an Orville monad within a database transaction. The transaction
+  in begun before the action is called. If the action completes without raising an exception,
+  the transaction will be comitted. If the action raises an exception, the transaction will
+  rollback.
+
+  This function in save to call from within another transaction. When called this way the
+  transaction will establish a new savepoint at the beginning of the nested transaction and
+  either release the savepoint or rollback to it as appropriate.
+
+  Note: Exceptions are handled using the implementation of
+  'MonadOrville.liftFinally' provided by the 'MonadOrville' instance for @m@.
+-}
+withTransaction :: MonadOrville.MonadOrville m => m a -> m a
+withTransaction action =
+  MonadOrville.withConnectedState $ \connectedState -> do
+    let conn = OrvilleState.connectedConnection connectedState
+        transaction = OrvilleState.newTransaction (OrvilleState.connectedTransaction connectedState)
+
+        innerConnectedState =
+          connectedState
+            { OrvilleState.connectedTransaction = Just transaction
+            }
+
+    committed <- liftIO $ IORef.newIORef False
+    let doAction = do
+          liftIO $ RawSql.executeVoid conn (openTransactionSql transaction)
+          value <-
+            OrvilleState.localOrvilleState
+              (OrvilleState.connectState innerConnectedState)
+              action
+          liftIO $ do
+            RawSql.executeVoid conn (transactionSuccessSql transaction)
+            liftIO $ IORef.writeIORef committed True
+          pure value
+    let rollbackUncommitted =
+          liftIO $ do
+            finished <- liftIO $ IORef.readIORef committed
+            Monad.when (not finished) (RawSql.executeVoid conn $ rollbackTransactionSql transaction)
+    MonadOrville.liftFinally Exception.finally doAction rollbackUncommitted
+
+openTransactionSql :: OrvilleState.TransactionState -> RawSql.RawSql
+openTransactionSql txnState =
+  case txnState of
+    OrvilleState.OutermostTransaction ->
+      RawSql.toRawSql $ Expr.beginTransaction Nothing
+    OrvilleState.SavepointTransaction savepoint ->
+      RawSql.toRawSql $ Expr.savepoint (savepointName savepoint)
+
+rollbackTransactionSql :: OrvilleState.TransactionState -> RawSql.RawSql
+rollbackTransactionSql txnState =
+  case txnState of
+    OrvilleState.OutermostTransaction ->
+      RawSql.toRawSql $ Expr.rollback
+    OrvilleState.SavepointTransaction savepoint ->
+      RawSql.toRawSql $ Expr.rollbackTo (savepointName savepoint)
+
+transactionSuccessSql :: OrvilleState.TransactionState -> RawSql.RawSql
+transactionSuccessSql txnState =
+  case txnState of
+    OrvilleState.OutermostTransaction ->
+      RawSql.toRawSql $ Expr.commit
+    OrvilleState.SavepointTransaction savepoint ->
+      RawSql.toRawSql $ Expr.releaseSavepoint (savepointName savepoint)
+
+{- |
+  INTERNAL: Constructs a savepoint name based on the current nesting level of
+  transactions, as tracked by the `OrvilleState.Savepoint` type. Strictly
+  speaking this is not necessary for PostgreSQL because it supports shadowing
+  savepoint names. The SQL standard doesn't allow for savepoint name shadowing,
+  however. Re-using this same name in other databases would overwrite the
+  savepoint rather than shadow it. This function constructs savepoint names
+  that will work on any database that implements savepoints accordings to the
+  SQL standard even though Orville only supports PostgreSQL currently.
+-}
+savepointName :: OrvilleState.Savepoint -> Expr.SavepointName
+savepointName savepoint =
+  let n = OrvilleState.savepointNestingLevel savepoint
+   in Expr.savepointName ("orville_savepoint_level_" <> show n)

--- a/orville-postgresql-libpq/test/Main.hs
+++ b/orville-postgresql-libpq/test/Main.hs
@@ -24,6 +24,7 @@ import qualified Test.SelectOptions as SelectOptions
 import qualified Test.SqlMarshaller as SqlMarshaller
 import qualified Test.SqlType as SqlType
 import qualified Test.TableDefinition as TableDefinition
+import qualified Test.Transaction as Transaction
 
 main :: IO ()
 main = do
@@ -44,9 +45,10 @@ main = do
       , ExprTableDefinition.tableDefinitionTests pool
       , SqlType.sqlTypeTests pool
       , SelectOptions.selectOptionsTests
+      , ReservedWords.reservedWordsTests pool
+      , Transaction.transactionTests pool
       , InformationSchema.informationSchemaTests pool
       , AutoMigration.autoMigrationTests pool
-      , ReservedWords.reservedWordsTests pool
       ]
 
   Monad.unless (Property.allPassed summary) SE.exitFailure

--- a/orville-postgresql-libpq/test/Test/Transaction.hs
+++ b/orville-postgresql-libpq/test/Test/Transaction.hs
@@ -1,0 +1,138 @@
+module Test.Transaction
+  ( transactionTests,
+  )
+where
+
+import qualified Control.Exception.Safe as ExSafe
+import qualified Control.Monad.IO.Class as MIO
+import qualified Data.Pool as Pool
+import qualified Data.String as String
+import qualified Data.Text as T
+import Hedgehog ((===))
+import qualified Hedgehog as HH
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+import qualified Orville.PostgreSQL as Orville
+import qualified Orville.PostgreSQL.Connection as Conn
+
+import qualified Test.Property as Property
+import qualified Test.TestTable as TestTable
+
+transactionTests :: Pool.Pool Conn.Connection -> Property.Group
+transactionTests pool =
+  Property.group "Transaction" $
+    [
+      ( String.fromString "Transactions without exceptions perform a commit"
+      , HH.property $ do
+          nestingLevel <- HH.forAll genNestingLevel
+
+          tracers <-
+            MIO.liftIO $ do
+              Pool.withResource pool $ \connection ->
+                TestTable.dropAndRecreateTableDef connection tracerTable
+
+              Orville.runOrville pool $ do
+                withNestedTransactions nestingLevel $
+                  NestedActions
+                    { atEachLevel = Orville.insertEntity tracerTable Tracer
+                    , atInnermost = pure ()
+                    }
+
+                Orville.findEntitiesBy tracerTable mempty
+
+          length tracers === (nestingLevel + 1)
+      )
+    ,
+      ( String.fromString "Exceptions within transaction blocks execute rollbock"
+      , HH.property $ do
+          nestingLevel <- HH.forAll genNestingLevel
+
+          tracers <-
+            MIO.liftIO $ do
+              Pool.withResource pool $ \connection ->
+                TestTable.dropAndRecreateTableDef connection tracerTable
+
+              Orville.runOrville pool $ do
+                ExSafe.handle (\TestError -> pure ()) $
+                  withNestedTransactions nestingLevel $
+                    NestedActions
+                      { atEachLevel = Orville.insertEntity tracerTable Tracer
+                      , atInnermost = ExSafe.throw TestError
+                      }
+
+                Orville.findEntitiesBy tracerTable mempty
+
+          length tracers === 0
+      )
+    ,
+      ( String.fromString "Savepoints allow inner transactions to rollback while outer transactions commit"
+      , HH.property $ do
+          outerNestingLevel <- HH.forAll genNestingLevel
+          innerNestingLevel <- HH.forAll genNestingLevel
+
+          let doInnerTransactions =
+                ExSafe.handle (\TestError -> pure ()) $
+                  withNestedTransactions innerNestingLevel $
+                    NestedActions
+                      { atEachLevel = Orville.insertEntity tracerTable Tracer
+                      , atInnermost = ExSafe.throw TestError
+                      }
+
+              doTransactions =
+                withNestedTransactions outerNestingLevel $
+                  NestedActions
+                    { atEachLevel = Orville.insertEntity tracerTable Tracer
+                    , atInnermost = doInnerTransactions
+                    }
+
+          tracers <-
+            MIO.liftIO $ do
+              Pool.withResource pool $ \connection ->
+                TestTable.dropAndRecreateTableDef connection tracerTable
+
+              Orville.runOrville pool $ do
+                doTransactions
+                Orville.findEntitiesBy tracerTable mempty
+
+          length tracers === (outerNestingLevel + 1)
+      )
+    ]
+
+data NestedActions = NestedActions
+  { atEachLevel :: Orville.Orville ()
+  , atInnermost :: Orville.Orville ()
+  }
+
+withNestedTransactions ::
+  Int ->
+  NestedActions ->
+  Orville.Orville ()
+withNestedTransactions nestingLevel nestedActions =
+  Orville.withTransaction $ do
+    atEachLevel nestedActions
+    if nestingLevel == 0
+      then atInnermost nestedActions
+      else withNestedTransactions (nestingLevel - 1) nestedActions
+
+genNestingLevel :: HH.Gen Int
+genNestingLevel =
+  Gen.integral $ Range.linear 0 5
+
+data Tracer
+  = Tracer
+
+tracerTable :: Orville.TableDefinition Orville.NoKey Tracer Tracer
+tracerTable =
+  Orville.mkTableDefinitionWithoutKey "tracer" tracerMarshaller
+
+tracerMarshaller :: Orville.SqlMarshaller Tracer Tracer
+tracerMarshaller =
+  const Tracer
+    <$> Orville.marshallField (const $ T.pack "tracer") (Orville.unboundedTextField "tracer")
+
+data TestError
+  = TestError
+  deriving (Show)
+
+instance ExSafe.Exception TestError


### PR DESCRIPTION
This adds the `withTransaction` function, similar to the 0.9 version.
The main different is that this version handles nested transactions by
using savepoints rather than just avoiding opening a new transaction.