### PR TITLE
Adds support for unique constraints

### DIFF
--- a/orville-postgresql-libpq/orville-postgresql-libpq.cabal
+++ b/orville-postgresql-libpq/orville-postgresql-libpq.cabal
@@ -51,6 +51,7 @@ library
       Orville.PostgreSQL.Plan.Syntax
       Orville.PostgreSQL.PgCatalog
   other-modules:
+      Orville.PostgreSQL.Internal.ConstraintDefinition
       Orville.PostgreSQL.Internal.EntityOperations
       Orville.PostgreSQL.Internal.Execute
       Orville.PostgreSQL.Internal.Expr.ColumnDefinition
@@ -62,6 +63,7 @@ library
       Orville.PostgreSQL.Internal.Expr.LimitExpr
       Orville.PostgreSQL.Internal.Expr.Name
       Orville.PostgreSQL.Internal.Expr.Name.ColumnName
+      Orville.PostgreSQL.Internal.Expr.Name.ConstraintName
       Orville.PostgreSQL.Internal.Expr.Name.Identifier
       Orville.PostgreSQL.Internal.Expr.Name.QualifiedTableName
       Orville.PostgreSQL.Internal.Expr.Name.SavepointName
@@ -80,6 +82,7 @@ library
       Orville.PostgreSQL.Internal.Expr.Select
       Orville.PostgreSQL.Internal.Expr.Select.SelectClause
       Orville.PostgreSQL.Internal.Expr.Select.SelectExpr
+      Orville.PostgreSQL.Internal.Expr.TableConstraint
       Orville.PostgreSQL.Internal.Expr.TableDefinition
       Orville.PostgreSQL.Internal.Expr.Transaction
       Orville.PostgreSQL.Internal.Expr.Update

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
@@ -20,6 +20,8 @@ module Orville.PostgreSQL
     TableDefinition.mkTableDefinition,
     TableDefinition.mkTableDefinitionWithoutKey,
     TableDefinition.setTableSchema,
+    TableDefinition.tableConstraints,
+    TableDefinition.addTableConstraints,
     TableDefinition.dropColumns,
     TableDefinition.columnsToDrop,
     TableDefinition.tableName,
@@ -32,6 +34,11 @@ module Orville.PostgreSQL
     TableDefinition.tableMarshaller,
     TableDefinition.HasKey,
     TableDefinition.NoKey,
+    ConstraintDefinition.ConstraintDefinition,
+    ConstraintDefinition.ConstraintMigrationKey (ConstraintMigrationKey, constrainedColumns),
+    ConstraintDefinition.uniqueConstraint,
+    ConstraintDefinition.constraintMigrationKey,
+    ConstraintDefinition.constraintSqlExpr,
     PrimaryKey.PrimaryKey,
     PrimaryKey.primaryKey,
     PrimaryKey.compositePrimaryKey,
@@ -65,7 +72,10 @@ module Orville.PostgreSQL
     FieldDefinition.fieldOfType,
     FieldDefinition.fieldColumnName,
     FieldDefinition.fieldName,
+    FieldDefinition.FieldName,
+    FieldDefinition.stringToFieldName,
     FieldDefinition.fieldNameToString,
+    FieldDefinition.fieldNameToColumnName,
     FieldDefinition.fieldNameToByteString,
     FieldDefinition.fieldType,
     FieldDefinition.fieldColumnDefinition,
@@ -146,6 +156,7 @@ module Orville.PostgreSQL
 where
 
 import qualified Orville.PostgreSQL.Connection as Connection
+import qualified Orville.PostgreSQL.Internal.ConstraintDefinition as ConstraintDefinition
 import qualified Orville.PostgreSQL.Internal.EntityOperations as EntityOperations
 import qualified Orville.PostgreSQL.Internal.Execute as Execute
 import qualified Orville.PostgreSQL.Internal.Expr as Expr

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/ConstraintDefinition.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/ConstraintDefinition.hs
@@ -1,0 +1,68 @@
+module Orville.PostgreSQL.Internal.ConstraintDefinition
+  ( ConstraintDefinition,
+    uniqueConstraint,
+    ConstraintMigrationKey (ConstraintMigrationKey, constrainedColumns),
+    constraintMigrationKey,
+    constraintSqlExpr,
+  )
+where
+
+import Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NEL
+
+import qualified Orville.PostgreSQL.Internal.Expr as Expr
+import qualified Orville.PostgreSQL.Internal.FieldDefinition as FieldDef
+
+{- |
+  Defines a constraint that can be added to a
+  'Orville.PostgreSQL.TableDefinition'. Use one of the constructor functions
+  below (such as 'uniqueConstraint') to construct the constraint definition you
+  wish to have and then use 'Orville.PostgreSQL.addTableConstraints'. to add
+  them to your table definition. Orville will then add the constraint next time
+  you run auto-migrations.
+-}
+data ConstraintDefinition = ConstraintDefinition
+  { _constraintSqlExpr :: Expr.TableConstraint
+  , _constraintMigrationKey :: ConstraintMigrationKey
+  }
+
+{- |
+  The key used by Orville to determine whether a constraint should be added to
+  a table when performing auto migrations. For most use cases the constructor
+  functions that build a 'ConstraintDefinition' will create this automatically
+  for you.
+-}
+data ConstraintMigrationKey = ConstraintMigrationKey
+  { constrainedColumns :: [FieldDef.FieldName]
+  }
+  deriving (Eq, Ord, Show)
+
+{- |
+  Gets the 'ConstraintMigrationKey' for the 'ConstraintDefinition'
+-}
+constraintMigrationKey :: ConstraintDefinition -> ConstraintMigrationKey
+constraintMigrationKey = _constraintMigrationKey
+
+{- |
+  Gets the SQL expression that will be used to add the constraint to the table.
+-}
+constraintSqlExpr :: ConstraintDefinition -> Expr.TableConstraint
+constraintSqlExpr = _constraintSqlExpr
+
+{- |
+  Constructs a 'ConstraintDefinition' for a @UNIQUE@ constraint on the given
+  columns.
+-}
+uniqueConstraint :: NonEmpty FieldDef.FieldName -> ConstraintDefinition
+uniqueConstraint columnNames =
+  let expr =
+        Expr.uniqueConstraint . fmap FieldDef.fieldNameToColumnName $ columnNames
+
+      metadata =
+        ConstraintMigrationKey
+          { constrainedColumns = NEL.toList columnNames
+          }
+   in ConstraintDefinition
+        { _constraintSqlExpr = expr
+        , _constraintMigrationKey = metadata
+        }

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr.hs
@@ -36,6 +36,9 @@ module Orville.PostgreSQL.Internal.Expr
     ColumnName,
     columnName,
     columnNameFromIdentifier,
+    ConstraintName,
+    constraintName,
+    constraintNameFromIdentifier,
     SavepointName,
     savepointName,
     savepointNameFromIdentifier,
@@ -118,9 +121,13 @@ module Orville.PostgreSQL.Internal.Expr
     primaryKeyExpr,
     AlterTableExpr,
     alterTableExpr,
+    TableConstraint,
+    uniqueConstraint,
     AlterTableAction,
     addColumn,
     dropColumn,
+    addConstraint,
+    dropConstraint,
     alterColumnType,
     UsingClause,
     usingCast,
@@ -162,6 +169,7 @@ import Orville.PostgreSQL.Internal.Expr.OffsetExpr
 import Orville.PostgreSQL.Internal.Expr.OrderBy
 import Orville.PostgreSQL.Internal.Expr.Query
 import Orville.PostgreSQL.Internal.Expr.ReturningExpr
+import Orville.PostgreSQL.Internal.Expr.TableConstraint
 import Orville.PostgreSQL.Internal.Expr.TableDefinition
 import Orville.PostgreSQL.Internal.Expr.Transaction
 import Orville.PostgreSQL.Internal.Expr.Update

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/GroupBy/GroupByExpr.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/GroupBy/GroupByExpr.hs
@@ -14,7 +14,6 @@ module Orville.PostgreSQL.Internal.Expr.GroupBy.GroupByExpr
 where
 
 import Data.List.NonEmpty (NonEmpty)
-import qualified Data.List.NonEmpty as NE
 
 import Orville.PostgreSQL.Internal.Expr.Name (ColumnName)
 import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
@@ -31,5 +30,5 @@ groupByExpr sql =
   GroupByExpr $ sql
 
 groupByColumnsExpr :: NonEmpty ColumnName -> GroupByExpr
-groupByColumnsExpr columns =
-  GroupByExpr . RawSql.intercalate RawSql.commaSpace . map RawSql.toRawSql $ NE.toList columns
+groupByColumnsExpr =
+  GroupByExpr . RawSql.intercalate RawSql.commaSpace

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/InsertExpr.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/InsertExpr.hs
@@ -51,7 +51,7 @@ insertColumnList :: [ColumnName] -> InsertColumnList
 insertColumnList columnNames =
   InsertColumnList $
     RawSql.leftParen
-      <> RawSql.intercalate RawSql.comma (map RawSql.toRawSql columnNames)
+      <> RawSql.intercalate RawSql.comma columnNames
       <> RawSql.rightParen
 
 newtype InsertSource
@@ -62,7 +62,7 @@ insertRowValues :: [RowValues] -> InsertSource
 insertRowValues rows =
   InsertSource $
     RawSql.fromString "VALUES "
-      <> RawSql.intercalate RawSql.comma (fmap RawSql.toRawSql rows)
+      <> RawSql.intercalate RawSql.comma rows
 
 insertSqlValues :: [[SqlValue]] -> InsertSource
 insertSqlValues rows =

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/Name.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/Name.hs
@@ -11,6 +11,7 @@ module Orville.PostgreSQL.Internal.Expr.Name
 where
 
 import Orville.PostgreSQL.Internal.Expr.Name.ColumnName as Export
+import Orville.PostgreSQL.Internal.Expr.Name.ConstraintName as Export
 import Orville.PostgreSQL.Internal.Expr.Name.Identifier as Export
 import Orville.PostgreSQL.Internal.Expr.Name.QualifiedTableName as Export
 import Orville.PostgreSQL.Internal.Expr.Name.SavepointName as Export

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/Name/ConstraintName.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/Name/ConstraintName.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+{- |
+Module    : Orville.PostgreSQL.Expr.Name.ConstraintName
+Copyright : Flipstone Technology Partners 2021
+License   : MIT
+-}
+module Orville.PostgreSQL.Internal.Expr.Name.ConstraintName
+  ( ConstraintName,
+    constraintName,
+    constraintNameFromIdentifier,
+  )
+where
+
+import Orville.PostgreSQL.Internal.Expr.Name.Identifier (Identifier, identifier)
+import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+
+newtype ConstraintName
+  = ConstraintName Identifier
+  deriving (RawSql.SqlExpression)
+
+constraintName :: String -> ConstraintName
+constraintName = ConstraintName . identifier
+
+constraintNameFromIdentifier :: Identifier -> ConstraintName
+constraintNameFromIdentifier = ConstraintName

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/OrderBy/OrderByExpr.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/OrderBy/OrderByExpr.hs
@@ -33,8 +33,7 @@ orderByExpr sql orderSql =
 
 orderByColumnsExpr :: NonEmpty (ColumnName, OrderByDirection) -> OrderByExpr
 orderByColumnsExpr columns =
-  OrderByExpr . RawSql.intercalate RawSql.commaSpace $
-    NE.toList $ NE.map columnOrdering columns
+  OrderByExpr . RawSql.intercalate RawSql.commaSpace . NE.map columnOrdering $ columns
   where
     columnOrdering :: (ColumnName, OrderByDirection) -> RawSql.RawSql
     columnOrdering (columnName, orderByDirection) =

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/Query/SelectList.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/Query/SelectList.hs
@@ -33,11 +33,8 @@ newtype DerivedColumn = DerivedColumn RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
 selectDerivedColumns :: [DerivedColumn] -> SelectList
-selectDerivedColumns derivedColumns =
-  SelectList $
-    RawSql.intercalate
-      RawSql.comma
-      (fmap RawSql.toRawSql derivedColumns)
+selectDerivedColumns =
+  SelectList . RawSql.intercalate RawSql.comma
 
 deriveColumn :: ColumnName -> DerivedColumn
 deriveColumn =

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/ReturningExpr.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/ReturningExpr.hs
@@ -17,4 +17,4 @@ returningExpr :: [ColumnName] -> ReturningExpr
 returningExpr columns =
   ReturningExpr $
     RawSql.fromString "RETURNING "
-      <> RawSql.intercalate RawSql.comma (map RawSql.toRawSql columns)
+      <> RawSql.intercalate RawSql.comma columns

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/TableConstraint.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/TableConstraint.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Orville.PostgreSQL.Internal.Expr.TableConstraint
+  ( TableConstraint,
+    uniqueConstraint,
+  )
+where
+
+import Data.List.NonEmpty (NonEmpty)
+
+import Orville.PostgreSQL.Internal.Expr.Name (ColumnName)
+import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+
+newtype TableConstraint
+  = TableConstraint RawSql.RawSql
+  deriving (RawSql.SqlExpression)
+
+uniqueConstraint :: NonEmpty ColumnName -> TableConstraint
+uniqueConstraint columnNames =
+  TableConstraint $
+    RawSql.fromString "UNIQUE "
+      <> RawSql.leftParen
+      <> RawSql.intercalate RawSql.comma columnNames
+      <> RawSql.rightParen

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/Update.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/Update.hs
@@ -45,11 +45,8 @@ newtype SetClauseList
   deriving (RawSql.SqlExpression)
 
 setClauseList :: [SetClause] -> SetClauseList
-setClauseList setClauses =
-  SetClauseList $
-    RawSql.intercalate
-      RawSql.comma
-      (map RawSql.toRawSql setClauses)
+setClauseList =
+  SetClauseList . RawSql.intercalate RawSql.comma
 
 newtype SetClause
   = SetClause RawSql.RawSql

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/Where/BooleanExpr.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/Where/BooleanExpr.hs
@@ -104,7 +104,7 @@ inValueList :: NE.NonEmpty RowValueExpression -> InValuePredicate
 inValueList values =
   InValuePredicate $
     RawSql.leftParen
-      <> RawSql.intercalate RawSql.commaSpace (map RawSql.toRawSql $ NE.toList values)
+      <> RawSql.intercalate RawSql.commaSpace values
       <> RawSql.rightParen
 
 parenthesized :: BooleanExpr -> BooleanExpr

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/Where/RowValueExpression.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/Where/RowValueExpression.hs
@@ -32,5 +32,5 @@ rowValueConstructor :: NE.NonEmpty RowValueExpression -> RowValueExpression
 rowValueConstructor elements =
   RowValueExpression $
     RawSql.leftParen
-      <> RawSql.intercalate RawSql.comma (map RawSql.toRawSql $ NE.toList elements)
+      <> RawSql.intercalate RawSql.comma elements
       <> RawSql.rightParen

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/FieldDefinition.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/FieldDefinition.hs
@@ -57,7 +57,7 @@ import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
 
 newtype FieldName
   = FieldName B8.ByteString
-  deriving (Eq, Show)
+  deriving (Eq, Ord, Show)
 
 fieldNameToColumnName :: FieldName -> Expr.ColumnName
 fieldNameToColumnName (FieldName name) =

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/RawSql.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/RawSql.hs
@@ -38,6 +38,7 @@ import qualified Data.ByteString.Builder as BSB
 import qualified Data.ByteString.Lazy as LBS
 import Data.DList (DList)
 import qualified Data.DList as DList
+import qualified Data.Foldable as Fold
 import qualified Data.List as List
 import qualified Database.PostgreSQL.LibPQ as LibPQ
 
@@ -191,9 +192,12 @@ parameter =
   Concatenates a list of 'RawSql' values using another 'RawSql' value as
   the a separator between the items.
 -}
-intercalate :: RawSql -> [RawSql] -> RawSql
-intercalate separator parts =
-  mconcat (List.intersperse separator parts)
+intercalate :: (SqlExpression sql, Foldable f) => RawSql -> f sql -> RawSql
+intercalate separator =
+  mconcat
+    . List.intersperse separator
+    . map toRawSql
+    . Fold.toList
 
 {- |
   Executes a 'RawSql' value using the 'Conn.executeRaw' function. Make sure

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/PgCatalog/PgConstraint.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/PgCatalog/PgConstraint.hs
@@ -4,6 +4,7 @@ module Orville.PostgreSQL.PgCatalog.PgConstraint
   ( PgConstraint (..),
     ConstraintType (..),
     ConstraintName,
+    constraintNameToString,
     pgConstraintTable,
     constraintRelationOidField,
   )
@@ -56,6 +57,13 @@ data PgConstraint = PgConstraint
 newtype ConstraintName
   = ConstraintName T.Text
   deriving (Show, Eq, Ord, String.IsString)
+
+{- |
+  Converts an 'ConstraintName' to a plain old string
+-}
+constraintNameToString :: ConstraintName -> String
+constraintNameToString (ConstraintName txt) =
+  T.unpack txt
 
 {- |
   The type of constraint that a 'PgConstraint' represents, as described at

--- a/orville-postgresql-libpq/test/Test/Expr/TableDefinition.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/TableDefinition.hs
@@ -30,12 +30,10 @@ prop_createWithOneColumn =
     MIO.liftIO $
       Orville.runOrville pool $ do
         Orville.executeVoid $ Expr.dropTableExpr (Just Expr.ifExists) exprTableName
-        Orville.executeVoid $ Expr.createTableExpr exprTableName [column1Definition] Nothing
+        Orville.executeVoid $ Expr.createTableExpr exprTableName [column1Definition] Nothing []
 
-    PgAssert.assertColumnNamesEqual
-      pool
-      tableNameString
-      [column1NameString]
+    tableDesc <- PgAssert.assertTableExists pool tableNameString
+    PgAssert.assertColumnNamesEqual tableDesc [column1NameString]
 
 prop_createWithMultipleColumns :: Property.NamedDBProperty
 prop_createWithMultipleColumns =
@@ -43,12 +41,10 @@ prop_createWithMultipleColumns =
     MIO.liftIO $
       Orville.runOrville pool $ do
         Orville.executeVoid $ Expr.dropTableExpr (Just Expr.ifExists) exprTableName
-        Orville.executeVoid $ Expr.createTableExpr exprTableName [column1Definition, column2Definition] Nothing
+        Orville.executeVoid $ Expr.createTableExpr exprTableName [column1Definition, column2Definition] Nothing []
 
-    PgAssert.assertColumnNamesEqual
-      pool
-      tableNameString
-      [column1NameString, column2NameString]
+    tableDesc <- PgAssert.assertTableExists pool tableNameString
+    PgAssert.assertColumnNamesEqual tableDesc [column1NameString, column2NameString]
 
 prop_addOneColumn :: Property.NamedDBProperty
 prop_addOneColumn =
@@ -56,13 +52,11 @@ prop_addOneColumn =
     MIO.liftIO $
       Orville.runOrville pool $ do
         Orville.executeVoid $ Expr.dropTableExpr (Just Expr.ifExists) exprTableName
-        Orville.executeVoid $ Expr.createTableExpr exprTableName [] Nothing
+        Orville.executeVoid $ Expr.createTableExpr exprTableName [] Nothing []
         Orville.executeVoid $ Expr.alterTableExpr exprTableName (Expr.addColumn column1Definition :| [])
 
-    PgAssert.assertColumnNamesEqual
-      pool
-      tableNameString
-      [column1NameString]
+    tableDesc <- PgAssert.assertTableExists pool tableNameString
+    PgAssert.assertColumnNamesEqual tableDesc [column1NameString]
 
 prop_addMultipleColumns :: Property.NamedDBProperty
 prop_addMultipleColumns =
@@ -70,13 +64,11 @@ prop_addMultipleColumns =
     MIO.liftIO $
       Orville.runOrville pool $ do
         Orville.executeVoid $ Expr.dropTableExpr (Just Expr.ifExists) exprTableName
-        Orville.executeVoid $ Expr.createTableExpr exprTableName [] Nothing
+        Orville.executeVoid $ Expr.createTableExpr exprTableName [] Nothing []
         Orville.executeVoid $ Expr.alterTableExpr exprTableName (Expr.addColumn column1Definition :| [Expr.addColumn column2Definition])
 
-    PgAssert.assertColumnNamesEqual
-      pool
-      tableNameString
-      [column1NameString, column2NameString]
+    tableDesc <- PgAssert.assertTableExists pool tableNameString
+    PgAssert.assertColumnNamesEqual tableDesc [column1NameString, column2NameString]
 
 exprTableName :: Expr.QualifiedTableName
 exprTableName =

--- a/orville-postgresql-libpq/test/Test/FieldDefinition.hs
+++ b/orville-postgresql-libpq/test/Test/FieldDefinition.hs
@@ -289,4 +289,4 @@ dropAndRecreateTestTable fieldDef connection = do
   RawSql.executeVoid connection (RawSql.fromString "DROP TABLE IF EXISTS " <> RawSql.toRawSql testTable)
 
   RawSql.executeVoid connection $
-    Expr.createTableExpr testTable [FieldDef.fieldColumnDefinition fieldDef] Nothing
+    Expr.createTableExpr testTable [FieldDef.fieldColumnDefinition fieldDef] Nothing []

--- a/orville-postgresql-libpq/test/Test/TableDefinition.hs
+++ b/orville-postgresql-libpq/test/Test/TableDefinition.hs
@@ -6,9 +6,10 @@ where
 import qualified Control.Exception as E
 import qualified Control.Monad.IO.Class as MIO
 import qualified Data.ByteString.Char8 as B8
-import qualified Data.List.NonEmpty as NEL
+import Data.List.NonEmpty (NonEmpty ((:|)))
 import qualified Data.Pool as Pool
-import qualified Data.String as String
+import qualified Data.Text as T
+import Hedgehog ((===))
 import qualified Hedgehog as HH
 
 import qualified Orville.PostgreSQL as Orville
@@ -25,70 +26,106 @@ import qualified Test.TestTable as TestTable
 tableDefinitionTests :: Pool.Pool Conn.Connection -> Property.Group
 tableDefinitionTests pool =
   Property.group "TableDefinition" $
-    [
-      ( String.fromString "Creates a table that can round trip an entity through it"
-      , HH.property $ do
-          originalFoo <- HH.forAll Foo.generate
-
-          let insertFoo =
-                TableDefinition.mkInsertExpr
-                  TableDefinition.WithoutReturning
-                  Foo.table
-                  (originalFoo NEL.:| [])
-
-              selectFoos =
-                Select.selectTable Foo.table mempty
-
-          foosFromDB <-
-            MIO.liftIO . Orville.runOrville pool $ do
-              Orville.withConnection $ \connection -> do
-                MIO.liftIO $ TestTable.dropAndRecreateTableDef connection Foo.table
-              Orville.executeVoid insertFoo
-              Select.executeSelect selectFoos
-
-          foosFromDB HH.=== [originalFoo]
-      )
-    ,
-      ( String.fromString "Creates a table that can read from read only fields"
-      , HH.property $ do
-          originalBar <- HH.forAll Bar.generate
-
-          let insertBar =
-                TableDefinition.mkInsertExpr TableDefinition.WithoutReturning Bar.table (originalBar NEL.:| [])
-
-              selectBars =
-                Select.selectTable Bar.table mempty
-
-          barsFromDB <-
-            MIO.liftIO . Orville.runOrville pool $ do
-              Orville.withConnection $ \connection -> do
-                MIO.liftIO $ TestTable.dropAndRecreateTableDef connection Bar.table
-              Orville.executeVoid insertBar
-              Select.executeSelect selectBars
-
-          (fmap Bar.barName) barsFromDB HH.=== [Bar.barName originalBar]
-      )
-    ,
-      ( String.fromString "Creates a primary key that rejects duplicate records"
-      , Property.singletonProperty $ do
-          originalFoo <- HH.forAll Foo.generate
-
-          let insertFoo =
-                TableDefinition.mkInsertExpr
-                  TableDefinition.WithoutReturning
-                  Foo.table
-                  (originalFoo NEL.:| [])
-
-          result <- MIO.liftIO . E.try . Pool.withResource pool $ \connection -> do
-            TestTable.dropAndRecreateTableDef connection Foo.table
-            RawSql.executeVoid connection insertFoo
-            RawSql.executeVoid connection insertFoo
-
-          case result of
-            Right () -> do
-              HH.footnote "Expected 'executeVoid' to return failure, but it did not"
-              HH.failure
-            Left err ->
-              Conn.sqlExecutionErrorSqlState err HH.=== Just (B8.pack "23505")
-      )
+    [ prop_roundTrip pool
+    , prop_readOnlyFields pool
+    , prop_primaryKey pool
+    , prop_uniqueConstraint pool
     ]
+
+prop_roundTrip :: Property.NamedDBProperty
+prop_roundTrip =
+  Property.namedDBProperty "Creates a table that can round trip an entity through it" $ \pool -> do
+    originalFoo <- HH.forAll Foo.generate
+
+    let insertFoo =
+          TableDefinition.mkInsertExpr
+            TableDefinition.WithoutReturning
+            Foo.table
+            (originalFoo :| [])
+
+        selectFoos =
+          Select.selectTable Foo.table mempty
+
+    foosFromDB <-
+      MIO.liftIO . Orville.runOrville pool $ do
+        Orville.withConnection $ \connection -> do
+          MIO.liftIO $ TestTable.dropAndRecreateTableDef connection Foo.table
+        Orville.executeVoid insertFoo
+        Select.executeSelect selectFoos
+
+    foosFromDB === [originalFoo]
+
+prop_readOnlyFields :: Property.NamedDBProperty
+prop_readOnlyFields =
+  Property.namedDBProperty "Creates a table that can read from read only fields" $ \pool -> do
+    originalBar <- HH.forAll Bar.generate
+
+    let insertBar =
+          TableDefinition.mkInsertExpr TableDefinition.WithoutReturning Bar.table (originalBar :| [])
+
+        selectBars =
+          Select.selectTable Bar.table mempty
+
+    barsFromDB <-
+      MIO.liftIO . Orville.runOrville pool $ do
+        Orville.withConnection $ \connection -> do
+          MIO.liftIO $ TestTable.dropAndRecreateTableDef connection Bar.table
+        Orville.executeVoid insertBar
+        Select.executeSelect selectBars
+
+    (fmap Bar.barName) barsFromDB === [Bar.barName originalBar]
+
+prop_primaryKey :: Property.NamedDBProperty
+prop_primaryKey =
+  Property.singletonNamedDBProperty "Creates a primary key that rejects duplicate records" $ \pool -> do
+    originalFoo <- HH.forAll Foo.generate
+
+    let conflictingFoo =
+          originalFoo {Foo.fooName = T.reverse $ Foo.fooName originalFoo}
+
+        insertFoos =
+          TableDefinition.mkInsertExpr
+            TableDefinition.WithoutReturning
+            Foo.table
+            (originalFoo :| [conflictingFoo])
+
+    result <- MIO.liftIO . E.try . Pool.withResource pool $ \connection -> do
+      TestTable.dropAndRecreateTableDef connection Foo.table
+      RawSql.executeVoid connection insertFoos
+
+    case result of
+      Right () -> do
+        HH.footnote "Expected 'executeVoid' to return failure, but it did not"
+        HH.failure
+      Left err ->
+        Conn.sqlExecutionErrorSqlState err === Just (B8.pack "23505")
+
+prop_uniqueConstraint :: Property.NamedDBProperty
+prop_uniqueConstraint =
+  Property.singletonNamedDBProperty "Creates a unique constraint that rejects duplicate records" $ \pool -> do
+    originalFoo <- HH.forAll Foo.generate
+
+    let fooTableWithUniqueNameConstraint =
+          Orville.addTableConstraints
+            [Orville.uniqueConstraint (Orville.fieldName Foo.fooNameField :| [])]
+            Foo.table
+
+        conflictingFoo =
+          originalFoo {Foo.fooId = 1 + Foo.fooId originalFoo}
+
+        insertFoos =
+          TableDefinition.mkInsertExpr
+            TableDefinition.WithoutReturning
+            Foo.table
+            (originalFoo :| [conflictingFoo])
+
+    result <- MIO.liftIO . E.try . Pool.withResource pool $ \connection -> do
+      TestTable.dropAndRecreateTableDef connection fooTableWithUniqueNameConstraint
+      RawSql.executeVoid connection insertFoos
+
+    case result of
+      Right () -> do
+        HH.footnote "Expected 'executeVoid' to return failure, but it did not"
+        HH.failure
+      Left err ->
+        Conn.sqlExecutionErrorSqlState err === Just (B8.pack "23505")


### PR DESCRIPTION
This adds support for unique constraints at the table level. Constraints
are added and dropped from the database during auto migration based on
whether an equivalent constraint exists.

This logic will be quickly improved by the following work, which will
add support for foreign key constraints, thus requiring support for two
different kinds of constraints.