### PR TITLE
Exports marshallNested

### DIFF
--- a/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
@@ -65,6 +65,7 @@ module Orville.PostgreSQL
     PrimaryKey.primaryKeyPart,
     SqlMarshaller.SqlMarshaller,
     SqlMarshaller.marshallField,
+    SqlMarshaller.marshallNested,
     SqlMarshaller.marshallSyntheticField,
     SqlMarshaller.marshallReadOnly,
     SqlMarshaller.marshallReadOnlyField,


### PR DESCRIPTION
I added a public export for `marshallNested`. It seems like this was
probably intended originally and either way the function is needed to
build SqlMarshallers that of arbitrary depth.