### PR TITLE
LibPQ: Adds error information to MarshallError

### DIFF
--- a/orville-postgresql-libpq/orville-postgresql-libpq.cabal
+++ b/orville-postgresql-libpq/orville-postgresql-libpq.cabal
@@ -33,9 +33,11 @@ library
       Orville.PostgreSQL.AutoMigration
       Orville.PostgreSQL.Connection
       Orville.PostgreSQL.Internal.DefaultValue
+      Orville.PostgreSQL.Internal.ErrorDetailLevel
       Orville.PostgreSQL.Internal.ExecutionResult
       Orville.PostgreSQL.Internal.Expr
       Orville.PostgreSQL.Internal.FieldDefinition
+      Orville.PostgreSQL.Internal.MarshallError
       Orville.PostgreSQL.Internal.PgTextFormatValue
       Orville.PostgreSQL.Internal.PrimaryKey
       Orville.PostgreSQL.Internal.RawSql
@@ -159,6 +161,7 @@ test-suite spec
       Test.Expr.TestSchema
       Test.Expr.Where
       Test.FieldDefinition
+      Test.MarshallError
       Test.PgAssert
       Test.PgCatalog
       Test.PgGen

--- a/orville-postgresql-libpq/package.yaml
+++ b/orville-postgresql-libpq/package.yaml
@@ -25,9 +25,11 @@ library:
     - Orville.PostgreSQL.AutoMigration
     - Orville.PostgreSQL.Connection
     - Orville.PostgreSQL.Internal.DefaultValue
+    - Orville.PostgreSQL.Internal.ErrorDetailLevel
     - Orville.PostgreSQL.Internal.ExecutionResult
     - Orville.PostgreSQL.Internal.Expr
     - Orville.PostgreSQL.Internal.FieldDefinition
+    - Orville.PostgreSQL.Internal.MarshallError
     - Orville.PostgreSQL.Internal.PgTextFormatValue
     - Orville.PostgreSQL.Internal.PrimaryKey
     - Orville.PostgreSQL.Internal.RawSql

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
@@ -64,6 +64,11 @@ module Orville.PostgreSQL
     PrimaryKey.compositePrimaryKey,
     PrimaryKey.primaryKeyPart,
     SqlMarshaller.SqlMarshaller,
+    SqlMarshaller.AnnotatedSqlMarshaller,
+    SqlMarshaller.annotateSqlMarshaller,
+    SqlMarshaller.annotateSqlMarshallerEmptyAnnotation,
+    SqlMarshaller.unannotatedSqlMarshaller,
+    SqlMarshaller.mapSqlMarshaller,
     SqlMarshaller.marshallField,
     SqlMarshaller.marshallNested,
     SqlMarshaller.marshallSyntheticField,
@@ -137,6 +142,7 @@ module Orville.PostgreSQL
     DefaultValue.rawSqlDefault,
     Orville.Orville,
     Orville.runOrville,
+    Orville.runOrvilleWithState,
     MonadOrville.MonadOrville,
     MonadOrville.withConnection,
     Transaction.withTransaction,
@@ -145,6 +151,10 @@ module Orville.PostgreSQL
     OrvilleState.OrvilleState,
     OrvilleState.newOrvilleState,
     OrvilleState.resetOrvilleState,
+    ErrorDetailLevel.ErrorDetailLevel (ErrorDetailLevel, includeErrorMessage, includeSchemaNames, includeRowIdentifierValues, includeNonIdentifierValues),
+    ErrorDetailLevel.defaultErrorDetailLevel,
+    ErrorDetailLevel.minimalErrorDetailLevel,
+    ErrorDetailLevel.maximalErrorDetailLevel,
     SelectOptions.SelectOptions,
     SelectOptions.where_,
     SelectOptions.emptySelectOptions,
@@ -205,7 +215,7 @@ module Orville.PostgreSQL
     -- type conversions
     SqlType.foreignRefType,
     SqlType.convertSqlType,
-    SqlType.maybeConvertSqlType,
+    SqlType.tryConvertSqlType,
     Expr.QueryExpr,
     Execute.executeAndDecode,
     Execute.executeVoid,
@@ -216,6 +226,7 @@ import qualified Orville.PostgreSQL.Connection as Connection
 import qualified Orville.PostgreSQL.Internal.ConstraintDefinition as ConstraintDefinition
 import qualified Orville.PostgreSQL.Internal.DefaultValue as DefaultValue
 import qualified Orville.PostgreSQL.Internal.EntityOperations as EntityOperations
+import qualified Orville.PostgreSQL.Internal.ErrorDetailLevel as ErrorDetailLevel
 import qualified Orville.PostgreSQL.Internal.Execute as Execute
 import qualified Orville.PostgreSQL.Internal.Expr as Expr
 import qualified Orville.PostgreSQL.Internal.FieldDefinition as FieldDefinition

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/AutoMigration.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/AutoMigration.hs
@@ -272,7 +272,7 @@ mkAlterTableSteps currentNamespace relationDesc tableDef =
   let addAlterColumnActions =
         concat $
           Orville.foldMarshallerFields
-            (Orville.tableMarshaller tableDef)
+            (Orville.unannotatedSqlMarshaller $ Orville.tableMarshaller tableDef)
             []
             (Orville.collectFromField Orville.IncludeReadOnlyColumns (mkAddAlterColumnActions relationDesc))
 
@@ -777,7 +777,7 @@ findCurrentNamespace = do
   results <-
     Orville.executeAndDecode
       currentNamespaceQuery
-      (Orville.marshallField id PgCatalog.namespaceNameField)
+      (Orville.annotateSqlMarshallerEmptyAnnotation $ Orville.marshallField id PgCatalog.namespaceNameField)
 
   liftIO $
     case results of

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/ErrorDetailLevel.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/ErrorDetailLevel.hs
@@ -1,0 +1,116 @@
+module Orville.PostgreSQL.Internal.ErrorDetailLevel
+  ( ErrorDetailLevel (ErrorDetailLevel, includeErrorMessage, includeSchemaNames, includeRowIdentifierValues, includeNonIdentifierValues),
+    defaultErrorDetailLevel,
+    minimalErrorDetailLevel,
+    maximalErrorDetailLevel,
+    redactErrorMessage,
+    redactSchemaName,
+    redactIdentifierValue,
+    redactNonIdentifierValue,
+  )
+where
+
+{- |
+  'ErrorDetailLevel' provides a means to configure what elements of information
+  are included in error messages that originate from decoding rows queried
+  from the database. This can be specified either my manually rendering the
+  error message and providing the desired configuration, or by setting the
+  desired detail level in the @OrvilleState@ as a default.
+
+  Information will be redacted from error messages for any of the fields
+  that are set to @False@.
+-}
+data ErrorDetailLevel = ErrorDetailLevel
+  { includeErrorMessage :: Bool
+  , includeSchemaNames :: Bool
+  , includeRowIdentifierValues :: Bool
+  , includeNonIdentifierValues :: Bool
+  }
+  deriving (Show)
+
+{- |
+  A minimal 'ErrorDetailLevel' where everything all information (including
+  any situationally-specific error message!) is redacted from error messages.
+-}
+minimalErrorDetailLevel :: ErrorDetailLevel
+minimalErrorDetailLevel =
+  ErrorDetailLevel
+    { includeErrorMessage = False
+    , includeSchemaNames = False
+    , includeRowIdentifierValues = False
+    , includeNonIdentifierValues = False
+    }
+
+{- |
+  A default 'ErrorDetailLevel' that strikes balance of including all "Generic"
+  information such as the error message, schema names and row identifiers, but
+  avoids untentionally leaking non-identifier values from the database by
+  redacting them.
+-}
+defaultErrorDetailLevel :: ErrorDetailLevel
+defaultErrorDetailLevel =
+  ErrorDetailLevel
+    { includeErrorMessage = True
+    , includeSchemaNames = True
+    , includeRowIdentifierValues = True
+    , includeNonIdentifierValues = False
+    }
+
+{- |
+  A maximal 'ErrorDetailLevel' that redacts no information from the error
+  messages. Error messages will include values from the database for any
+  columns are involved in a decoding failure, including some which you may
+  not have intended to expose through error message. Use with caution.
+-}
+maximalErrorDetailLevel :: ErrorDetailLevel
+maximalErrorDetailLevel =
+  ErrorDetailLevel
+    { includeErrorMessage = True
+    , includeSchemaNames = True
+    , includeRowIdentifierValues = True
+    , includeNonIdentifierValues = True
+    }
+
+{- |
+  Redacts given the error message string if the 'ErrorDetailLevel' indicates
+  that error messages should be redacted.
+-}
+redactErrorMessage :: ErrorDetailLevel -> String -> String
+redactErrorMessage detailLevel message =
+  if includeErrorMessage detailLevel
+    then message
+    else redactedValue
+
+{- |
+  Redacts given the schema name string if the 'ErrorDetailLevel' indicates
+  that schema names should be redacted.
+-}
+redactSchemaName :: ErrorDetailLevel -> String -> String
+redactSchemaName detailLevel schemaName =
+  if includeSchemaNames detailLevel
+    then schemaName
+    else redactedValue
+
+{- |
+  Redacts given the identifier value string if the 'ErrorDetailLevel' indicates
+  that identifier values should be redacted.
+-}
+redactIdentifierValue :: ErrorDetailLevel -> String -> String
+redactIdentifierValue detailLevel idValue =
+  if includeRowIdentifierValues detailLevel
+    then idValue
+    else redactedValue
+
+{- |
+  Redacts given the non-identifier value string if the 'ErrorDetailLevel' indicates
+  that non-identifier values should be redacted.
+-}
+redactNonIdentifierValue :: ErrorDetailLevel -> String -> String
+redactNonIdentifierValue detailLevel nonIdValue =
+  if includeNonIdentifierValues detailLevel
+    then nonIdValue
+    else redactedValue
+
+redactedValue :: String
+redactedValue =
+  "[REDACTED]"

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/FieldDefinition.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/FieldDefinition.hs
@@ -115,7 +115,8 @@ fieldType = _fieldType
 fieldDefaultValue :: FieldDefinition nullability a -> Maybe (DefaultValue a)
 fieldDefaultValue = _fieldDefaultValue
 
-{- | A 'FieldNullability is returned by the 'fieldNullability' function, which
+{- |
+ A 'FieldNullability is returned by the 'fieldNullability' function, which
  can be used when a function works on both 'Nullable' and 'NotNull' functions
  but needs to deal with each type of field separately. It adds wrapper
  constructors around the 'FieldDefinition' that you can pattern match on to
@@ -125,7 +126,8 @@ data FieldNullability a
   = NullableField (FieldDefinition Nullable a)
   | NotNullField (FieldDefinition NotNull a)
 
-{- | Resolves the 'nullablity' of a field to a concrete type, which is returned
+{- |
+ Resolves the 'nullablity' of a field to a concrete type, which is returned
  via the 'FieldNullability' type. You can pattern match on this type to then
  extract the either 'Nullable' or 'NotNull' not field for cases where you
  may require different logic based on the nullability of a field.
@@ -155,9 +157,9 @@ fieldValueToSqlValue =
 
 {- |
   Marshalls a 'SqlValue' from the database into the Haskell value that represents it.
-  This may fail, in which case 'Nothing' is returned.
+  This may fail, in which case a 'Left' is returned with an error message.
 -}
-fieldValueFromSqlValue :: FieldDefinition nullability a -> SqlValue.SqlValue -> Maybe a
+fieldValueFromSqlValue :: FieldDefinition nullability a -> SqlValue.SqlValue -> Either String a
 fieldValueFromSqlValue =
   SqlType.sqlTypeFromSql . fieldType
 
@@ -419,7 +421,7 @@ nullableField field =
           , SqlType.sqlTypeFromSql =
               \sqlValue ->
                 if SqlValue.isSqlNull sqlValue
-                  then Just Nothing
+                  then Right Nothing
                   else Just <$> SqlType.sqlTypeFromSql sqlType sqlValue
           }
    in FieldDefinition

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Insert.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Insert.hs
@@ -13,7 +13,7 @@ import Data.List.NonEmpty (NonEmpty)
 import qualified Orville.PostgreSQL.Internal.Execute as Execute
 import qualified Orville.PostgreSQL.Internal.Expr as Expr
 import qualified Orville.PostgreSQL.Internal.MonadOrville as MonadOrville
-import Orville.PostgreSQL.Internal.SqlMarshaller (SqlMarshaller)
+import Orville.PostgreSQL.Internal.SqlMarshaller (AnnotatedSqlMarshaller)
 import Orville.PostgreSQL.Internal.TableDefinition (ReturningOption (WithReturning, WithoutReturning), TableDefinition, mkInsertExpr, tableMarshaller)
 
 {- | Represents an @INSERT@ statement that can be executed against a database. An 'Insert' has a
@@ -21,7 +21,7 @@ import Orville.PostgreSQL.Internal.TableDefinition (ReturningOption (WithReturni
   decode the database result set when it is executed.
 -}
 data Insert readEntity where
-  Insert :: SqlMarshaller writeEntity readEntity -> Expr.InsertExpr -> Insert readEntity
+  Insert :: AnnotatedSqlMarshaller writeEntity readEntity -> Expr.InsertExpr -> Insert readEntity
 
 {- |
   Extracts the query that will be run when the insert is executed. Normally you
@@ -75,7 +75,9 @@ insertTable ::
   NonEmpty writeEntity ->
   Insert readEntity
 insertTable returningOption tableDef entities =
-  rawInsertExpr (tableMarshaller tableDef) (mkInsertExpr returningOption tableDef entities)
+  rawInsertExpr
+    (tableMarshaller tableDef)
+    (mkInsertExpr returningOption tableDef entities)
 
 {- |
   Builds an 'Insert' that will execute the specified query and use the given 'SqlMarshaller' to
@@ -87,5 +89,5 @@ insertTable returningOption tableDef entities =
   that Orville supports using the expression building functions, or use @RawSql.fromRawSql@ to build
   a raw 'Expr.InsertExpr'.
 -}
-rawInsertExpr :: SqlMarshaller writeEntity readEntity -> Expr.InsertExpr -> Insert readEntity
+rawInsertExpr :: AnnotatedSqlMarshaller writeEntity readEntity -> Expr.InsertExpr -> Insert readEntity
 rawInsertExpr = Insert

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/MarshallError.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/MarshallError.hs
@@ -1,0 +1,171 @@
+module Orville.PostgreSQL.Internal.MarshallError
+  ( MarshallError (MarshallError, marshallErrorDetailLevel, marshallErrorRowIdentifier, marshallErrorDetails),
+    renderMarshallError,
+    MarshallErrorDetails (DecodingError, MissingColumnError),
+    renderMarshallErrorDetails,
+    DecodingErrorDetails (DecodingErrorDetails, decodingErrorValues, decodingErrorMessage),
+    renderDecodingErrorDetails,
+    MissingColumnErrorDetails (MissingColumnErrorDetails, missingColumnName, actualColumnNames),
+    renderMissingColumnErrorDetails,
+  )
+where
+
+import Control.Exception (Exception)
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.List as List
+import qualified Data.Set as Set
+
+import Orville.PostgreSQL.Internal.ErrorDetailLevel (ErrorDetailLevel, redactErrorMessage, redactIdentifierValue, redactNonIdentifierValue, redactSchemaName)
+import qualified Orville.PostgreSQL.Internal.PgTextFormatValue as PgTextFormatValue
+import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
+
+{- |
+  A 'MarshallError' may be returned from 'marshallResultFromSql' when a row being
+  decoded from the database doesn't meet the expectations of the
+  'SqlMarshaller' that is decoding it.
+-}
+data MarshallError = MarshallError
+  { -- | The level of details that will be used to render this error as a
+    -- message if 'show' is called
+    marshallErrorDetailLevel :: ErrorDetailLevel
+  , -- | The identifier of the row that caused the error. This is a list
+    -- of pairs of column name and value in their raw form from the database
+    -- to avoid further possible decoding errors when reading the values
+    marshallErrorRowIdentifier :: [(B8.ByteString, SqlValue.SqlValue)]
+  , -- | The detailed information about the error that occurred during
+    -- decoding
+    marshallErrorDetails :: MarshallErrorDetails
+  }
+
+instance Show MarshallError where
+  show decodingError =
+    renderMarshallError
+      (marshallErrorDetailLevel decodingError)
+      decodingError
+
+instance Exception MarshallError
+
+{- |
+  Renders a 'MarshallError' to a string using the specified 'ErrorDetailLevel'.
+
+  This ingores any 'ErrorDetailLevel' that was captured by default from
+  the Orville context and uses the specified level of detail instead.
+
+  You may want to use this function to render certain with a higher level of
+  detail that you consider safe for (for example) you application logs while
+  using a lower default error detail level to be used with the 'Show' instance
+  of 'MarhallError' in case an exception is handled in a more visible section
+  of code that return information more publicly (e.g. a request handler for a
+  public endpoint).
+-}
+renderMarshallError :: ErrorDetailLevel -> MarshallError -> String
+renderMarshallError detailLevel marshallError =
+  let presentableRowId =
+        map
+          (presentSqlColumnValue detailLevel redactIdentifierValue)
+          (marshallErrorRowIdentifier marshallError)
+   in concat
+        [ "Unable to decode row with identifier ["
+        , List.intercalate ", " presentableRowId
+        , "]: "
+        , renderMarshallErrorDetails detailLevel (marshallErrorDetails marshallError)
+        ]
+
+{- |
+  A internal helper to present a redacted column name and sql value in an error
+  message. The redacter function is passed as an argument here so that this
+  function can be used to present either ID values or general values as
+  required by the context of the caller.
+-}
+presentSqlColumnValue ::
+  ErrorDetailLevel ->
+  (ErrorDetailLevel -> String -> String) ->
+  (B8.ByteString, SqlValue.SqlValue) ->
+  String
+presentSqlColumnValue detailLevel redacter (columnName, sqlValue) =
+  let sqlValueString =
+        redacter detailLevel $
+          case SqlValue.toPgValue sqlValue of
+            Nothing ->
+              "NULL"
+            Just pgValue ->
+              B8.unpack . PgTextFormatValue.toByteString $ pgValue
+   in redactSchemaName detailLevel (B8.unpack columnName)
+        <> " = "
+        <> sqlValueString
+
+{- |
+  A 'MarshallErrorDetails' may be returned from 'marshallFromSql' if the result set
+  being decoded from the database doesn't meet the expectations of the
+  'SqlMarshaller' that is decoding it.
+-}
+data MarshallErrorDetails
+  = -- | Indicates that a one ore more values in a columns could not be decoded,
+    -- either individually or as a group
+    DecodingError DecodingErrorDetails
+  | -- | Indicates that an expected column was not found in the result set
+    MissingColumnError MissingColumnErrorDetails
+
+{- |
+  Renders a 'MarshallErrorDetails' to a 'String' with a specified
+  'ErrorDetailLevel'.
+-}
+renderMarshallErrorDetails :: ErrorDetailLevel -> MarshallErrorDetails -> String
+renderMarshallErrorDetails detailLevel err =
+  case err of
+    DecodingError details -> renderDecodingErrorDetails detailLevel details
+    MissingColumnError details -> renderMissingColumnErrorDetails detailLevel details
+
+{- |
+  Details about an error that occurred while decoding values found a SQL
+  result set.
+-}
+data DecodingErrorDetails = DecodingErrorDetails
+  { decodingErrorValues :: [(B8.ByteString, SqlValue.SqlValue)]
+  , decodingErrorMessage :: String
+  }
+
+{- |
+  Renders a 'DecodingErrorDetails to a 'String' with a specified
+  'ErrorDetailLevel'.
+-}
+renderDecodingErrorDetails :: ErrorDetailLevel -> DecodingErrorDetails -> String
+renderDecodingErrorDetails detailLevel details =
+  let presentableErrorValues =
+        map
+          (presentSqlColumnValue detailLevel redactNonIdentifierValue)
+          (decodingErrorValues details)
+   in concat
+        [ "Unable to decode columns from result set: "
+        , redactErrorMessage detailLevel (decodingErrorMessage details)
+        , ". Value(s) that failed to decode: ["
+        , List.intercalate ", " presentableErrorValues
+        , "]"
+        ]
+
+{- |
+  Details about an column that was found to be missing in a SQL result set
+  during decoding.
+-}
+data MissingColumnErrorDetails = MissingColumnErrorDetails
+  { missingColumnName :: B8.ByteString
+  , actualColumnNames :: (Set.Set B8.ByteString)
+  }
+
+{- |
+  Renders a 'MissingColumnErrorDetails' to a 'String' with a specified
+  'ErrorDetailLevel'.
+-}
+renderMissingColumnErrorDetails :: ErrorDetailLevel -> MissingColumnErrorDetails -> String
+renderMissingColumnErrorDetails detailLevel details =
+  let presentableActualNames =
+        map
+          (redactSchemaName detailLevel . B8.unpack)
+          (Set.toList $ actualColumnNames details)
+   in concat
+        [ "Column "
+        , redactSchemaName detailLevel (B8.unpack $ missingColumnName details)
+        , " not found in results set. Actual columns were ["
+        , List.intercalate ", " presentableActualNames
+        , "]"
+        ]

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/MigrationLock.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/MigrationLock.hs
@@ -66,9 +66,10 @@ orvilleLockScope = 17772
 migrationLockId :: Int32
 migrationLockId = 7995632
 
-lockedMarshaller :: SqlMarshaller.SqlMarshaller Bool Bool
+lockedMarshaller :: SqlMarshaller.AnnotatedSqlMarshaller Bool Bool
 lockedMarshaller =
-  SqlMarshaller.marshallField id (FieldDefinition.booleanField "locked")
+  SqlMarshaller.annotateSqlMarshallerEmptyAnnotation $
+    SqlMarshaller.marshallField id (FieldDefinition.booleanField "locked")
 
 tryLockExpr :: RawSql.RawSql
 tryLockExpr =

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Orville.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Orville.hs
@@ -13,6 +13,7 @@ import Control.Monad.Trans.Reader (ReaderT, runReaderT)
 import Data.Pool (Pool)
 
 import Orville.PostgreSQL.Connection (Connection)
+import qualified Orville.PostgreSQL.Internal.ErrorDetailLevel as ErrorDetailLevel
 import qualified Orville.PostgreSQL.Internal.MonadOrville as MonadOrville
 import qualified Orville.PostgreSQL.Internal.OrvilleState as OrvilleState
 
@@ -43,10 +44,16 @@ instance MonadOrville.MonadOrville Orville
 {- |
   Runs an 'Orville' operation in the 'IO' monad using the given connection
   pool.
+
+  This will run the 'Orville' operation with the 'ErrorDetailLevel' set to the
+  default. If want to run with a different detail level, you can use
+  'OrvilleState.newOrvilleState' to create a state with the desired detail
+  level and then use 'runOrvilleWithState'.
 -}
 runOrville :: Pool Connection -> Orville a -> IO a
-runOrville pool =
-  runOrvilleWithState (OrvilleState.newOrvilleState pool)
+runOrville =
+  runOrvilleWithState
+    . OrvilleState.newOrvilleState ErrorDetailLevel.defaultErrorDetailLevel
 
 {- |
   Runs an 'Orville' operation in the 'IO' monad, starting from the provided

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/PgTime.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/PgTime.hs
@@ -8,7 +8,7 @@ module Orville.PostgreSQL.Internal.PgTime
   )
 where
 
-import Control.Applicative ((<|>))
+import qualified Control.Exception as Exc
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TextEnc
@@ -25,18 +25,10 @@ dayToPostgreSQL =
   Parses a 'Time.Day' from a PostgreSQL textual representation. Returns
   'Nothing' if the parsing fails.
 -}
-dayFromPostgreSQL :: B8.ByteString -> Maybe Time.Day
+dayFromPostgreSQL :: B8.ByteString -> Either String Time.Day
 dayFromPostgreSQL bytes = do
-  txt <-
-    case TextEnc.decodeUtf8' bytes of
-      Right t -> Just t
-      Left _ -> Nothing
-
-  Time.parseTimeM
-    False
-    Time.defaultTimeLocale
-    (Time.iso8601DateFormat Nothing)
-    (T.unpack txt)
+  string <- utf8BytesToString bytes
+  decodeTime (Time.iso8601DateFormat Nothing) string
 
 {- |
   Renders a 'Time.UTCTime' value to a textual representation for PostgreSQL
@@ -49,22 +41,19 @@ utcTimeToPostgreSQL =
   Parses a 'Time.UTCTime' from a PostgreSQL textual representation. Returns
   'Nothing' if the parsing fails.
 -}
-utcTimeFromPostgreSQL :: B8.ByteString -> Maybe Time.UTCTime
+utcTimeFromPostgreSQL :: B8.ByteString -> Either String Time.UTCTime
 utcTimeFromPostgreSQL bytes = do
   -- N.B. There are dragons here... Notably the iso8601DateFormat (at least as of time-1.9.x)
   -- However PostgreSQL adheres to a different version of the standard which ommitted the 'T' and instead used a space.
   -- Further... PostgreSQL uses the short format for the UTC offset and the haskell library does not support this.
   -- Leading to the ugly hacks below.
-  txt <-
-    case TextEnc.decodeUtf8' bytes of
-      Right t -> Just t
-      Left _ -> Nothing
+  string <- utf8BytesToString bytes
 
-  let parseTime = Time.parseTimeM False Time.defaultTimeLocale
-      unTxt = T.unpack txt
+  let stringWithOffsetPad = string <> "00"
 
-  parseTime "%F %T%Q%Z" (unTxt <> "00")
-    <|> parseTime "%F %T%Z" (unTxt <> "00")
+  firstThenTry
+    (decodeTime "%F %T%Q%Z" stringWithOffsetPad)
+    (decodeTime "%F %T%Z" stringWithOffsetPad)
 
 {- |
   Renders a 'Time.LocalTime value to a textual representation for PostgreSQL
@@ -77,19 +66,34 @@ localTimeToPostgreSQL =
   Parses a 'Time.LocalTime' from a PostgreSQL textual representation. Returns
   'Nothing' if the parsing fails.
 -}
-localTimeFromPostgreSQL :: B8.ByteString -> Maybe Time.LocalTime
+localTimeFromPostgreSQL :: B8.ByteString -> Either String Time.LocalTime
 localTimeFromPostgreSQL bytes = do
   -- N.B. There are dragons here... Notably the iso8601DateFormat (at least as of time-1.9.x)
   -- However PostgreSQL adheres to a different version of the standard which ommitted the 'T' and instead used a space.
   -- Further... PostgreSQL uses the short format for the UTC offset and the haskell library does not support this.
   -- Leading to the ugly hacks below.
-  txt <-
-    case TextEnc.decodeUtf8' bytes of
-      Right t -> Just t
-      Left _ -> Nothing
+  string <- utf8BytesToString bytes
 
-  let parseTime = Time.parseTimeM False Time.defaultTimeLocale
-      unTxt = T.unpack txt
+  firstThenTry
+    (decodeTime "%F %T%Q" string)
+    (decodeTime "%F %T" string)
 
-  parseTime "%F %T%Q" unTxt
-    <|> parseTime "%F %T" unTxt
+firstThenTry :: Either String a -> Either String a -> Either String a
+firstThenTry first thenTry =
+  case first of
+    Right _ -> first
+    Left _ -> thenTry
+
+utf8BytesToString :: B8.ByteString -> Either String String
+utf8BytesToString bytes =
+  case TextEnc.decodeUtf8' bytes of
+    Right t -> Right (T.unpack t)
+    Left err -> Left (Exc.displayException err)
+
+decodeTime :: Time.ParseTime a => String -> String -> Either String a
+decodeTime format string =
+  case Time.parseTimeM False Time.defaultTimeLocale format string of
+    Just t ->
+      Right t
+    Nothing ->
+      Left $ "Unable to decode time value in format " <> show format

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/PrimaryKey.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/PrimaryKey.hs
@@ -4,6 +4,7 @@
 module Orville.PostgreSQL.Internal.PrimaryKey
   ( PrimaryKey,
     primaryKeyDescription,
+    primaryKeyFieldNames,
     primaryKeyToSql,
     primaryKey,
     PrimaryKeyPart,
@@ -20,7 +21,7 @@ import qualified Data.List as List
 import Data.List.NonEmpty (NonEmpty ((:|)), toList)
 
 import qualified Orville.PostgreSQL.Internal.Expr as Expr
-import Orville.PostgreSQL.Internal.FieldDefinition (FieldDefinition, NotNull, fieldColumnName, fieldName, fieldNameToString, fieldValueToSqlValue)
+import Orville.PostgreSQL.Internal.FieldDefinition (FieldDefinition, FieldName, NotNull, fieldColumnName, fieldName, fieldNameToString, fieldValueToSqlValue)
 import Orville.PostgreSQL.Internal.SelectOptions (WhereCondition, fieldEquals, whereAnd, whereConditionToBooleanExpr)
 import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
 
@@ -46,11 +47,21 @@ data PrimaryKeyPart key
   list of the names of the fields that make up the primary key.
 -}
 primaryKeyDescription :: PrimaryKey key -> String
-primaryKeyDescription keyDef =
-  let partName :: (part -> key) -> FieldDefinition NotNull a -> String
+primaryKeyDescription =
+  List.intercalate ", "
+    . map fieldNameToString
+    . toList
+    . primaryKeyFieldNames
+
+{- |
+  Retrieves the names of the fields that are part of the primary key.
+-}
+primaryKeyFieldNames :: PrimaryKey key -> NonEmpty FieldName
+primaryKeyFieldNames =
+  let partName :: (part -> key) -> FieldDefinition NotNull a -> FieldName
       partName _ field =
-        fieldNameToString (fieldName field)
-   in List.intercalate ", " (toList $ mapPrimaryKeyParts partName keyDef)
+        fieldName field
+   in mapPrimaryKeyParts partName
 
 {- |
   'primaryKeyToSql' converts a Haskell value for a primary key into the

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/RawSql.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/RawSql.hs
@@ -230,7 +230,7 @@ buildSqlWithProgress escaping progress rawSql =
 
       pure (builder, progress)
     Parameter value ->
-      let newProgress = snocParam progress (SqlValue.toPGValue value)
+      let newProgress = snocParam progress (SqlValue.toPgValue value)
           placeholder = BSB.stringUtf8 "$" <> BSB.intDec (paramCount newProgress)
        in pure (placeholder, newProgress)
     Append first second -> do

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/SqlType.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/SqlType.hs
@@ -37,7 +37,7 @@ module Orville.PostgreSQL.Internal.SqlType
     -- type conversions
     foreignRefType,
     convertSqlType,
-    maybeConvertSqlType,
+    tryConvertSqlType,
   )
 where
 
@@ -80,7 +80,7 @@ data SqlType a = SqlType
     -- into Haskell values. This function should return 'Nothing' to indicate
     -- an error if the conversion is impossible. Otherwise it should return
     -- 'Just' the corresponding 'a' value.
-    sqlTypeFromSql :: SqlValue -> Maybe a
+    sqlTypeFromSql :: SqlValue -> Either String a
   , -- | The SERIAL and BIGSERIAL PostgreSQL types are really pesudo types that
     -- create an implicit default value. This flag tells Orville's auto
     -- migration logic to ignore the default value rather than drop it as it
@@ -267,15 +267,19 @@ textSearchVector =
 -}
 uuid :: SqlType UUID.UUID
 uuid =
-  SqlType
-    { sqlTypeExpr = Expr.uuid
-    , sqlTypeReferenceExpr = Nothing
-    , sqlTypeOid = LibPQ.Oid 2950
-    , sqlTypeMaximumLength = Nothing
-    , sqlTypeToSql = SqlValue.fromText . UUID.toText
-    , sqlTypeFromSql = \a -> UUID.fromText =<< SqlValue.toText a
-    , sqlTypeDontDropImplicitDefaultDuringMigrate = False
-    }
+  let uuidFromText t =
+        case UUID.fromText t of
+          Nothing -> Left "Invalid UUID value"
+          Just validUuid -> Right validUuid
+   in SqlType
+        { sqlTypeExpr = Expr.uuid
+        , sqlTypeReferenceExpr = Nothing
+        , sqlTypeOid = LibPQ.Oid 2950
+        , sqlTypeMaximumLength = Nothing
+        , sqlTypeToSql = SqlValue.fromText . UUID.toText
+        , sqlTypeFromSql = \a -> uuidFromText =<< SqlValue.toText a
+        , sqlTypeDontDropImplicitDefaultDuringMigrate = False
+        }
 
 {- |
   'date' defines a type representing a calendar date (without time zone). It corresponds
@@ -365,15 +369,15 @@ foreignRefType sqlType =
     Just refExpr -> sqlType {sqlTypeExpr = refExpr, sqlTypeReferenceExpr = Nothing}
 
 {- |
-  'maybeConvertSqlType' changes the Haskell type used by a 'SqlType' which changing
-  the column type that will be used in the database schema. The functions given
-  will be used to convert the now Haskell type to and from the original type when
-  reading and writing values from the database. When reading an 'a' value from
-  the database, the conversion function should produce 'Nothing' if the value
-  cannot be successfully converted to a 'b'
+  'tryConvertSqlType' changes the Haskell type used by a 'SqlType' which
+  changing the column type that will be used in the database schema. The
+  functions given will be used to convert the now Haskell type to and from the
+  original type when reading and writing values from the database. When reading
+  an 'a' value from the database, the conversion function should produce 'Left
+  with an error message if the value cannot be successfully converted to a 'b'
 -}
-maybeConvertSqlType :: (b -> a) -> (a -> Maybe b) -> SqlType a -> SqlType b
-maybeConvertSqlType bToA aToB sqlType =
+tryConvertSqlType :: (b -> a) -> (a -> Either String b) -> SqlType a -> SqlType b
+tryConvertSqlType bToA aToB sqlType =
   sqlType
     { sqlTypeToSql = sqlTypeToSql sqlType . bToA
     , sqlTypeFromSql = \sql -> do
@@ -387,4 +391,4 @@ maybeConvertSqlType bToA aToB sqlType =
 -}
 convertSqlType :: (b -> a) -> (a -> b) -> SqlType a -> SqlType b
 convertSqlType bToA aToB =
-  maybeConvertSqlType bToA (Just . aToB)
+  tryConvertSqlType bToA (Right . aToB)

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/PgCatalog/PgClass.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/PgCatalog/PgClass.hs
@@ -108,7 +108,7 @@ relationNameField =
 relationKindField :: Orville.FieldDefinition Orville.NotNull RelationKind
 relationKindField =
   Orville.convertField
-    (Orville.maybeConvertSqlType relationKindToPgText pgTextToRelationKind)
+    (Orville.tryConvertSqlType relationKindToPgText pgTextToRelationKind)
     (Orville.unboundedTextField "relkind")
 
 {- |
@@ -138,17 +138,17 @@ relationKindToPgText kind =
 
   See also 'relationKindToPgText'
 -}
-pgTextToRelationKind :: T.Text -> Maybe RelationKind
+pgTextToRelationKind :: T.Text -> Either String RelationKind
 pgTextToRelationKind text =
   case T.unpack text of
-    "r" -> Just OrdinaryTable
-    "i" -> Just Index
-    "S" -> Just Sequence
-    "t" -> Just ToastTable
-    "v" -> Just View
-    "m" -> Just MaterializedView
-    "c" -> Just CompositeType
-    "f" -> Just ForeignTable
-    "p" -> Just PartitionedTable
-    "I" -> Just PartitionedIndex
-    _ -> Nothing
+    "r" -> Right OrdinaryTable
+    "i" -> Right Index
+    "S" -> Right Sequence
+    "t" -> Right ToastTable
+    "v" -> Right View
+    "m" -> Right MaterializedView
+    "c" -> Right CompositeType
+    "f" -> Right ForeignTable
+    "p" -> Right PartitionedTable
+    "I" -> Right PartitionedIndex
+    kind -> Left ("Unrecognized PostgreSQL relation kind: " <> kind)

--- a/orville-postgresql-libpq/test/Main.hs
+++ b/orville-postgresql-libpq/test/Main.hs
@@ -18,6 +18,7 @@ import qualified Test.Expr.OrderBy as ExprOrderBy
 import qualified Test.Expr.TableDefinition as ExprTableDefinition
 import qualified Test.Expr.Where as ExprWhere
 import qualified Test.FieldDefinition as FieldDefinition
+import qualified Test.MarshallError as MarshallError
 import qualified Test.PgCatalog as PgCatalog
 import qualified Test.Plan as Plan
 import qualified Test.Property as Property
@@ -37,15 +38,16 @@ main = do
     Property.checkGroups
       [ Connection.connectionTests pool
       , RawSql.rawSqlTests
-      , TableDefinition.tableDefinitionTests pool
-      , SqlMarshaller.sqlMarshallerTests
-      , FieldDefinition.fieldDefinitionTests pool
-      , EntityOperations.entityOperationsTests pool
+      , SqlType.sqlTypeTests pool
       , ExprInsertUpdateDelete.insertUpdateDeleteTests pool
       , ExprWhere.whereTests pool
       , ExprOrderBy.orderByTests pool
       , ExprTableDefinition.tableDefinitionTests pool
-      , SqlType.sqlTypeTests pool
+      , FieldDefinition.fieldDefinitionTests pool
+      , SqlMarshaller.sqlMarshallerTests
+      , MarshallError.marshallErrorTests pool
+      , TableDefinition.tableDefinitionTests pool
+      , EntityOperations.entityOperationsTests pool
       , SelectOptions.selectOptionsTests
       , ReservedWords.reservedWordsTests pool
       , Transaction.transactionTests pool

--- a/orville-postgresql-libpq/test/Test/Expr/TestSchema.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/TestSchema.hs
@@ -81,5 +81,5 @@ assertEqualSqlRows ::
   m ()
 assertEqualSqlRows l r = sqlRowsToText l HH.=== sqlRowsToText r
 
-sqlRowsToText :: [[(a, SqlValue.SqlValue)]] -> [[(a, Maybe T.Text)]]
+sqlRowsToText :: [[(a, SqlValue.SqlValue)]] -> [[(a, Either String T.Text)]]
 sqlRowsToText = fmap (fmap (\(a, b) -> (a, SqlValue.toText b)))

--- a/orville-postgresql-libpq/test/Test/FieldDefinition.hs
+++ b/orville-postgresql-libpq/test/Test/FieldDefinition.hs
@@ -10,6 +10,7 @@ import qualified Data.Pool as Pool
 import qualified Data.String as String
 import qualified Data.Text as T
 import qualified Data.UUID as UUID
+import Hedgehog ((===))
 import qualified Hedgehog as HH
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
@@ -254,11 +255,11 @@ runRoundTripTest pool testCase =
     let roundTripResult =
           case rows of
             [[(_, sqlValue)]] ->
-              Right (FieldDef.fieldValueFromSqlValue fieldDef sqlValue)
+              FieldDef.fieldValueFromSqlValue fieldDef sqlValue
             _ ->
               Left ("Expected one row with one value in results, but got: " ++ show (sqlRowsToText rows))
 
-    roundTripResult HH.=== Right (Just value)
+    roundTripResult === Right value
 
 runNullableRoundTripTest :: (Show a, Eq a) => Pool.Pool Connection.Connection -> FieldDefinitionTest a -> HH.PropertyT IO ()
 runNullableRoundTripTest pool testCase =
@@ -297,11 +298,11 @@ runNullableRoundTripTest pool testCase =
     let roundTripResult =
           case rows of
             [[(_, sqlValue)]] ->
-              Right (FieldDef.fieldValueFromSqlValue fieldDef sqlValue)
+              FieldDef.fieldValueFromSqlValue fieldDef sqlValue
             _ ->
               Left ("Expected one row with one value in results, but got: " ++ show (sqlRowsToText rows))
 
-    roundTripResult HH.=== Right (Just value)
+    roundTripResult === Right value
 
 runNullCounterExampleTest :: Pool.Pool Connection.Connection -> FieldDefinitionTest a -> HH.PropertyT IO ()
 runNullCounterExampleTest pool testCase =
@@ -320,7 +321,7 @@ runNullCounterExampleTest pool testCase =
 
     case result of
       Left err ->
-        Connection.sqlExecutionErrorSqlState err HH.=== Just (B8.pack "23502")
+        Connection.sqlExecutionErrorSqlState err === Just (B8.pack "23502")
       Right _ -> do
         HH.footnote "Expected insert query to fail, but it did not"
         HH.failure
@@ -363,11 +364,11 @@ runDefaultValueFieldDefinitionTest pool testCase mkDefaultValue =
     let roundTripResult =
           case rows of
             [[(_, sqlValue)]] ->
-              Right (FieldDef.fieldValueFromSqlValue fieldDef sqlValue)
+              FieldDef.fieldValueFromSqlValue fieldDef sqlValue
             _ ->
               Left ("Expected one row with one value in results, but got: " ++ show (sqlRowsToText rows))
 
-    roundTripResult HH.=== Right (Just value)
+    roundTripResult === Right value
 
 runDefaultValueInsertOnlyTest ::
   Pool.Pool Connection.Connection ->

--- a/orville-postgresql-libpq/test/Test/MarshallError.hs
+++ b/orville-postgresql-libpq/test/Test/MarshallError.hs
@@ -1,0 +1,205 @@
+module Test.MarshallError
+  ( marshallErrorTests,
+  )
+where
+
+import qualified Control.Exception as E
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.Pool as Pool
+import qualified Data.Set as Set
+import qualified Data.Text as T
+import Hedgehog ((===))
+import qualified Hedgehog as HH
+import qualified Hedgehog.Gen as Gen
+
+import qualified Orville.PostgreSQL as Orville
+import qualified Orville.PostgreSQL.Connection as Connection
+import qualified Orville.PostgreSQL.Internal.ErrorDetailLevel as ErrorDetailLevel
+import qualified Orville.PostgreSQL.Internal.MarshallError as MarshallError
+import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
+
+import qualified Test.Property as Property
+
+marshallErrorTests :: Pool.Pool Connection.Connection -> Property.Group
+marshallErrorTests pool =
+  Property.group
+    "MarshallError"
+    [ prop_renderDecodingErrorWithFullDetails
+    , prop_renderDecodingErrorWithoutSchemaNames
+    , prop_renderDecodingErrorWithoutRowIdValues
+    , prop_renderDecodingErrorWithoutNonIdValues
+    , prop_renderDecodingErrorWithoutErrorMessage
+    , prop_renderMissingErrorDetailsWithFullDetails
+    , prop_renderMissingErrorDetailsWithoutSchemaNames
+    , prop_showMarshallErrorRaisedFromOrvilleContext pool
+    ]
+
+{- |
+  Shared example used to test error detail level rendering of decoding errors
+  below.
+-}
+exampleDecodingError :: MarshallError.MarshallError
+exampleDecodingError =
+  MarshallError.MarshallError
+    { MarshallError.marshallErrorDetailLevel = ErrorDetailLevel.minimalErrorDetailLevel
+    , MarshallError.marshallErrorRowIdentifier = [(B8.pack "foo", SqlValue.fromInt8 1)]
+    , MarshallError.marshallErrorDetails =
+        MarshallError.DecodingError $
+          MarshallError.DecodingErrorDetails
+            { MarshallError.decodingErrorValues = [(B8.pack "bar", SqlValue.fromText (T.pack "baz"))]
+            , MarshallError.decodingErrorMessage = "Failure"
+            }
+    }
+
+prop_renderDecodingErrorWithFullDetails :: Property.NamedProperty
+prop_renderDecodingErrorWithFullDetails =
+  Property.singletonNamedProperty "Render decoding error with full details" $
+    let rendered =
+          MarshallError.renderMarshallError
+            ErrorDetailLevel.maximalErrorDetailLevel
+            exampleDecodingError
+     in rendered
+          === "Unable to decode row with identifier [foo = 1]: \
+              \Unable to decode columns from result set: Failure. \
+              \Value(s) that failed to decode: [bar = baz]"
+
+prop_renderDecodingErrorWithoutSchemaNames :: Property.NamedProperty
+prop_renderDecodingErrorWithoutSchemaNames =
+  Property.singletonNamedProperty "Render decoding error without schema names" $
+    let rendered =
+          MarshallError.renderMarshallError
+            ( ErrorDetailLevel.maximalErrorDetailLevel
+                { ErrorDetailLevel.includeSchemaNames = False
+                }
+            )
+            exampleDecodingError
+     in rendered
+          === "Unable to decode row with identifier [[REDACTED] = 1]: \
+              \Unable to decode columns from result set: Failure. \
+              \Value(s) that failed to decode: [[REDACTED] = baz]"
+
+prop_renderDecodingErrorWithoutRowIdValues :: Property.NamedProperty
+prop_renderDecodingErrorWithoutRowIdValues =
+  Property.singletonNamedProperty "Render decoding error without row id values" $
+    let rendered =
+          MarshallError.renderMarshallError
+            ( ErrorDetailLevel.maximalErrorDetailLevel
+                { ErrorDetailLevel.includeRowIdentifierValues = False
+                }
+            )
+            exampleDecodingError
+     in rendered
+          === "Unable to decode row with identifier [foo = [REDACTED]]: \
+              \Unable to decode columns from result set: Failure. \
+              \Value(s) that failed to decode: [bar = baz]"
+
+prop_renderDecodingErrorWithoutNonIdValues :: Property.NamedProperty
+prop_renderDecodingErrorWithoutNonIdValues =
+  Property.singletonNamedProperty "Render decoding error without non id values" $
+    let rendered =
+          MarshallError.renderMarshallError
+            ( ErrorDetailLevel.maximalErrorDetailLevel
+                { ErrorDetailLevel.includeNonIdentifierValues = False
+                }
+            )
+            exampleDecodingError
+     in rendered
+          === "Unable to decode row with identifier [foo = 1]: \
+              \Unable to decode columns from result set: Failure. \
+              \Value(s) that failed to decode: [bar = [REDACTED]]"
+
+prop_renderDecodingErrorWithoutErrorMessage :: Property.NamedProperty
+prop_renderDecodingErrorWithoutErrorMessage =
+  Property.singletonNamedProperty "Render decoding error without non id values" $
+    let rendered =
+          MarshallError.renderMarshallError
+            ( ErrorDetailLevel.maximalErrorDetailLevel
+                { ErrorDetailLevel.includeErrorMessage = False
+                }
+            )
+            exampleDecodingError
+     in rendered
+          === "Unable to decode row with identifier [foo = 1]: \
+              \Unable to decode columns from result set: [REDACTED]. \
+              \Value(s) that failed to decode: [bar = baz]"
+
+{- |
+  Shared example used to test error detail level rendering of missing column
+  errors below.
+-}
+exampleMissingColumnError :: MarshallError.MarshallError
+exampleMissingColumnError =
+  MarshallError.MarshallError
+    { MarshallError.marshallErrorDetailLevel = ErrorDetailLevel.minimalErrorDetailLevel
+    , MarshallError.marshallErrorRowIdentifier = [(B8.pack "foo", SqlValue.fromInt8 1)]
+    , MarshallError.marshallErrorDetails =
+        MarshallError.MissingColumnError $
+          MarshallError.MissingColumnErrorDetails
+            { MarshallError.missingColumnName = B8.pack "baz"
+            , MarshallError.actualColumnNames = Set.fromList [B8.pack "foo", B8.pack "bar"]
+            }
+    }
+
+prop_renderMissingErrorDetailsWithFullDetails :: Property.NamedProperty
+prop_renderMissingErrorDetailsWithFullDetails =
+  Property.singletonNamedProperty "Render missing column error with full details" $
+    let rendered =
+          MarshallError.renderMarshallError
+            ErrorDetailLevel.maximalErrorDetailLevel
+            exampleMissingColumnError
+     in rendered
+          === "Unable to decode row with identifier [foo = 1]: \
+              \Column baz not found in results set. \
+              \Actual columns were [bar, foo]"
+
+prop_renderMissingErrorDetailsWithoutSchemaNames :: Property.NamedProperty
+prop_renderMissingErrorDetailsWithoutSchemaNames =
+  Property.singletonNamedProperty "Render missing column error without schema names" $
+    let rendered =
+          MarshallError.renderMarshallError
+            ( ErrorDetailLevel.maximalErrorDetailLevel
+                { ErrorDetailLevel.includeSchemaNames = False
+                }
+            )
+            exampleMissingColumnError
+     in rendered
+          === "Unable to decode row with identifier [[REDACTED] = 1]: \
+              \Column [REDACTED] not found in results set. \
+              \Actual columns were [[REDACTED], [REDACTED]]"
+
+prop_showMarshallErrorRaisedFromOrvilleContext :: Property.NamedDBProperty
+prop_showMarshallErrorRaisedFromOrvilleContext =
+  Property.namedDBProperty "Showing a MarshallError raised from an Orville context" $ \pool -> do
+    errorDetailLevel <- HH.forAll generateErrorDetailLevel
+
+    let sql =
+          RawSql.fromString "SELECT 1 as id, 'notAnNumber' as number"
+
+        marshaller =
+          Orville.annotateSqlMarshaller [Orville.stringToFieldName "id"] $
+            Orville.marshallField id (Orville.integerField "number")
+
+        orvilleState =
+          Orville.newOrvilleState errorDetailLevel pool
+
+    result <-
+      HH.evalIO $ do
+        E.try . Orville.runOrvilleWithState orvilleState $ do
+          Orville.executeAndDecode sql marshaller
+
+    case result of
+      Right _ -> do
+        HH.annotate "Expected decoding result set to fail, but it did not"
+        HH.failure
+      Left marshallError ->
+        show marshallError
+          === MarshallError.renderMarshallError errorDetailLevel marshallError
+
+generateErrorDetailLevel :: HH.Gen ErrorDetailLevel.ErrorDetailLevel
+generateErrorDetailLevel =
+  ErrorDetailLevel.ErrorDetailLevel
+    <$> Gen.bool
+    <*> Gen.bool
+    <*> Gen.bool
+    <*> Gen.bool

--- a/orville-postgresql-libpq/test/Test/SqlMarshaller.hs
+++ b/orville-postgresql-libpq/test/Test/SqlMarshaller.hs
@@ -4,16 +4,22 @@ module Test.SqlMarshaller
 where
 
 import qualified Control.Monad.IO.Class as MIO
+import qualified Data.Bifunctor as Bifunctor
 import qualified Data.ByteString.Char8 as B8
+import qualified Data.Either as Either
 import qualified Data.Int as Int
+import qualified Data.Set as Set
 import qualified Data.String as String
 import qualified Data.Text as T
+import Hedgehog ((===))
 import qualified Hedgehog as HH
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
+import qualified Orville.PostgreSQL.Internal.ErrorDetailLevel as ErrorDetailLevel
 import qualified Orville.PostgreSQL.Internal.ExecutionResult as Result
 import qualified Orville.PostgreSQL.Internal.FieldDefinition as FieldDefinition
+import qualified Orville.PostgreSQL.Internal.MarshallError as MarshallError
 import qualified Orville.PostgreSQL.Internal.SqlMarshaller as SqlMarshaller
 import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
 
@@ -25,184 +31,240 @@ sqlMarshallerTests :: Property.Group
 sqlMarshallerTests =
   Property.group
     "SqlMarshaller"
-    [
-      ( String.fromString "Can round read a pure Int via SqlMarshaller"
-      , HH.property $ do
-          someInt <- HH.forAll generateInt
-          result <- MIO.liftIO $ SqlMarshaller.marshallRowFromSql (pure someInt) (Result.Row 0) (Result.mkFakeLibPQResult [] [])
-          result HH.=== Right someInt
-      )
-    ,
-      ( String.fromString "Can combine SqlMarshallers with <*>"
-      , HH.property $ do
-          firstInt <- HH.forAll generateInt
-          secondInt <- HH.forAll generateInt
-          result <- MIO.liftIO $ SqlMarshaller.marshallRowFromSql ((pure (+ firstInt)) <*> (pure secondInt)) (Result.Row 0) (Result.mkFakeLibPQResult [] [])
-          result HH.=== Right (firstInt + secondInt)
-      )
-    ,
-      ( String.fromString "Read a single field from a result row using marshallField"
-      , HH.property $ do
-          targetName <- HH.forAll generateName
-          targetValue <- HH.forAll generateInt32
-
-          namesBefore <- HH.forAll (generateNamesOtherThan targetName)
-          namesAfter <- HH.forAll (generateNamesOtherThan targetName)
-
-          valuesBefore <- HH.forAll (generateAssociatedValues namesBefore generateInt32)
-          valuesAfter <- HH.forAll (generateAssociatedValues namesAfter generateInt32)
-
-          let fieldDef = FieldDefinition.integerField targetName
-              marshaller = SqlMarshaller.marshallField id fieldDef
-              input =
-                Result.mkFakeLibPQResult
-                  (map B8.pack (namesBefore ++ (targetName : namesAfter)))
-                  [map SqlValue.fromInt32 (valuesBefore ++ (targetValue : valuesAfter))]
-
-          result <- MIO.liftIO $ SqlMarshaller.marshallRowFromSql marshaller (Result.Row 0) input
-          result HH.=== Right targetValue
-      )
-    ,
-      ( String.fromString "marshallField fails gracefully when decoding a non-existent column"
-      , HH.property $ do
-          targetName <- HH.forAll generateName
-          otherNames <- HH.forAll (generateNamesOtherThan targetName)
-          otherValues <- HH.forAll (generateAssociatedValues otherNames generateInt32)
-
-          let fieldDef = FieldDefinition.integerField targetName
-              marshaller = SqlMarshaller.marshallField id fieldDef
-              input =
-                Result.mkFakeLibPQResult
-                  (map B8.pack otherNames)
-                  [map SqlValue.fromInt32 otherValues]
-
-          result <- MIO.liftIO $ SqlMarshaller.marshallRowFromSql marshaller (Result.Row 0) input
-          result HH.=== Left SqlMarshaller.FieldNotFoundInResultSet
-      )
-    ,
-      ( String.fromString "marshallField fails gracefully when decoding a bad value"
-      , HH.property $ do
-          targetName <- HH.forAll generateName
-          nonIntegerText <- HH.forAll (Gen.text (Range.linear 0 10) Gen.alpha)
-
-          let fieldDef = FieldDefinition.integerField targetName
-              marshaller = SqlMarshaller.marshallField id fieldDef
-              input =
-                Result.mkFakeLibPQResult
-                  [B8.pack targetName]
-                  [[SqlValue.fromText nonIntegerText]]
-
-          result <- MIO.liftIO $ SqlMarshaller.marshallRowFromSql marshaller (Result.Row 0) input
-          result HH.=== Left SqlMarshaller.FailedToDecodeValue
-      )
-    ,
-      ( String.fromString "marshallResultFromSql decodes all rows in Foo result set"
-      , HH.property $ do
-          foos <- HH.forAll $ Gen.list (Range.linear 0 10) generateFoo
-
-          let mkRowValues foo =
-                [ SqlValue.fromText (fooName foo)
-                , SqlValue.fromInt32 (fooSize foo)
-                , maybe SqlValue.sqlNull SqlValue.fromBool (fooOption foo)
-                ]
-
-              input =
-                Result.mkFakeLibPQResult
-                  [B8.pack "name", B8.pack "size", B8.pack "option"]
-                  (map mkRowValues foos)
-
-          result <- MIO.liftIO $ SqlMarshaller.marshallResultFromSql fooMarshaller input
-          result HH.=== Right foos
-      )
-    ,
-      ( String.fromString "marshallResultFromSql decodes all rows in Bar result set"
-      , HH.property $ do
-          bars <- HH.forAll $ Gen.list (Range.linear 0 10) generateBar
-
-          let mkRowValues bar =
-                [ SqlValue.fromDouble (barNumber bar)
-                , maybe SqlValue.sqlNull SqlValue.fromText (barComment bar)
-                , maybe SqlValue.sqlNull SqlValue.fromText (barLabel bar)
-                ]
-
-              input =
-                Result.mkFakeLibPQResult
-                  [B8.pack "number", B8.pack "comment", B8.pack "label"]
-                  (map mkRowValues bars)
-
-          result <- MIO.liftIO $ SqlMarshaller.marshallResultFromSql barMarshaller input
-          result HH.=== Right bars
-      )
-    ,
-      ( String.fromString "foldMarshallerFields collects all fields as their sql values"
-      , HH.property $ do
-          foo <- HH.forAll generateFoo
-
-          let addField entry fields =
-                case entry of
-                  SqlMarshaller.Natural fieldDef (Just getValue) ->
-                    (FieldDefinition.fieldName fieldDef, FieldDefinition.fieldValueToSqlValue fieldDef (getValue foo)) : fields
-                  SqlMarshaller.Natural _ Nothing ->
-                    fields
-                  SqlMarshaller.Synthetic _ ->
-                    fields
-
-              actualFooRow =
-                SqlMarshaller.foldMarshallerFields
-                  fooMarshaller
-                  []
-                  addField
-
-              expectedFooRow =
-                [ (FieldDefinition.stringToFieldName "name", SqlValue.fromText $ fooName foo)
-                , (FieldDefinition.stringToFieldName "size", SqlValue.fromInt32 $ fooSize foo)
-                , (FieldDefinition.stringToFieldName "option", maybe SqlValue.sqlNull SqlValue.fromBool $ fooOption foo)
-                ]
-
-          [actualFooRow] `assertEqualSqlRows` [expectedFooRow]
-      )
-    ,
-      ( String.fromString "can pass a Maybe through SqlMarshaller"
-      , HH.property $ do
-          someMaybeBool <- HH.forAll $ Gen.maybe Gen.bool
-          result <- MIO.liftIO $ SqlMarshaller.marshallRowFromSql (pure someMaybeBool) (Result.Row 0) (Result.mkFakeLibPQResult [] [])
-          result HH.=== Right someMaybeBool
-      )
-    ,
-      ( String.fromString "can use a partialMap with SqlMarshaller with no error"
-      , HH.property $ do
-          bazs <- HH.forAll $ Gen.list (Range.linear 0 10) generateBaz
-
-          let mkRowValues baz =
-                [ SqlValue.fromText (bazField baz)
-                ]
-
-              input =
-                Result.mkFakeLibPQResult
-                  [B8.pack "field"]
-                  (map mkRowValues bazs)
-
-          result <- MIO.liftIO $ SqlMarshaller.marshallResultFromSql bazMarshallerRight input
-          result HH.=== Right bazs
-      )
-    ,
-      ( String.fromString "can use a partialMap with SqlMarshaller with an error"
-      , HH.property $ do
-          bazs <- HH.forAll $ Gen.list (Range.linear 0 10) generateBaz
-
-          let mkRowValues baz =
-                [ SqlValue.fromText (bazField baz)
-                ]
-
-              input =
-                Result.mkFakeLibPQResult
-                  [B8.pack "field"]
-                  (map mkRowValues bazs)
-
-          result <- MIO.liftIO $ SqlMarshaller.marshallResultFromSql bazMarshallerLeft input
-          result HH.=== if null bazs then Right [] else Left SqlMarshaller.FailedToDecodeValue
-      )
+    [ property_returnPureValue
+    , property_combineWithApplicative
+    , property_marshellField_readSingleField
+    , prop_marshallField_missingColumn
+    , prop_marshallField_decodeValueFailure
+    , prop_marshallResultFromSql_Foo
+    , prop_marshallResultFromSql_Bar
+    , prop_foldMarshallerFields
+    , prop_passMaybeThrough
+    , prop_partialMap
     ]
+
+property_returnPureValue :: Property.NamedProperty
+property_returnPureValue =
+  Property.namedProperty "Can read a pure Int via SqlMarshaller" $ do
+    someInt <- HH.forAll generateInt
+    result <- marshallTestRowFromSql (pure someInt) (Result.mkFakeLibPQResult [] [[]])
+    Bifunctor.first show result === Right [someInt]
+
+property_combineWithApplicative :: Property.NamedProperty
+property_combineWithApplicative =
+  Property.namedProperty "Can combine SqlMarshallers with <*>" $ do
+    firstInt <- HH.forAll generateInt
+    secondInt <- HH.forAll generateInt
+    result <- marshallTestRowFromSql ((pure (+ firstInt)) <*> (pure secondInt)) (Result.mkFakeLibPQResult [] [[]])
+    Bifunctor.first show result === Right [firstInt + secondInt]
+
+property_marshellField_readSingleField :: Property.NamedProperty
+property_marshellField_readSingleField =
+  Property.namedProperty "Read a single field from a result row using marshallField" $ do
+    targetName <- HH.forAll generateName
+    targetValue <- HH.forAll generateInt32
+
+    namesBefore <- HH.forAll (generateNamesOtherThan targetName)
+    namesAfter <- HH.forAll (generateNamesOtherThan targetName)
+
+    valuesBefore <- HH.forAll (generateAssociatedValues namesBefore generateInt32)
+    valuesAfter <- HH.forAll (generateAssociatedValues namesAfter generateInt32)
+
+    let fieldDef = FieldDefinition.integerField targetName
+        marshaller = SqlMarshaller.marshallField id fieldDef
+        input =
+          Result.mkFakeLibPQResult
+            (map B8.pack (namesBefore ++ (targetName : namesAfter)))
+            [map SqlValue.fromInt32 (valuesBefore ++ (targetValue : valuesAfter))]
+
+    result <- marshallTestRowFromSql marshaller input
+    Bifunctor.first show result === Right [targetValue]
+
+prop_marshallField_missingColumn :: Property.NamedProperty
+prop_marshallField_missingColumn =
+  Property.namedProperty "marshallField fails gracefully when decoding a non-existent column" $ do
+    targetName <- HH.forAll generateName
+    otherNames <- HH.forAll (generateNamesOtherThan targetName)
+    otherValues <- HH.forAll (generateAssociatedValues otherNames generateInt32)
+
+    let fieldDef = FieldDefinition.integerField targetName
+        marshaller = SqlMarshaller.marshallField id fieldDef
+        input =
+          Result.mkFakeLibPQResult
+            (map B8.pack otherNames)
+            [map SqlValue.fromInt32 otherValues]
+
+        expectedError =
+          MarshallError.MarshallError
+            { MarshallError.marshallErrorDetailLevel = ErrorDetailLevel.maximalErrorDetailLevel
+            , MarshallError.marshallErrorRowIdentifier = mempty
+            , MarshallError.marshallErrorDetails =
+                MarshallError.MissingColumnError $
+                  MarshallError.MissingColumnErrorDetails
+                    { MarshallError.missingColumnName = B8.pack targetName
+                    , MarshallError.actualColumnNames = Set.fromList $ fmap B8.pack otherNames
+                    }
+            }
+
+    result <- marshallTestRowFromSql marshaller input
+    -- Use show on the error here so MarshallError and friends don't
+    -- need an Eq instance
+    Bifunctor.first show result === Left (show expectedError)
+
+prop_marshallField_decodeValueFailure :: Property.NamedProperty
+prop_marshallField_decodeValueFailure =
+  Property.namedProperty "marshallField fails gracefully when failing to decode a value" $ do
+    targetName <- HH.forAll generateName
+    nonIntegerText <- HH.forAll (Gen.text (Range.linear 0 10) Gen.alpha)
+
+    let fieldDef = FieldDefinition.integerField targetName
+        marshaller = SqlMarshaller.marshallField id fieldDef
+        input =
+          Result.mkFakeLibPQResult
+            [B8.pack targetName]
+            [[SqlValue.fromText nonIntegerText]]
+
+    result <- marshallTestRowFromSql marshaller input
+
+    case result of
+      Right n -> do
+        HH.annotateShow n
+        HH.footnote "Expected decoding failure, but got success"
+        HH.failure
+      Left rowDecodeErr ->
+        case MarshallError.marshallErrorDetails rowDecodeErr of
+          MarshallError.DecodingError details ->
+            map fst (MarshallError.decodingErrorValues details) === [B8.pack targetName]
+          err -> do
+            HH.annotate $ MarshallError.renderMarshallErrorDetails ErrorDetailLevel.maximalErrorDetailLevel err
+            HH.footnote "Expected DecodingError error, but got another error instead."
+            HH.failure
+
+prop_marshallResultFromSql_Foo :: Property.NamedProperty
+prop_marshallResultFromSql_Foo =
+  Property.namedProperty "marshallResultFromSql decodes all rows in Foo result set" $ do
+    foos <- HH.forAll $ Gen.list (Range.linear 0 10) generateFoo
+
+    let mkRowValues foo =
+          [ SqlValue.fromText (fooName foo)
+          , SqlValue.fromInt32 (fooSize foo)
+          , maybe SqlValue.sqlNull SqlValue.fromBool (fooOption foo)
+          ]
+
+        input =
+          Result.mkFakeLibPQResult
+            [B8.pack "name", B8.pack "size", B8.pack "option"]
+            (map mkRowValues foos)
+
+    result <- marshallTestRowFromSql fooMarshaller input
+    Bifunctor.first show result === Right foos
+
+prop_marshallResultFromSql_Bar :: Property.NamedProperty
+prop_marshallResultFromSql_Bar =
+  Property.namedProperty "marshallResultFromSql decodes all rows in Bar result set" $ do
+    bars <- HH.forAll $ Gen.list (Range.linear 0 10) generateBar
+
+    let mkRowValues bar =
+          [ SqlValue.fromDouble (barNumber bar)
+          , maybe SqlValue.sqlNull SqlValue.fromText (barComment bar)
+          , maybe SqlValue.sqlNull SqlValue.fromText (barLabel bar)
+          ]
+
+        input =
+          Result.mkFakeLibPQResult
+            [B8.pack "number", B8.pack "comment", B8.pack "label"]
+            (map mkRowValues bars)
+
+    result <- marshallTestRowFromSql barMarshaller input
+    Bifunctor.first show result === Right bars
+
+prop_foldMarshallerFields :: Property.NamedProperty
+prop_foldMarshallerFields =
+  Property.namedProperty "foldMarshallerFields collects all fields as their sql values" $ do
+    foo <- HH.forAll generateFoo
+
+    let addField entry fields =
+          case entry of
+            SqlMarshaller.Natural fieldDef (Just getValue) ->
+              (FieldDefinition.fieldName fieldDef, FieldDefinition.fieldValueToSqlValue fieldDef (getValue foo)) : fields
+            SqlMarshaller.Natural _ Nothing ->
+              fields
+            SqlMarshaller.Synthetic _ ->
+              fields
+
+        actualFooRow =
+          SqlMarshaller.foldMarshallerFields
+            fooMarshaller
+            []
+            addField
+
+        expectedFooRow =
+          [ (FieldDefinition.stringToFieldName "name", SqlValue.fromText $ fooName foo)
+          , (FieldDefinition.stringToFieldName "size", SqlValue.fromInt32 $ fooSize foo)
+          , (FieldDefinition.stringToFieldName "option", maybe SqlValue.sqlNull SqlValue.fromBool $ fooOption foo)
+          ]
+
+    [actualFooRow] `assertEqualSqlRows` [expectedFooRow]
+
+prop_passMaybeThrough :: Property.NamedProperty
+prop_passMaybeThrough =
+  Property.namedProperty "can pass a Maybe through SqlMarshaller" $ do
+    someMaybeBool <- HH.forAll $ Gen.maybe Gen.bool
+    result <- marshallTestRowFromSql (pure someMaybeBool) (Result.mkFakeLibPQResult [] [[]])
+    Bifunctor.first show result === Right [someMaybeBool]
+
+prop_partialMap :: Property.NamedProperty
+prop_partialMap =
+  Property.namedProperty "can use marshallPartial to fail decoding with in a custom way" $ do
+    texts <- HH.forAll $ Gen.list (Range.linear 0 10) (PgGen.pgText (Range.linear 0 10))
+
+    let validateText text =
+          if T.length text > 8
+            then Left "Text too long"
+            else Right text
+
+        mkRowValues text =
+          [ SqlValue.fromText text
+          ]
+
+        input =
+          Result.mkFakeLibPQResult
+            [B8.pack "text"]
+            (map mkRowValues texts)
+
+        marshaller =
+          SqlMarshaller.marshallPartial $
+            validateText
+              <$> SqlMarshaller.marshallField id (FieldDefinition.unboundedTextField "text")
+
+        mkExpected text =
+          case validateText text of
+            Right validText ->
+              Right validText
+            Left message ->
+              Left $
+                -- Use show here to render the error so that MarshallError
+                -- and friends don't need to have an Eq instance
+                show $
+                  MarshallError.MarshallError
+                    { MarshallError.marshallErrorDetailLevel = ErrorDetailLevel.maximalErrorDetailLevel
+                    , MarshallError.marshallErrorRowIdentifier = mempty
+                    , MarshallError.marshallErrorDetails =
+                        MarshallError.DecodingError $
+                          MarshallError.DecodingErrorDetails
+                            { MarshallError.decodingErrorValues = [(B8.pack "text", SqlValue.fromText text)]
+                            , MarshallError.decodingErrorMessage = message
+                            }
+                    }
+
+        expected =
+          traverse mkExpected texts
+
+    HH.cover 1 (String.fromString "With no errors") (Either.isRight expected)
+    HH.cover 1 (String.fromString "With at least one error") (Either.isLeft expected)
+
+    result <- marshallTestRowFromSql marshaller input
+    Bifunctor.first show result === expected
 
 data Foo = Foo
   { fooName :: T.Text
@@ -215,11 +277,6 @@ data Bar = Bar
   { barNumber :: Double
   , barComment :: Maybe T.Text
   , barLabel :: Maybe T.Text
-  }
-  deriving (Eq, Show)
-
-data Baz = Baz
-  { bazField :: T.Text
   }
   deriving (Eq, Show)
 
@@ -251,25 +308,6 @@ generateBar =
     <*> Gen.maybe (PgGen.pgText $ Range.linear 0 32)
     <*> Gen.maybe (PgGen.pgText $ Range.linear 1 16)
 
-bazMarshallerRight :: SqlMarshaller.SqlMarshaller Baz Baz
-bazMarshallerRight =
-  SqlMarshaller.marshallPartial $
-    fmap Right $
-      Baz
-        <$> SqlMarshaller.marshallField bazField (FieldDefinition.unboundedTextField "field")
-
-bazMarshallerLeft :: SqlMarshaller.SqlMarshaller Baz Baz
-bazMarshallerLeft =
-  SqlMarshaller.marshallPartial $
-    fmap (Left . const SqlMarshaller.FailedToDecodeValue) $
-      Baz
-        <$> SqlMarshaller.marshallField bazField (FieldDefinition.unboundedTextField "field")
-
-generateBaz :: HH.Gen Baz
-generateBaz =
-  Baz
-    <$> PgGen.pgText (Range.linear 1 5)
-
 generateNamesOtherThan :: String -> HH.Gen [String]
 generateNamesOtherThan specialName =
   Gen.list
@@ -294,3 +332,19 @@ generateName =
 
 generateInt :: HH.MonadGen m => m Int
 generateInt = Gen.int $ Range.exponential 1 1024
+
+marshallTestRowFromSql ::
+  ( HH.MonadTest m
+  , MIO.MonadIO m
+  , Result.ExecutionResult result
+  ) =>
+  SqlMarshaller.SqlMarshaller writeEntity readEntity ->
+  result ->
+  m (Either MarshallError.MarshallError [readEntity])
+marshallTestRowFromSql marshaller input =
+  HH.evalIO $
+    SqlMarshaller.marshallResultFromSqlUsingRowIdExtractor
+      ErrorDetailLevel.maximalErrorDetailLevel
+      (SqlMarshaller.mkRowIdentityExtractor [] input)
+      marshaller
+      input


### PR DESCRIPTION
This adds detail error information to the `MarshallError` produced by
`SqlMarshaller` when marshalling fails. This includes row identifiers
for the row being decode, as well as details about the column and values
being decode and any more general message provided by the source of the
decoding failure.

A new `ErrorDetailLevel` type controls the level of detailed actually
included in when the `MarshallError` is rendered to a `String` to be
displayed. This can be specified manually simply by catching the error
and providing the desired detail level to the render function. A default
value can be provided as well when constructing the `OrvilleState`,
which is what will be used if the `MarshallError` is rendered as an
`Exception` (via its `Show` instance).

The `SqlMarshaller` lacks any notion of which columns might be the row
identifiers to inlude in the error message. A new wrapper type, the
`AnnotatedSqlMarshaller` now captures that information. This new type
is automatically created when the `TableDefinition` is built, using
the primary key of the table as the row id.