### PR TITLE
Adds support for creating and dropping indexes

### DIFF
--- a/orville-postgresql-libpq/orville-postgresql-libpq.cabal
+++ b/orville-postgresql-libpq/orville-postgresql-libpq.cabal
@@ -59,12 +59,14 @@ library
       Orville.PostgreSQL.Internal.Expr.GroupBy
       Orville.PostgreSQL.Internal.Expr.GroupBy.GroupByClause
       Orville.PostgreSQL.Internal.Expr.GroupBy.GroupByExpr
+      Orville.PostgreSQL.Internal.Expr.Index
       Orville.PostgreSQL.Internal.Expr.InsertExpr
       Orville.PostgreSQL.Internal.Expr.LimitExpr
       Orville.PostgreSQL.Internal.Expr.Name
       Orville.PostgreSQL.Internal.Expr.Name.ColumnName
       Orville.PostgreSQL.Internal.Expr.Name.ConstraintName
       Orville.PostgreSQL.Internal.Expr.Name.Identifier
+      Orville.PostgreSQL.Internal.Expr.Name.IndexName
       Orville.PostgreSQL.Internal.Expr.Name.QualifiedTableName
       Orville.PostgreSQL.Internal.Expr.Name.SavepointName
       Orville.PostgreSQL.Internal.Expr.Name.SchemaName
@@ -91,6 +93,7 @@ library
       Orville.PostgreSQL.Internal.Expr.Where.ComparisonOperator
       Orville.PostgreSQL.Internal.Expr.Where.RowValueExpression
       Orville.PostgreSQL.Internal.Expr.Where.WhereClause
+      Orville.PostgreSQL.Internal.IndexDefinition
       Orville.PostgreSQL.Internal.MigrationLock
       Orville.PostgreSQL.Internal.MonadOrville
       Orville.PostgreSQL.Internal.Orville
@@ -105,6 +108,7 @@ library
       Orville.PostgreSQL.PgCatalog.PgAttribute
       Orville.PostgreSQL.PgCatalog.PgClass
       Orville.PostgreSQL.PgCatalog.PgConstraint
+      Orville.PostgreSQL.PgCatalog.PgIndex
       Orville.PostgreSQL.PgCatalog.PgNamespace
       Paths_orville_postgresql_libpq
   hs-source-dirs:
@@ -147,7 +151,7 @@ test-suite spec
       Test.FieldDefinition
       Test.PgAssert
       Test.PgCatalog
-      Test.PGGen
+      Test.PgGen
       Test.Plan
       Test.Property
       Test.RawSql

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
@@ -22,6 +22,8 @@ module Orville.PostgreSQL
     TableDefinition.setTableSchema,
     TableDefinition.tableConstraints,
     TableDefinition.addTableConstraints,
+    TableDefinition.tableIndexes,
+    TableDefinition.addTableIndexes,
     TableDefinition.dropColumns,
     TableDefinition.columnsToDrop,
     TableDefinition.tableIdentifier,
@@ -48,9 +50,18 @@ module Orville.PostgreSQL
     ConstraintDefinition.ConstraintKeyType (UniqueConstraint, ForeignKeyConstraint),
     ConstraintDefinition.constraintMigrationKey,
     ConstraintDefinition.constraintSqlExpr,
+    IndexDefinition.IndexDefinition,
+    IndexDefinition.uniqueIndex,
+    IndexDefinition.nonUniqueIndex,
+    IndexDefinition.mkIndexDefinition,
+    IndexDefinition.IndexUniqueness (UniqueIndex, NonUniqueIndex),
+    IndexDefinition.IndexMigrationKey (IndexMigrationKey, indexKeyUniqueness, indexKeyColumns),
+    IndexDefinition.indexMigrationKey,
+    IndexDefinition.indexCreateExpr,
     PrimaryKey.PrimaryKey,
     PrimaryKey.primaryKey,
     PrimaryKey.compositePrimaryKey,
+    PrimaryKey.primaryKeyPart,
     SqlMarshaller.SqlMarshaller,
     SqlMarshaller.marshallField,
     SqlMarshaller.marshallReadOnly,
@@ -173,6 +184,7 @@ import qualified Orville.PostgreSQL.Internal.EntityOperations as EntityOperation
 import qualified Orville.PostgreSQL.Internal.Execute as Execute
 import qualified Orville.PostgreSQL.Internal.Expr as Expr
 import qualified Orville.PostgreSQL.Internal.FieldDefinition as FieldDefinition
+import qualified Orville.PostgreSQL.Internal.IndexDefinition as IndexDefinition
 import qualified Orville.PostgreSQL.Internal.MonadOrville as MonadOrville
 import qualified Orville.PostgreSQL.Internal.Orville as Orville
 import qualified Orville.PostgreSQL.Internal.OrvilleState as OrvilleState

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/AutoMigration.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/AutoMigration.hs
@@ -23,6 +23,7 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Maybe as Maybe
 import qualified Data.Set as Set
 import qualified Data.String as String
+import qualified Database.PostgreSQL.LibPQ as LibPQ
 
 import qualified Orville.PostgreSQL as Orville
 import qualified Orville.PostgreSQL.Internal.Expr as Expr
@@ -101,7 +102,9 @@ mkMigrationStepWithType stepType sql =
 data StepType
   = DropForeignKeys
   | DropUniqueConstraints
+  | DropIndexes
   | AddRemoveTablesAndColumns
+  | AddIndexes
   | AddUniqueConstraints
   | AddForeignKeys
   deriving (Eq, Ord)
@@ -218,8 +221,14 @@ mkCreateTableSteps currentNamespace tableDef =
         concatMap
           (mkAddConstraintActions currentNamespace Set.empty)
           (Orville.tableConstraints tableDef)
+
+      addIndexSteps =
+        concatMap
+          (mkAddIndexSteps Set.empty tableName)
+          (Orville.tableIndexes tableDef)
    in mkMigrationStepWithType AddRemoveTablesAndColumns createTableExpr :
       mkConstraintSteps tableName addConstraintActions
+        <> addIndexSteps
 
 {- |
   Builds migration steps that are required to create or alter the table's
@@ -269,10 +278,45 @@ mkAlterTableSteps currentNamespace relationDesc tableDef =
           (mkDropConstraintActions constraintsToKeep)
           (PgCatalog.relationConstraints relationDesc)
 
+      systemIndexOids =
+        Set.fromList
+          . Maybe.mapMaybe (pgConstraintImpliedIndexOid . PgCatalog.constraintRecord)
+          . PgCatalog.relationConstraints
+          $ relationDesc
+
+      isSystemIndex indexDesc =
+        Set.member
+          (PgCatalog.pgIndexPgClassOid $ PgCatalog.indexRecord indexDesc)
+          systemIndexOids
+
+      existingIndexes =
+        Set.fromList
+          . Maybe.mapMaybe pgIndexMigrationKey
+          . filter (not . isSystemIndex)
+          . PgCatalog.relationIndexes
+          $ relationDesc
+
+      indexesToKeep =
+        Map.keysSet
+          . Orville.tableIndexes
+          $ tableDef
+
+      addIndexSteps =
+        concatMap
+          (mkAddIndexSteps existingIndexes tableName)
+          (Orville.tableIndexes tableDef)
+
+      dropIndexSteps =
+        concatMap
+          (mkDropIndexSteps indexesToKeep systemIndexOids)
+          (PgCatalog.relationIndexes relationDesc)
+
       tableName =
         Orville.tableName tableDef
    in mkAlterColumnSteps tableName (addAlterColumnActions <> dropColumnActions)
         <> mkConstraintSteps tableName (addConstraintActions <> dropConstraintActions)
+        <> addIndexSteps
+        <> dropIndexSteps
 
 {- |
   Consolidates alter table actions (which should all be related to adding and
@@ -473,7 +517,7 @@ mkDropConstraintActions constraintsToKeep constraint =
   important to set the schema names for the constraints found in the table
   definition before comparing them. See 'setDefaultSchemaNameOnConstraintKey'.
 
-  If the descriptionis for a kind of constraint that Orville does not support,
+  If the description is for a kind of constraint that Orville does not support,
   'Nothing' is returned.
 -}
 pgConstraintMigrationKey ::
@@ -524,6 +568,106 @@ pgConstraintMigrationKey constraintDesc =
                   (PgCatalog.constraintForeignKey constraintDesc)
             }
 
+{- |
+  Builds migration steps to create an index if it does not exist.
+-}
+mkAddIndexSteps ::
+  Set.Set Orville.IndexMigrationKey ->
+  Expr.QualifiedTableName ->
+  Orville.IndexDefinition ->
+  [MigrationStepWithType]
+mkAddIndexSteps existingIndexes tableName indexDef =
+  let indexKey =
+        Orville.indexMigrationKey indexDef
+   in if Set.member indexKey existingIndexes
+        then []
+        else [mkMigrationStepWithType AddIndexes (Orville.indexCreateExpr indexDef tableName)]
+
+{- |
+  Builds migration steps to create an index if it does not exist.
+-}
+mkDropIndexSteps ::
+  Set.Set Orville.IndexMigrationKey ->
+  Set.Set LibPQ.Oid ->
+  PgCatalog.IndexDescription ->
+  [MigrationStepWithType]
+mkDropIndexSteps indexesToKeep systemIndexOids indexDesc =
+  case pgIndexMigrationKey indexDesc of
+    Nothing ->
+      []
+    Just indexKey ->
+      let pgClass =
+            PgCatalog.indexPgClass indexDesc
+
+          indexName =
+            Expr.indexName
+              . PgCatalog.relationNameToString
+              . PgCatalog.pgClassRelationName
+              $ pgClass
+
+          indexOid =
+            PgCatalog.pgClassOid pgClass
+       in if Set.member indexKey indexesToKeep
+            || Set.member indexOid systemIndexOids
+            then []
+            else [mkMigrationStepWithType DropIndexes (Expr.dropIndexExpr indexName)]
+
+{- |
+  Primary Key, Unique, and Exclusion constraints automatically create indexes
+  that we don't want orville to consider for the purposes of migrations. This
+  function checks the constraint type and returns the OID of the supporting
+  index if the constraint is one of these types.
+
+  Foreign key constraints also have a supporting index OID in @pg_catalog@, but
+  this index is not automatically created due to the constraint, so we don't
+  return the index's OID for that case.
+-}
+pgConstraintImpliedIndexOid :: PgCatalog.PgConstraint -> Maybe LibPQ.Oid
+pgConstraintImpliedIndexOid pgConstraint =
+  case PgCatalog.pgConstraintType pgConstraint of
+    PgCatalog.PrimaryKeyConstraint ->
+      Just $ PgCatalog.pgConstraintIndexOid pgConstraint
+    PgCatalog.UniqueConstraint ->
+      Just $ PgCatalog.pgConstraintIndexOid pgConstraint
+    PgCatalog.ExclusionConstraint ->
+      Just $ PgCatalog.pgConstraintIndexOid pgConstraint
+    PgCatalog.CheckConstraint ->
+      Nothing
+    PgCatalog.ForeignKeyConstraint ->
+      Nothing
+    PgCatalog.ConstraintTrigger ->
+      Nothing
+
+{- |
+  Builds the orville migration key for a description of an existing index
+  so that it can be compared with indexs found in a table definition.
+
+  If the description is for includes expressions as members of the index
+  rather than simple attributes, 'Nothing' is returned.
+-}
+pgIndexMigrationKey ::
+  PgCatalog.IndexDescription ->
+  Maybe Orville.IndexMigrationKey
+pgIndexMigrationKey indexDesc = do
+  let indexMemberToFieldName member =
+        case member of
+          PgCatalog.IndexAttribute attr ->
+            Just (Orville.stringToFieldName . PgCatalog.attributeNameToString . PgCatalog.pgAttributeName $ attr)
+          PgCatalog.IndexExpression ->
+            Nothing
+
+      uniqueness =
+        if PgCatalog.pgIndexIsUnique (PgCatalog.indexRecord indexDesc)
+          then Orville.UniqueIndex
+          else Orville.NonUniqueIndex
+
+  fieldNames <- traverse indexMemberToFieldName (PgCatalog.indexMembers indexDesc)
+  pure $
+    Orville.IndexMigrationKey
+      { Orville.indexKeyUniqueness = uniqueness
+      , Orville.indexKeyColumns = fieldNames
+      }
+
 schemaItemPgCatalogRelation ::
   PgCatalog.NamespaceName ->
   SchemaItem ->
@@ -553,7 +697,7 @@ currentNamespaceQuery =
             -- current_schema is a special reserved word in postgresql. If you
             -- put it in quotes it tries to treat it as a regular column name,
             -- which then can't be found as a column in the query.
-            (Expr.columnNameFromIdentifier (Expr.unquotedIdentifier "current_schema"))
+            (Expr.fromIdentifier (Expr.unquotedIdentifier "current_schema"))
             (Orville.fieldColumnName PgCatalog.namespaceNameField)
         ]
     )

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr.hs
@@ -25,23 +25,21 @@ module Orville.PostgreSQL.Internal.Expr
     identifierFromBytes,
     unquotedIdentifier,
     unquotedIdentifierFromBytes,
+    IdentifierExpression (toIdentifier, fromIdentifier),
     TableName,
     tableName,
-    tableNameFromIdentifier,
     QualifiedTableName,
     qualifiedTableName,
     SchemaName,
     schemaName,
-    schemaNameFromIdentifier,
     ColumnName,
     columnName,
-    columnNameFromIdentifier,
     ConstraintName,
     constraintName,
-    constraintNameFromIdentifier,
+    IndexName,
+    indexName,
     SavepointName,
     savepointName,
-    savepointNameFromIdentifier,
     WhereClause,
     whereClause,
     BooleanExpr,
@@ -138,6 +136,11 @@ module Orville.PostgreSQL.Internal.Expr
     dropNotNull,
     DropTableExpr,
     dropTableExpr,
+    CreateIndexExpr,
+    createIndexExpr,
+    IndexUniqueness (UniqueIndex, NonUniqueIndex),
+    DropIndexExpr,
+    dropIndexExpr,
     IfExists,
     ifExists,
     Distinct (Distinct),
@@ -163,6 +166,7 @@ where
 import Orville.PostgreSQL.Internal.Expr.ColumnDefinition
 import Orville.PostgreSQL.Internal.Expr.Delete
 import Orville.PostgreSQL.Internal.Expr.GroupBy
+import Orville.PostgreSQL.Internal.Expr.Index
 import Orville.PostgreSQL.Internal.Expr.InsertExpr
 import Orville.PostgreSQL.Internal.Expr.LimitExpr
 import Orville.PostgreSQL.Internal.Expr.Name

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/Index.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/Index.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Orville.PostgreSQL.Internal.Expr.Index
+  ( CreateIndexExpr,
+    createIndexExpr,
+    IndexUniqueness (UniqueIndex, NonUniqueIndex),
+    DropIndexExpr,
+    dropIndexExpr,
+  )
+where
+
+import Data.List.NonEmpty (NonEmpty)
+
+import Orville.PostgreSQL.Internal.Expr.Name (ColumnName, IndexName, QualifiedTableName)
+import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+
+newtype CreateIndexExpr
+  = CreateIndexExpr RawSql.RawSql
+  deriving (RawSql.SqlExpression)
+
+createIndexExpr ::
+  IndexUniqueness ->
+  QualifiedTableName ->
+  NonEmpty ColumnName ->
+  CreateIndexExpr
+createIndexExpr uniqueness tableName columns =
+  CreateIndexExpr $
+    RawSql.fromString "CREATE "
+      <> uniquenessToSql uniqueness
+      <> RawSql.fromString "INDEX ON "
+      <> RawSql.toRawSql tableName
+      <> RawSql.space
+      <> RawSql.leftParen
+      <> RawSql.intercalate RawSql.comma columns
+      <> RawSql.rightParen
+
+data IndexUniqueness
+  = UniqueIndex
+  | NonUniqueIndex
+  deriving (Eq, Ord, Show)
+
+uniquenessToSql :: IndexUniqueness -> RawSql.RawSql
+uniquenessToSql uniqueness =
+  case uniqueness of
+    UniqueIndex -> RawSql.fromString "UNIQUE "
+    NonUniqueIndex -> mempty
+
+newtype DropIndexExpr
+  = DropIndexExpr RawSql.RawSql
+  deriving (RawSql.SqlExpression)
+
+dropIndexExpr :: IndexName -> DropIndexExpr
+dropIndexExpr indexName =
+  DropIndexExpr $
+    RawSql.fromString "DROP INDEX " <> RawSql.toRawSql indexName

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/Name.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/Name.hs
@@ -13,6 +13,7 @@ where
 import Orville.PostgreSQL.Internal.Expr.Name.ColumnName as Export
 import Orville.PostgreSQL.Internal.Expr.Name.ConstraintName as Export
 import Orville.PostgreSQL.Internal.Expr.Name.Identifier as Export
+import Orville.PostgreSQL.Internal.Expr.Name.IndexName as Export
 import Orville.PostgreSQL.Internal.Expr.Name.QualifiedTableName as Export
 import Orville.PostgreSQL.Internal.Expr.Name.SavepointName as Export
 import Orville.PostgreSQL.Internal.Expr.Name.SchemaName as Export

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/Name/ColumnName.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/Name/ColumnName.hs
@@ -8,19 +8,15 @@ License   : MIT
 module Orville.PostgreSQL.Internal.Expr.Name.ColumnName
   ( ColumnName,
     columnName,
-    columnNameFromIdentifier,
   )
 where
 
-import Orville.PostgreSQL.Internal.Expr.Name.Identifier (Identifier, identifier)
+import Orville.PostgreSQL.Internal.Expr.Name.Identifier (Identifier, IdentifierExpression, identifier)
 import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
 
 newtype ColumnName
   = ColumnName Identifier
-  deriving (RawSql.SqlExpression)
+  deriving (RawSql.SqlExpression, IdentifierExpression)
 
 columnName :: String -> ColumnName
 columnName = ColumnName . identifier
-
-columnNameFromIdentifier :: Identifier -> ColumnName
-columnNameFromIdentifier = ColumnName

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/Name/Identifier.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/Name/Identifier.hs
@@ -11,6 +11,7 @@ module Orville.PostgreSQL.Internal.Expr.Name.Identifier
     identifierFromBytes,
     unquotedIdentifier,
     unquotedIdentifierFromBytes,
+    IdentifierExpression (toIdentifier, fromIdentifier),
   )
 where
 
@@ -37,3 +38,11 @@ unquotedIdentifier =
 unquotedIdentifierFromBytes :: B8.ByteString -> Identifier
 unquotedIdentifierFromBytes =
   Identifier . RawSql.fromBytes
+
+class IdentifierExpression name where
+  toIdentifier :: name -> Identifier
+  fromIdentifier :: Identifier -> name
+
+instance IdentifierExpression Identifier where
+  toIdentifier = id
+  fromIdentifier = id

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/Name/IndexName.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/Name/IndexName.hs
@@ -1,22 +1,22 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 {- |
-Module    : Orville.PostgreSQL.Expr.Name.ConstraintName
+Module    : Orville.PostgreSQL.Expr.Name.IndexName
 Copyright : Flipstone Technology Partners 2021
 License   : MIT
 -}
-module Orville.PostgreSQL.Internal.Expr.Name.ConstraintName
-  ( ConstraintName,
-    constraintName,
+module Orville.PostgreSQL.Internal.Expr.Name.IndexName
+  ( IndexName,
+    indexName,
   )
 where
 
 import Orville.PostgreSQL.Internal.Expr.Name.Identifier (Identifier, IdentifierExpression, identifier)
 import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
 
-newtype ConstraintName
-  = ConstraintName Identifier
+newtype IndexName
+  = IndexName Identifier
   deriving (RawSql.SqlExpression, IdentifierExpression)
 
-constraintName :: String -> ConstraintName
-constraintName = ConstraintName . identifier
+indexName :: String -> IndexName
+indexName = IndexName . identifier

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/Name/SavepointName.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/Name/SavepointName.hs
@@ -8,19 +8,15 @@ License   : MIT
 module Orville.PostgreSQL.Internal.Expr.Name.SavepointName
   ( SavepointName,
     savepointName,
-    savepointNameFromIdentifier,
   )
 where
 
-import Orville.PostgreSQL.Internal.Expr.Name.Identifier (Identifier, identifier)
+import Orville.PostgreSQL.Internal.Expr.Name.Identifier (Identifier, IdentifierExpression, identifier)
 import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
 
 newtype SavepointName
   = SavepointName Identifier
-  deriving (RawSql.SqlExpression)
+  deriving (RawSql.SqlExpression, IdentifierExpression)
 
 savepointName :: String -> SavepointName
 savepointName = SavepointName . identifier
-
-savepointNameFromIdentifier :: Identifier -> SavepointName
-savepointNameFromIdentifier = SavepointName

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/Name/SchemaName.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/Name/SchemaName.hs
@@ -8,21 +8,16 @@ License   : MIT
 module Orville.PostgreSQL.Internal.Expr.Name.SchemaName
   ( SchemaName,
     schemaName,
-    schemaNameFromIdentifier,
   )
 where
 
-import Orville.PostgreSQL.Internal.Expr.Name.Identifier (Identifier, identifier)
+import Orville.PostgreSQL.Internal.Expr.Name.Identifier (Identifier, IdentifierExpression, identifier)
 import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
 
 newtype SchemaName
   = SchemaName Identifier
-  deriving (RawSql.SqlExpression)
+  deriving (RawSql.SqlExpression, IdentifierExpression)
 
 schemaName :: String -> SchemaName
 schemaName =
   SchemaName . identifier
-
-schemaNameFromIdentifier :: Identifier -> SchemaName
-schemaNameFromIdentifier =
-  SchemaName

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/Name/TableName.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/Name/TableName.hs
@@ -8,20 +8,16 @@ License   : MIT
 module Orville.PostgreSQL.Internal.Expr.Name.TableName
   ( TableName,
     tableName,
-    tableNameFromIdentifier,
   )
 where
 
-import Orville.PostgreSQL.Internal.Expr.Name.Identifier (Identifier, identifier)
+import Orville.PostgreSQL.Internal.Expr.Name.Identifier (Identifier, IdentifierExpression, identifier)
 import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
 
 newtype TableName
   = TableName Identifier
-  deriving (RawSql.SqlExpression)
+  deriving (RawSql.SqlExpression, IdentifierExpression)
 
 tableName :: String -> TableName
 tableName =
   TableName . identifier
-
-tableNameFromIdentifier :: Identifier -> TableName
-tableNameFromIdentifier = TableName

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/FieldDefinition.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/FieldDefinition.hs
@@ -61,7 +61,7 @@ newtype FieldName
 
 fieldNameToColumnName :: FieldName -> Expr.ColumnName
 fieldNameToColumnName (FieldName name) =
-  Expr.columnNameFromIdentifier (Expr.identifierFromBytes name)
+  Expr.fromIdentifier (Expr.identifierFromBytes name)
 
 stringToFieldName :: String -> FieldName
 stringToFieldName =

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/IndexDefinition.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/IndexDefinition.hs
@@ -1,0 +1,95 @@
+module Orville.PostgreSQL.Internal.IndexDefinition
+  ( IndexDefinition,
+    uniqueIndex,
+    nonUniqueIndex,
+    mkIndexDefinition,
+    Expr.IndexUniqueness (UniqueIndex, NonUniqueIndex),
+    IndexMigrationKey (IndexMigrationKey, indexKeyUniqueness, indexKeyColumns),
+    indexMigrationKey,
+    indexCreateExpr,
+  )
+where
+
+import Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NEL
+
+import qualified Orville.PostgreSQL.Internal.Expr as Expr
+import qualified Orville.PostgreSQL.Internal.FieldDefinition as FieldDefinition
+
+{- |
+  Defines an index that can be added to a 'Orville.PostgreSQL.TableDefinition'.
+  Use one of the constructor functions below (such as 'uniqueIndex') to
+  construct the index definition you wish to have and then use
+  'Orville.PostgreSQL.addTableIndexes'. to add them to your table definition.
+  Orville will then add the index next time you run auto-migrations.
+-}
+data IndexDefinition = IndexDefinition
+  { _indexCreateExpr :: Expr.QualifiedTableName -> Expr.CreateIndexExpr
+  , _indexMigrationKey :: IndexMigrationKey
+  }
+
+{- |
+  The key used by Orville to determine whether an index should be added to
+  a table when performing auto migrations. For most use cases the constructor
+  functions that build an 'IndexDefinition' will create this automatically
+  for you.
+-}
+data IndexMigrationKey = IndexMigrationKey
+  { indexKeyUniqueness :: Expr.IndexUniqueness
+  , indexKeyColumns :: [FieldDefinition.FieldName]
+  }
+  deriving (Eq, Ord, Show)
+
+{- |
+  Gets the 'IndexMigrationKey' for the 'IndexDefinition'
+-}
+indexMigrationKey :: IndexDefinition -> IndexMigrationKey
+indexMigrationKey = _indexMigrationKey
+
+{- |
+  Gets the SQL expression that will be used to add the index to the specified
+  table.
+-}
+indexCreateExpr :: IndexDefinition -> Expr.QualifiedTableName -> Expr.CreateIndexExpr
+indexCreateExpr = _indexCreateExpr
+
+{- |
+  Constructs an 'IndexDefinition' for a @UNIQUE@ index on the given
+  columns.
+-}
+nonUniqueIndex :: NonEmpty FieldDefinition.FieldName -> IndexDefinition
+nonUniqueIndex =
+  mkIndexDefinition Expr.NonUniqueIndex
+
+{- |
+  Constructs an 'IndexDefinition' for a @UNIQUE@ index on the given
+  columns.
+-}
+uniqueIndex :: NonEmpty FieldDefinition.FieldName -> IndexDefinition
+uniqueIndex =
+  mkIndexDefinition Expr.UniqueIndex
+
+{- |
+  Constructs an 'IndexDefinition' for an index on the given columns with the
+  given uniquness.
+-}
+mkIndexDefinition ::
+  Expr.IndexUniqueness ->
+  NonEmpty FieldDefinition.FieldName ->
+  IndexDefinition
+mkIndexDefinition uniqueness fieldNames =
+  let expr tableName =
+        Expr.createIndexExpr
+          uniqueness
+          tableName
+          (fmap FieldDefinition.fieldNameToColumnName fieldNames)
+
+      migrationKey =
+        IndexMigrationKey
+          { indexKeyUniqueness = uniqueness
+          , indexKeyColumns = NEL.toList fieldNames
+          }
+   in IndexDefinition
+        { _indexCreateExpr = expr
+        , _indexMigrationKey = migrationKey
+        }

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/PgCatalog.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/PgCatalog.hs
@@ -10,4 +10,5 @@ import Orville.PostgreSQL.PgCatalog.OidField as Export
 import Orville.PostgreSQL.PgCatalog.PgAttribute as Export
 import Orville.PostgreSQL.PgCatalog.PgClass as Export
 import Orville.PostgreSQL.PgCatalog.PgConstraint as Export
+import Orville.PostgreSQL.PgCatalog.PgIndex as Export
 import Orville.PostgreSQL.PgCatalog.PgNamespace as Export

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/PgCatalog/PgAttribute.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/PgCatalog/PgAttribute.hs
@@ -7,6 +7,8 @@ module Orville.PostgreSQL.PgCatalog.PgAttribute
     attributeNameToString,
     AttributeNumber,
     attributeNumberToInt16,
+    attributeNumberTextBuilder,
+    attributeNumberParser,
     isOrdinaryColumn,
     pgAttributeTable,
     attributeRelationOidField,
@@ -17,9 +19,12 @@ module Orville.PostgreSQL.PgCatalog.PgAttribute
   )
 where
 
+import qualified Data.Attoparsec.Text as AttoText
 import Data.Int (Int16, Int32)
 import qualified Data.String as String
 import qualified Data.Text as T
+import qualified Data.Text.Lazy.Builder as LTB
+import qualified Data.Text.Lazy.Builder.Int as LTBI
 import qualified Database.PostgreSQL.LibPQ as LibPQ
 
 import qualified Orville.PostgreSQL as Orville
@@ -121,6 +126,20 @@ newtype AttributeNumber
 -}
 attributeNumberToInt16 :: AttributeNumber -> Int16
 attributeNumberToInt16 (AttributeNumber int) = int
+
+{- |
+  Attoparsec parser for 'AttributeNumber'
+-}
+attributeNumberParser :: AttoText.Parser AttributeNumber
+attributeNumberParser =
+  AttoText.signed AttoText.decimal
+
+{- |
+  Encodes an 'AttributeNumber' to lazy text as a builder
+-}
+attributeNumberTextBuilder :: AttributeNumber -> LTB.Builder
+attributeNumberTextBuilder =
+  LTBI.decimal . attributeNumberToInt16
 
 {- |
   An Orville 'Orville.TableDefinition' for querying the

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/PgCatalog/PgIndex.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/PgCatalog/PgIndex.hs
@@ -1,0 +1,129 @@
+module Orville.PostgreSQL.PgCatalog.PgIndex
+  ( PgIndex (..),
+    pgIndexTable,
+    indexRelationOidField,
+    indexIsLiveField,
+  )
+where
+
+import qualified Data.Attoparsec.Text as AttoText
+import qualified Data.List as List
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as LT
+import qualified Data.Text.Lazy.Builder as LTB
+import qualified Database.PostgreSQL.LibPQ as LibPQ
+
+import qualified Orville.PostgreSQL as Orville
+import Orville.PostgreSQL.PgCatalog.OidField (oidTypeField)
+import Orville.PostgreSQL.PgCatalog.PgAttribute (AttributeNumber, attributeNumberParser, attributeNumberTextBuilder)
+
+{- |
+  The Haskell representation of data read from the @pg_catalog.pg_index@ tale.
+  Rows in this table contain extended information about indices. Information
+  about indices is also contained in the @pg_catalog.pg_class@ table as well.
+-}
+data PgIndex = PgIndex
+  { -- | The PostgreSQL @oid@ of the @pg_class@ entry for this index.
+    pgIndexPgClassOid :: LibPQ.Oid
+  , -- | The PostgreSQL @oid@ of the @pg_class@ entry for the table that this
+    -- index is for.
+    pgIndexRelationOid :: LibPQ.Oid
+  , -- | An array of attribute numbers references the columns the table that
+    -- are included in the index. An attribute number of @0@ indicates an
+    -- expression over the table's columns rather than just a reference to a
+    -- column.
+    --
+    -- In PostgreSQL 11+ this includes both key columns and non-key
+    -- included columns. Orville is currently not aware of this distinction,
+    -- however.
+    pgIndexAttributeNumbers :: [AttributeNumber]
+  , -- | Indicates whether this is a unique index
+    pgIndexIsUnique :: Bool
+  , -- | Indicates whether this is the primary key index for the table
+    pgIndexIsPrimary :: Bool
+  , -- | When @False@, indicates that this index is in the process of being dropped and should be ignored
+    pgIndexIsLive :: Bool
+  }
+
+{- |
+  An Orville 'Orville.TableDefinition' for querying the
+  @pg_catalog.pg_index@ table
+-}
+pgIndexTable :: Orville.TableDefinition Orville.NoKey PgIndex PgIndex
+pgIndexTable =
+  Orville.setTableSchema "pg_catalog" $
+    Orville.mkTableDefinitionWithoutKey
+      "pg_index"
+      pgIndexMarshaller
+
+pgIndexMarshaller :: Orville.SqlMarshaller PgIndex PgIndex
+pgIndexMarshaller =
+  PgIndex
+    <$> Orville.marshallField pgIndexPgClassOid indexPgClassOidField
+    <*> Orville.marshallField pgIndexRelationOid indexRelationOidField
+    <*> Orville.marshallField pgIndexAttributeNumbers indexAttributeNumbersField
+    <*> Orville.marshallField pgIndexIsUnique indexIsUniqueField
+    <*> Orville.marshallField pgIndexIsPrimary indexIsPrimaryField
+    <*> Orville.marshallField pgIndexIsLive indexIsLiveField
+
+{- |
+  The @indexrelid@ column of the @pg_index@ table
+-}
+indexPgClassOidField :: Orville.FieldDefinition Orville.NotNull LibPQ.Oid
+indexPgClassOidField =
+  oidTypeField "indexrelid"
+
+{- |
+  The @indrelid@ column of the @pg_index@ table
+-}
+indexRelationOidField :: Orville.FieldDefinition Orville.NotNull LibPQ.Oid
+indexRelationOidField =
+  oidTypeField "indrelid"
+
+{- |
+  The @indkey@ column of the @pg_index@ table
+-}
+indexAttributeNumbersField :: Orville.FieldDefinition Orville.NotNull [AttributeNumber]
+indexAttributeNumbersField =
+  Orville.convertField
+    (Orville.maybeConvertSqlType attributeNumberListToPgVectorText pgVectorTextToAttributeNumberList)
+    (Orville.unboundedTextField "indkey")
+
+{- |
+  The @indisunique@ column of the @pg_index@ table
+-}
+indexIsUniqueField :: Orville.FieldDefinition Orville.NotNull Bool
+indexIsUniqueField =
+  Orville.booleanField "indisunique"
+
+{- |
+  The @indisprimary@ column of the @pg_index@ table
+-}
+indexIsPrimaryField :: Orville.FieldDefinition Orville.NotNull Bool
+indexIsPrimaryField =
+  Orville.booleanField "indisprimary"
+
+{- |
+  The @indislive@ column of the @pg_index@ table
+-}
+indexIsLiveField :: Orville.FieldDefinition Orville.NotNull Bool
+indexIsLiveField =
+  Orville.booleanField "indislive"
+
+pgVectorTextToAttributeNumberList :: T.Text -> Maybe [AttributeNumber]
+pgVectorTextToAttributeNumberList text =
+  let parser = do
+        attNums <- AttoText.sepBy attributeNumberParser (AttoText.char ' ')
+        AttoText.endOfInput
+        pure attNums
+   in case AttoText.parseOnly parser text of
+        Left _ -> Nothing
+        Right nums -> Just nums
+
+attributeNumberListToPgVectorText :: [AttributeNumber] -> T.Text
+attributeNumberListToPgVectorText attNums =
+  let spaceDelimitedAttributeNumbers =
+        mconcat $
+          List.intersperse (LTB.singleton ' ') (map attributeNumberTextBuilder attNums)
+   in LT.toStrict . LTB.toLazyText $
+        spaceDelimitedAttributeNumbers

--- a/orville-postgresql-libpq/test/Main.hs
+++ b/orville-postgresql-libpq/test/Main.hs
@@ -58,7 +58,7 @@ main = do
 
 createTestConnectionPool :: IO (Connection.Pool Connection.Connection)
 createTestConnectionPool =
-  Connection.createConnectionPool 1 10 1 $
+  Connection.createConnectionPool Connection.DisableNoticeReporting 1 10 1 $
     B8.pack "host=testdb user=orville_test password=orville"
 
 recheckDBProperty :: HH.Size -> HH.Seed -> Property.NamedDBProperty -> IO ()

--- a/orville-postgresql-libpq/test/Test/Connection.hs
+++ b/orville-postgresql-libpq/test/Test/Connection.hs
@@ -18,7 +18,7 @@ import qualified Hedgehog.Range as Range
 import qualified Orville.PostgreSQL.Connection as Connection
 import qualified Orville.PostgreSQL.Internal.PGTextFormatValue as PGTextFormatValue
 
-import qualified Test.PGGen as PGGen
+import qualified Test.PgGen as PgGen
 import qualified Test.Property as Property
 
 connectionTests :: Pool.Pool Connection.Connection -> Property.Group
@@ -27,7 +27,7 @@ connectionTests pool =
     [
       ( String.fromString "executeRaw can pass non-null bytes equivalents whether checked for NUL or not"
       , HH.property $ do
-          text <- HH.forAll $ PGGen.pgText (Range.linear 0 256)
+          text <- HH.forAll $ PgGen.pgText (Range.linear 0 256)
 
           let notNulBytes =
                 Enc.encodeUtf8 text
@@ -49,8 +49,8 @@ connectionTests pool =
     ,
       ( String.fromString "executeRaw returns error if nul byte is given using safe constructor"
       , HH.property $ do
-          textBefore <- HH.forAll $ PGGen.pgText (Range.linear 0 32)
-          textAfter <- HH.forAll $ PGGen.pgText (Range.linear 0 32)
+          textBefore <- HH.forAll $ PgGen.pgText (Range.linear 0 32)
+          textAfter <- HH.forAll $ PgGen.pgText (Range.linear 0 32)
 
           let bytesWithNul =
                 B8.concat
@@ -77,8 +77,8 @@ connectionTests pool =
     ,
       ( String.fromString "executeRaw truncates values at the nul byte given using unsafe constructor"
       , HH.property $ do
-          textBefore <- HH.forAll $ PGGen.pgText (Range.linear 0 32)
-          textAfter <- HH.forAll $ PGGen.pgText (Range.linear 0 32)
+          textBefore <- HH.forAll $ PgGen.pgText (Range.linear 0 32)
+          textAfter <- HH.forAll $ PgGen.pgText (Range.linear 0 32)
 
           let bytesBefore =
                 Enc.encodeUtf8 textBefore
@@ -110,7 +110,7 @@ connectionTests pool =
       , Property.singletonProperty $ do
           -- We generate non-empty queries here becaues libpq returns different
           -- error details when an empty string is passed
-          randomText <- HH.forAll $ PGGen.pgText (Range.constant 1 16)
+          randomText <- HH.forAll $ PgGen.pgText (Range.constant 1 16)
 
           result <-
             MIO.liftIO . E.try . Pool.withResource pool $ \connection ->

--- a/orville-postgresql-libpq/test/Test/Entities/Bar.hs
+++ b/orville-postgresql-libpq/test/Test/Entities/Bar.hs
@@ -19,7 +19,7 @@ import qualified Hedgehog.Range as Range
 import qualified Orville.PostgreSQL as Orville
 import Orville.PostgreSQL.Connection (Connection)
 
-import qualified Test.PGGen as PGGen
+import qualified Test.PgGen as PgGen
 import qualified Test.TestTable as TestTable
 
 type BarId = Int32
@@ -55,7 +55,7 @@ barNameField =
 generate :: HH.Gen BarWrite
 generate =
   Bar ()
-    <$> PGGen.pgText (Range.constant 0 10)
+    <$> PgGen.pgText (Range.constant 0 10)
 
 generateList :: HH.Range Int -> HH.Gen [BarWrite]
 generateList range =

--- a/orville-postgresql-libpq/test/Test/Entities/Foo.hs
+++ b/orville-postgresql-libpq/test/Test/Entities/Foo.hs
@@ -31,7 +31,7 @@ import qualified Hedgehog.Range as Range
 import qualified Orville.PostgreSQL as Orville
 import Orville.PostgreSQL.Connection (Connection)
 
-import qualified Test.PGGen as PGGen
+import qualified Test.PgGen as PgGen
 import qualified Test.TestTable as TestTable
 
 type FooId = Int32
@@ -84,11 +84,11 @@ generateFooWithName name =
 
 generateFooId :: HH.Gen FooId
 generateFooId =
-  PGGen.pgInt32
+  PgGen.pgInt32
 
 generateFooName :: HH.Gen FooName
 generateFooName =
-  PGGen.pgText (Range.constant 0 10)
+  PgGen.pgText (Range.constant 0 10)
 
 generateFooAge :: HH.Gen FooAge
 generateFooAge =

--- a/orville-postgresql-libpq/test/Test/Entities/FooChild.hs
+++ b/orville-postgresql-libpq/test/Test/Entities/FooChild.hs
@@ -22,7 +22,7 @@ import qualified Orville.PostgreSQL as Orville
 import Orville.PostgreSQL.Connection (Connection)
 
 import qualified Test.Entities.Foo as Foo
-import qualified Test.PGGen as PGGen
+import qualified Test.PgGen as PgGen
 import qualified Test.TestTable as TestTable
 
 type FooChildId = Int32
@@ -58,7 +58,7 @@ fooChildFooIdField =
 generate :: [Foo.Foo] -> HH.Gen FooChild
 generate foos =
   FooChild
-    <$> PGGen.pgInt32
+    <$> PgGen.pgInt32
     <*> Gen.element (Foo.fooId <$> foos)
 
 generateList :: HH.Range Int -> [Foo.Foo] -> HH.Gen [FooChild]

--- a/orville-postgresql-libpq/test/Test/Entities/User.hs
+++ b/orville-postgresql-libpq/test/Test/Entities/User.hs
@@ -11,7 +11,7 @@ import qualified Hedgehog.Range as Range
 
 import qualified Orville.PostgreSQL as Orville
 
-import qualified Test.PGGen as PGGen
+import qualified Test.PgGen as PgGen
 
 data User = User
   { user :: T.Text
@@ -34,4 +34,4 @@ userField =
 generate :: HH.Gen User
 generate =
   User
-    <$> PGGen.pgText (Range.constant 0 10)
+    <$> PgGen.pgText (Range.constant 0 10)

--- a/orville-postgresql-libpq/test/Test/FieldDefinition.hs
+++ b/orville-postgresql-libpq/test/Test/FieldDefinition.hs
@@ -23,7 +23,7 @@ import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
 import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
 
 import Test.Expr.TestSchema (sqlRowsToText)
-import qualified Test.PGGen as PGGen
+import qualified Test.PgGen as PgGen
 import qualified Test.Property as Property
 
 fieldDefinitionTests :: Pool.Pool Connection.Connection -> Property.Group
@@ -46,7 +46,7 @@ integerField pool =
   testFieldProperties pool "integerField" $
     RoundTripTest
       { roundTripFieldDef = FieldDef.integerField "foo"
-      , roundTripGen = PGGen.pgInt32
+      , roundTripGen = PgGen.pgInt32
       }
 
 bigIntegerField :: Pool.Pool Connection.Connection -> [(HH.PropertyName, HH.Property)]
@@ -62,7 +62,7 @@ doubleField pool =
   testFieldProperties pool "doubleField" $
     RoundTripTest
       { roundTripFieldDef = FieldDef.doubleField "foo"
-      , roundTripGen = PGGen.pgDouble
+      , roundTripGen = PgGen.pgDouble
       }
 
 booleanField :: Pool.Pool Connection.Connection -> [(HH.PropertyName, HH.Property)]
@@ -78,7 +78,7 @@ unboundedTextField pool =
   testFieldProperties pool "unboundedTextField" $
     RoundTripTest
       { roundTripFieldDef = FieldDef.unboundedTextField "foo"
-      , roundTripGen = PGGen.pgText (Range.constant 0 1024)
+      , roundTripGen = PgGen.pgText (Range.constant 0 1024)
       }
 
 boundedTextField :: Pool.Pool Connection.Connection -> [(HH.PropertyName, HH.Property)]
@@ -86,7 +86,7 @@ boundedTextField pool =
   testFieldProperties pool "boundedTextField" $
     RoundTripTest
       { roundTripFieldDef = FieldDef.boundedTextField "foo" 4
-      , roundTripGen = PGGen.pgText (Range.constant 0 4)
+      , roundTripGen = PgGen.pgText (Range.constant 0 4)
       }
 
 fixedTextField :: Pool.Pool Connection.Connection -> [(HH.PropertyName, HH.Property)]
@@ -94,7 +94,7 @@ fixedTextField pool =
   testFieldProperties pool "fixedTextField" $
     RoundTripTest
       { roundTripFieldDef = FieldDef.fixedTextField "foo" 4
-      , roundTripGen = PGGen.pgText (Range.constant 4 4)
+      , roundTripGen = PgGen.pgText (Range.constant 4 4)
       }
 
 textSearchVectorField :: Pool.Pool Connection.Connection -> [(HH.PropertyName, HH.Property)]

--- a/orville-postgresql-libpq/test/Test/PgGen.hs
+++ b/orville-postgresql-libpq/test/Test/PgGen.hs
@@ -1,7 +1,8 @@
-module Test.PGGen
+module Test.PgGen
   ( pgText,
     pgDouble,
     pgInt32,
+    pgIdentifier,
   )
 where
 
@@ -27,3 +28,19 @@ pgDouble =
       truncateLongDouble :: Double -> Double
       truncateLongDouble = (/ 1e12) . (fromIntegral :: Int -> Double) . round . (* 1e12)
    in flip Gen.subterm truncateLongDouble . Gen.double $ Range.linearFracFrom 0 (-1000) 1000
+
+pgIdentifier :: HH.Gen String
+pgIdentifier =
+  Gen.string (Range.linear 1 63) $ Gen.element pgIdentifierChars
+
+{- |
+  A list of characters to include in identifiers when testing. Not all of these
+  are valid in unquoted identifiers -- this helps ensure that Orville is
+  properly quoting ids.
+-}
+pgIdentifierChars :: [Char]
+pgIdentifierChars =
+  ['a' .. 'z']
+    <> ['A' .. 'Z']
+    <> ['0' .. '9']
+    <> "{}[]()<>!?:;_~^'%&"

--- a/orville-postgresql-libpq/test/Test/SqlMarshaller.hs
+++ b/orville-postgresql-libpq/test/Test/SqlMarshaller.hs
@@ -18,7 +18,7 @@ import qualified Orville.PostgreSQL.Internal.SqlMarshaller as SqlMarshaller
 import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
 
 import Test.Expr.TestSchema (assertEqualSqlRows)
-import qualified Test.PGGen as PGGen
+import qualified Test.PgGen as PgGen
 import qualified Test.Property as Property
 
 sqlMarshallerTests :: Property.Group
@@ -231,7 +231,7 @@ fooMarshaller =
 generateFoo :: HH.Gen Foo
 generateFoo =
   Foo
-    <$> PGGen.pgText (Range.linear 0 16)
+    <$> PgGen.pgText (Range.linear 0 16)
     <*> generateInt32
     <*> Gen.maybe Gen.bool
 
@@ -245,9 +245,9 @@ barMarshaller =
 generateBar :: HH.Gen Bar
 generateBar =
   Bar
-    <$> PGGen.pgDouble
-    <*> Gen.maybe (PGGen.pgText $ Range.linear 0 32)
-    <*> Gen.maybe (PGGen.pgText $ Range.linear 1 16)
+    <$> PgGen.pgDouble
+    <*> Gen.maybe (PgGen.pgText $ Range.linear 0 32)
+    <*> Gen.maybe (PgGen.pgText $ Range.linear 1 16)
 
 bazMarshallerRight :: SqlMarshaller.SqlMarshaller Baz Baz
 bazMarshallerRight =
@@ -266,7 +266,7 @@ bazMarshallerLeft =
 generateBaz :: HH.Gen Baz
 generateBaz =
   Baz
-    <$> PGGen.pgText (Range.linear 1 5)
+    <$> PgGen.pgText (Range.linear 1 5)
 
 generateNamesOtherThan :: String -> HH.Gen [String]
 generateNamesOtherThan specialName =

--- a/orville-postgresql-libpq/test/Test/TestTable.hs
+++ b/orville-postgresql-libpq/test/Test/TestTable.hs
@@ -2,10 +2,12 @@ module Test.TestTable
   ( dropAndRecreateTableDef,
     dropTableDef,
     dropTableDefSql,
+    dropTableNameSql,
   )
 where
 
 import Orville.PostgreSQL.Connection (Connection)
+import qualified Orville.PostgreSQL.Internal.Expr as Expr
 import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
 import Orville.PostgreSQL.Internal.TableDefinition (TableDefinition, mkCreateTableExpr, tableName)
 
@@ -27,5 +29,17 @@ dropAndRecreateTableDef connection tableDef = do
 dropTableDefSql ::
   TableDefinition key writeEntity readEntity ->
   RawSql.RawSql
-dropTableDefSql tableDef = do
-  RawSql.fromString "DROP TABLE IF EXISTS " <> RawSql.toRawSql (tableName tableDef)
+dropTableDefSql =
+  dropTableNameExprSql . tableName
+
+dropTableNameSql ::
+  String ->
+  RawSql.RawSql
+dropTableNameSql =
+  dropTableNameExprSql . Expr.qualifiedTableName Nothing . Expr.tableName
+
+dropTableNameExprSql ::
+  Expr.QualifiedTableName ->
+  RawSql.RawSql
+dropTableNameExprSql name =
+  RawSql.fromString "DROP TABLE IF EXISTS " <> RawSql.toRawSql name


### PR DESCRIPTION
This adds `IndexDefinition`, similar to `ConstraintDefinition`, which
can be added to a `TableDefinition` to define unique and non-unique
indexes.

Any indexes found that are not included in the `TableDefinition` auto
automatically dropped in the same way constraints are dropped. Indexes
automatically created by PostgreSQL to support constraints not
considered for dropping.