### PR TITLE
Fix statement parameter limit overflow for `insertRecordMany`

### DIFF
--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/Execute.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/Execute.hs
@@ -13,7 +13,7 @@ import Database.Orville.PostgreSQL.Internal.Monad
 executingSql :: MonadOrville conn m => QueryType -> String -> IO a -> m a
 executingSql queryType sql action = do
   runningQuery <-
-    (\queryType -> ormEnvRunningQuery queryType)
+    (\queryTy -> ormEnvRunningQuery queryTy)
       <$> getOrvilleEnv
   liftIO $ runningQuery queryType sql (catchSqlErr sql action)
 

--- a/orville-postgresql/test/AppManagedEntity/CrudTest.hs
+++ b/orville-postgresql/test/AppManagedEntity/CrudTest.hs
@@ -55,6 +55,15 @@ test_crud =
             (Map.fromList [(bpsId, bpsVirus), (brnId, brnVirus)])
             foundViruses
 
+      , testCase "insertRecordMany doesn't overflow parameter limit" $ do
+          let viruses = do
+                vId <- VirusId <$> [1..65536]
+                pure $ Virus vId bpsVirusName bpsDiscoveredAt
+
+          run $ do
+            TestDB.reset schema
+            O.insertRecordMany virusTable viruses
+
       , testCase "Update" $ do
           let testId = VirusId 1234
               bpsVirus = Virus testId bpsVirusName bpsDiscoveredAt


### PR DESCRIPTION
If you attempt to run a statement with too many parameters, postgres
will throw an exception. We are seeing this occur with `insertRecordMany`.
There are fancier, more efficient ways to solve this issue (as shown in
[this blog post](https://klotzandrew.com/blog/postgres-passing-65535-parameter-limit)), but I have opted to use a simple batching strategy.