### PR TITLE
LibPQ: Add support for dropping tables

### DIFF
--- a/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
@@ -38,6 +38,7 @@ module Orville.PostgreSQL
     TableIdentifier.TableIdentifier,
     TableIdentifier.unqualifiedNameToTableId,
     TableIdentifier.tableIdUnqualifiedNameString,
+    TableIdentifier.tableIdQualifiedName,
     TableIdentifier.setTableIdSchema,
     TableIdentifier.tableIdSchemaNameString,
     TableIdentifier.tableIdToString,

--- a/orville-postgresql-libpq/test/Test/FieldDefinition.hs
+++ b/orville-postgresql-libpq/test/Test/FieldDefinition.hs
@@ -246,7 +246,12 @@ runNullableRoundTripTest pool testCase =
   Pool.withResource pool $ \connection -> do
     let fieldDef = FieldDef.nullableField (roundTripFieldDef testCase)
 
-    value <- HH.forAll (Gen.maybe $ roundTripGen testCase)
+    value <-
+      HH.forAll $
+        Gen.frequency
+          [ (1, pure Nothing)
+          , (3, Just <$> roundTripGen testCase)
+          ]
 
     HH.cover 1 (String.fromString "Nothing") (Maybe.isNothing value)
     HH.cover 20 (String.fromString "Just") (Maybe.isJust value)


### PR DESCRIPTION
This adds a new 'SchemaItem' that directs orville to drop the specified
table.