### PR TITLE
LibPQ: Adds support for column default values

### DIFF
--- a/orville-postgresql-libpq/orville-postgresql-libpq.cabal
+++ b/orville-postgresql-libpq/orville-postgresql-libpq.cabal
@@ -32,10 +32,11 @@ library
       Orville.PostgreSQL
       Orville.PostgreSQL.AutoMigration
       Orville.PostgreSQL.Connection
+      Orville.PostgreSQL.Internal.DefaultValue
       Orville.PostgreSQL.Internal.ExecutionResult
       Orville.PostgreSQL.Internal.Expr
       Orville.PostgreSQL.Internal.FieldDefinition
-      Orville.PostgreSQL.Internal.PGTextFormatValue
+      Orville.PostgreSQL.Internal.PgTextFormatValue
       Orville.PostgreSQL.Internal.PrimaryKey
       Orville.PostgreSQL.Internal.RawSql
       Orville.PostgreSQL.Internal.Select
@@ -92,10 +93,10 @@ library
       Orville.PostgreSQL.Internal.Expr.TableDefinition
       Orville.PostgreSQL.Internal.Expr.Transaction
       Orville.PostgreSQL.Internal.Expr.Update
+      Orville.PostgreSQL.Internal.Expr.ValueExpression
       Orville.PostgreSQL.Internal.Expr.Where
       Orville.PostgreSQL.Internal.Expr.Where.BooleanExpr
       Orville.PostgreSQL.Internal.Expr.Where.ComparisonOperator
-      Orville.PostgreSQL.Internal.Expr.Where.RowValueExpression
       Orville.PostgreSQL.Internal.Expr.Where.WhereClause
       Orville.PostgreSQL.Internal.IndexDefinition
       Orville.PostgreSQL.Internal.Insert
@@ -103,14 +104,17 @@ library
       Orville.PostgreSQL.Internal.MonadOrville
       Orville.PostgreSQL.Internal.Orville
       Orville.PostgreSQL.Internal.OrvilleState
+      Orville.PostgreSQL.Internal.PgTime
       Orville.PostgreSQL.Internal.SelectOptions.OrderBy
       Orville.PostgreSQL.Internal.SelectOptions.SelectOptions
       Orville.PostgreSQL.Internal.SelectOptions.WhereCondition
+      Orville.PostgreSQL.Internal.SyntheticField
       Orville.PostgreSQL.Internal.TableIdentifier
       Orville.PostgreSQL.Internal.Transaction
       Orville.PostgreSQL.PgCatalog.DatabaseDescription
       Orville.PostgreSQL.PgCatalog.OidField
       Orville.PostgreSQL.PgCatalog.PgAttribute
+      Orville.PostgreSQL.PgCatalog.PgAttributeDefault
       Orville.PostgreSQL.PgCatalog.PgClass
       Orville.PostgreSQL.PgCatalog.PgConstraint
       Orville.PostgreSQL.PgCatalog.PgIndex

--- a/orville-postgresql-libpq/package.yaml
+++ b/orville-postgresql-libpq/package.yaml
@@ -24,10 +24,11 @@ library:
     - Orville.PostgreSQL
     - Orville.PostgreSQL.AutoMigration
     - Orville.PostgreSQL.Connection
+    - Orville.PostgreSQL.Internal.DefaultValue
     - Orville.PostgreSQL.Internal.ExecutionResult
     - Orville.PostgreSQL.Internal.Expr
     - Orville.PostgreSQL.Internal.FieldDefinition
-    - Orville.PostgreSQL.Internal.PGTextFormatValue
+    - Orville.PostgreSQL.Internal.PgTextFormatValue
     - Orville.PostgreSQL.Internal.PrimaryKey
     - Orville.PostgreSQL.Internal.RawSql
     - Orville.PostgreSQL.Internal.Select

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
@@ -64,6 +64,7 @@ module Orville.PostgreSQL
     PrimaryKey.primaryKeyPart,
     SqlMarshaller.SqlMarshaller,
     SqlMarshaller.marshallField,
+    SqlMarshaller.marshallSyntheticField,
     SqlMarshaller.marshallReadOnly,
     SqlMarshaller.marshallReadOnlyField,
     SqlMarshaller.marshallPartial,
@@ -71,6 +72,12 @@ module Orville.PostgreSQL
     SqlMarshaller.foldMarshallerFields,
     SqlMarshaller.collectFromField,
     SqlMarshaller.ReadOnlyColumnOption (IncludeReadOnlyColumns, ExcludeReadOnlyColumns),
+    SyntheticField.SyntheticField,
+    SyntheticField.syntheticFieldExpression,
+    SyntheticField.syntheticFieldAlias,
+    SyntheticField.syntheticFieldValueFromSqlValue,
+    SyntheticField.syntheticField,
+    SyntheticField.nullableSyntheticField,
     FieldDefinition.FieldDefinition,
     FieldDefinition.NotNull,
     FieldDefinition.Nullable,
@@ -78,6 +85,8 @@ module Orville.PostgreSQL
     FieldDefinition.asymmetricNullableField,
     FieldDefinition.convertField,
     FieldDefinition.coerceField,
+    FieldDefinition.setDefaultValue,
+    FieldDefinition.removeDefaultValue,
     FieldDefinition.integerField,
     FieldDefinition.serialField,
     FieldDefinition.smallIntegerField,
@@ -101,10 +110,28 @@ module Orville.PostgreSQL
     FieldDefinition.fieldNameToColumnName,
     FieldDefinition.fieldNameToByteString,
     FieldDefinition.fieldType,
+    FieldDefinition.fieldDefaultValue,
     FieldDefinition.fieldColumnDefinition,
     FieldDefinition.fieldIsNotNullable,
     FieldDefinition.fieldNullability,
     FieldDefinition.FieldNullability (NotNullField, NullableField),
+    DefaultValue.DefaultValue,
+    DefaultValue.integerDefault,
+    DefaultValue.smallIntegerDefault,
+    DefaultValue.bigIntegerDefault,
+    DefaultValue.integralDefault,
+    DefaultValue.doubleDefault,
+    DefaultValue.booleanDefault,
+    DefaultValue.textDefault,
+    DefaultValue.dateDefault,
+    DefaultValue.currentDateDefault,
+    DefaultValue.utcTimestampDefault,
+    DefaultValue.currentUTCTimestampDefault,
+    DefaultValue.localTimestampDefault,
+    DefaultValue.currentLocalTimestampDefault,
+    DefaultValue.coerceDefaultValue,
+    DefaultValue.defaultValueExpression,
+    DefaultValue.rawSqlDefault,
     Orville.Orville,
     Orville.runOrville,
     MonadOrville.MonadOrville,
@@ -182,6 +209,7 @@ where
 
 import qualified Orville.PostgreSQL.Connection as Connection
 import qualified Orville.PostgreSQL.Internal.ConstraintDefinition as ConstraintDefinition
+import qualified Orville.PostgreSQL.Internal.DefaultValue as DefaultValue
 import qualified Orville.PostgreSQL.Internal.EntityOperations as EntityOperations
 import qualified Orville.PostgreSQL.Internal.Execute as Execute
 import qualified Orville.PostgreSQL.Internal.Expr as Expr
@@ -194,6 +222,7 @@ import qualified Orville.PostgreSQL.Internal.PrimaryKey as PrimaryKey
 import qualified Orville.PostgreSQL.Internal.SelectOptions as SelectOptions
 import qualified Orville.PostgreSQL.Internal.SqlMarshaller as SqlMarshaller
 import qualified Orville.PostgreSQL.Internal.SqlType as SqlType
+import qualified Orville.PostgreSQL.Internal.SyntheticField as SyntheticField
 import qualified Orville.PostgreSQL.Internal.TableDefinition as TableDefinition
 import qualified Orville.PostgreSQL.Internal.TableIdentifier as TableIdentifier
 import qualified Orville.PostgreSQL.Internal.Transaction as Transaction

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
@@ -177,7 +177,8 @@ module Orville.PostgreSQL
         SqlType.sqlTypeOid,
         SqlType.sqlTypeMaximumLength,
         SqlType.sqlTypeToSql,
-        SqlType.sqlTypeFromSql
+        SqlType.sqlTypeFromSql,
+        SqlType.sqlTypeDontDropImplicitDefaultDuringMigrate
       ),
 
     -- * numeric types

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/AutoMigration.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/AutoMigration.hs
@@ -414,9 +414,12 @@ mkAddAlterColumnActions relationDesc fieldDef =
                     (Nothing, Nothing) ->
                       (Nothing, Nothing)
                     (Just _, Nothing) ->
-                      ( Just (Expr.alterColumnDropDefault columnName)
-                      , Nothing
-                      )
+                      if Orville.sqlTypeDontDropImplicitDefaultDuringMigrate sqlType
+                        then (Nothing, Nothing)
+                        else
+                          ( Just (Expr.alterColumnDropDefault columnName)
+                          , Nothing
+                          )
                     (Nothing, Just newDefault) ->
                       ( Nothing
                       , Just (Expr.alterColumnSetDefault columnName newDefault)

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/DefaultValue.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/DefaultValue.hs
@@ -27,6 +27,7 @@ import Data.Int (Int16, Int32, Int64)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TextEnc
 import qualified Data.Time as Time
+import qualified Numeric as Numeric
 
 import qualified Orville.PostgreSQL.Internal.Expr as Expr
 import qualified Orville.PostgreSQL.Internal.PgTime as PgTime
@@ -99,8 +100,8 @@ doubleDefault d =
   let decimalBytes =
         LBS.toStrict
           . BSB.toLazyByteString
-          . BSB.doubleDec
-          $ d
+          . BSB.string7
+          $ Numeric.showFFloat Nothing d ""
    in if d < 0
         then
           DefaultValue . RawSql.unsafeFromRawSql $

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/DefaultValue.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/DefaultValue.hs
@@ -1,0 +1,244 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Orville.PostgreSQL.Internal.DefaultValue
+  ( DefaultValue,
+    integerDefault,
+    smallIntegerDefault,
+    bigIntegerDefault,
+    integralDefault,
+    doubleDefault,
+    booleanDefault,
+    textDefault,
+    dateDefault,
+    currentDateDefault,
+    utcTimestampDefault,
+    currentUTCTimestampDefault,
+    localTimestampDefault,
+    currentLocalTimestampDefault,
+    coerceDefaultValue,
+    defaultValueExpression,
+    rawSqlDefault,
+  )
+where
+
+import qualified Data.ByteString.Builder as BSB
+import qualified Data.ByteString.Lazy as LBS
+import Data.Int (Int16, Int32, Int64)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TextEnc
+import qualified Data.Time as Time
+
+import qualified Orville.PostgreSQL.Internal.Expr as Expr
+import qualified Orville.PostgreSQL.Internal.PgTime as PgTime
+import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+
+{- |
+  A 'DefaultValue' is a SQL expression that can be attached to a
+  field definition to give a default value for a column at the database level.
+  The default value will be used if an insert is done and the column is not
+  provided.
+
+  This is useful if you want to add a new column to a table that is already
+  in production without breaking a previous version of your application that
+  is running (e.g. during a zero-down-time deployment) and without needing to
+  make the new column nullable. Default values can also be used to create
+  database-assigned values such as using 'now()' to set a 'created_at' column
+  on a row automatically in the database.
+-}
+newtype DefaultValue a
+  = DefaultValue Expr.ValueExpression
+
+{- |
+  Builds a default value for any 'Integral' type @n@ by converting it an
+  'Integer'.
+-}
+integralDefault :: Integral n => n -> DefaultValue n
+integralDefault n =
+  let decimalBytes =
+        LBS.toStrict
+          . BSB.toLazyByteString
+          . BSB.integerDec
+          . toInteger
+          $ n
+   in if n < 0
+        then
+          DefaultValue . RawSql.unsafeFromRawSql $
+            RawSql.stringLiteral decimalBytes
+              <> RawSql.fromString "::integer"
+        else DefaultValue . RawSql.unsafeFromRawSql . RawSql.fromBytes $ decimalBytes
+
+{- |
+  Builds a default value from an 'Int16' for use with small integer fields.
+
+  This is a specialization of 'integerDefault'.
+-}
+smallIntegerDefault :: Int16 -> DefaultValue Int16
+smallIntegerDefault = integralDefault
+
+{- |
+  Builds a default value from an 'Int32' for use with integer fields.
+
+  This is a specialization of 'integerDefault'.
+-}
+integerDefault :: Int32 -> DefaultValue Int32
+integerDefault = integralDefault
+
+{- |
+  Builds a default value from an 'Int16' for use with big integer fields.
+
+  This is a specialization of 'integerDefault'.
+-}
+bigIntegerDefault :: Int64 -> DefaultValue Int64
+bigIntegerDefault = integralDefault
+
+{- |
+  Builds a default value from a 'Double' field with double fields.
+-}
+doubleDefault :: Double -> DefaultValue Double
+doubleDefault d =
+  let decimalBytes =
+        LBS.toStrict
+          . BSB.toLazyByteString
+          . BSB.doubleDec
+          $ d
+   in if d < 0
+        then
+          DefaultValue . RawSql.unsafeFromRawSql $
+            RawSql.stringLiteral decimalBytes
+              <> RawSql.fromString "::numeric"
+        else DefaultValue . RawSql.unsafeFromRawSql . RawSql.fromBytes $ decimalBytes
+
+{- |
+  Builds a default value from a 'Bool', for use with boolean fields.
+-}
+booleanDefault :: Bool -> DefaultValue Bool
+booleanDefault bool =
+  let pgString =
+        case bool of
+          True -> "true"
+          False -> "false"
+   in DefaultValue . RawSql.unsafeFromRawSql . RawSql.fromString $ pgString
+
+{- |
+  Builds a default value from a 'T.Text', for use with unbounded, bounded
+  and fixed-length text fields.
+-}
+textDefault :: T.Text -> DefaultValue T.Text
+textDefault text =
+  DefaultValue . RawSql.unsafeFromRawSql $
+    RawSql.stringLiteral (TextEnc.encodeUtf8 text)
+      <> RawSql.fromString "::text"
+
+{- |
+  Builds a default value from a 'Time.Day' for use with date fields.
+-}
+dateDefault :: Time.Day -> DefaultValue Time.Day
+dateDefault day =
+  let pgText =
+        PgTime.dayToPostgreSQL day
+   in DefaultValue . RawSql.unsafeFromRawSql $
+        RawSql.stringLiteral pgText
+          <> RawSql.fromString "::date"
+
+{- |
+  Builds a default value that will default to the current date (i.e. the
+  date at which the database populates the default value on a given row).
+
+  For use with date fields.
+-}
+currentDateDefault :: DefaultValue Time.Day
+currentDateDefault =
+  DefaultValue
+    . RawSql.unsafeFromRawSql
+    . RawSql.fromString
+    $ "('now'::text)::date"
+
+{- |
+  Builds a default value from a 'Time.UTCTime' for use with utc timestamp fields.
+-}
+utcTimestampDefault :: Time.UTCTime -> DefaultValue Time.UTCTime
+utcTimestampDefault utcTime =
+  let pgText =
+        PgTime.utcTimeToPostgreSQL utcTime
+   in DefaultValue . RawSql.unsafeFromRawSql $
+        RawSql.stringLiteral pgText
+          <> RawSql.fromString "::timestamp with time zone"
+
+{- |
+  Builds a default value that will default to the current utc time (i.e. the
+  time at which the database populates the default value on a given row).
+
+  For use with utc timestamp fields.
+-}
+currentUTCTimestampDefault :: DefaultValue Time.UTCTime
+currentUTCTimestampDefault =
+  DefaultValue
+    . RawSql.unsafeFromRawSql
+    . RawSql.fromString
+    $ "now()"
+
+{- |
+  Builds a default value from a 'Time.LocalTime' for use with local timestamp fields.
+-}
+localTimestampDefault :: Time.LocalTime -> DefaultValue Time.LocalTime
+localTimestampDefault localTime =
+  let pgText =
+        PgTime.localTimeToPostgreSQL localTime
+   in DefaultValue
+        . RawSql.unsafeFromRawSql
+        $ RawSql.stringLiteral pgText
+          <> RawSql.fromString "::timestamp without time zone"
+
+{- |
+  Builds a default value that will default to the current local time (i.e. the
+  time at which the database populates the default value on a given row).
+
+  Note: "local" time here will be determined by the database itself, subject to
+  whatever timezone offset has been configured in its settings.
+
+  For use with local timestamp fields.
+-}
+currentLocalTimestampDefault :: DefaultValue Time.LocalTime
+currentLocalTimestampDefault =
+  DefaultValue
+    . RawSql.unsafeFromRawSql
+    . RawSql.fromString
+    $ "('now'::text)::timestamp without time zone"
+
+{- |
+  Coerce's a 'DefaultValue' so that it can be used with field definitions of
+  a different Haskell type. The coercion will always succeed, and is safe as
+  far as Haskell itself it concerned. As long as the 'DefaultValue' is used
+  with a column whose database type is the same as the one the 'DefaultValue'
+  was originally intended for, everything will work as expected.
+-}
+coerceDefaultValue :: DefaultValue a -> DefaultValue b
+coerceDefaultValue (DefaultValue expression) =
+  DefaultValue expression
+
+{- |
+  Returns database value expression for the default value
+-}
+defaultValueExpression :: DefaultValue a -> Expr.ValueExpression
+defaultValueExpression (DefaultValue expression) =
+  expression
+
+{- |
+  Constructs a default value from a 'ValueExpression'. You can use this
+  to construct default values for any SQL expression that Orville does not
+  support directly.
+
+  Note: If you are using auto migrations, the 'Expr.ValueExpression' that you
+  pass here must match what is returned by the PostgreSQL @pg_get_expr@
+  function. @pg_get_expr@ decompiles the compiled version of the default
+  experssion back to source text, sometimes in non-obvious ways. Orville's auto
+  migration compares expression given in the field definition with the
+  decompiled expression from the database to determine whether the default
+  value needs to be updated in the schema or not.  If the expression given by a
+  'DefaultValue' is logically equivalent but does not match the decompiled
+  form, auto migration will continue to execute SQL statements to update the
+  schema even when it does not need to.
+-}
+rawSqlDefault :: Expr.ValueExpression -> DefaultValue a
+rawSqlDefault =
+  DefaultValue

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr.hs
@@ -16,6 +16,7 @@ module Orville.PostgreSQL.Internal.Expr
     selectStar,
     selectColumns,
     selectDerivedColumns,
+    DerivedColumn,
     deriveColumn,
     deriveColumnAs,
     TableExpr,
@@ -106,6 +107,8 @@ module Orville.PostgreSQL.Internal.Expr
     ColumnConstraint,
     notNullConstraint,
     nullConstraint,
+    ColumnDefault,
+    columnDefault,
     OrderByClause,
     orderByClause,
     appendOrderByExpr,
@@ -130,6 +133,8 @@ module Orville.PostgreSQL.Internal.Expr
     addConstraint,
     dropConstraint,
     alterColumnType,
+    alterColumnSetDefault,
+    alterColumnDropDefault,
     UsingClause,
     usingCast,
     alterColumnNullability,
@@ -162,6 +167,10 @@ module Orville.PostgreSQL.Internal.Expr
     savepoint,
     ReleaseSavepointExpr,
     releaseSavepoint,
+    ValueExpression,
+    columnReference,
+    valueExpression,
+    rowValueConstructor,
   )
 where
 
@@ -180,4 +189,5 @@ import Orville.PostgreSQL.Internal.Expr.TableConstraint
 import Orville.PostgreSQL.Internal.Expr.TableDefinition
 import Orville.PostgreSQL.Internal.Expr.Transaction
 import Orville.PostgreSQL.Internal.Expr.Update
+import Orville.PostgreSQL.Internal.Expr.ValueExpression
 import Orville.PostgreSQL.Internal.Expr.Where

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/ReturningExpr.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/ReturningExpr.hs
@@ -6,15 +6,15 @@ module Orville.PostgreSQL.Internal.Expr.ReturningExpr
   )
 where
 
-import Orville.PostgreSQL.Internal.Expr.Name (ColumnName)
+import Orville.PostgreSQL.Internal.Expr.Query (SelectList)
 import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
 
 newtype ReturningExpr
   = ReturningExpr RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
-returningExpr :: [ColumnName] -> ReturningExpr
-returningExpr columns =
+returningExpr :: SelectList -> ReturningExpr
+returningExpr selectList =
   ReturningExpr $
     RawSql.fromString "RETURNING "
-      <> RawSql.intercalate RawSql.comma columns
+      <> RawSql.toRawSql selectList

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/TableDefinition.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/TableDefinition.hs
@@ -13,6 +13,8 @@ module Orville.PostgreSQL.Internal.Expr.TableDefinition
     addConstraint,
     dropConstraint,
     alterColumnType,
+    alterColumnSetDefault,
+    alterColumnDropDefault,
     UsingClause,
     usingCast,
     alterColumnNullability,
@@ -166,6 +168,31 @@ setNotNull =
 dropNotNull :: AlterNotNull
 dropNotNull =
   AlterNotNull $ RawSql.fromString "DROP NOT NULL"
+
+alterColumnDropDefault :: ColumnName -> AlterTableAction
+alterColumnDropDefault columnName =
+  AlterTableAction $
+    RawSql.intercalate
+      RawSql.space
+      [ RawSql.fromString "ALTER COLUMN"
+      , RawSql.toRawSql columnName
+      , RawSql.fromString "DROP DEFAULT"
+      ]
+
+alterColumnSetDefault ::
+  RawSql.SqlExpression valueExpression =>
+  ColumnName ->
+  valueExpression ->
+  AlterTableAction
+alterColumnSetDefault columnName defaultValue =
+  AlterTableAction $
+    RawSql.intercalate
+      RawSql.space
+      [ RawSql.fromString "ALTER COLUMN"
+      , RawSql.toRawSql columnName
+      , RawSql.fromString "SET DEFAULT"
+      , RawSql.toRawSql defaultValue
+      ]
 
 newtype DropTableExpr
   = DropTableExpr RawSql.RawSql

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/ValueExpression.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/ValueExpression.hs
@@ -1,12 +1,12 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 {- |
-Module    : Orville.PostgreSQL.Expr.Where.RowValueExpression
+Module    : Orville.PostgreSQL.Expr.Where.ValueExpression
 Copyright : Flipstone Technology Partners 2016-2021
 License   : MIT
 -}
-module Orville.PostgreSQL.Internal.Expr.Where.RowValueExpression
-  ( RowValueExpression,
+module Orville.PostgreSQL.Internal.Expr.ValueExpression
+  ( ValueExpression,
     columnReference,
     valueExpression,
     rowValueConstructor,
@@ -19,18 +19,18 @@ import Orville.PostgreSQL.Internal.Expr.Name (ColumnName)
 import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
 import Orville.PostgreSQL.Internal.SqlValue (SqlValue)
 
-newtype RowValueExpression = RowValueExpression RawSql.RawSql
+newtype ValueExpression = ValueExpression RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
-columnReference :: ColumnName -> RowValueExpression
-columnReference = RowValueExpression . RawSql.toRawSql
+columnReference :: ColumnName -> ValueExpression
+columnReference = ValueExpression . RawSql.toRawSql
 
-valueExpression :: SqlValue -> RowValueExpression
-valueExpression = RowValueExpression . RawSql.parameter
+valueExpression :: SqlValue -> ValueExpression
+valueExpression = ValueExpression . RawSql.parameter
 
-rowValueConstructor :: NE.NonEmpty RowValueExpression -> RowValueExpression
+rowValueConstructor :: NE.NonEmpty ValueExpression -> ValueExpression
 rowValueConstructor elements =
-  RowValueExpression $
+  ValueExpression $
     RawSql.leftParen
       <> RawSql.intercalate RawSql.comma elements
       <> RawSql.rightParen

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/Where/BooleanExpr.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/Where/BooleanExpr.hs
@@ -31,8 +31,8 @@ where
 
 import qualified Data.List.NonEmpty as NE
 import Orville.PostgreSQL.Internal.Expr.Name (ColumnName)
+import Orville.PostgreSQL.Internal.Expr.ValueExpression (ValueExpression, columnReference, rowValueConstructor, valueExpression)
 import Orville.PostgreSQL.Internal.Expr.Where.ComparisonOperator (ComparisonOperator, equalsOp, greaterThanOp, greaterThanOrEqualsOp, lessThanOp, lessThanOrEqualsOp, notEqualsOp)
-import Orville.PostgreSQL.Internal.Expr.Where.RowValueExpression (RowValueExpression, columnReference, rowValueConstructor, valueExpression)
 import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
 import Orville.PostgreSQL.Internal.SqlValue (SqlValue)
 
@@ -84,14 +84,14 @@ columnTupleNotIn columnNames valueLists =
     (rowValueConstructor $ fmap columnReference columnNames)
     (inValueList $ fmap (rowValueConstructor . fmap valueExpression) valueLists)
 
-inPredicate :: RowValueExpression -> InValuePredicate -> BooleanExpr
+inPredicate :: ValueExpression -> InValuePredicate -> BooleanExpr
 inPredicate predicand predicate =
   BooleanExpr $
     RawSql.toRawSql predicand
       <> RawSql.fromString " IN "
       <> RawSql.toRawSql predicate
 
-notInPredicate :: RowValueExpression -> InValuePredicate -> BooleanExpr
+notInPredicate :: ValueExpression -> InValuePredicate -> BooleanExpr
 notInPredicate predicand predicate =
   BooleanExpr $
     RawSql.toRawSql predicand
@@ -102,7 +102,7 @@ newtype InValuePredicate
   = InValuePredicate RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
-inValueList :: NE.NonEmpty RowValueExpression -> InValuePredicate
+inValueList :: NE.NonEmpty ValueExpression -> InValuePredicate
 inValueList values =
   InValuePredicate $
     RawSql.leftParen
@@ -115,9 +115,9 @@ parenthesized expr =
     RawSql.leftParen <> RawSql.toRawSql expr <> RawSql.rightParen
 
 comparison ::
-  RowValueExpression ->
+  ValueExpression ->
   ComparisonOperator ->
-  RowValueExpression ->
+  ValueExpression ->
   BooleanExpr
 comparison left op right =
   BooleanExpr $

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/PgTextFormatValue.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/PgTextFormatValue.hs
@@ -1,5 +1,5 @@
-module Orville.PostgreSQL.Internal.PGTextFormatValue
-  ( PGTextFormatValue,
+module Orville.PostgreSQL.Internal.PgTextFormatValue
+  ( PgTextFormatValue,
     NULByteFoundError (NULByteFoundError),
     unsafeFromByteString,
     fromByteString,
@@ -12,15 +12,15 @@ import Control.Exception (Exception)
 import qualified Data.ByteString as BS
 
 {- |
-  A 'PGTextFormatValue' represents raw bytes that will be passed to postgresql
+  A 'PgTextFormatValue' represents raw bytes that will be passed to postgresql
   via libpq. These bytes must conform to the TEXT format of values that
   postgresql expects. In all cases postgresql will be allowed to infer the type
   of the value based on its usage in the query.
 
   Note that postgresql does not allow NUL bytes in text values, and the LibPQ C
   library expects text values to be given as NULL-terminated C Strings, so
-  '\NUL' bytes cannot be included in a 'PGTextFormatValue'. If 'fromByteString'
-  is used to construct the 'PGTextFormatValue' (normally what you should do),
+  '\NUL' bytes cannot be included in a 'PgTextFormatValue'. If 'fromByteString'
+  is used to construct the 'PgTextFormatValue' (normally what you should do),
   an error will be raised before libpq is called to execute the query. If
   'unsafeFromByteString' is used, the caller is expected to ensure that no
   '\NUL' bytes are present. If a '\NUL' byte is included with
@@ -28,12 +28,12 @@ import qualified Data.ByteString as BS
   the '\NUL' byte because it will be interpreted as the end of the C String by
   libpq.
 -}
-data PGTextFormatValue
+data PgTextFormatValue
   = NoAssumptionsMade BS.ByteString
   | AssumedToHaveNoNULValues BS.ByteString
   deriving (Show)
 
-instance Eq PGTextFormatValue where
+instance Eq PgTextFormatValue where
   left == right =
     toBytesForLibPQ left == toBytesForLibPQ right
 
@@ -44,7 +44,7 @@ data NULByteFoundError
 instance Exception NULByteFoundError
 
 {- |
-  Constructs a 'PGTextFormatValue' from the given bytes directly, without checking
+  Constructs a 'PgTextFormatValue' from the given bytes directly, without checking
   whether any of the bytes are '\NUL' or not. If a 'BS.ByteString' containing
   a '\NUL' byte is given, the value will be truncated at the '\NUL' when it
   is passed to libpq.
@@ -53,25 +53,25 @@ instance Exception NULByteFoundError
   in a way that guarantees no '\NUL' bytes are present, such as when serializing
   an integer value to its decimal representation.
 -}
-unsafeFromByteString :: BS.ByteString -> PGTextFormatValue
+unsafeFromByteString :: BS.ByteString -> PgTextFormatValue
 unsafeFromByteString =
   AssumedToHaveNoNULValues
 
 {- |
-  Constructs a 'PGTextFormatValue' from the given bytes, which will be checked
+  Constructs a 'PgTextFormatValue' from the given bytes, which will be checked
   to ensure none of them are '\NUL' before being passed to libpq. If a '\NUL'
   byte is found an error will be raised.
 -}
-fromByteString :: BS.ByteString -> PGTextFormatValue
+fromByteString :: BS.ByteString -> PgTextFormatValue
 fromByteString =
   NoAssumptionsMade
 
 {- |
-  Converts the 'PGTextFormatValue' to bytes intended to be passed to libpq.
+  Converts the 'PgTextFormatValue' to bytes intended to be passed to libpq.
   If any '\NUL' bytes are found, 'NULByteErrorFound' will be returned (unless
   'unsafeFromByteString' was used to construct the value).
 -}
-toBytesForLibPQ :: PGTextFormatValue -> Either NULByteFoundError BS.ByteString
+toBytesForLibPQ :: PgTextFormatValue -> Either NULByteFoundError BS.ByteString
 toBytesForLibPQ value =
   case value of
     AssumedToHaveNoNULValues noNULBytes ->
@@ -82,11 +82,11 @@ toBytesForLibPQ value =
         else Right anyBytes
 
 {- |
-  Convents the 'PGTextFormatValue' back to the bytes that were used to
+  Convents the 'PgTextFormatValue' back to the bytes that were used to
   construct it, losing the information about whether it would be checked
   for '\NUL' bytes or not.
 -}
-toByteString :: PGTextFormatValue -> BS.ByteString
+toByteString :: PgTextFormatValue -> BS.ByteString
 toByteString value =
   case value of
     AssumedToHaveNoNULValues bytes ->

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/PgTime.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/PgTime.hs
@@ -1,0 +1,95 @@
+module Orville.PostgreSQL.Internal.PgTime
+  ( dayToPostgreSQL,
+    dayFromPostgreSQL,
+    utcTimeToPostgreSQL,
+    utcTimeFromPostgreSQL,
+    localTimeToPostgreSQL,
+    localTimeFromPostgreSQL,
+  )
+where
+
+import Control.Applicative ((<|>))
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TextEnc
+import qualified Data.Time as Time
+
+{- |
+  Renders a 'Time.Day' value to a textual representation for PostgreSQL
+-}
+dayToPostgreSQL :: Time.Day -> B8.ByteString
+dayToPostgreSQL =
+  B8.pack . Time.showGregorian
+
+{- |
+  Parses a 'Time.Day' from a PostgreSQL textual representation. Returns
+  'Nothing' if the parsing fails.
+-}
+dayFromPostgreSQL :: B8.ByteString -> Maybe Time.Day
+dayFromPostgreSQL bytes = do
+  txt <-
+    case TextEnc.decodeUtf8' bytes of
+      Right t -> Just t
+      Left _ -> Nothing
+
+  Time.parseTimeM
+    False
+    Time.defaultTimeLocale
+    (Time.iso8601DateFormat Nothing)
+    (T.unpack txt)
+
+{- |
+  Renders a 'Time.UTCTime' value to a textual representation for PostgreSQL
+-}
+utcTimeToPostgreSQL :: Time.UTCTime -> B8.ByteString
+utcTimeToPostgreSQL =
+  B8.pack . Time.formatTime Time.defaultTimeLocale "%0Y-%m-%d %H:%M:%S+00"
+
+{- |
+  Parses a 'Time.UTCTime' from a PostgreSQL textual representation. Returns
+  'Nothing' if the parsing fails.
+-}
+utcTimeFromPostgreSQL :: B8.ByteString -> Maybe Time.UTCTime
+utcTimeFromPostgreSQL bytes = do
+  -- N.B. There are dragons here... Notably the iso8601DateFormat (at least as of time-1.9.x)
+  -- However PostgreSQL adheres to a different version of the standard which ommitted the 'T' and instead used a space.
+  -- Further... PostgreSQL uses the short format for the UTC offset and the haskell library does not support this.
+  -- Leading to the ugly hacks below.
+  txt <-
+    case TextEnc.decodeUtf8' bytes of
+      Right t -> Just t
+      Left _ -> Nothing
+
+  let parseTime = Time.parseTimeM False Time.defaultTimeLocale
+      unTxt = T.unpack txt
+
+  parseTime "%F %T%Q%Z" (unTxt <> "00")
+    <|> parseTime "%F %T%Z" (unTxt <> "00")
+
+{- |
+  Renders a 'Time.LocalTime value to a textual representation for PostgreSQL
+-}
+localTimeToPostgreSQL :: Time.LocalTime -> B8.ByteString
+localTimeToPostgreSQL =
+  B8.pack . Time.formatTime Time.defaultTimeLocale "%0Y-%m-%d %H:%M:%S"
+
+{- |
+  Parses a 'Time.LocalTime' from a PostgreSQL textual representation. Returns
+  'Nothing' if the parsing fails.
+-}
+localTimeFromPostgreSQL :: B8.ByteString -> Maybe Time.LocalTime
+localTimeFromPostgreSQL bytes = do
+  -- N.B. There are dragons here... Notably the iso8601DateFormat (at least as of time-1.9.x)
+  -- However PostgreSQL adheres to a different version of the standard which ommitted the 'T' and instead used a space.
+  -- Further... PostgreSQL uses the short format for the UTC offset and the haskell library does not support this.
+  -- Leading to the ugly hacks below.
+  txt <-
+    case TextEnc.decodeUtf8' bytes of
+      Right t -> Just t
+      Left _ -> Nothing
+
+  let parseTime = Time.parseTimeM False Time.defaultTimeLocale
+      unTxt = T.unpack txt
+
+  parseTime "%F %T%Q" unTxt
+    <|> parseTime "%F %T" unTxt

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Select.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Select.hs
@@ -15,7 +15,7 @@ import qualified Orville.PostgreSQL.Internal.Execute as Execute
 import qualified Orville.PostgreSQL.Internal.Expr as Expr
 import qualified Orville.PostgreSQL.Internal.MonadOrville as MonadOrville
 import qualified Orville.PostgreSQL.Internal.SelectOptions as SelectOptions
-import Orville.PostgreSQL.Internal.SqlMarshaller (ReadOnlyColumnOption (IncludeReadOnlyColumns), SqlMarshaller, marshallerColumnNames)
+import Orville.PostgreSQL.Internal.SqlMarshaller (SqlMarshaller, marshallerDerivedColumns)
 import Orville.PostgreSQL.Internal.TableDefinition (TableDefinition, tableMarshaller, tableName)
 
 {- |
@@ -71,7 +71,7 @@ selectMarshalledColumns ::
   Select readEntity
 selectMarshalledColumns marshaller =
   selectSelectList
-    (Expr.selectColumns (marshallerColumnNames IncludeReadOnlyColumns marshaller))
+    (Expr.selectDerivedColumns (marshallerDerivedColumns marshaller))
     marshaller
 
 {- |

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/SqlType.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/SqlType.hs
@@ -11,7 +11,8 @@ module Orville.PostgreSQL.Internal.SqlType
         sqlTypeOid,
         sqlTypeMaximumLength,
         sqlTypeToSql,
-        sqlTypeFromSql
+        sqlTypeFromSql,
+        sqlTypeDontDropImplicitDefaultDuringMigrate
       ),
     -- numeric types
     integer,
@@ -78,6 +79,11 @@ data SqlType a = SqlType
     -- an error if the conversion is impossible. Otherwise it should return
     -- 'Just' the corresponding 'a' value.
     sqlTypeFromSql :: SqlValue -> Maybe a
+  , -- | The SERIAL and BIGSERIAL PostgreSQL types are really pesudo types that
+    -- create an implicit default value. This flag tells Orville's auto
+    -- migration logic to ignore the default value rather than drop it as it
+    -- normally would.
+    sqlTypeDontDropImplicitDefaultDuringMigrate :: Bool
   }
 
 {- |
@@ -92,6 +98,7 @@ integer =
     , sqlTypeMaximumLength = Nothing
     , sqlTypeToSql = SqlValue.fromInt32
     , sqlTypeFromSql = SqlValue.toInt32
+    , sqlTypeDontDropImplicitDefaultDuringMigrate = False
     }
 
 {- |
@@ -107,6 +114,7 @@ serial =
     , sqlTypeMaximumLength = Nothing
     , sqlTypeToSql = SqlValue.fromInt32
     , sqlTypeFromSql = SqlValue.toInt32
+    , sqlTypeDontDropImplicitDefaultDuringMigrate = True
     }
 
 {- |
@@ -122,6 +130,7 @@ bigInteger =
     , sqlTypeMaximumLength = Nothing
     , sqlTypeToSql = SqlValue.fromInt64
     , sqlTypeFromSql = SqlValue.toInt64
+    , sqlTypeDontDropImplicitDefaultDuringMigrate = False
     }
 
 {- |
@@ -137,6 +146,7 @@ bigSerial =
     , sqlTypeMaximumLength = Nothing
     , sqlTypeToSql = SqlValue.fromInt64
     , sqlTypeFromSql = SqlValue.toInt64
+    , sqlTypeDontDropImplicitDefaultDuringMigrate = True
     }
 
 {- |
@@ -151,6 +161,7 @@ smallInteger =
     , sqlTypeMaximumLength = Nothing
     , sqlTypeToSql = SqlValue.fromInt16
     , sqlTypeFromSql = SqlValue.toInt16
+    , sqlTypeDontDropImplicitDefaultDuringMigrate = False
     }
 
 {- |
@@ -166,6 +177,7 @@ double =
     , sqlTypeMaximumLength = Nothing
     , sqlTypeToSql = SqlValue.fromDouble
     , sqlTypeFromSql = SqlValue.toDouble
+    , sqlTypeDontDropImplicitDefaultDuringMigrate = False
     }
 
 {- |
@@ -181,6 +193,7 @@ boolean =
     , sqlTypeMaximumLength = Nothing
     , sqlTypeToSql = SqlValue.fromBool
     , sqlTypeFromSql = SqlValue.toBool
+    , sqlTypeDontDropImplicitDefaultDuringMigrate = False
     }
 
 {- |
@@ -196,6 +209,7 @@ unboundedText =
     , sqlTypeMaximumLength = Nothing
     , sqlTypeToSql = SqlValue.fromText
     , sqlTypeFromSql = SqlValue.toText
+    , sqlTypeDontDropImplicitDefaultDuringMigrate = False
     }
 
 {- |
@@ -211,6 +225,7 @@ fixedText len =
     , sqlTypeMaximumLength = Just len
     , sqlTypeToSql = SqlValue.fromText
     , sqlTypeFromSql = SqlValue.toText
+    , sqlTypeDontDropImplicitDefaultDuringMigrate = False
     }
 
 {- |
@@ -226,6 +241,7 @@ boundedText len =
     , sqlTypeMaximumLength = Just len
     , sqlTypeToSql = SqlValue.fromText
     , sqlTypeFromSql = SqlValue.toText
+    , sqlTypeDontDropImplicitDefaultDuringMigrate = False
     }
 
 {- |
@@ -241,6 +257,7 @@ textSearchVector =
     , sqlTypeMaximumLength = Nothing
     , sqlTypeToSql = SqlValue.fromText
     , sqlTypeFromSql = SqlValue.toText
+    , sqlTypeDontDropImplicitDefaultDuringMigrate = False
     }
 
 {- |
@@ -256,6 +273,7 @@ date =
     , sqlTypeMaximumLength = Nothing
     , sqlTypeToSql = SqlValue.fromDay
     , sqlTypeFromSql = SqlValue.toDay
+    , sqlTypeDontDropImplicitDefaultDuringMigrate = False
     }
 
 {- |
@@ -277,6 +295,7 @@ timestamp =
     , sqlTypeMaximumLength = Nothing
     , sqlTypeToSql = SqlValue.fromUTCTime
     , sqlTypeFromSql = SqlValue.toUTCTime
+    , sqlTypeDontDropImplicitDefaultDuringMigrate = False
     }
 
 {- |
@@ -294,6 +313,7 @@ timestampWithoutZone =
     , sqlTypeMaximumLength = Nothing
     , sqlTypeToSql = SqlValue.fromLocalTime
     , sqlTypeFromSql = SqlValue.toLocalTime
+    , sqlTypeDontDropImplicitDefaultDuringMigrate = False
     }
 
 {- |
@@ -309,6 +329,7 @@ oid =
     , sqlTypeMaximumLength = Nothing
     , sqlTypeToSql = \(LibPQ.Oid (CTypes.CUInt word)) -> SqlValue.fromWord32 word
     , sqlTypeFromSql = fmap (LibPQ.Oid . CTypes.CUInt) . SqlValue.toWord32
+    , sqlTypeDontDropImplicitDefaultDuringMigrate = False
     }
 
 {- |

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/SyntheticField.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/SyntheticField.hs
@@ -1,0 +1,79 @@
+module Orville.PostgreSQL.Internal.SyntheticField
+  ( SyntheticField,
+    syntheticFieldExpression,
+    syntheticFieldAlias,
+    syntheticFieldValueFromSqlValue,
+    syntheticField,
+    nullableSyntheticField,
+  )
+where
+
+import qualified Orville.PostgreSQL.Internal.Expr as Expr
+import Orville.PostgreSQL.Internal.FieldDefinition (FieldName, stringToFieldName)
+import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
+
+{- |
+  A 'SyntheticField' can be used to evaluate a SQL expression based on the
+  columns of a table when records are selected from the database. Synthetic
+  fields are inherently read-only.
+-}
+data SyntheticField a = SyntheticField
+  { _syntheticFieldExpression :: Expr.ValueExpression
+  , _syntheticFieldAlias :: FieldName
+  , _syntheticFieldValueFromSqlValue :: SqlValue.SqlValue -> Maybe a
+  }
+
+{- |
+  Returns the SQL expression that should be in with select statements to
+  calculated the sythetic field.
+-}
+syntheticFieldExpression :: SyntheticField a -> Expr.ValueExpression
+syntheticFieldExpression =
+  _syntheticFieldExpression
+
+{- |
+  Returns the alias that should be used in select statements to name the
+  the synthetic field.
+-}
+syntheticFieldAlias :: SyntheticField a -> FieldName
+syntheticFieldAlias =
+  _syntheticFieldAlias
+
+{- |
+  Decodes a calculated value selected from the database to its expected
+  Haskell type. Returns 'Nothing' if the decoding fails.
+-}
+syntheticFieldValueFromSqlValue :: SyntheticField a -> SqlValue.SqlValue -> Maybe a
+syntheticFieldValueFromSqlValue =
+  _syntheticFieldValueFromSqlValue
+
+{- |
+  Constructs a 'SyntheticField' that will select a SQL expression using
+  the given alias.
+-}
+syntheticField ::
+  -- | The SQL expression to be selected
+  Expr.ValueExpression ->
+  -- | The alias to be used to name the calculation in SQL experios
+  String ->
+  -- | A function to decode the expression result from a 'SqlValue.SqlValue'
+  (SqlValue.SqlValue -> Maybe a) ->
+  SyntheticField a
+syntheticField expression alias fromSqlValue =
+  SyntheticField
+    { _syntheticFieldExpression = expression
+    , _syntheticFieldAlias = stringToFieldName alias
+    , _syntheticFieldValueFromSqlValue = fromSqlValue
+    }
+
+{- |
+  Modifies a 'SyntheticField' to allow it to decode @NULL@ values.
+-}
+nullableSyntheticField :: SyntheticField a -> SyntheticField (Maybe a)
+nullableSyntheticField synthField =
+  synthField
+    { _syntheticFieldValueFromSqlValue = \sqlValue ->
+        if SqlValue.isSqlNull sqlValue
+          then Just Nothing
+          else Just <$> syntheticFieldValueFromSqlValue synthField sqlValue
+    }

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/PgCatalog.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/PgCatalog.hs
@@ -8,6 +8,7 @@ where
 import Orville.PostgreSQL.PgCatalog.DatabaseDescription as Export
 import Orville.PostgreSQL.PgCatalog.OidField as Export
 import Orville.PostgreSQL.PgCatalog.PgAttribute as Export
+import Orville.PostgreSQL.PgCatalog.PgAttributeDefault as Export
 import Orville.PostgreSQL.PgCatalog.PgClass as Export
 import Orville.PostgreSQL.PgCatalog.PgConstraint as Export
 import Orville.PostgreSQL.PgCatalog.PgIndex as Export

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/PgCatalog/PgAttribute.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/PgCatalog/PgAttribute.hs
@@ -7,6 +7,7 @@ module Orville.PostgreSQL.PgCatalog.PgAttribute
     attributeNameToString,
     AttributeNumber,
     attributeNumberToInt16,
+    attributeNumberFromInt16,
     attributeNumberTextBuilder,
     attributeNumberParser,
     isOrdinaryColumn,
@@ -16,6 +17,7 @@ module Orville.PostgreSQL.PgCatalog.PgAttribute
     attributeTypeOidField,
     attributeLengthField,
     attributeIsDroppedField,
+    attributeNumberTypeField,
   )
 where
 
@@ -128,6 +130,12 @@ attributeNumberToInt16 :: AttributeNumber -> Int16
 attributeNumberToInt16 (AttributeNumber int) = int
 
 {- |
+  Converts an integer to an 'AttributeNumber'
+-}
+attributeNumberFromInt16 :: Int16 -> AttributeNumber
+attributeNumberFromInt16 = AttributeNumber
+
+{- |
   Attoparsec parser for 'AttributeNumber'
 -}
 attributeNumberParser :: AttoText.Parser AttributeNumber
@@ -184,8 +192,14 @@ attributeNameField =
 -}
 attributeNumberField :: Orville.FieldDefinition Orville.NotNull AttributeNumber
 attributeNumberField =
-  Orville.coerceField $
-    Orville.smallIntegerField "attnum"
+  attributeNumberTypeField "attnum"
+
+{- |
+  Builds a 'Orville.FieldDefinition' for a field with type 'AttributeNumber'
+-}
+attributeNumberTypeField :: String -> Orville.FieldDefinition Orville.NotNull AttributeNumber
+attributeNumberTypeField =
+  Orville.coerceField . Orville.smallIntegerField
 
 {- |
   The @atttypid@ column of the @pg_catalog.pg_attribute@ table

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/PgCatalog/PgAttributeDefault.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/PgCatalog/PgAttributeDefault.hs
@@ -1,0 +1,79 @@
+module Orville.PostgreSQL.PgCatalog.PgAttributeDefault
+  ( PgAttributeDefault (..),
+    pgAttributeDefaultTable,
+    attributeDefaultRelationOidField,
+  )
+where
+
+import qualified Data.Text as T
+import qualified Database.PostgreSQL.LibPQ as LibPQ
+
+import qualified Orville.PostgreSQL as Orville
+import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
+import Orville.PostgreSQL.PgCatalog.OidField (oidField, oidTypeField)
+import Orville.PostgreSQL.PgCatalog.PgAttribute (AttributeNumber, attributeNumberTypeField)
+
+{- |
+  The Haskell representation of data read from the @pg_catalog.pg_attrdef@
+  table.
+-}
+data PgAttributeDefault = PgAttributeDefault
+  { -- | The PostgreSQL @oid@ for the default value
+    pgAttributeDefaultOid :: LibPQ.Oid
+  , -- | The PostgreSQL @oid@ for the relation that this
+    -- attribute belongs to. References @pg_class.oid@
+    pgAttributeDefaultRelationOid :: LibPQ.Oid
+  , -- | The PostgreSQL attribute number for the column that this
+    -- default belongs to. References @pg_attribute.attnum@.
+    pgAttributeDefaultAttributeNumber :: AttributeNumber
+  , -- | The PostgreSQL default value expression, as decompiled from the
+    -- @adbin@ column using the PostgreSQL @pg_get_expr@ function.
+    pgAttributeDefaultExpression :: T.Text
+  }
+
+{- |
+  An Orville 'Orville.TableDefinition' for querying the
+  @pg_catalog.pg_attrdef@ table
+-}
+pgAttributeDefaultTable :: Orville.TableDefinition Orville.NoKey PgAttributeDefault PgAttributeDefault
+pgAttributeDefaultTable =
+  Orville.setTableSchema "pg_catalog" $
+    Orville.mkTableDefinitionWithoutKey
+      "pg_attrdef"
+      pgAttributeDefaultMarshaller
+
+pgAttributeDefaultMarshaller :: Orville.SqlMarshaller PgAttributeDefault PgAttributeDefault
+pgAttributeDefaultMarshaller =
+  PgAttributeDefault
+    <$> Orville.marshallField pgAttributeDefaultOid oidField
+    <*> Orville.marshallField pgAttributeDefaultRelationOid attributeDefaultRelationOidField
+    <*> Orville.marshallField pgAttributeDefaultAttributeNumber attributeDefaultAttributeNumberField
+    <*> Orville.marshallSyntheticField attributeDefaultExpressionField
+
+{- |
+  The @adrelid@ column of the @pg_catalog.pg_attrdef@ table
+-}
+attributeDefaultRelationOidField :: Orville.FieldDefinition Orville.NotNull LibPQ.Oid
+attributeDefaultRelationOidField =
+  oidTypeField "adrelid"
+
+{- |
+  The @adnum@ column of the @pg_catalog.pg_attrdef@ table
+-}
+attributeDefaultAttributeNumberField :: Orville.FieldDefinition Orville.NotNull AttributeNumber
+attributeDefaultAttributeNumberField =
+  attributeNumberTypeField "adnum"
+
+{- |
+  A syntheticField for selecting the default expression by decompling the
+  @adbin@ column of the @pg_catalog.pg_attrdef@ table. The @pg_node_tree@ found
+  in the column is decompiled by selecting the expression
+  @pg_get_expr(adbin,adrelid)@.
+-}
+attributeDefaultExpressionField :: Orville.SyntheticField T.Text
+attributeDefaultExpressionField =
+  Orville.syntheticField
+    (RawSql.unsafeFromRawSql $ RawSql.fromString "pg_get_expr(adbin,adrelid)")
+    "expression"
+    SqlValue.toText

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Plan/Operation.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Plan/Operation.hs
@@ -464,7 +464,7 @@ selectOperation selectOp =
 
 explainSelect :: Select row -> Exp.Explanation
 explainSelect =
-  Exp.explainStep . BS8.unpack . RawSql.toBytes . Select.selectToQueryExpr
+  Exp.explainStep . BS8.unpack . RawSql.toExampleBytes . Select.selectToQueryExpr
 
 {- |
   'runSelectOne' is an internal helper function that executes a

--- a/orville-postgresql-libpq/test/Test/Connection.hs
+++ b/orville-postgresql-libpq/test/Test/Connection.hs
@@ -16,7 +16,7 @@ import qualified Hedgehog as HH
 import qualified Hedgehog.Range as Range
 
 import qualified Orville.PostgreSQL.Connection as Connection
-import qualified Orville.PostgreSQL.Internal.PGTextFormatValue as PGTextFormatValue
+import qualified Orville.PostgreSQL.Internal.PgTextFormatValue as PgTextFormatValue
 
 import qualified Test.PgGen as PgGen
 import qualified Test.Property as Property
@@ -38,8 +38,8 @@ connectionTests pool =
                 Connection.executeRaw
                   connection
                   (B8.pack "SELECT $1::text = $2::text")
-                  [ Just $ PGTextFormatValue.fromByteString notNulBytes
-                  , Just $ PGTextFormatValue.unsafeFromByteString notNulBytes
+                  [ Just $ PgTextFormatValue.fromByteString notNulBytes
+                  , Just $ PgTextFormatValue.unsafeFromByteString notNulBytes
                   ]
 
               LibPQ.getvalue' result 0 0
@@ -64,11 +64,11 @@ connectionTests pool =
               Connection.executeRaw
                 connection
                 (B8.pack "SELECT $1::text")
-                [ Just $ PGTextFormatValue.fromByteString bytesWithNul
+                [ Just $ PgTextFormatValue.fromByteString bytesWithNul
                 ]
 
           case result of
-            Left PGTextFormatValue.NULByteFoundError ->
+            Left PgTextFormatValue.NULByteFoundError ->
               HH.success
             Right _ -> do
               HH.footnote "Expected 'executeRaw' to return failure, but it did not"
@@ -96,7 +96,7 @@ connectionTests pool =
                 Connection.executeRaw
                   connection
                   (B8.pack "SELECT $1::text")
-                  [ Just $ PGTextFormatValue.unsafeFromByteString bytesWithNul
+                  [ Just $ PgTextFormatValue.unsafeFromByteString bytesWithNul
                   ]
 
               LibPQ.getvalue' result 0 0

--- a/orville-postgresql-libpq/test/Test/Expr/InsertUpdateDelete.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/InsertUpdateDelete.hs
@@ -65,7 +65,7 @@ prop_insertExprWithReturning =
                 fooBarTable
                 Nothing
                 (insertFooBarSource fooBars)
-                (Just $ Expr.returningExpr [fooColumn, barColumn])
+                (Just $ Expr.returningExpr $ Expr.selectColumns [fooColumn, barColumn])
 
           ExecResult.readRows result
 
@@ -140,7 +140,7 @@ prop_updateExprWithReturning =
             fooBarTable
             (Expr.setClauseList [Expr.setColumn barColumn (SqlValue.fromText (T.pack "ferret"))])
             Nothing
-            (Just $ Expr.returningExpr [fooColumn, barColumn])
+            (Just $ Expr.returningExpr $ Expr.selectColumns [fooColumn, barColumn])
 
     rows <-
       MIO.liftIO $
@@ -220,7 +220,7 @@ prop_deleteExprWithReturning =
           Expr.deleteExpr
             fooBarTable
             Nothing
-            (Just $ Expr.returningExpr [fooColumn, barColumn])
+            (Just $ Expr.returningExpr $ Expr.selectColumns [fooColumn, barColumn])
 
     rows <-
       MIO.liftIO $

--- a/orville-postgresql-libpq/test/Test/Expr/TableDefinition.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/TableDefinition.hs
@@ -84,6 +84,7 @@ column1Definition =
     (Expr.columnName column1NameString)
     Expr.text
     Nothing
+    Nothing
 
 column1NameString :: String
 column1NameString =
@@ -94,6 +95,7 @@ column2Definition =
   Expr.columnDefinition
     (Expr.columnName column2NameString)
     Expr.text
+    Nothing
     Nothing
 
 column2NameString :: String

--- a/orville-postgresql-libpq/test/Test/PgAssert.hs
+++ b/orville-postgresql-libpq/test/Test/PgAssert.hs
@@ -3,6 +3,7 @@ module Test.PgAssert
     assertTableExistsInSchema,
     assertColumnNamesEqual,
     assertColumnExists,
+    assertColumnDefaultExists,
     assertColumnDefaultMatches,
     assertUniqueConstraintExists,
     assertForeignKeyConstraintExists,
@@ -85,6 +86,24 @@ assertColumnExists relationDesc columnName = do
         HH.failure
     Just attr ->
       pure attr
+
+assertColumnDefaultExists ::
+  (HH.MonadTest m, HasCallStack) =>
+  PgCatalog.RelationDescription ->
+  String ->
+  m ()
+assertColumnDefaultExists relationDesc columnName = do
+  attr <- assertColumnExists relationDesc columnName
+
+  let actualDefault = PgCatalog.lookupAttributeDefault attr relationDesc
+
+  withFrozenCallStack $
+    case actualDefault of
+      Nothing -> do
+        HH.annotate $ columnName <> " expected to have a default, but it did not"
+        HH.failure
+      Just _ ->
+        pure ()
 
 assertColumnDefaultMatches ::
   (HH.MonadTest m, HasCallStack) =>

--- a/orville-postgresql-libpq/test/Test/PgGen.hs
+++ b/orville-postgresql-libpq/test/Test/PgGen.hs
@@ -3,11 +3,15 @@ module Test.PgGen
     pgDouble,
     pgInt32,
     pgIdentifier,
+    pgUTCTime,
+    pgLocalTime,
+    pgDay,
   )
 where
 
 import Data.Int (Int32)
 import qualified Data.Text as T
+import qualified Data.Time as Time
 import qualified Hedgehog as HH
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
@@ -44,3 +48,26 @@ pgIdentifierChars =
     <> ['A' .. 'Z']
     <> ['0' .. '9']
     <> "{}[]()<>!?:;_~^'%&"
+
+pgUTCTime :: HH.Gen Time.UTCTime
+pgUTCTime =
+  Time.UTCTime <$> pgDay <*> pgDiffTime
+
+pgLocalTime :: HH.Gen Time.LocalTime
+pgLocalTime =
+  Time.LocalTime <$> pgDay <*> pgTimeOfDay
+
+pgDay :: HH.Gen Time.Day
+pgDay = do
+  year <- Gen.integral (Range.linearFrom 2000 0 3000)
+  month <- Gen.integral (Range.constant 1 12)
+  day <- Gen.integral (Range.constant 1 (Time.gregorianMonthLength year month))
+
+  pure (Time.fromGregorian year month day)
+
+pgTimeOfDay :: HH.Gen Time.TimeOfDay
+pgTimeOfDay = fmap Time.timeToTimeOfDay pgDiffTime
+
+pgDiffTime :: HH.Gen Time.DiffTime
+pgDiffTime =
+  Time.secondsToDiffTime <$> Gen.integral (Range.constant 0 85399)

--- a/orville-postgresql-libpq/test/Test/RawSql.hs
+++ b/orville-postgresql-libpq/test/Test/RawSql.hs
@@ -4,11 +4,11 @@ module Test.RawSql
 where
 
 import qualified Data.ByteString.Char8 as B8
-import qualified Data.String as String
+import Data.Functor.Identity (runIdentity)
 import qualified Data.Text as T
 import qualified Hedgehog as HH
 
-import qualified Orville.PostgreSQL.Internal.PGTextFormatValue as PGTextFormatValue
+import qualified Orville.PostgreSQL.Internal.PgTextFormatValue as PgTextFormatValue
 import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
 import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
 
@@ -18,56 +18,75 @@ rawSqlTests :: Property.Group
 rawSqlTests =
   Property.group
     "RawSql"
-    [
-      ( String.fromString "Builds concatenated sql from strings"
-      , Property.singletonProperty $ do
-          let rawSql =
-                RawSql.fromString "SELECT * "
-                  <> RawSql.fromString "FROM foo "
-                  <> RawSql.fromString "WHERE id = 1"
-
-              expectedBytes =
-                B8.pack "SELECT * FROM foo WHERE id = 1"
-
-              (actualBytes, actualParams) =
-                RawSql.toBytesAndParams rawSql
-
-          actualBytes HH.=== expectedBytes
-          actualParams HH.=== []
-      )
-    ,
-      ( String.fromString "Tracks value placeholders in concatenated order"
-      , Property.singletonProperty $ do
-          let rawSql =
-                RawSql.fromString "SELECT * "
-                  <> RawSql.fromString "FROM foo "
-                  <> RawSql.fromString "WHERE id = "
-                  <> RawSql.parameter (SqlValue.fromInt32 1)
-                  <> RawSql.fromString " AND "
-                  <> RawSql.fromString "bar IN ("
-                  <> RawSql.intercalate RawSql.comma bars
-                  <> RawSql.fromString ")"
-
-              bars =
-                map
-                  RawSql.parameter
-                  [ SqlValue.fromText (T.pack "pants")
-                  , SqlValue.fromText (T.pack "cheese")
-                  ]
-
-              expectedBytes =
-                B8.pack "SELECT * FROM foo WHERE id = $1 AND bar IN ($2,$3)"
-
-              expectedParams =
-                [ Just . PGTextFormatValue.fromByteString . B8.pack $ "1"
-                , Just . PGTextFormatValue.fromByteString . B8.pack $ "pants"
-                , Just . PGTextFormatValue.fromByteString . B8.pack $ "cheese"
-                ]
-
-              (actualBytes, actualParams) =
-                RawSql.toBytesAndParams rawSql
-
-          actualBytes HH.=== expectedBytes
-          actualParams HH.=== expectedParams
-      )
+    [ prop_concatenatesSQLStrings
+    , prop_tracksPlaceholders
+    , prop_escapesStringLiteralsForExamples
     ]
+
+prop_concatenatesSQLStrings :: Property.NamedProperty
+prop_concatenatesSQLStrings =
+  Property.singletonNamedProperty "Builds concatenated sql from strings" $ do
+    let rawSql =
+          RawSql.fromString "SELECT * "
+            <> RawSql.fromString "FROM foo "
+            <> RawSql.fromString "WHERE id = 1"
+
+        expectedBytes =
+          B8.pack "SELECT * FROM foo WHERE id = 1"
+
+        (actualBytes, actualParams) =
+          runIdentity $
+            RawSql.toBytesAndParams RawSql.exampleEscaping rawSql
+
+    actualBytes HH.=== expectedBytes
+    actualParams HH.=== []
+
+prop_tracksPlaceholders :: Property.NamedProperty
+prop_tracksPlaceholders =
+  Property.singletonNamedProperty "Tracks value placeholders in concatenated order" $ do
+    let rawSql =
+          RawSql.fromString "SELECT * "
+            <> RawSql.fromString "FROM foo "
+            <> RawSql.fromString "WHERE id = "
+            <> RawSql.parameter (SqlValue.fromInt32 1)
+            <> RawSql.fromString " AND "
+            <> RawSql.fromString "bar IN ("
+            <> RawSql.intercalate RawSql.comma bars
+            <> RawSql.fromString ")"
+
+        bars =
+          map
+            RawSql.parameter
+            [ SqlValue.fromText (T.pack "pants")
+            , SqlValue.fromText (T.pack "cheese")
+            ]
+
+        expectedBytes =
+          B8.pack "SELECT * FROM foo WHERE id = $1 AND bar IN ($2,$3)"
+
+        expectedParams =
+          [ Just . PgTextFormatValue.fromByteString . B8.pack $ "1"
+          , Just . PgTextFormatValue.fromByteString . B8.pack $ "pants"
+          , Just . PgTextFormatValue.fromByteString . B8.pack $ "cheese"
+          ]
+
+        (actualBytes, actualParams) =
+          runIdentity $
+            RawSql.toBytesAndParams RawSql.exampleEscaping rawSql
+
+    actualBytes HH.=== expectedBytes
+    actualParams HH.=== expectedParams
+
+prop_escapesStringLiteralsForExamples :: Property.NamedProperty
+prop_escapesStringLiteralsForExamples =
+  Property.singletonNamedProperty "Escapes and quotes string literals for examples" $ do
+    let rawSql =
+          RawSql.stringLiteral (B8.pack "Hel\\lo W'orld")
+
+        expectedBytes =
+          B8.pack "'Hel\\\\lo W\\'orld'"
+
+        actualBytes =
+          RawSql.toExampleBytes rawSql
+
+    actualBytes HH.=== expectedBytes

--- a/orville-postgresql-libpq/test/Test/SelectOptions.hs
+++ b/orville-postgresql-libpq/test/Test/SelectOptions.hs
@@ -186,19 +186,19 @@ prop_groupByCombined =
 
 assertDistinctEquals :: HH.MonadTest m => String -> SO.SelectOptions -> m ()
 assertDistinctEquals mbDistinct selectOptions =
-  RawSql.toBytes (SO.selectDistinct selectOptions) HH.=== B8.pack mbDistinct
+  RawSql.toExampleBytes (SO.selectDistinct selectOptions) HH.=== B8.pack mbDistinct
 
 assertWhereClauseEquals :: HH.MonadTest m => Maybe String -> SO.SelectOptions -> m ()
 assertWhereClauseEquals mbWhereClause selectOptions =
-  fmap RawSql.toBytes (SO.selectWhereClause selectOptions) HH.=== fmap B8.pack mbWhereClause
+  fmap RawSql.toExampleBytes (SO.selectWhereClause selectOptions) HH.=== fmap B8.pack mbWhereClause
 
 assertOrderByClauseEquals :: HH.MonadTest m => Maybe String -> SO.SelectOptions -> m ()
 assertOrderByClauseEquals mbOrderByClause selectOptions =
-  fmap RawSql.toBytes (SO.selectOrderByClause selectOptions) HH.=== fmap B8.pack mbOrderByClause
+  fmap RawSql.toExampleBytes (SO.selectOrderByClause selectOptions) HH.=== fmap B8.pack mbOrderByClause
 
 assertGroupByClauseEquals :: HH.MonadTest m => Maybe String -> SO.SelectOptions -> m ()
 assertGroupByClauseEquals mbGroupByClause selectOptions =
-  fmap RawSql.toBytes (SO.selectGroupByClause selectOptions) HH.=== fmap B8.pack mbGroupByClause
+  fmap RawSql.toExampleBytes (SO.selectGroupByClause selectOptions) HH.=== fmap B8.pack mbGroupByClause
 
 fooField :: FieldDef.FieldDefinition FieldDef.NotNull Int.Int32
 fooField =

--- a/orville-postgresql-libpq/test/Test/SqlMarshaller.hs
+++ b/orville-postgresql-libpq/test/Test/SqlMarshaller.hs
@@ -138,12 +138,14 @@ sqlMarshallerTests =
       , HH.property $ do
           foo <- HH.forAll generateFoo
 
-          let addField :: SqlMarshaller.FieldFold Foo [(FieldDefinition.FieldName, SqlValue.SqlValue)]
-              addField fieldDef mbGetValue fields =
-                case mbGetValue of
-                  Just getValue ->
+          let addField entry fields =
+                case entry of
+                  SqlMarshaller.Natural fieldDef (Just getValue) ->
                     (FieldDefinition.fieldName fieldDef, FieldDefinition.fieldValueToSqlValue fieldDef (getValue foo)) : fields
-                  Nothing -> fields
+                  SqlMarshaller.Natural _ Nothing ->
+                    fields
+                  SqlMarshaller.Synthetic _ ->
+                    fields
 
               actualFooRow =
                 SqlMarshaller.foldMarshallerFields


### PR DESCRIPTION
This adds the ability to set default values for `FieldDefinition`.
Default values set on fields will then be reflected in the database
schema as part of migrations.

There is a significant potential gotcha will creating custom default
values -- in order to determine whether migration is necessary, Orville
must use PostgreSQL's `pg_get_expr` function to decompile the expression
and compare it to the default specified on the `FieldDefinition`. The
expression returned by `pg_get_expr` for any given input can often be
surprising. We will want to follow this up with some better help to
ensure the result of migrations in a fixed-point for Orville's migration
logic and provide useful error output to help the user identify why when
it does not.

This required two new low-level features from Orville:

* String literal support for the `RawSql` type, which in turn required
  escaping. LibPQ provides escaping functions, but the require a
  `Connection` to use which complicates the code a bit.

* Support for marshalling a sql expression during selections rather than
  a regular column. `SyntheticField` was added to support this.