### PR TITLE
Adds support for dropping columns

### DIFF
--- a/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
@@ -20,6 +20,8 @@ module Orville.PostgreSQL
     TableDefinition.mkTableDefinition,
     TableDefinition.mkTableDefinitionWithoutKey,
     TableDefinition.setTableSchema,
+    TableDefinition.dropColumns,
+    TableDefinition.columnsToDrop,
     TableDefinition.tableName,
     TableDefinition.unqualifiedTableName,
     TableDefinition.unqualifiedTableNameString,

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr.hs
@@ -117,6 +117,7 @@ module Orville.PostgreSQL.Internal.Expr
     alterTableExpr,
     AlterTableAction,
     addColumn,
+    dropColumn,
     alterColumnType,
     UsingClause,
     usingCast,

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/TableDefinition.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/TableDefinition.hs
@@ -9,6 +9,7 @@ module Orville.PostgreSQL.Internal.Expr.TableDefinition
     alterTableExpr,
     AlterTableAction,
     addColumn,
+    dropColumn,
     alterColumnType,
     UsingClause,
     usingCast,
@@ -93,6 +94,11 @@ addColumn :: ColumnDefinition -> AlterTableAction
 addColumn columnDef =
   AlterTableAction $
     RawSql.fromString "ADD COLUMN " <> RawSql.toRawSql columnDef
+
+dropColumn :: ColumnName -> AlterTableAction
+dropColumn columnName =
+  AlterTableAction $
+    RawSql.fromString "DROP COLUMN " <> RawSql.toRawSql columnName
 
 alterColumnType ::
   ColumnName ->

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/PgCatalog/PgAttribute.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/PgCatalog/PgAttribute.hs
@@ -4,6 +4,7 @@ module Orville.PostgreSQL.PgCatalog.PgAttribute
   ( PgAttribute (..),
     pgAttributeMaxLength,
     AttributeName,
+    attributeNameToString,
     isOrdinaryColumn,
     pgAttributeTable,
     relationOidField,
@@ -98,6 +99,13 @@ isOrdinaryColumn attr =
 newtype AttributeName
   = AttributeName T.Text
   deriving (Show, Eq, Ord, String.IsString)
+
+{- |
+  Converts an 'Attribute' name to a plain old string
+-}
+attributeNameToString :: AttributeName -> String
+attributeNameToString (AttributeName txt) =
+  T.unpack txt
 
 {- |
   A Haskell type for the number of the attribute represented by a 'PgAttribute'


### PR DESCRIPTION
This adds a `dropColumns` function that adds a notated list of columns
to drop to a `TableDefinition`. The auto-migrations now respect this
list and drop columns found in it.