### PR TITLE
Add Plans to LibPQ Orville

### DIFF
--- a/orville-postgresql-libpq/orville-postgresql-libpq.cabal
+++ b/orville-postgresql-libpq/orville-postgresql-libpq.cabal
@@ -45,6 +45,10 @@ library
       Orville.PostgreSQL.Internal.SqlType
       Orville.PostgreSQL.Internal.SqlValue
       Orville.PostgreSQL.Internal.TableDefinition
+      Orville.PostgreSQL.Plan.Explanation
+      Orville.PostgreSQL.Plan.Many
+      Orville.PostgreSQL.Plan.Operation
+      Orville.PostgreSQL.Plan
   other-modules:
       Orville.PostgreSQL.InformationSchema.ColumnName
       Orville.PostgreSQL.InformationSchema.InformationSchemaColumn
@@ -125,6 +129,7 @@ test-suite spec
       Test.Connection
       Test.Entities.Bar
       Test.Entities.Foo
+      Test.Entities.FooChild
       Test.Entities.User
       Test.EntityOperations
       Test.Expr.GroupBy
@@ -136,6 +141,7 @@ test-suite spec
       Test.FieldDefinition
       Test.InformationSchema
       Test.PGGen
+      Test.Plan
       Test.Property
       Test.RawSql
       Test.ReservedWords

--- a/orville-postgresql-libpq/package.yaml
+++ b/orville-postgresql-libpq/package.yaml
@@ -37,6 +37,10 @@ library:
     - Orville.PostgreSQL.Internal.SqlType
     - Orville.PostgreSQL.Internal.SqlValue
     - Orville.PostgreSQL.Internal.TableDefinition
+    - Orville.PostgreSQL.Plan.Explanation
+    - Orville.PostgreSQL.Plan.Many
+    - Orville.PostgreSQL.Plan.Operation
+    - Orville.PostgreSQL.Plan
   when:
     - condition: flag(ci)
       then:

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Plan.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Plan.hs
@@ -1,0 +1,648 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Orville.PostgreSQL.Plan
+  ( Plan,
+    Planned,
+    Execute,
+    Explain,
+    askParam,
+
+    -- * Using a Plan after it is constructed
+    execute,
+    explain,
+
+    -- * Making a Plan to find rows in the database
+    findMaybeOne,
+    findMaybeOneWhere,
+    findOne,
+    findOneWhere,
+    findAll,
+    findAllWhere,
+
+    -- * Creating a multi-step Plan from other Plan values
+    bind,
+    use,
+    using,
+    chain,
+    apply,
+    planMany,
+    planList,
+    focusParam,
+    planEither,
+    planMaybe,
+
+    -- * Bridges from other types into Plan
+    Op.AssertionFailed,
+    assert,
+    planSelect,
+    planOperation,
+  )
+where
+
+import Control.Exception (throwIO)
+import qualified Control.Monad.IO.Class as MIO
+import Data.Either (partitionEithers)
+import qualified Data.List.NonEmpty as NEL
+
+-- import qualified Database.Orville.PostgreSQL.Core as Core
+import qualified Orville.PostgreSQL.Internal.FieldDefinition as FieldDefinition
+import qualified Orville.PostgreSQL.Internal.MonadOrville as MonadOrville
+import Orville.PostgreSQL.Internal.Select (Select)
+import qualified Orville.PostgreSQL.Internal.SelectOptions as SelectOptions
+import qualified Orville.PostgreSQL.Internal.TableDefinition as TableDefinition
+import qualified Orville.PostgreSQL.Plan.Explanation as Exp
+import Orville.PostgreSQL.Plan.Many (Many)
+import qualified Orville.PostgreSQL.Plan.Many as Many
+import qualified Orville.PostgreSQL.Plan.Operation as Op
+
+{- |
+  A 'Plan' is an executable set of queries that can be executed to load data
+  from the database, using the results of prior queries as input parameters to
+  following queries in controlled ways. In particular, the "controlled" aspect
+  of this allows plans that take a single input to be adapted to take multiple
+  input parameters in a list without the resulting plan executing N+1 queries.
+  This restriction means that while query results can be used as input
+  parameters to later queries, they cannot be used to decide to run completely
+  different queries based on other query results. Allowing this would prevent
+  the 'Plan' structure from eliminating N+1 query loops.
+
+  Note that during execution queries are never combined across tables to form
+  joins or subqueries. Queries are still executed in the same sequence as
+  specified in the plan, just on all the inputs at once rather than in a loop.
+  If you need to do a join with a plan, you can always construction your
+  own custom 'Op.Operation' and use 'planOperation' to incorporate into a plan.
+
+  The @param@ type variable indicates what type of value is expected as input
+  when the plan is executed.
+
+  The @result@ type for a plan indicates what Haskell type is produced
+  when the plan is executed.
+
+  The @scope@ type is used internally by Orville to track the plan is currently
+  executed against a single input or multiple inputs. This type parameter
+  should never specified as a concrete type in user code, but must be exposed
+  as a variable to ensure that execute scope is tracked correctly through
+  usages of 'bind'.
+-}
+data Plan scope param result where
+  PlanOp :: Op.Operation param result -> Plan scope param result
+  PlanMany ::
+    (forall manyScope. Plan manyScope param result) ->
+    Plan scope [param] (Many param result)
+  PlanEither ::
+    Plan scope leftParam leftResult ->
+    Plan scope rightParam rightResult ->
+    Plan scope (Either leftParam rightParam) (Either leftResult rightResult)
+  Bind ::
+    Plan scope param a ->
+    (Planned scope param a -> Plan scope param result) ->
+    Plan scope param result
+  Use :: Planned scope param a -> Plan scope param a
+  Pure :: a -> Plan scope param a
+  Apply ::
+    Plan scope param (a -> b) ->
+    Plan scope param a ->
+    Plan scope param b
+  Chain ::
+    Plan scope a b ->
+    Plan scope b c ->
+    Plan scope a c
+
+instance Functor (Plan scope param) where
+  fmap f = Apply (Pure f)
+
+instance Applicative (Plan scope param) where
+  pure = Pure
+  (<*>) = Apply
+
+{- |
+  'Execute' is a tag type used by as the 'scope' variable for
+  'Plan' values when executing them via the 'execute' function.
+-}
+data Execute
+
+{- |
+  'ExecuteMany' is an internal tag type used by as the 'scope' variable for
+  'Plan' values when executing them against multiple inputs via the
+  'executeMany' internal function.
+-}
+data ExecuteMany
+
+{- |
+  A 'Planned' value is a wrapper around the results of previous run queries
+  when using the 'bind' function. At the time that you are writing a plan you
+  do not know whether the 'Plan' will be run with a single input or multiple
+  inputs. A 'Planned' value may end up being either an individual item or a
+  list of items. Due to this, your ability to interact with the value is
+  limited to the use of 'fmap' to extract (or build) other values from the
+  results. 'Planned' values can be used together with the 'use' function to
+  make a 'Plan' that produces the extracted value.
+
+  Note that while 'Planned' could provide an 'Applicative' instance as well, it
+  does not to avoid confusion with 'Applicative' instance for 'Plan' itself.
+  If you need to build a value from several 'Planned' values using
+  'Applicative', you should call 'use' on each of the values and use the
+  'Applicative' instance for 'Plan'.
+-}
+data Planned scope param a where
+  PlannedOne :: a -> Planned Execute param a
+  PlannedMany :: Many k a -> Planned ExecuteMany k a
+  PlannedExplain :: Planned Explain param a
+
+instance Functor (Planned scope param) where
+  fmap = mapPlanned
+
+{- |
+  'mapPlanned' applies a function to what value or values have been produced by
+  the plan. This function can also be called as 'fmap' or '<$>' thorugh the
+  'Functor' instance for 'Planned'.
+-}
+mapPlanned :: (a -> b) -> Planned scope param a -> Planned scope param b
+mapPlanned f planned =
+  case planned of
+    PlannedOne a ->
+      PlannedOne (f a)
+    PlannedMany manyAs ->
+      PlannedMany (fmap f manyAs)
+    PlannedExplain ->
+      PlannedExplain
+
+{- |
+  'resolveOne' resolves a 'Planned' value that is known to be in the 'One'
+  scope to its single wrapped value.
+-}
+resolveOne :: Planned Execute param a -> a
+resolveOne (PlannedOne a) = a
+
+{- |
+  'resolveMany resolves a 'Planned' value that is known to be in the 'Many'
+  scope to the 'Many' value wrapped inside it.
+-}
+resolveMany :: Planned ExecuteMany k a -> Many k a
+resolveMany (PlannedMany as) = as
+
+{- |
+  'planOperation' allows any primitive 'Op.Operation' to be used as an atomic step
+  in a plan. When the plan is executed, the appropriate 'Op.Operation' functions
+  will be used depending on the execution context.
+-}
+planOperation ::
+  Op.Operation param result ->
+  Plan scope param result
+planOperation =
+  PlanOp
+
+{- |
+  'planSelect' allows any Orville 'Select' query to be incorporated into a
+  plan. Note that the 'Select' cannot depend on the plan's input parameters in
+  this case. If the plan is executed with multiple inputs the same set of all
+  the results will be used as the results for each of the input parameters.
+-}
+planSelect :: Select row -> Plan scope () [row]
+planSelect select =
+  planOperation (Op.findSelect select)
+
+{- |
+  'askParam' allows the input parameter for the plan to be retrieved as the
+  result of the plan. Together with 'bind' you can use this to get access to
+  the input parameter as a 'Planned' value.
+-}
+askParam :: Plan scope param param
+askParam =
+  planOperation Op.askParam
+
+{- |
+  'findMaybeOne' constructs a 'Plan' that will find at most one row from
+  the given table where the plan's input value matches the given database
+  field.
+-}
+findMaybeOne ::
+  Ord fieldValue =>
+  TableDefinition.TableDefinition key writeEntity readEntity ->
+  FieldDefinition.FieldDefinition nullability fieldValue ->
+  Plan scope fieldValue (Maybe readEntity)
+findMaybeOne tableDef fieldDef =
+  planOperation (Op.findOne tableDef fieldDef)
+
+{- |
+  'findMaybeOneWhere' is similar to 'findMaybeOne', but allows a
+  'WhereCondition' to be specified to restrict which rows are matched by the
+  database query.
+-}
+findMaybeOneWhere ::
+  Ord fieldValue =>
+  TableDefinition.TableDefinition key writeEntity readEntity ->
+  FieldDefinition.FieldDefinition nullability fieldValue ->
+  SelectOptions.WhereCondition ->
+  Plan scope fieldValue (Maybe readEntity)
+findMaybeOneWhere tableDef fieldDef cond =
+  planOperation (Op.findOneWhere tableDef fieldDef cond)
+
+{- |
+  'findOne' is similar to 'findMaybeOne, but it expects that there will always
+  be a row found matching the plan's input value. If no row is found an
+  'Op.AssertionFailed' exception will be thrown. This is a useful convenience
+  when looking up foreign-key associations that are expected to be enforced
+  by the database itself.
+-}
+findOne ::
+  (Show fieldValue, Ord fieldValue) =>
+  TableDefinition.TableDefinition key writeEntity readEntity ->
+  FieldDefinition.FieldDefinition nullability fieldValue ->
+  Plan scope fieldValue readEntity
+findOne tableDef fieldDef =
+  assert
+    (assertFound tableDef fieldDef)
+    (findMaybeOne tableDef fieldDef)
+
+{- |
+  'findOneWhere' is similar to 'findOne', but allows a 'WhereCondition' to be
+  specified to restrict which rows are matched by the database query.
+-}
+findOneWhere ::
+  (Show fieldValue, Ord fieldValue) =>
+  TableDefinition.TableDefinition key writeEntity readEntity ->
+  FieldDefinition.FieldDefinition nullability fieldValue ->
+  SelectOptions.WhereCondition ->
+  Plan scope fieldValue readEntity
+findOneWhere tableDef fieldDef cond =
+  assert
+    (assertFound tableDef fieldDef)
+    (findMaybeOneWhere tableDef fieldDef cond)
+
+{- |
+  'assertFound' is an internal helper that checks that row was found where
+  one was expected.
+-}
+assertFound ::
+  Show fieldValue =>
+  TableDefinition.TableDefinition key writeEntity readEntity ->
+  FieldDefinition.FieldDefinition nullability fieldValue ->
+  fieldValue ->
+  Maybe result ->
+  Either String result
+assertFound tableDef fieldDef param maybeRecord =
+  case maybeRecord of
+    Just a ->
+      Right a
+    Nothing ->
+      Left $
+        unwords
+          [ "Failed to find record in table"
+          , TableDefinition.unqualifiedTableNameString tableDef
+          , "where"
+          , FieldDefinition.fieldNameToString $ FieldDefinition.fieldName fieldDef
+          , " = "
+          , show param
+          ]
+
+{- |
+  'findAll' constructs a 'Plan' that will find all the rows from the given
+  table there the plan's input value matches the given database field.
+-}
+findAll ::
+  Ord fieldValue =>
+  TableDefinition.TableDefinition key writeEntity readEntity ->
+  FieldDefinition.FieldDefinition nullability fieldValue ->
+  Plan scope fieldValue [readEntity]
+findAll tableDef fieldDef =
+  planOperation (Op.findAll tableDef fieldDef)
+
+{- |
+  'findAllWhere' is similar to 'findAll', but allows a 'WhereCondition' to be
+  specified to restrict which rows are matched by the database query.
+-}
+findAllWhere ::
+  Ord fieldValue =>
+  TableDefinition.TableDefinition key writeEntity readEntity ->
+  FieldDefinition.FieldDefinition nullability fieldValue ->
+  SelectOptions.WhereCondition ->
+  Plan scope fieldValue [readEntity]
+findAllWhere tableDef fieldDef cond =
+  planOperation (Op.findAllWhere tableDef fieldDef cond)
+
+{- |
+  'planMany' adapts a plan that takes a single input parameter to work on
+  multiple input parameters. When the new plan is executed each query will
+  execute in the same basic order, but with adjusted conditions to find all the
+  rows for all inputs at once rather than running the planned queries once for
+  each input.
+-}
+planMany ::
+  (forall manyScope. Plan manyScope param result) ->
+  Plan scope [param] (Many param result)
+planMany =
+  PlanMany
+
+{- |
+  'planList' lifts a plan so both its param and result become lists.
+  This saves you from having to fmap in 'Many.elems' when all you want back
+  from a 'Many' is the list of results inside it.
+-}
+planList ::
+  (forall scope. Plan scope param result) ->
+  Plan listScope [param] [result]
+planList plan =
+  Many.elems <$> planMany plan
+
+{- |
+  'focusParam' builds a plan from a function and an existing plan taking the
+  result of that function as input. This is especially useful when there is some
+  structure, and a plan that only needs a part of that structure as input. The
+  function argument can access part of the structure for the plan argument to use,
+  so the final returned plan can take the entire structure as input.
+-}
+focusParam ::
+  (a -> b) ->
+  Plan scope b result ->
+  Plan scope a result
+focusParam focuser plan =
+  chain (focuser <$> askParam) plan
+
+{- |
+  'planEither' lets you construct a plan that branches by executing a different
+  plan for the 'Left' and 'Right' sides of an 'Either' value. When used with a
+  single input parameter only one of the two plans will be used, based on the
+  input parameter. When used on multiple input parameters, each of the two
+  plans will be executed only once with all the 'Left' and 'Right' values
+  provided as input parameters respectively.
+-}
+planEither ::
+  Plan scope leftParam leftResult ->
+  Plan scope rightParam rightResult ->
+  Plan scope (Either leftParam rightParam) (Either leftResult rightResult)
+planEither =
+  PlanEither
+
+{- |
+  'planMaybe' lifts a plan so both its param and result become 'Maybe's. This is
+  useful when modifying an existing plan to deal with optionality. Writing just
+  one plan can then easily produce both the required and optional versions.
+-}
+planMaybe :: Plan scope a b -> Plan scope (Maybe a) (Maybe b)
+planMaybe plan =
+  focusParam (maybe (Left ()) Right) $
+    either id id <$> planEither (pure Nothing) (Just <$> plan)
+
+{- |
+  'bind' gives access to the results of a plan to use as input values to future
+  plans. The plan result is given the input parameter to the provided function,
+  which must produce the remaining 'Plan' to be executed. The value will be
+  wrapped in the 'Planned' type, which may represent either a result or
+  multiple results, depending on whether one plan is currently be executed with
+  one and multiple input parameters. This ensures that the caller produces only
+  a single remaining 'Plan' to be used for all inputs when there are multiple
+  to eliminate the need to possibly run different queries for different inputs
+  (which would an introduce N+1 query execution).
+
+  The 'Planned' value (or values) provided by 'bind' have actually been
+  retrieved from the database, so the value can be used multiple times when
+  constructing the remaining 'Plan' without fear of causing the query to run
+  multiple times.
+
+  Also see 'use' for how to lift a 'Planned' value back into a 'Plan'.
+-}
+bind ::
+  Plan scope param a ->
+  (Planned scope param a -> Plan scope param result) ->
+  Plan scope param result
+bind =
+  Bind
+
+{- |
+  'use' constructs a 'Plan' that always produces the 'Planned' value
+  as its result, regardless of the parameter given as input to the plan.
+-}
+use :: Planned scope param a -> Plan scope param a
+use =
+  Use
+
+{- |
+  'using' uses a 'Planned' value in the input to another 'Plan'. The
+  resulting plan will ignore its input and use the 'Planned' value as
+  the input to produce its result instead.
+-}
+using ::
+  Planned scope param a ->
+  Plan scope a b ->
+  Plan scope param b
+using planned plan =
+  chain (use planned) plan
+
+{- |
+  'apply' applies a function produced by a plan to the value produced
+  by another plan. This is usually used via the '<*>' operator through
+  the 'Applicative' instance for 'Plan'.
+-}
+apply ::
+  Plan scope param (a -> b) ->
+  Plan scope param a ->
+  Plan scope param b
+apply =
+  Apply
+
+{- |
+  'chain' connects the output of one plan to the input of another to form a
+  larger plan that will execute the first followed by the second.
+-}
+chain ::
+  Plan scope a b ->
+  Plan scope b c ->
+  Plan scope a c
+chain =
+  Chain
+
+{- |
+  'assert' allows you to make an assertion about a plans result that will throw
+  an 'Op.AssertionFailed' failed exception during execution if it proves to be
+  false. The first parameter is the assertion function, which should return
+  either an error message to be given in the exception or the value to be used
+  as the plan's result.
+-}
+assert ::
+  (param -> a -> Either String b) ->
+  Plan scope param a ->
+  Plan scope param b
+assert assertion aPlan =
+  let eitherPlan =
+        assertion
+          <$> askParam
+          <*> aPlan
+   in chain eitherPlan (PlanOp Op.assertRight)
+
+{- |
+  'execute' accepts the input parameter (or parameters) expected by a 'Plan'
+  and runs the plan to completion, either throwing an 'Op.AssertionFailed'
+  exception in the monad 'm' or producing the expected result.
+
+  If you have a plan that takes one input and want to provide a list of
+  input, use 'planMany' to adapt it to a multple-input plan before calling
+  'execute'.
+-}
+execute ::
+  MonadOrville.MonadOrville m =>
+  Plan Execute param result ->
+  param ->
+  m result
+execute plan param =
+  executeOne plan param
+
+{- |
+  'executeOne' is an internal helper that executes a 'Plan' with a concrete
+  'scope' type to ensure all 'Planned' values are built with 'PlannedOne'.
+-}
+executeOne ::
+  MonadOrville.MonadOrville m =>
+  Plan Execute param result ->
+  param ->
+  m result
+executeOne plan param =
+  case plan of
+    PlanOp operation -> do
+      opResult <- Op.executeOperationOne operation param
+
+      case opResult of
+        Left err ->
+          MIO.liftIO (throwIO err)
+        Right result ->
+          pure result
+    PlanMany manyPlan ->
+      executeMany manyPlan param
+    PlanEither leftPlan rightPlan ->
+      case param of
+        Left leftParam ->
+          Left <$> executeOne leftPlan leftParam
+        Right rightParam ->
+          Right <$> executeOne rightPlan rightParam
+    Bind intermPlan continue -> do
+      interm <- executeOne intermPlan param
+      executeOne
+        (continue (PlannedOne interm))
+        param
+    Use planned ->
+      pure . resolveOne $ planned
+    Pure a ->
+      pure a
+    Apply planF planA ->
+      executeOne planF param <*> executeOne planA param
+    Chain planAB planBC -> do
+      b <- executeOne planAB param
+      executeOne planBC b
+
+{- |
+  'executeMany' is an internal helper that executes a 'Plan' with a concrete
+  @scope@ type to ensure all 'Planned' values are built with 'PlannedMany'.
+-}
+executeMany ::
+  MonadOrville.MonadOrville m =>
+  Plan ExecuteMany param result ->
+  [param] ->
+  m (Many.Many param result)
+executeMany plan params =
+  case plan of
+    PlanOp operation -> do
+      case NEL.nonEmpty params of
+        Nothing ->
+          pure $ Many.fromKeys params (const $ Left Many.NotAKey)
+        Just nonEmptyParams -> do
+          opResult <- Op.executeOperationMany operation nonEmptyParams
+
+          case opResult of
+            Left err ->
+              MIO.liftIO (throwIO err)
+            Right results ->
+              pure results
+    PlanMany manyPlan -> do
+      let flatParams = concat params
+
+      allResults <- executeMany manyPlan flatParams
+
+      let restrictResults subParams =
+            Many.fromKeys subParams (\k -> Many.lookup k allResults)
+
+      pure $ Many.fromKeys params (Right . restrictResults)
+    PlanEither leftPlan rightPlan -> do
+      let (leftParams, rightParams) = partitionEithers params
+
+      leftResults <- executeMany leftPlan leftParams
+      rightResults <- executeMany rightPlan rightParams
+
+      let eitherResult eitherK =
+            case eitherK of
+              Left k ->
+                Left <$> Many.lookup k leftResults
+              Right k ->
+                Right <$> Many.lookup k rightResults
+
+      pure $ Many.fromKeys params eitherResult
+    Bind intermPlan continue -> do
+      interms <- executeMany intermPlan params
+      executeMany
+        (continue (PlannedMany interms))
+        params
+    Use planned ->
+      pure . resolveMany $ planned
+    Pure a ->
+      pure $ Many.fromKeys params (const (Right a))
+    Apply planF planA -> do
+      manyFs <- executeMany planF params
+      manyAs <- executeMany planA params
+
+      pure (Many.apply manyFs manyAs)
+    Chain planAB planBC -> do
+      bs <- executeMany planAB params
+      cs <- executeMany planBC (Many.elems bs)
+      pure $ Many.compose cs bs
+
+{- |
+  'Explain' is an tag type used as the 'scope' variable when explaining a
+  'Plan' via the 'explain' function.
+-}
+data Explain
+  = ExplainOne
+  | ExplainMany
+
+{- |
+  'explain' produces a textual description of the steps outlined by
+  a 'Plan' -- in most cases example SQL queries. If you want to see
+  the explanation of how the plan will run with multiple input parameters,
+  you can use 'planMany' to adapt it before calling 'explain'.
+-}
+explain :: Plan Explain param result -> [String]
+explain plan =
+  Exp.explanationSteps $
+    explainPlan ExplainOne plan
+
+{- |
+  'explainPlan' is an internal helper to executes a plan with the
+  'scope' type fixed to 'Explain' to ensure that all 'Planned'
+  values are constructed with the 'PlannedExplain' constructor.
+-}
+explainPlan ::
+  Explain ->
+  Plan Explain param result ->
+  Exp.Explanation
+explainPlan mult plan =
+  case plan of
+    PlanOp operation -> do
+      case mult of
+        ExplainOne ->
+          Op.explainOperationOne operation
+        ExplainMany ->
+          Op.explainOperationMany operation
+    PlanMany manyPlan -> do
+      explainPlan ExplainMany manyPlan
+    PlanEither leftPlan rightPlan ->
+      explainPlan mult leftPlan <> explainPlan mult rightPlan
+    Bind intermPlan continue ->
+      let nextPlan = continue PlannedExplain
+       in explainPlan mult intermPlan <> explainPlan mult nextPlan
+    Use _ ->
+      Exp.noExplanation
+    Pure _ ->
+      Exp.noExplanation
+    Apply planF planA -> do
+      explainPlan mult planF <> explainPlan mult planA
+    Chain planAB planBC -> do
+      explainPlan mult planAB <> explainPlan mult planBC

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Plan/Explanation.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Plan/Explanation.hs
@@ -1,0 +1,32 @@
+module Orville.PostgreSQL.Plan.Explanation
+  ( Explanation,
+    noExplanation,
+    explainStep,
+    explanationSteps,
+  )
+where
+
+newtype Explanation
+  = Explanation ([String] -> [String])
+
+instance Semigroup Explanation where
+  (<>) = appendExplanation
+
+instance Monoid Explanation where
+  mempty = noExplanation
+
+appendExplanation :: Explanation -> Explanation -> Explanation
+appendExplanation (Explanation front) (Explanation back) =
+  Explanation (front . back)
+
+noExplanation :: Explanation
+noExplanation =
+  Explanation id
+
+explainStep :: String -> Explanation
+explainStep str =
+  Explanation (str :)
+
+explanationSteps :: Explanation -> [String]
+explanationSteps (Explanation prependTo) =
+  prependTo []

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Plan/Many.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Plan/Many.hs
@@ -1,0 +1,138 @@
+module Orville.PostgreSQL.Plan.Many
+  ( Many,
+    NotAKey (NotAKey),
+    fromKeys,
+    lookup,
+    keys,
+    elems,
+    map,
+    toMap,
+    apply,
+    compose,
+  )
+where
+
+import Prelude (Either (Left, Right), Functor (fmap), Maybe (Just, Nothing), Ord, ($), (.), (<*>))
+
+import qualified Data.Either as Either
+import qualified Data.Map as Map
+import qualified Data.Maybe as Maybe
+
+{- |
+  'NotAKey' is returned from various 'Many' related functions when presented
+  with an input parameter that was not one of the original inputs that the
+  'Many' was constructed with.
+-}
+data NotAKey
+  = NotAKey
+
+{- |
+  A 'Many k a' represents a group of values keyed by list of parameters and
+  is used to return the results of executing an Orville Plan with a list of
+  input parameters. If you need to find the result of the query associated
+  with a particular input parameter, you can use 'lookup' to find it. If you
+  don't care about the association with particular inputs, you can simply
+  use 'elems' to get a list of all the results.
+-}
+data Many k a
+  = Many [k] (k -> Either NotAKey a)
+
+instance Functor (Many k) where
+  fmap = map
+
+{- |
+  'fromKeys' constructs a 'Many' value from a list of keys and a function that
+  maps them to their values. The order and duplication of keys in the list will
+  be preserved by the 'Many' type in the relevant functions. The mapping
+  function provided should be a total function -- i.e. it should not produce a
+  runtime error. If it is not possible to map every @k@ (even those not in the
+  input list provided to 'fromKeys'), the values should be wrapped in an
+  appropriate type such as 'Maybe' so that an empty or default value can be
+  returned.
+-}
+fromKeys :: [k] -> (k -> Either NotAKey a) -> Many k a
+fromKeys =
+  Many
+
+{- |
+   'map' calls a function on all the values found in a 'Many' collection.
+-}
+map :: (a -> b) -> Many k a -> Many k b
+map f (Many ks keyToValue) =
+  Many ks (fmap f . keyToValue)
+
+{- |
+   'apply' allows you to apply many functions to many values. The function
+   associated with each parameter is applied to the value associated with the
+   same paremeter.
+
+   (If you're looking for 'pure' or an 'Applicative' instance for 'Many', this
+   is as good as it gets. 'Many' cannot be an 'Applicative' because there is no
+   correct implementation of 'pure' that we can reasonably provide).
+-}
+apply ::
+  (Many param (a -> b)) ->
+  (Many param a) ->
+  (Many param b)
+apply manyFs manyAs =
+  fromKeys (keys manyFs) applyF
+  where
+    applyF param =
+      lookup param manyFs <*> lookup param manyAs
+
+{- |
+  'compose' uses the values of a 'Many' value as keys to a second 'Many' to
+  create a 'Many' mapping from the original keys to the final values.
+-}
+compose :: Many b c -> Many a b -> Many a c
+compose manyBC manyAB =
+  fromKeys (keys manyAB) aToC
+  where
+    aToC a = do
+      b <- lookup a manyAB
+      lookup b manyBC
+
+{- |
+  'keys' fetches the list of keys from a 'Many'. Note that is a list and not
+  a set. 'Many' preserves the order and duplication of any key values that were
+  in the key list at the time of construction.
+-}
+keys :: Many k a -> [k]
+keys (Many ks _) =
+  ks
+
+{- |
+  'elems' returns all the values that correspond the keys of the 'Many'. The
+  values will be returned in the same order that the keys were present at the
+  time of creation, though if you truly care about this it's probably better to
+  use 'lookup' to make that correspondence explicit.
+-}
+elems :: Many k a -> [a]
+elems (Many ks keyToValue) =
+  Either.rights $ fmap keyToValue ks
+
+{- |
+  'toMap' converts the 'Many' into a 'Map' value. If all you wanted to do was
+  find the value for a specific key, you should probably use 'lookup' instead.
+-}
+toMap :: Ord k => Many k a -> Map.Map k a
+toMap (Many ks keyToValue) =
+  Map.fromList (Maybe.mapMaybe mkPair ks)
+  where
+    mkPair k =
+      case keyToValue k of
+        Left NotAKey ->
+          Nothing
+        Right value ->
+          Just (k, value)
+
+{- |
+  'lookup' returns the value for the given parameter. If the given @k@ is
+  not one of the original input values that the 'Many' was constructed with,
+  the mapping function given at the contructor will determine what value to
+  return. Often this will be whatever a reasonable empty or default value for
+  the type @a@ is.
+-}
+lookup :: k -> Many k a -> Either NotAKey a
+lookup k (Many _ keyToValue) =
+  keyToValue k

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Plan/Operation.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Plan/Operation.hs
@@ -1,0 +1,443 @@
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Orville.PostgreSQL.Plan.Operation
+  ( Operation (..),
+    AssertionFailed,
+    mkAssertionFailed,
+    findOne,
+    findOneWhere,
+    findAll,
+    findAllWhere,
+    findSelect,
+    askParam,
+    assertRight,
+    SelectOperation (..),
+    selectOperation,
+  )
+where
+
+import Control.Exception (Exception)
+import qualified Data.ByteString.Char8 as BS8
+import qualified Data.Foldable as Fold
+import Data.List.NonEmpty (NonEmpty ((:|)))
+import qualified Data.Map.Strict as Map
+import qualified Data.Maybe as Maybe
+import qualified Data.Text as T
+
+import qualified Orville.PostgreSQL.Internal.FieldDefinition as FieldDefinition
+import qualified Orville.PostgreSQL.Internal.MonadOrville as MonadOrville
+import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+import Orville.PostgreSQL.Internal.Select (Select)
+import qualified Orville.PostgreSQL.Internal.Select as Select
+import qualified Orville.PostgreSQL.Internal.SelectOptions as SelectOptions
+import qualified Orville.PostgreSQL.Internal.SqlMarshaller as SqlMarshaller
+import qualified Orville.PostgreSQL.Internal.SqlType as SqlType
+import qualified Orville.PostgreSQL.Internal.TableDefinition as TableDefinition
+import qualified Orville.PostgreSQL.Plan.Explanation as Exp
+import Orville.PostgreSQL.Plan.Many (Many)
+import qualified Orville.PostgreSQL.Plan.Many as Many
+
+{- |
+  'Operation' provides a stucture for building primitive operations that can be
+  incorporated into a 'Database.Orville.PostgreSQL.Plan.Plan'. An 'Operation'
+  provides base case implementations of the various plan execution functions.
+  You only need to care about this type if you want to create new custom
+  operations to include in a 'Database.Orville.PostgreSQL.Plan.Plan' beyond
+  those already provided in the 'Database.Orville.PostgreSQL.Plan.Plan'
+  api.
+-}
+data Operation param result = Operation
+  { -- | 'executeOperationOne' will be called when an plan is
+    -- executed with a single input parameter
+    executeOperationOne ::
+      forall m.
+      (MonadOrville.MonadOrville m) =>
+      param ->
+      m (Either AssertionFailed result)
+  , -- | 'executeOperationMany' will be called when an plan is
+    -- executed with multiple input parameters (via 'planMany').
+    executeOperationMany ::
+      forall m.
+      (MonadOrville.MonadOrville m) =>
+      NonEmpty param ->
+      m (Either AssertionFailed (Many param result))
+  , -- | 'explainOperationOne' will be called when producing an explanation
+    -- of what the plan will do when given one input parameter. Plans that do
+    -- not perform any interesting IO interactions should generally return an
+    -- empty explanation.
+    explainOperationOne :: Exp.Explanation
+  , -- | 'explainOperationMany' will be called when producing an explanation
+    -- of what the plan will do when given multiple input parameters (via
+    -- 'planMany'). Plans that do not perform any interesting IO interactions
+    -- should generally return an empty explanation.
+    explainOperationMany :: Exp.Explanation
+  }
+
+{- |
+  'AssertionFailed' may be returned from the execute functions of an
+  'Operation' to indicate that some expected invariant has failed. For example,
+  following a foreign key that is enforced by the database only to find that no
+  record exists. When an 'Operation' returns an 'AssertionFailed' value during
+  plan execution the error is thrown as an exception using the
+  'Control.Monad.Catch.MonadThrow' instance for whatever monad the plan is
+  executing in.
+-}
+newtype AssertionFailed
+  = AssertionFailed String
+  deriving (Show)
+
+{- |
+  'mkAssertionFailed' builds an 'AssertionFailed' error from an error message.
+-}
+mkAssertionFailed :: String -> AssertionFailed
+mkAssertionFailed =
+  AssertionFailed
+
+instance Exception AssertionFailed
+
+{- |
+  'askParam' simply returns the paremeter given from the plan.
+-}
+askParam :: Operation param param
+askParam =
+  Operation
+    { executeOperationOne = pure . Right
+    , executeOperationMany = \params -> pure . Right $ Many.fromKeys (Fold.toList params) Right
+    , explainOperationOne = Exp.noExplanation
+    , explainOperationMany = Exp.noExplanation
+    }
+
+{- |
+  'assertRight' returns the value on the 'Right' side of an 'Either'. If
+  the 'Either' is a 'Left', it raises 'AssertionFailed' with the message
+  from the left side of the either.
+-}
+assertRight :: Operation (Either String a) a
+assertRight =
+  Operation
+    { executeOperationOne = \eitherA ->
+        pure $
+          case eitherA of
+            Left err ->
+              Left (AssertionFailed $ "Assertion failed: " <> err)
+            Right b ->
+              Right b
+    , executeOperationMany = \eitherAs ->
+        pure $
+          case sequence eitherAs of
+            Left err ->
+              Left (AssertionFailed $ "Assertion failed: " <> err)
+            Right _ ->
+              let errorOnLeft :: forall a b. Either a b -> Either Many.NotAKey b
+                  errorOnLeft eitherA =
+                    case eitherA of
+                      Left _ ->
+                        -- We proved all the values above didn't have any lefts in
+                        -- then, so if we get a left here it must not be one of the
+                        -- keys from the Many.
+                        Left Many.NotAKey
+                      Right a ->
+                        Right a
+               in Right $ Many.fromKeys (Fold.toList eitherAs) errorOnLeft
+    , explainOperationOne = Exp.noExplanation
+    , explainOperationMany = Exp.noExplanation
+    }
+
+{- |
+  'findOne' builds a planning primitive that finds (at most) one row from the
+  given table where the column value for the provided 'Core.FieldDefinition' matches
+  the plan's input parameter. When executed on multiple parameters it fetches
+  all rows where the field matches the inputs and arbitrarily picks at most one
+  of those rows to use as the result for each input.
+-}
+findOne ::
+  Ord fieldValue =>
+  TableDefinition.TableDefinition key writeEntity readEntity ->
+  FieldDefinition.FieldDefinition nullability fieldValue ->
+  Operation fieldValue (Maybe readEntity)
+findOne tableDef fieldDef =
+  findOneWithOpts tableDef fieldDef mempty
+
+{- |
+  'findOneWhere' is similar to 'findOne' but allows a 'WhereCondition' to be
+  specified that is added to the database query to restrict which rows are
+  returned.
+-}
+findOneWhere ::
+  Ord fieldValue =>
+  TableDefinition.TableDefinition key writeEntity readEntity ->
+  FieldDefinition.FieldDefinition nullability fieldValue ->
+  SelectOptions.WhereCondition ->
+  Operation fieldValue (Maybe readEntity)
+findOneWhere tableDef fieldDef cond =
+  findOneWithOpts tableDef fieldDef (SelectOptions.where_ cond)
+
+{- |
+  'findOneWithOpts' is a internal helper used by 'findOne' and 'findOneWhere'
+-}
+findOneWithOpts ::
+  Ord fieldValue =>
+  TableDefinition.TableDefinition key writeEntity readEntity ->
+  FieldDefinition.FieldDefinition nullability fieldValue ->
+  SelectOptions.SelectOptions ->
+  Operation fieldValue (Maybe readEntity)
+findOneWithOpts tableDef fieldDef opts =
+  selectOperation selectOp
+  where
+    selectOp =
+      SelectOperation
+        { selectOne = \fieldValue ->
+            select (opts <> SelectOptions.where_ (SelectOptions.fieldEquals fieldDef fieldValue) <> SelectOptions.limit 1)
+        , selectMany = \fieldValues ->
+            select (opts <> SelectOptions.where_ (SelectOptions.fieldIn fieldDef fieldValues))
+        , explainSelectOne =
+            select (opts <> SelectOptions.where_ (SelectOptions.fieldEquals stringyField $ T.pack "EXAMPLE VALUE"))
+        , explainSelectMany =
+            select (opts <> SelectOptions.where_ (SelectOptions.fieldIn stringyField $ fmap T.pack ("EXAMPLE VALUE 1" :| ["EXAMPLE VALUE 2"])))
+        , categorizeRow = fst
+        , produceResult = fmap snd . Maybe.listToMaybe
+        }
+
+    select =
+      Select.selectMarshalledColumns
+        marshaller
+        (TableDefinition.tableName tableDef)
+
+    stringyField =
+      stringifyField fieldDef
+
+    marshaller =
+      (,)
+        <$> SqlMarshaller.marshallField fst fieldDef
+        <*> SqlMarshaller.marshallNested snd (TableDefinition.tableMarshaller tableDef)
+
+{- |
+  'findAll' builds a planning primitive that finds all the rows from the
+  given table where the column value for the provided field matches the
+  plan's input parameter. Where executed on multiple parameters all rows
+  are fetch in a single query and then associated with their respective
+  inputs after being fetched.
+-}
+findAll ::
+  Ord fieldValue =>
+  TableDefinition.TableDefinition key writeEntity readEntity ->
+  FieldDefinition.FieldDefinition nullability fieldValue ->
+  Operation fieldValue [readEntity]
+findAll tableDef fieldDef =
+  findAllWithOpts tableDef fieldDef mempty
+
+{- |
+  'findAllWhere' is similar to 'findAll' but allows a 'WhereCondition' to be
+  specified that is added to the database query to restrict which rows are
+  returned.
+-}
+findAllWhere ::
+  Ord fieldValue =>
+  TableDefinition.TableDefinition key writeEntity readEntity ->
+  FieldDefinition.FieldDefinition nullability fieldValue ->
+  SelectOptions.WhereCondition ->
+  Operation fieldValue [readEntity]
+findAllWhere tableDef fieldDef cond =
+  findAllWithOpts tableDef fieldDef (SelectOptions.where_ cond)
+
+{- |
+  'findAllWithOpts' is an internal helper used by 'findAll' and 'findAllWhere'
+-}
+findAllWithOpts ::
+  Ord fieldValue =>
+  TableDefinition.TableDefinition key writeEntity readEntity ->
+  FieldDefinition.FieldDefinition nullability fieldValue ->
+  SelectOptions.SelectOptions ->
+  Operation fieldValue [readEntity]
+findAllWithOpts tableDef fieldDef opts =
+  selectOperation selectOp
+  where
+    selectOp =
+      SelectOperation
+        { selectOne = \fieldValue ->
+            select (opts <> SelectOptions.where_ (SelectOptions.fieldEquals fieldDef fieldValue))
+        , selectMany = \fieldValues ->
+            select (opts <> SelectOptions.where_ (SelectOptions.fieldIn fieldDef fieldValues))
+        , explainSelectOne =
+            select (opts <> SelectOptions.where_ (SelectOptions.fieldEquals stringyField $ T.pack "EXAMPLE VALUE"))
+        , explainSelectMany =
+            select (opts <> SelectOptions.where_ (SelectOptions.fieldIn stringyField $ fmap T.pack ("EXAMPLE VALUE 1" :| ["EXAMPLE VALUE 2"])))
+        , categorizeRow = fst
+        , produceResult = map snd
+        }
+
+    select =
+      Select.selectMarshalledColumns
+        marshaller
+        (TableDefinition.tableName tableDef)
+
+    stringyField =
+      stringifyField fieldDef
+
+    marshaller =
+      (,)
+        <$> SqlMarshaller.marshallField fst fieldDef
+        <*> SqlMarshaller.marshallNested snd (TableDefinition.tableMarshaller tableDef)
+
+{- |
+  'stringifyField' arbitrarily re-labels the 'SqlType' of a field definition
+  as text. It is an internal helper function that is used for constructing
+  'WhereCondition' clauses used to generate sql when explaining how a plan
+  will be executed. Relabeling the type as 'T.Text' allows us to use text
+  values as example inputs in the queries when for explaining plans.
+-}
+stringifyField ::
+  FieldDefinition.FieldDefinition nullability a ->
+  FieldDefinition.FieldDefinition nullability T.Text
+stringifyField =
+  FieldDefinition.convertField (const SqlType.unboundedText)
+
+{- |
+  'SelectOperation' is a helper type for building 'Operation' primitives that
+  run 'Select' queries. Specifying the fields of 'SelectOperation' and then
+  using the 'selectOperation' function to build an 'Operation' is more
+  convenient that building functions to execute the queries thate are required
+  by the 'Operation' type.
+-}
+data SelectOperation param row result = SelectOperation
+  { -- | 'selectOne' will be called to build the 'Select' query that should
+    -- be run when there is a single input parameter while executing a plan.
+    -- Note that the "One-ness" here refers to the single input parameter
+    -- rather than result. See 'produceResult' below for more information
+    -- about returning one values vs. many from a 'SelectOperation'.
+    selectOne :: param -> Select row
+  , -- | 'selectMany' will be called to build the 'Select' query that should
+    -- be run when there are multiple parameters while executing a plan.
+    -- Note that the "Many-ness" here refers to the multiple input parameters
+    -- rather than result. See 'produceResult' below for more information
+    -- about returning one values vs. many from a 'SelectOperation'.
+    selectMany :: NonEmpty param -> Select row
+  , -- | 'explainSelectOne' should show a representative query of what will
+    -- be returned when 'selectOne' is used. No input parameter is available
+    -- here to build the query, however, because this value is used to
+    -- explain a plan without actually running it.
+    explainSelectOne :: Select row
+  , -- | 'explainSelectMany' should show a representative query of what will
+    -- be returned when 'selectMany is used. No input parameters are available
+    -- here to build the query, however, because this value is used to
+    -- explain a plan without actually running it.
+    explainSelectMany :: Select row
+  , -- | 'categorizeRow' will be used when a plan is executed with multiple
+    -- parameters to determine which input parameter the row should be
+    -- associated with.
+    categorizeRow :: row -> param
+  , -- | 'produceResult' will be used convert the 'row' type returned by the
+    -- 'Select' queries for the operation input the 'result' type that is
+    -- present as the output of the operation. The input rows will be all the
+    -- inputs associated with a single parameter. The 'result' type
+    -- constructed here need not be a single value. For instance, 'findAll'
+    -- uses the list type as the 'result' type and 'findOne' uses 'Maybe'.
+    produceResult :: [row] -> result
+  }
+
+{- |
+  'selectOperation' builds a primitive planning 'Operation' using the functions
+  given by a 'SelectOperation'. If you are implementing a custom operation that
+  runs a select statement, it is probably easier to use this function rather
+  than building the 'Operation' functions directly.
+-}
+selectOperation ::
+  Ord param =>
+  SelectOperation param row result ->
+  Operation param result
+selectOperation selectOp =
+  Operation
+    { executeOperationOne = executeSelectOne selectOp
+    , executeOperationMany = executeSelectMany selectOp
+    , explainOperationOne = explainSelect $ explainSelectOne selectOp
+    , explainOperationMany = explainSelect $ explainSelectMany selectOp
+    }
+
+explainSelect :: Select row -> Exp.Explanation
+explainSelect =
+  Exp.explainStep . BS8.unpack . RawSql.toBytes . Select.selectToQueryExpr
+
+{- |
+  'runSelectOne' is an internal helper function that executes a
+  'SelectOperation' on a single input parameter.
+-}
+executeSelectOne ::
+  MonadOrville.MonadOrville m =>
+  SelectOperation param row result ->
+  param ->
+  m (Either AssertionFailed result)
+executeSelectOne selectOp param =
+  Right . produceResult selectOp
+    <$> (Select.executeSelect . selectOne selectOp $ param)
+
+{- |
+  'executeSelectMany' is an internal helper function that executes a
+  'SelectOperation' on multiple input parameters.
+-}
+executeSelectMany ::
+  forall param row result m.
+  (Ord param, MonadOrville.MonadOrville m) =>
+  SelectOperation param row result ->
+  NonEmpty param ->
+  m (Either AssertionFailed (Many param result))
+executeSelectMany selectOp params = do
+  rows <- Select.executeSelect . selectMany selectOp $ params
+
+  let -- Seed add initial map with an empty list for every input parameter
+      -- to guarantee that each param is a key in the map even if no rows
+      -- where returned from the select query for that param.
+      emptyRowsMap :: Map.Map param [a]
+      emptyRowsMap =
+        Map.fromList
+          . map (\param -> (param, []))
+          . Fold.toList
+          $ params
+
+      insertRow results row =
+        Map.alter
+          (\mbRows -> Just (row : Maybe.fromMaybe [] mbRows))
+          (categorizeRow selectOp row)
+          results
+
+      rowMap =
+        produceResult selectOp <$> Fold.foldl' insertRow emptyRowsMap rows
+
+      manyRows =
+        Many.fromKeys (Fold.toList params) $ \param ->
+          case Map.lookup param rowMap of
+            Nothing ->
+              -- Because we seeded the map above with all the input parameters we
+              -- can be sure that if we don't find a value in the map here it is
+              -- because the function parameter is not one of the original inputs
+              -- rather than just an input for which no rows were returned by the
+              -- select query.
+              Left Many.NotAKey
+            Just row ->
+              Right row
+
+  pure . Right $ manyRows
+
+{- |
+  'findSelect' builds a plan 'Operation' where the select that is run does not
+  use the input parameters for the plan in any way. If the
+  'executeOperationMany' function of the resulting 'Operation' will run the
+  query once and use the entire result set as the result each of the input
+  parameters in turn.
+-}
+findSelect :: forall param row. Select.Select row -> Operation param [row]
+findSelect select =
+  let executeOne :: MonadOrville.MonadOrville m => param -> m (Either a [row])
+      executeOne _ =
+        Right <$> Select.executeSelect select
+
+      executeMany :: MonadOrville.MonadOrville m => NonEmpty param -> m (Either a (Many param [row]))
+      executeMany params = do
+        rows <- Select.executeSelect select
+        pure . Right $ Many.fromKeys (Fold.toList params) (const (Right rows))
+   in Operation
+        { executeOperationOne = executeOne
+        , executeOperationMany = executeMany
+        , explainOperationOne = Exp.explainStep undefined --(SelectInternal.selectSql select)
+        , explainOperationMany = Exp.explainStep undefined --(SelectInternal.selectSql select)
+        }

--- a/orville-postgresql-libpq/test/Main.hs
+++ b/orville-postgresql-libpq/test/Main.hs
@@ -17,6 +17,7 @@ import qualified Test.Expr.TableDefinition as ExprTableDefinition
 import qualified Test.Expr.Where as ExprWhere
 import qualified Test.FieldDefinition as FieldDefinition
 import qualified Test.InformationSchema as InformationSchema
+import qualified Test.Plan as Plan
 import qualified Test.Property as Property
 import qualified Test.RawSql as RawSql
 import qualified Test.ReservedWords as ReservedWords
@@ -47,6 +48,7 @@ main = do
       , SelectOptions.selectOptionsTests
       , ReservedWords.reservedWordsTests pool
       , Transaction.transactionTests pool
+      , Plan.planTests pool
       , InformationSchema.informationSchemaTests pool
       , AutoMigration.autoMigrationTests pool
       ]

--- a/orville-postgresql-libpq/test/Test/Entities/FooChild.hs
+++ b/orville-postgresql-libpq/test/Test/Entities/FooChild.hs
@@ -1,0 +1,76 @@
+module Test.Entities.FooChild
+  ( FooChild (..),
+    isChildOf,
+    table,
+    fooChildIdField,
+    fooChildFooIdField,
+    generate,
+    generateList,
+    withTables,
+  )
+where
+
+import Control.Monad.IO.Class (MonadIO (liftIO))
+import Data.Function (on)
+import Data.Int (Int32)
+import qualified Data.List as List
+import Data.Pool (Pool, withResource)
+import qualified Hedgehog as HH
+import qualified Hedgehog.Gen as Gen
+
+import qualified Orville.PostgreSQL as Orville
+import Orville.PostgreSQL.Connection (Connection)
+
+import qualified Test.Entities.Foo as Foo
+import qualified Test.PGGen as PGGen
+import qualified Test.TestTable as TestTable
+
+type FooChildId = Int32
+
+data FooChild = FooChild
+  { fooChildId :: FooChildId
+  , fooChildFooId :: Foo.FooId
+  }
+  deriving (Eq, Show)
+
+isChildOf :: Foo.Foo -> FooChild -> Bool
+isChildOf foo child =
+  Foo.fooId foo == fooChildFooId child
+
+table :: Orville.TableDefinition (Orville.HasKey FooChildId) FooChild FooChild
+table =
+  Orville.mkTableDefinition "foo_child" (Orville.primaryKey fooChildIdField) fooChildMarshaller
+
+fooChildMarshaller :: Orville.SqlMarshaller FooChild FooChild
+fooChildMarshaller =
+  FooChild
+    <$> Orville.marshallField fooChildId fooChildIdField
+    <*> Orville.marshallField fooChildFooId fooChildFooIdField
+
+fooChildIdField :: Orville.FieldDefinition Orville.NotNull FooChildId
+fooChildIdField =
+  Orville.integerField "id"
+
+fooChildFooIdField :: Orville.FieldDefinition Orville.NotNull Foo.FooId
+fooChildFooIdField =
+  Orville.integerField "foo_id"
+
+generate :: [Foo.Foo] -> HH.Gen FooChild
+generate foos =
+  FooChild
+    <$> PGGen.pgInt32
+    <*> Gen.element (Foo.fooId <$> foos)
+
+generateList :: HH.Range Int -> [Foo.Foo] -> HH.Gen [FooChild]
+generateList range foos =
+  fmap
+    (List.nubBy ((==) `on` fooChildId))
+    (Gen.list range $ generate foos)
+
+withTables :: MonadIO m => Pool Connection -> Orville.Orville a -> m a
+withTables pool operation =
+  liftIO $ do
+    withResource pool $ \connection -> do
+      TestTable.dropAndRecreateTableDef connection Foo.table
+      TestTable.dropAndRecreateTableDef connection table
+    Orville.runOrville pool operation

--- a/orville-postgresql-libpq/test/Test/Plan.hs
+++ b/orville-postgresql-libpq/test/Test/Plan.hs
@@ -1,0 +1,461 @@
+module Test.Plan
+  ( planTests,
+  )
+where
+
+import qualified Control.Exception as Exception
+import qualified Control.Monad.IO.Class as MIO
+import qualified Data.Either as Either
+import Data.Foldable (traverse_)
+import qualified Data.List as List
+import qualified Data.List.NonEmpty as NEL
+import qualified Data.Pool as Pool
+import qualified Data.String as String
+import Hedgehog ((===))
+import qualified Hedgehog as HH
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+import qualified Orville.PostgreSQL as Orville
+import qualified Orville.PostgreSQL.Connection as Connection
+import qualified Orville.PostgreSQL.Plan as Plan
+import qualified Orville.PostgreSQL.Plan.Many as Many
+
+import qualified Test.Entities.Foo as Foo
+import qualified Test.Entities.FooChild as FooChild
+import qualified Test.Property as Property
+
+planTests :: Pool.Pool Connection.Connection -> Property.Group
+planTests pool =
+  Property.group "Plan" $
+    [ prop_askParam pool
+    , prop_findMaybeOne pool
+    , prop_findMaybeOneWhere pool
+    , prop_findAll pool
+    , prop_findAllWhere pool
+    , prop_planMany_findMaybeOne pool
+    , prop_planMany_findMaybeOneWhere pool
+    , prop_planMany_findAll pool
+    , prop_planMany_findAllWhere pool
+    , prop_planEither pool
+    , prop_planMany_planEither pool
+    , prop_bindAndUse pool
+    , prop_planMany_bindAndUse pool
+    , prop_assert pool
+    , prop_explain
+    ]
+
+prop_askParam :: Property.NamedDBProperty
+prop_askParam =
+  Property.namedDBProperty "askParam returns the plan's parameter" $ \pool -> do
+    let plan :: Plan.Plan scope Int Int
+        plan = Plan.askParam
+
+    inputParam <- HH.forAll $ Gen.integral (Range.constant minBound maxBound)
+    resultParam <- MIO.liftIO $ Orville.runOrville pool (Plan.execute plan inputParam)
+    resultParam === inputParam
+
+prop_findMaybeOne :: Property.NamedDBProperty
+prop_findMaybeOne =
+  Property.namedDBProperty "findMaybeOne finds a row where the field matches (if any)" $ \pool -> do
+    let plan :: Plan.Plan scope Foo.FooName (Maybe Foo.Foo)
+        plan = Plan.findMaybeOne Foo.table Foo.fooNameField
+
+    (targetName, foos) <- HH.forAll generateSearchTargetAndSubjects
+    maybeResult <-
+      Foo.withTable pool $ do
+        traverse_ (Orville.insertEntities Foo.table) (NEL.nonEmpty foos)
+        Plan.execute plan targetName
+
+    let isMatch = Foo.hasName targetName
+
+    coverSearchResultCases isMatch foos
+    assertMatchIsFromPredicate maybeResult isMatch foos
+
+prop_planMany_findMaybeOne :: Property.NamedDBProperty
+prop_planMany_findMaybeOne =
+  Property.namedDBProperty "(planMany findMaybeOne) finds a row where the field matches for each input" $ \pool -> do
+    let plan :: Plan.Plan scope [Foo.FooName] (Many.Many Foo.FooName (Maybe Foo.Foo))
+        plan = Plan.planMany $ Plan.findMaybeOne Foo.table Foo.fooNameField
+
+    (targetNames, foos) <- HH.forAll generateSearchTargetListAndSubjects
+    results <-
+      Foo.withTable pool $ do
+        traverse_ (Orville.insertEntities Foo.table) (NEL.nonEmpty foos)
+        Plan.execute plan targetNames
+
+    let isMatch foo = elem (Foo.fooName foo) targetNames
+
+    coverSearchResultCases isMatch foos
+
+    assertEachManyResult targetNames results $ \targetName maybeFoo ->
+      assertMatchIsFromPredicate
+        maybeFoo
+        (\foo -> Foo.hasName targetName foo && isMatch foo)
+        foos
+
+prop_findMaybeOneWhere :: Property.NamedDBProperty
+prop_findMaybeOneWhere =
+  Property.namedDBProperty "findMaybeOneWhere finds a row where the field matches (if any), with the given condition" $ \pool -> do
+    let plan :: Plan.Plan scope Foo.FooName (Maybe Foo.Foo)
+        plan =
+          Plan.findMaybeOneWhere
+            Foo.table
+            Foo.fooNameField
+            (Orville.fieldGreaterThan Foo.fooAgeField Foo.averageFooAge)
+
+    (targetName, foos) <- HH.forAll generateSearchTargetAndSubjects
+    maybeResult <-
+      Foo.withTable pool $ do
+        traverse_ (Orville.insertEntities Foo.table) (NEL.nonEmpty foos)
+        Plan.execute plan targetName
+
+    let isMatch foo = Foo.hasName targetName foo && Foo.fooAge foo > Foo.averageFooAge
+
+    coverSearchResultCases isMatch foos
+    assertMatchIsFromPredicate maybeResult isMatch foos
+
+prop_planMany_findMaybeOneWhere :: Property.NamedDBProperty
+prop_planMany_findMaybeOneWhere =
+  Property.namedDBProperty "(planMany findMaybeOneWhere) finds a row where the field matches for each input, with the given condition" $ \pool -> do
+    let plan :: Plan.Plan scope [Foo.FooName] (Many.Many Foo.FooName (Maybe Foo.Foo))
+        plan =
+          Plan.planMany $
+            Plan.findMaybeOneWhere
+              Foo.table
+              Foo.fooNameField
+              (Orville.fieldGreaterThan Foo.fooAgeField Foo.averageFooAge)
+
+    (targetNames, foos) <- HH.forAll generateSearchTargetListAndSubjects
+    results <-
+      Foo.withTable pool $ do
+        traverse_ (Orville.insertEntities Foo.table) (NEL.nonEmpty foos)
+        Plan.execute plan targetNames
+
+    let isMatch foo =
+          elem (Foo.fooName foo) targetNames
+            && Foo.fooAge foo > Foo.averageFooAge
+
+    coverSearchResultCases isMatch foos
+
+    assertEachManyResult targetNames results $ \targetName maybeFoo ->
+      assertMatchIsFromPredicate
+        maybeFoo
+        (\foo -> Foo.hasName targetName foo && isMatch foo)
+        foos
+
+prop_findAll :: Property.NamedDBProperty
+prop_findAll =
+  Property.namedDBProperty "findAll finds all rows where the field matches" $ \pool -> do
+    let plan :: Plan.Plan scope Foo.FooName [Foo.Foo]
+        plan = Plan.findAll Foo.table Foo.fooNameField
+
+    (targetName, foos) <- HH.forAll generateSearchTargetAndSubjects
+    results <-
+      Foo.withTable pool $ do
+        traverse_ (Orville.insertEntities Foo.table) (NEL.nonEmpty foos)
+        Plan.execute plan targetName
+
+    let isMatch = Foo.hasName targetName
+
+    coverSearchResultCases isMatch foos
+    assertAllMatchesFound Foo.fooId results isMatch foos
+
+prop_planMany_findAll :: Property.NamedDBProperty
+prop_planMany_findAll =
+  Property.namedDBProperty "(planMany findAll) finds all rows where the field matches for each list of inputs" $ \pool -> do
+    let plan :: Plan.Plan scope [Foo.FooName] (Many.Many Foo.FooName [Foo.Foo])
+        plan = Plan.planMany (Plan.findAll Foo.table Foo.fooNameField)
+
+    (targetNames, foos) <- HH.forAll generateSearchTargetListAndSubjects
+    results <-
+      Foo.withTable pool $ do
+        traverse_ (Orville.insertEntities Foo.table) (NEL.nonEmpty foos)
+        Plan.execute plan targetNames
+
+    let isMatch foo = elem (Foo.fooName foo) targetNames
+
+    coverSearchResultCases isMatch foos
+    assertEachManyResult targetNames results $ \targetName foundFoos ->
+      assertAllMatchesFound Foo.fooId foundFoos (\foo -> Foo.hasName targetName foo && isMatch foo) foos
+
+prop_findAllWhere :: Property.NamedDBProperty
+prop_findAllWhere =
+  Property.namedDBProperty "findAllWhere finds all rows where the field matches, with the given condition" $ \pool -> do
+    let plan :: Plan.Plan scope Foo.FooName [Foo.Foo]
+        plan =
+          Plan.findAllWhere
+            Foo.table
+            Foo.fooNameField
+            (Orville.fieldGreaterThan Foo.fooAgeField Foo.averageFooAge)
+
+    (targetName, foos) <- HH.forAll generateSearchTargetAndSubjects
+    results <-
+      Foo.withTable pool $ do
+        traverse_ (Orville.insertEntities Foo.table) (NEL.nonEmpty foos)
+        Plan.execute plan targetName
+
+    let isMatch foo = Foo.hasName targetName foo && Foo.fooAge foo > Foo.averageFooAge
+
+    coverSearchResultCases isMatch foos
+    assertAllMatchesFound Foo.fooId results isMatch foos
+
+prop_planMany_findAllWhere :: Property.NamedDBProperty
+prop_planMany_findAllWhere =
+  Property.namedDBProperty "(planMany findAllWhere) finds all rows where the field matches for each list of inputs, with the given condition" $ \pool -> do
+    let plan :: Plan.Plan scope [Foo.FooName] (Many.Many Foo.FooName [Foo.Foo])
+        plan =
+          Plan.planMany $
+            Plan.findAllWhere
+              Foo.table
+              Foo.fooNameField
+              (Orville.fieldGreaterThan Foo.fooAgeField Foo.averageFooAge)
+
+    (targetNames, foos) <- HH.forAll generateSearchTargetListAndSubjects
+    results <-
+      Foo.withTable pool $ do
+        traverse_ (Orville.insertEntities Foo.table) (NEL.nonEmpty foos)
+        Plan.execute plan targetNames
+
+    let isMatch foo = elem (Foo.fooName foo) targetNames && Foo.fooAge foo > Foo.averageFooAge
+
+    coverSearchResultCases isMatch foos
+    assertEachManyResult targetNames results $ \targetName foundFoos ->
+      assertAllMatchesFound Foo.fooId foundFoos (\foo -> Foo.hasName targetName foo && isMatch foo) foos
+
+prop_planEither :: Property.NamedDBProperty
+prop_planEither =
+  Property.namedDBProperty "planEither executes either the right or left plan based on input" $ \pool -> do
+    let plan :: Plan.Plan scope (Either Foo.FooId Foo.FooName) Foo.Foo
+        plan =
+          either id id
+            <$> Plan.planEither
+              (Plan.findOne Foo.table Foo.fooIdField)
+              (Plan.findOne Foo.table Foo.fooNameField)
+
+    foo <- HH.forAll Foo.generate
+    param <-
+      HH.forAll . Gen.element $
+        [ Left (Foo.fooId foo)
+        , Right (Foo.fooName foo)
+        ]
+
+    foundFoo <-
+      Foo.withTable pool $ do
+        Orville.insertEntity Foo.table foo
+        Plan.execute plan param
+
+    foundFoo === foo
+
+prop_planMany_planEither :: Property.NamedDBProperty
+prop_planMany_planEither =
+  Property.namedDBProperty "(planMany planEither) executes either the right and left plans with appropriate inputs" $ \pool -> do
+    let plan :: Plan.Plan scope [Either Foo.FooId Foo.FooName] (Many.Many (Either Foo.FooId Foo.FooName) Foo.Foo)
+        plan =
+          Plan.planMany $
+            either id id
+              <$> Plan.planEither
+                (Plan.findOne Foo.table Foo.fooIdField)
+                (Plan.findOne Foo.table Foo.fooNameField)
+
+    foos <- HH.forAll $ Foo.generateList (Range.linear 0 10)
+
+    let pickInput :: Foo.Foo -> HH.PropertyT IO (Either Foo.FooId Foo.FooName)
+        pickInput foo =
+          HH.forAll . Gen.element $
+            [ Left (Foo.fooId foo)
+            , Right (Foo.fooName foo)
+            ]
+
+    params <- traverse pickInput foos
+
+    foundFoos <-
+      Foo.withTable pool $ do
+        traverse_ (Orville.insertEntities Foo.table) (NEL.nonEmpty foos)
+        Plan.execute plan params
+
+    assertEachManyResult params foundFoos $ \input foo ->
+      case input of
+        Left fooId ->
+          Foo.fooId foo === fooId
+        Right fooName ->
+          Foo.fooName foo === fooName
+
+prop_bindAndUse :: Property.NamedDBProperty
+prop_bindAndUse =
+  Property.namedDBProperty "bind/use allows caller to use plan output as input for another plan" $ \pool -> do
+    let plan :: Plan.Plan scope Foo.FooName (Foo.Foo, [FooChild.FooChild])
+        plan =
+          Plan.bind (Plan.findOne Foo.table Foo.fooNameField) $ \foo ->
+            let fooId = Foo.fooId <$> foo
+             in (,)
+                  <$> Plan.use foo
+                  <*> Plan.using fooId (Plan.findAll FooChild.table FooChild.fooChildFooIdField)
+
+    foo <- HH.forAll Foo.generate
+    fooChild <- HH.forAll $ FooChild.generate [foo]
+
+    result <-
+      FooChild.withTables pool $ do
+        Orville.insertEntity Foo.table foo
+        Orville.insertEntity FooChild.table fooChild
+        Plan.execute plan (Foo.fooName foo)
+
+    result === (foo, [fooChild])
+
+prop_planMany_bindAndUse :: Property.NamedDBProperty
+prop_planMany_bindAndUse =
+  Property.namedDBProperty "(planMany bind/use) allows caller to use plan output as input for another plan" $ \pool -> do
+    let plan :: Plan.Plan scope [Foo.FooName] (Many.Many Foo.FooName (Foo.Foo, [FooChild.FooChild]))
+        plan =
+          Plan.planMany $
+            Plan.bind (Plan.findOne Foo.table Foo.fooNameField) $ \foo ->
+              let fooId = Foo.fooId <$> foo
+               in (,)
+                    <$> Plan.use foo
+                    <*> Plan.using fooId (Plan.findAll FooChild.table FooChild.fooChildFooIdField)
+
+    allFoos <- HH.forAll $ Foo.generateList (Range.linear 1 5)
+    allChildren <- HH.forAll $ FooChild.generateList (Range.linear 0 20) allFoos
+
+    let allFooNames = Foo.fooName <$> allFoos
+
+    results <-
+      FooChild.withTables pool $ do
+        traverse_ (Orville.insertEntities Foo.table) (NEL.nonEmpty allFoos)
+        traverse_ (Orville.insertEntities FooChild.table) (NEL.nonEmpty allChildren)
+        Plan.execute plan allFooNames
+
+    assertEachManyResult allFooNames results $ \fooName (foo, children) -> do
+      Foo.fooName foo === fooName
+      assertAllMatchesFound FooChild.fooChildId children (FooChild.isChildOf foo) allChildren
+
+prop_assert :: Property.NamedDBProperty
+prop_assert =
+  Property.namedDBProperty "assert raises an AssertionError in IO" $ \pool -> do
+    let plan :: Plan.Plan scope (Either String ()) ()
+        plan =
+          Plan.assert (\_ value -> value) Plan.askParam
+
+    input <- HH.forAll $ Gen.element [Left "Test Error", Right ()]
+    result <- MIO.liftIO $ Exception.try $ Orville.runOrville pool (Plan.execute plan input)
+    Either.isLeft (result :: Either Plan.AssertionFailed ()) === Either.isLeft input
+
+prop_explain :: Property.NamedProperty
+prop_explain =
+  Property.namedProperty "explain shows the SQL steps that will be executed" $ do
+    let plan :: Plan.Plan scope Foo.FooName [FooChild.FooChild]
+        plan =
+          Plan.chain
+            (Plan.findOne Foo.table Foo.fooNameField)
+            (Plan.focusParam Foo.fooId $ Plan.findAll FooChild.table FooChild.fooChildFooIdField)
+
+        explanation =
+          Plan.explain plan
+
+    explanation
+      === [ "SELECT \"name\",\"id\",\"name\",\"age\" FROM \"foo\" WHERE (\"name\" = $1)"
+          , "SELECT \"foo_id\",\"id\",\"foo_id\" FROM \"foo_child\" WHERE (\"foo_id\" = $1)"
+          ]
+
+{- |
+  Generates a list of Foos that along with FooName that could plausibly be
+  found in the list zero, one or more times.
+-}
+generateSearchTargetAndSubjects :: HH.Gen (Foo.FooName, [Foo.Foo])
+generateSearchTargetAndSubjects = do
+  targetName <- Foo.generateFooName
+
+  let generatePossibleTargetFoo =
+        Gen.choice
+          [ Foo.generateFooWithName targetName
+          , Foo.generate
+          ]
+
+  foos <- Foo.generateListUsing (Range.linear 0 5) generatePossibleTargetFoo
+  pure (targetName, foos)
+
+{- |
+  Generates a list of Foos that along with FooName that could plausibly be
+  found in the list zero, one or more times.
+-}
+generateSearchTargetListAndSubjects :: HH.Gen ([Foo.FooName], [Foo.Foo])
+generateSearchTargetListAndSubjects = do
+  targetNames <- Gen.list (Range.linear 0 5) Foo.generateFooName
+
+  let generatePossibleTargetFoo =
+        Gen.choice (Foo.generate : fmap Foo.generateFooWithName targetNames)
+
+  foos <- Foo.generateListUsing (Range.linear 0 5) generatePossibleTargetFoo
+  pure (targetNames, foos)
+
+{- |
+  Uses Hedgehog's cover function to make sure common edge cases are covered
+  for tests that are conducting a search. The predicate given should indicate
+  whether the item would be expected to match the search being tested. The
+  list of items should be the list that will be searced against.
+-}
+coverSearchResultCases :: HH.MonadTest m => (a -> Bool) -> [a] -> m ()
+coverSearchResultCases predicate subjects = do
+  HH.cover 1 (String.fromString "no search subjects") (null subjects)
+  HH.cover 1 (String.fromString "subjects present with no matches") (not (null subjects) && not (any predicate subjects))
+  HH.cover 1 (String.fromString "at least 1 match") (length (filter predicate subjects) >= 1)
+
+{- |
+  Asserts that the given result is one that could have been produced by apply
+  the predicate to the given list to find a single result. This assertion
+  doesn't care which particular item from the list was found, as long as it the
+  result matches the predicate and it is one from the list, or that nothing in
+  the list matches if the 'Nothing' was found.
+-}
+assertMatchIsFromPredicate ::
+  (HH.MonadTest m, Eq entity) =>
+  Maybe entity ->
+  (entity -> Bool) ->
+  [entity] ->
+  m ()
+assertMatchIsFromPredicate maybeEntity predicate subjects =
+  case maybeEntity of
+    Nothing ->
+      HH.assert (not $ any predicate subjects)
+    Just entity ->
+      HH.assert (predicate entity && elem entity subjects)
+
+{- |
+  Asserts that the found items are all of those from the list that match the
+  predicate, but without caring about order.
+-}
+assertAllMatchesFound ::
+  (HH.MonadTest m, Ord key, Eq entity, Show entity) =>
+  -- | Key value to sort on to eliminate order dependencies
+  (entity -> key) ->
+  -- | the actual matches
+  [entity] ->
+  -- | the predicate to use for matching
+  (entity -> Bool) ->
+  -- | the full search space
+  [entity] ->
+  m ()
+assertAllMatchesFound keyAttr foundEntities predicate allEntities =
+  List.sortOn keyAttr foundEntities === List.sortOn keyAttr (filter predicate allEntities)
+
+{- |
+  Applies the given assertion for every key in the list. If any of the key
+  is not found in the provided 'Many.Many' value, this assertion will fail.
+-}
+assertEachManyResult ::
+  (Show key, HH.MonadTest m) =>
+  [key] ->
+  Many.Many key value ->
+  (key -> value -> m ()) ->
+  m ()
+assertEachManyResult expectedKeys manyValues assertion = do
+  let checkResult key =
+        case Many.lookup key manyValues of
+          Left Many.NotAKey -> do
+            HH.footnote $ "Expected " <> show key <> " to be a key in results, but it was not"
+            HH.failure
+          Right value ->
+            assertion key value
+
+  traverse_ checkResult expectedKeys

--- a/orville-postgresql-libpq/test/Test/Property.hs
+++ b/orville-postgresql-libpq/test/Test/Property.hs
@@ -1,5 +1,9 @@
 module Test.Property
-  ( singletonProperty,
+  ( NamedProperty,
+    namedProperty,
+    NamedDBProperty,
+    namedDBProperty,
+    singletonProperty,
     Group (..),
     group,
     checkGroups,
@@ -9,6 +13,7 @@ module Test.Property
 where
 
 import qualified Control.Monad as Monad
+import qualified Data.String as String
 import qualified GHC.Stack as CallStack
 import qualified Hedgehog as HH
 import qualified Hedgehog.Internal.Config as Config
@@ -17,15 +22,32 @@ import qualified Hedgehog.Internal.Report as Report
 import qualified Hedgehog.Internal.Runner as Runner
 import qualified Hedgehog.Internal.Seed as Seed
 
+import qualified Data.Pool as Pool
+import qualified Orville.PostgreSQL.Connection as Connection
+
+type NamedProperty = (HH.PropertyName, HH.Property)
+type NamedDBProperty = Pool.Pool Connection.Connection -> NamedProperty
+
+namedProperty :: String -> HH.PropertyT IO () -> NamedProperty
+namedProperty nameString propertyT =
+  (String.fromString nameString, HH.property propertyT)
+
+namedDBProperty ::
+  String ->
+  (Pool.Pool Connection.Connection -> HH.PropertyT IO ()) ->
+  NamedDBProperty
+namedDBProperty nameString dbProperty pool =
+  namedProperty nameString (dbProperty pool)
+
 singletonProperty :: CallStack.HasCallStack => HH.PropertyT IO () -> HH.Property
 singletonProperty = HH.withTests 1 . HH.property
 
 data Group = Group
   { groupName :: String
-  , groupProperties :: [(HH.PropertyName, HH.Property)]
+  , groupProperties :: [NamedProperty]
   }
 
-group :: String -> [(HH.PropertyName, HH.Property)] -> Group
+group :: String -> [NamedProperty] -> Group
 group = Group
 
 checkGroups :: Foldable f => f Group -> IO Report.Summary
@@ -43,7 +65,7 @@ checkGroup useColor propGroup = do
   putStrLn $ "• " <> name <> " : " <> show (length properties) <> " properties"
   foldMap (checkProperty useColor) properties
 
-checkProperty :: Config.UseColor -> (HH.PropertyName, HH.Property) -> IO Report.Summary
+checkProperty :: Config.UseColor -> NamedProperty -> IO Report.Summary
 checkProperty useColor (name, prop) = do
   seed <- Seed.random
   report <-


### PR DESCRIPTION
This is mostly a straight copy of the plan code from HDBC. The
`Operation` module needed to be adjusted a bit to match the new API, and
a couple of spots required `NonEmpty` handling, but otherwise the code
is unchanged.

The tests are completely new, however, and I think better targeted at
the plan functions.