### PR TITLE
Upgrade Stack to 2.7.1

### DIFF
--- a/orville-postgresql/Dockerfile
+++ b/orville-postgresql/Dockerfile
@@ -1,4 +1,4 @@
-FROM flipstone/stack:v2-1.9.3
+FROM flipstone/stack:v4-2.7.1
 
 # The fpco.list apt source was causing an error build:
 #   E: The method driver /usr/lib/apt/methods/https could not be found.

--- a/orville-postgresql/orville-postgresql.cabal
+++ b/orville-postgresql/orville-postgresql.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.31.1.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: f0032f4f862488c5d30ecca0be6bfcb9efb01e3f61f4fa0e0ea91ed55ba0ff59
+-- hash: 671edec7076d0e3f187aef5cb98e6d2bbc5bf0a554eb69945f503117cf8617b5
 
 name:           orville-postgresql
 version:        0.9.0.0
@@ -15,7 +15,8 @@ author:         Flipstone Technology Partners
 maintainer:     development@flipstone.com
 license:        MIT
 license-file:   LICENSE
-tested-with:    GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4
+tested-with:
+    GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4
 build-type:     Simple
 extra-source-files:
     README.md
@@ -85,7 +86,9 @@ library
       Paths_orville_postgresql
   hs-source-dirs:
       src
-  default-extensions: GeneralizedNewtypeDeriving MultiParamTypeClasses
+  default-extensions:
+      GeneralizedNewtypeDeriving
+      MultiParamTypeClasses
   ghc-options: -Wall -fno-warn-orphans -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
   build-depends:
       HDBC >=2.4
@@ -121,7 +124,9 @@ executable orville-sample-exe
       Paths_orville_postgresql
   hs-source-dirs:
       sample-project
-  default-extensions: GeneralizedNewtypeDeriving MultiParamTypeClasses
+  default-extensions:
+      GeneralizedNewtypeDeriving
+      MultiParamTypeClasses
   ghc-options: -Wall -fno-warn-orphans -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       HDBC >=2.4
@@ -189,7 +194,9 @@ test-suite spec
       Paths_orville_postgresql
   hs-source-dirs:
       test
-  default-extensions: GeneralizedNewtypeDeriving MultiParamTypeClasses
+  default-extensions:
+      GeneralizedNewtypeDeriving
+      MultiParamTypeClasses
   ghc-options: -Wall -fno-warn-orphans -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
   build-depends:
       HDBC >=2.4


### PR DESCRIPTION
Projects that use Orville by way of submodule, and use a Stack version newer than 1.9.3, may also have a newer hpack version, which upon execution will then overwrite the old cabal file and cause the submodule's tree to be dirty. By upgrading to a Stack release that consumers are more likely to use, this nuisance is minimized.

Because the generated Cabal file only contains cosmetic changes, builds made by Cabal will be unaffected.