### PR TITLE
Ports the Select module from HDBC Orville in prep for Plan

### DIFF
--- a/orville-postgresql-libpq/orville-postgresql-libpq.cabal
+++ b/orville-postgresql-libpq/orville-postgresql-libpq.cabal
@@ -39,6 +39,7 @@ library
       Orville.PostgreSQL.Internal.PGTextFormatValue
       Orville.PostgreSQL.Internal.PrimaryKey
       Orville.PostgreSQL.Internal.RawSql
+      Orville.PostgreSQL.Internal.Select
       Orville.PostgreSQL.Internal.SelectOptions
       Orville.PostgreSQL.Internal.SqlMarshaller
       Orville.PostgreSQL.Internal.SqlType

--- a/orville-postgresql-libpq/package.yaml
+++ b/orville-postgresql-libpq/package.yaml
@@ -31,6 +31,7 @@ library:
     - Orville.PostgreSQL.Internal.PGTextFormatValue
     - Orville.PostgreSQL.Internal.PrimaryKey
     - Orville.PostgreSQL.Internal.RawSql
+    - Orville.PostgreSQL.Internal.Select
     - Orville.PostgreSQL.Internal.SelectOptions
     - Orville.PostgreSQL.Internal.SqlMarshaller
     - Orville.PostgreSQL.Internal.SqlType

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
@@ -86,11 +86,11 @@ module Orville.PostgreSQL
     SelectOptions.fieldLessThan,
     SelectOptions.fieldGreaterThanOrEqualTo,
     SelectOptions.fieldLessThanOrEqualTo,
+    SelectOptions.fieldIn,
+    SelectOptions.fieldNotIn,
     SelectOptions.whereBooleanExpr,
     SelectOptions.whereAnd,
     SelectOptions.whereOr,
-    SelectOptions.whereIn,
-    SelectOptions.whereNotIn,
     SqlType.SqlType
       ( SqlType.SqlType,
         SqlType.sqlTypeExpr,

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/AutoMigration.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/AutoMigration.hs
@@ -300,7 +300,7 @@ findTablesInSchemas currentCatalog schemaNameSet =
         ( Orville.where_
             ( Orville.whereAnd
                 ( Orville.fieldEquals IS.tableCatalogField currentCatalog
-                    :| [Orville.whereIn IS.tableSchemaField nonEmptySchemaNames]
+                    :| [Orville.fieldIn IS.tableSchemaField nonEmptySchemaNames]
                 )
             )
         )

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/EntityOperations.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/EntityOperations.hs
@@ -21,6 +21,7 @@ import Data.Maybe (listToMaybe)
 import qualified Orville.PostgreSQL.Internal.Execute as Execute
 import qualified Orville.PostgreSQL.Internal.MonadOrville as MonadOrville
 import qualified Orville.PostgreSQL.Internal.PrimaryKey as PrimaryKey
+import qualified Orville.PostgreSQL.Internal.Select as Select
 import qualified Orville.PostgreSQL.Internal.SelectOptions as SelectOptions
 import qualified Orville.PostgreSQL.Internal.TableDefinition as TableDef
 
@@ -160,18 +161,8 @@ findEntitiesBy ::
   SelectOptions.SelectOptions ->
   m [readEntity]
 findEntitiesBy entityTable selectOptions =
-  let selectExpr =
-        TableDef.mkQueryExpr
-          entityTable
-          (SelectOptions.selectDistinct selectOptions)
-          (SelectOptions.selectWhereClause selectOptions)
-          Nothing
-          Nothing
-          Nothing
-          Nothing
-   in Execute.executeAndDecode
-        selectExpr
-        (TableDef.tableMarshaller entityTable)
+  Select.executeSelect $
+    Select.selectTable entityTable selectOptions
 
 {- |
   Like 'findEntitiesBy, but adds a 'LIMIT 1' to the query and then returns

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Select.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Select.hs
@@ -1,0 +1,126 @@
+{-# LANGUAGE GADTs #-}
+
+module Orville.PostgreSQL.Internal.Select
+  ( Select,
+    executeSelect,
+    selectToQueryExpr,
+    selectTable,
+    selectMarshalledColumns,
+    selectSelectList,
+    selectQueryExpr,
+  )
+where
+
+import qualified Orville.PostgreSQL.Internal.Execute as Execute
+import qualified Orville.PostgreSQL.Internal.Expr as Expr
+import qualified Orville.PostgreSQL.Internal.MonadOrville as MonadOrville
+import qualified Orville.PostgreSQL.Internal.SelectOptions as SelectOptions
+import Orville.PostgreSQL.Internal.SqlMarshaller (ReadOnlyColumnOption (IncludeReadOnlyColumns), SqlMarshaller, marshallerColumnNames)
+import Orville.PostgreSQL.Internal.TableDefinition (TableDefinition, tableMarshaller, tableName)
+
+{- |
+  Represents a @SELECT@ statement that can be executed against a database. A
+  'Select' has a 'SqlMarshaller' bound to it that will be used to decode the
+  database result set when it is executed.
+-}
+data Select readEntity where
+  Select :: SqlMarshaller writeEntity readEntity -> Expr.QueryExpr -> Select readEntity
+
+{- |
+  Extracts the query that will be run when the select is executed. Normally you
+  don't want to extract the query and run it yourself, but this function is
+  useful to view the query for debugging or query explanation.
+-}
+selectToQueryExpr :: Select readEntity -> Expr.QueryExpr
+selectToQueryExpr (Select _ query) = query
+
+{- |
+  Excutes the database query for the 'Select' and uses its 'SqlMarshaller' to
+  decode the result set.
+-}
+executeSelect :: MonadOrville.MonadOrville m => Select row -> m [row]
+executeSelect (Select marshaller query) =
+  Execute.executeAndDecode query marshaller
+
+{- |
+  Builds a 'Select' that will select all the columns described in the
+  'TableDefinition'. This is the safest way to build a 'Select', because table
+  name and columns are all read from the 'TableDefinition'. If the table is
+  being managed with Orville auto migrations, this will match the schema in the
+  database.
+-}
+selectTable ::
+  TableDefinition key writeEntity readEntity ->
+  SelectOptions.SelectOptions ->
+  Select readEntity
+selectTable tableDef =
+  selectMarshalledColumns (tableMarshaller tableDef) (tableName tableDef)
+
+{- |
+  Builds a 'Select' that will select the columns described by the marshaller
+  from the specified table. It is up to the caller to ensure that the columns
+  in the marshaller make sense for the table.
+
+  This function is useful for query a subset of table columns using a custom
+  marshaller.
+-}
+selectMarshalledColumns ::
+  SqlMarshaller writeEntity readEntity ->
+  Expr.QualifiedTableName ->
+  SelectOptions.SelectOptions ->
+  Select readEntity
+selectMarshalledColumns marshaller =
+  selectSelectList
+    (Expr.selectColumns (marshallerColumnNames IncludeReadOnlyColumns marshaller))
+    marshaller
+
+{- |
+  Builds a 'Select' that will use the specified 'Expr.SelectList' when building
+  the @SELECT@ statement to execute. It it up to the caller to make sure that
+  the 'Expr.SelectList' expression makes sens for the table being queried, and
+  that the names of the columns in the result set match those expected by the
+  given 'SqlMarshaller', which will be used to decode it.
+
+  This function is useful for building more advanced queries that need to
+  select things other than simple columns from the table, such as using
+  aggregate functions. The 'Expr.SelectList' can be built however the caller
+  desires. If Orville does not support building the 'Expr.SelectList' you need
+  using any of the expression building functions, you can resort to
+  @RawSql.fromRawSql@ as an escape hatch to build the 'Expr.SelectList' here.
+-}
+selectSelectList ::
+  Expr.SelectList ->
+  SqlMarshaller writeEntity readEntity ->
+  Expr.QualifiedTableName ->
+  SelectOptions.SelectOptions ->
+  Select readEntity
+selectSelectList selectList marshaller qualifiedTableName selectOptions =
+  selectQueryExpr marshaller $
+    Expr.queryExpr
+      (SelectOptions.selectDistinct selectOptions)
+      selectList
+      ( Just $
+          Expr.tableExpr
+            qualifiedTableName
+            (SelectOptions.selectWhereClause selectOptions)
+            (SelectOptions.selectOrderByClause selectOptions)
+            (SelectOptions.selectGroupByClause selectOptions)
+            (SelectOptions.selectLimitExpr selectOptions)
+            (SelectOptions.selectOffsetExpr selectOptions)
+      )
+
+{- |
+  Builds a 'Select' that will execute the specified query and use the given
+  'SqlMarshaller' to decode it. It is up to the caller to ensure that the given
+  'Expr.QueryExpr' makes sense and produces a result set that the
+  'SqlMarshaller' can decode.
+
+  This is the lowest level of escape hatch available for 'Select'. The caller
+  can build any query that Orville supports using the expression building
+  functions, or use @RawSql.fromRawSql@ to build a raw 'Expr.QueryExpr'.
+-}
+selectQueryExpr ::
+  SqlMarshaller writeEntity readEntity ->
+  Expr.QueryExpr ->
+  Select readEntity
+selectQueryExpr = Select

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/SelectOptions/SelectOptions.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/SelectOptions/SelectOptions.hs
@@ -6,6 +6,8 @@ module Orville.PostgreSQL.Internal.SelectOptions.SelectOptions
     selectWhereClause,
     selectOrderByClause,
     selectGroupByClause,
+    selectLimitExpr,
+    selectOffsetExpr,
     distinct,
     where_,
     orderBy,
@@ -16,7 +18,7 @@ module Orville.PostgreSQL.Internal.SelectOptions.SelectOptions
 where
 
 import Data.List.NonEmpty (NonEmpty ((:|)))
-import Data.Monoid (First (First))
+import Data.Monoid (First (First, getFirst))
 
 import qualified Orville.PostgreSQL.Internal.Expr as Expr
 import qualified Orville.PostgreSQL.Internal.Expr.GroupBy.GroupByExpr as Expr
@@ -130,6 +132,22 @@ selectGroupByClause selectOptions =
       Nothing
     (first : rest) ->
       Just . Expr.groupByClause $ foldl Expr.appendGroupBy first rest
+
+{- |
+  Builds a 'Expr.LimitExpr' that will limit the query results to the
+  number specified in the 'SelectOptions' (if any)
+-}
+selectLimitExpr :: SelectOptions -> Maybe Expr.LimitExpr
+selectLimitExpr =
+  getFirst . i_limitExpr
+
+{- |
+  Builds a 'Expr.OffsetExpr' that will limit the query results to the
+  number specified in the 'SelectOptions' (if any)
+-}
+selectOffsetExpr :: SelectOptions -> Maybe Expr.OffsetExpr
+selectOffsetExpr =
+  getFirst . i_offsetExpr
 
 {- |
   Constructs a 'SelectOptions' with just the given 'WhereCondition'.

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/SelectOptions/WhereCondition.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/SelectOptions/WhereCondition.hs
@@ -8,12 +8,12 @@ module Orville.PostgreSQL.Internal.SelectOptions.WhereCondition
     fieldLessThan,
     fieldGreaterThanOrEqualTo,
     fieldLessThanOrEqualTo,
+    fieldIn,
+    fieldNotIn,
     whereAnd,
     whereOr,
     whereBooleanExpr,
     whereConditionToBooleanExpr,
-    whereIn,
-    whereNotIn,
   )
 where
 
@@ -95,6 +95,26 @@ fieldLessThanOrEqualTo =
   whereColumnComparison Expr.columnLessThanOrEqualTo
 
 {- |
+  Checks that a field matches a list of values
+-}
+fieldIn :: FieldDef.FieldDefinition nullability a -> NonEmpty a -> WhereCondition
+fieldIn fieldDef values =
+  WhereCondition $
+    Expr.columnIn
+      (FieldDef.fieldColumnName fieldDef)
+      (fmap (FieldDef.fieldValueToSqlValue fieldDef) values)
+
+{- |
+  Checks that a field does not match a list of values
+-}
+fieldNotIn :: FieldDef.FieldDefinition nullability a -> NonEmpty a -> WhereCondition
+fieldNotIn fieldDef values =
+  WhereCondition $
+    Expr.columnNotIn
+      (FieldDef.fieldColumnName fieldDef)
+      (fmap (FieldDef.fieldValueToSqlValue fieldDef) values)
+
+{- |
   INTERNAL: Constructs a field-based 'WhereCondition' using a function that
   builds a 'Expr.BooleanExpr'
 -}
@@ -120,26 +140,6 @@ whereAnd =
 whereOr :: NonEmpty WhereCondition -> WhereCondition
 whereOr =
   foldParenthenizedExprs Expr.orExpr
-
-{- |
-  Checks that a field matches a list of values
--}
-whereIn :: FieldDef.FieldDefinition nullability a -> NonEmpty a -> WhereCondition
-whereIn fieldDef values =
-  WhereCondition $
-    Expr.columnIn
-      (FieldDef.fieldColumnName fieldDef)
-      (fmap (FieldDef.fieldValueToSqlValue fieldDef) values)
-
-{- |
-  Checks that a field does not match a list of values
--}
-whereNotIn :: FieldDef.FieldDefinition nullability a -> NonEmpty a -> WhereCondition
-whereNotIn fieldDef values =
-  WhereCondition $
-    Expr.columnNotIn
-      (FieldDef.fieldColumnName fieldDef)
-      (fmap (FieldDef.fieldValueToSqlValue fieldDef) values)
 
 {- |
   INTERNAL: Combines a (non-empty) list of 'WhereCondition's together using

--- a/orville-postgresql-libpq/test/Test/SelectOptions.hs
+++ b/orville-postgresql-libpq/test/Test/SelectOptions.hs
@@ -92,18 +92,18 @@ selectOptionsTests =
             )
       )
     ,
-      ( String.fromString "whereIn generates expected sql"
+      ( String.fromString "fieldIn generates expected sql"
       , Property.singletonProperty $
           assertWhereClauseEquals
             (Just "WHERE (\"foo\" IN ($1))")
-            (SO.where_ $ SO.whereIn fooField (10 :| []))
+            (SO.where_ $ SO.fieldIn fooField (10 :| []))
       )
     ,
-      ( String.fromString "whereNotIn generates expected sql"
+      ( String.fromString "fieldNotIn generates expected sql"
       , Property.singletonProperty $
           assertWhereClauseEquals
             (Just "WHERE (\"foo\" NOT IN ($1, $2))")
-            (SO.where_ $ SO.whereNotIn fooField (10 :| [20]))
+            (SO.where_ $ SO.fieldNotIn fooField (10 :| [20]))
       )
     ,
       ( String.fromString "distinct generates expected sql"


### PR DESCRIPTION
This ports the `Select` module for building safer select custom select
statements from HDBC orville. `Select` the is basis for the primitive
plan operations, so this needed to be ported.

The `Select` modure replaces the `mkQueryExpr` function that previously
lived in the `TableDefinition` module. I imagine we will add similar
`Insert`, `Update` and `Delete` modules to replace the other query
building fuctions from `TableDefinition` as well.

This fixes `findEntitiesBy` not passing all it's `SelectOptions` parts
through as well, by virtue of using the new `Select` module.

A couple of other minor things ended up in this as way that I decided
not to tease so for the sake of getting this in this morning:

* `marshallNested` was added
* `whereIn` and `whereNotIn` renamed to `fieldIn` and `fieldNotIn`