### PR TITLE
Ports orville 0.9 triggers to orville-libpq as EntityTrace

### DIFF
--- a/orville-postgresql-libpq/orville-postgresql-libpq.cabal
+++ b/orville-postgresql-libpq/orville-postgresql-libpq.cabal
@@ -32,6 +32,7 @@ library
       Orville.PostgreSQL
       Orville.PostgreSQL.AutoMigration
       Orville.PostgreSQL.Connection
+      Orville.PostgreSQL.EntityTrace
       Orville.PostgreSQL.Internal.DefaultValue
       Orville.PostgreSQL.Internal.ErrorDetailLevel
       Orville.PostgreSQL.Internal.ExecutionResult
@@ -160,6 +161,7 @@ test-suite spec
       Test.Entities.FooChild
       Test.Entities.User
       Test.EntityOperations
+      Test.EntityTrace
       Test.Expr.GroupBy
       Test.Expr.InsertUpdateDelete
       Test.Expr.OrderBy
@@ -181,6 +183,7 @@ test-suite spec
       Test.TableDefinition
       Test.TestTable
       Test.Transaction
+      Test.Transaction.Util
       Paths_orville_postgresql_libpq
   hs-source-dirs:
       test

--- a/orville-postgresql-libpq/package.yaml
+++ b/orville-postgresql-libpq/package.yaml
@@ -24,6 +24,7 @@ library:
     - Orville.PostgreSQL
     - Orville.PostgreSQL.AutoMigration
     - Orville.PostgreSQL.Connection
+    - Orville.PostgreSQL.EntityTrace
     - Orville.PostgreSQL.Internal.DefaultValue
     - Orville.PostgreSQL.Internal.ErrorDetailLevel
     - Orville.PostgreSQL.Internal.ExecutionResult

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/EntityTrace.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/EntityTrace.hs
@@ -1,0 +1,710 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Orville.PostgreSQL.EntityTrace
+  ( EntityTraceT,
+    EntityTraceState,
+    runEntityTraceT,
+    insertEntityTraced,
+    updateEntityTraced,
+    deleteEntityTraced,
+    TracedTable,
+    mkTracedTable,
+    addInsertTrace,
+    addUpdateTrace,
+    addDeleteTrace,
+    untracedTableDefinition,
+    MonadEntityTrace (recordTraces, liftOrvilleUntraced),
+  )
+where
+
+import qualified Control.Exception as Ex
+import Control.Monad.IO.Class (MonadIO (liftIO))
+import Control.Monad.Trans.Class (MonadTrans (lift))
+import Control.Monad.Trans.Reader (ReaderT, ask, runReaderT)
+import qualified Data.DList as DList
+import Data.Foldable (traverse_)
+import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef)
+import Data.Pool (Pool)
+
+import qualified Orville.PostgreSQL as O
+import qualified Orville.PostgreSQL.Connection as Conn
+
+{- |
+ 'MonadEntityTrace' provides the interface used by functions such as
+ 'insertEntityTraced' to perform tracing as part of their operation. An
+ instance for 'ReaderT EntityTraceState' is provided which can be used via
+ 'runEntityTraceT'.
+-}
+class Monad m => MonadEntityTrace trace m | m -> trace where
+  recordTraces :: [trace] -> m ()
+  liftOrvilleUntraced :: (forall n. O.MonadOrville n => n a) -> m a
+
+{- |
+  INTERNAL: A list of functions for constructing traces
+-}
+newtype Constructors f
+  = Constructors (DList.DList f)
+
+emptyConstructors :: Constructors f
+emptyConstructors =
+  Constructors DList.empty
+
+addConstructor :: f -> Constructors f -> Constructors f
+addConstructor f (Constructors fs) =
+  Constructors (DList.snoc fs f)
+
+applyConstructors :: (f -> [a]) -> Constructors f -> [a]
+applyConstructors runF (Constructors fs) =
+  concatMap runF fs
+
+{- |
+  A 'TracedTable' is a regular 'O.TableDefinition' with callbacks for
+  constructing the @trace@ items that will be captured when functions such as
+  'insertEntityTraced' are used. Use 'mkTracedTable' to build a 'TracedTable'
+  with no callbacks and then use 'addInsertTrace' and friends to register
+  callbacks callbacks on the table.
+-}
+data TracedTable trace key writeEntity readEntity = TracedTable
+  { _untracedTableDefinition :: O.TableDefinition (O.HasKey key) writeEntity readEntity
+  , _getTracedEntityKey :: readEntity -> key
+  , _insertTraceConstructors :: Constructors (writeEntity -> readEntity -> [trace])
+  , _updateTraceConstructors :: Constructors (readEntity -> writeEntity -> Maybe readEntity -> [trace])
+  , _deleteTraceConstructors :: Constructors (key -> Maybe readEntity -> [trace])
+  }
+
+{- |
+  Constructs a 'TracedTable' that wraps the given 'O.TableDefinition' so that
+  it can be used with functions such as 'insertEntityTraced'. The resulting
+  'TracedTable' has no trace callbacks initially. You can 'addInsertTrace' and
+  similar functions ta add callbacks.
+-}
+mkTracedTable ::
+  (readEntity -> key) ->
+  O.TableDefinition (O.HasKey key) writeEntity readEntity ->
+  TracedTable trace key writeEntity readEntity
+mkTracedTable getEntityKey tableDef =
+  TracedTable
+    { _untracedTableDefinition = tableDef
+    , _getTracedEntityKey = getEntityKey
+    , _insertTraceConstructors = emptyConstructors
+    , _updateTraceConstructors = emptyConstructors
+    , _deleteTraceConstructors = emptyConstructors
+    }
+
+{- |
+  INTERNAL: Construct traces to be recorded by 'insertEntityTraced' based on
+  all the constructor callbacks there were added via 'addInsertTrace'
+-}
+mkInsertTraces ::
+  TracedTable trace key writeEntity readEntity ->
+  writeEntity ->
+  readEntity ->
+  [trace]
+mkInsertTraces tracedTable readEntity writeEntity =
+  applyConstructors
+    (\f -> f readEntity writeEntity)
+    (_insertTraceConstructors tracedTable)
+
+{- |
+  INTERNAL: Construct traces to be recorded by 'updateEntityTraced' based on
+  all the constructor callbacks there were added via 'addUpdateTrace'
+-}
+mkUpdateTraces ::
+  TracedTable trace key writeEntity readEntity ->
+  readEntity ->
+  writeEntity ->
+  Maybe readEntity ->
+  [trace]
+mkUpdateTraces tracedTable readEntity writeEntity mbUpdatedEntity =
+  applyConstructors
+    (\f -> f readEntity writeEntity mbUpdatedEntity)
+    (_updateTraceConstructors tracedTable)
+
+{- |
+  INTERNAL: Construct traces to be recorded by 'deleteEntityTraced' based on
+  all the constructor callbacks that were added via 'addDeleteTrace'
+-}
+mkDeleteTraces ::
+  TracedTable trace key writeEntity readEntity ->
+  key ->
+  Maybe readEntity ->
+  [trace]
+mkDeleteTraces tracedTable key mbDeletedEntity =
+  applyConstructors
+    (\f -> f key mbDeletedEntity)
+    (_deleteTraceConstructors tracedTable)
+
+{- |
+  Returns the 'O.TableDefinition' underlying a 'TracedTable'. You can use this
+  to get access to the table definiton to use the regular untraced Orville
+  functions without having to keep a separate reference to the untraced table
+  around.
+-}
+untracedTableDefinition ::
+  TracedTable trace key writeEntity readEntity ->
+  O.TableDefinition (O.HasKey key) writeEntity readEntity
+untracedTableDefinition =
+  _untracedTableDefinition
+
+{- |
+  Adds a callback that will be used during 'insertEntityTraced' to build the
+  @trace@ items to be recorded for that insert. The trace building function
+  will be passed the @writeEntity@ given to 'insertEntityTraced' as well as
+  the @readEntity@ that is returned as a result of the insert.
+-}
+addInsertTrace ::
+  (writeEntity -> readEntity -> [trace]) ->
+  TracedTable trace key writeEntity readEntity ->
+  TracedTable trace key writeEntity readEntity
+addInsertTrace mkTraces tracedTable =
+  tracedTable
+    { _insertTraceConstructors = addConstructor mkTraces (_insertTraceConstructors tracedTable)
+    }
+
+{- |
+  Adds a callback that will be used during 'updateEntityTraced' to build the
+  @trace@ items to be recorded for that update. The trace building function
+  will be passed the @readEntity@ and @writeEntity@ that were given to
+  'updateEntityTraced' as well as the any @readEntity@ that is returned as a
+  result of the insert. If the update matches no rows in the database, 'Nothing'
+  will be passed as the last argument to the trace building function.
+-}
+addUpdateTrace ::
+  (readEntity -> writeEntity -> Maybe readEntity -> [trace]) ->
+  TracedTable trace key writeEntity readEntity ->
+  TracedTable trace key writeEntity readEntity
+addUpdateTrace mkTraces tracedTable =
+  tracedTable
+    { _updateTraceConstructors = addConstructor mkTraces (_updateTraceConstructors tracedTable)
+    }
+
+{- |
+  Adds a callback that will be used during 'deleteEntityTraced' to build the
+  @trace@ items to be recorded for that update. The trace building function
+  will be passed the @key@ that sa given to 'deleteEntityTraced' as well as the
+  any @readEntity@ that is returned as a result of the delete. If the delete
+  matches no rows in the database, 'Nothing' will be passed as the last
+  argument to the trace building function.
+-}
+addDeleteTrace ::
+  (key -> Maybe readEntity -> [trace]) ->
+  TracedTable trace key writeEntity readEntity ->
+  TracedTable trace key writeEntity readEntity
+addDeleteTrace mkTraces tracedTable =
+  tracedTable
+    { _deleteTraceConstructors = addConstructor mkTraces (_deleteTraceConstructors tracedTable)
+    }
+
+{- |
+  Inserts an entity into the database via 'O.insertAndReturnEntity', then records
+  any traces returned by the 'addInsertTrace' callbacks on the 'TracedTable'
+  via 'recordTraces'.
+
+  See 'runEntityTraceT' for a stock way to run actions using these trace
+  operations and get access to the traces that are recorded.
+-}
+insertEntityTraced ::
+  MonadEntityTrace trace m =>
+  TracedTable trace key writeEntity readEntity ->
+  writeEntity ->
+  m readEntity
+insertEntityTraced tracedTable writeEntity = do
+  readEntity <-
+    liftOrvilleUntraced $
+      O.insertAndReturnEntity
+        (_untracedTableDefinition tracedTable)
+        writeEntity
+
+  recordTraces $ mkInsertTraces tracedTable writeEntity readEntity
+  pure readEntity
+
+{- |
+  Updates an entity in the database via 'O.updateAndReturnEntity', then records
+  any traces returned by the 'addUpdateTrace' callbacks on the 'TracedTable'
+  via 'recordTraces'.
+
+  See 'runEntityTraceT' for a stock way to run actions using these trace
+  operations and get access to the traces that are recorded.
+-}
+updateEntityTraced ::
+  MonadEntityTrace trace m =>
+  TracedTable trace key writeEntity readEntity ->
+  readEntity ->
+  writeEntity ->
+  m ()
+updateEntityTraced tracedTable oldEntity newEntity = do
+  updatedEntity <-
+    liftOrvilleUntraced $
+      O.updateAndReturnEntity
+        (_untracedTableDefinition tracedTable)
+        (_getTracedEntityKey tracedTable oldEntity)
+        newEntity
+
+  recordTraces $ mkUpdateTraces tracedTable oldEntity newEntity updatedEntity
+
+{- |
+  Updates an entity in the database via 'O.deleteAndReturnEntity', then records
+  any traces returned by the 'addDeleteTrace' callbacks on the 'TracedTable'
+  via 'recordTraces'.
+
+  See 'runEntityTraceT' for a stock way to run actions using these trace
+  operations and get access to the traces that are recorded.
+-}
+deleteEntityTraced ::
+  MonadEntityTrace trace m =>
+  TracedTable trace key writeEntity readEntity ->
+  key ->
+  m ()
+deleteEntityTraced tracedTable key = do
+  readEntity <-
+    liftOrvilleUntraced $
+      O.deleteAndReturnEntity
+        (_untracedTableDefinition tracedTable)
+        key
+
+  recordTraces $ mkDeleteTraces tracedTable key readEntity
+
+{- |
+  An 'EntityTraceState' is created by 'runEntityTraceT' to keep track of
+  the state of traces that are to be returned when the function finishes.
+-}
+newtype EntityTraceState trace = EntityTraceState
+  { _entityTraceStateRef :: IORef (RecordedTraces trace)
+  }
+
+{- |
+  INTERNAL: The 'RecordedTraces' structure stores all the data necessary to
+  keep the list of traces to be returned by 'runEntityTraceT' in sync with the
+  state of committed and rolled-back transactions that happen at the database
+  level, including savepoints. The 'EntityTraceState' keeps track of the
+  stricture in an 'IORef' that is modified over the life of the action that is
+  run by 'runEntityTraceT'
+-}
+data RecordedTraces trace = RecordedTraces
+  { committedTracesDList :: DList.DList trace
+  , currentTransactionStack :: Maybe (TransactionStack trace)
+  }
+
+{- |
+  INTERNAL: Tracks the state of any traces that occur while a transaction is
+  open. These are kept in a stack so that savepoints can be created, released
+  and rolled-back in sync with any `O.withTransaction` operations that occur
+  during 'runEntityTraceT'.
+-}
+data TransactionStack trace
+  = TransactionOpened (DList.DList trace)
+  | SavepointCreated O.Savepoint (DList.DList trace) (TransactionStack trace)
+
+{- |
+  INTERNAL: Assembles all the traces for the 'TransactionStack' into a 'DList'
+  in the order in which they originally occurred
+-}
+allTransactionStackTraces :: TransactionStack trace -> DList.DList trace
+allTransactionStackTraces stack =
+  case stack of
+    TransactionOpened traces ->
+      traces
+    SavepointCreated _ traces remainingStack ->
+      allTransactionStackTraces remainingStack <> traces
+
+{- |
+  INTERNAL: Adds some traces to whatever the currently open (innermost)
+  transaction or savepoint is for this stack.
+-}
+appendTracesAtTopOfStack ::
+  DList.DList trace ->
+  TransactionStack trace ->
+  TransactionStack trace
+appendTracesAtTopOfStack newTraces stack =
+  case stack of
+    TransactionOpened traces ->
+      TransactionOpened (traces <> newTraces)
+    SavepointCreated savepoint traces remainingStack ->
+      SavepointCreated savepoint (traces <> newTraces) remainingStack
+
+{- |
+  INTERNAL: Releases a savepoint (and any savepoints that were created after
+  it) from the stack, effectively "committing" it within the context of any
+  outer transaction that may exist.
+
+  If no matching savepoint can be found a 'Left' is produced with an error
+  message.
+-}
+releaseTransactionStackSavepoint ::
+  O.Savepoint ->
+  TransactionStack trace ->
+  Either String (TransactionStack trace)
+releaseTransactionStackSavepoint targetSavepoint =
+  let go ::
+        DList.DList trace ->
+        TransactionStack trace ->
+        Either String (TransactionStack trace)
+      go savedTraces stack =
+        case stack of
+          TransactionOpened _ ->
+            Left "Tried to release savepoint that could not be found in EntityTrace TransactionStack"
+          SavepointCreated currentSavepoint traces remainingStack ->
+            if currentSavepoint == targetSavepoint
+              then Right (appendTracesAtTopOfStack (traces <> savedTraces) remainingStack)
+              else go (traces <> savedTraces) remainingStack
+   in go DList.empty
+
+{- |
+  INTERNAL: Rolls back the transaction stack to a savepoint, eliminating any
+  traces or savepoints that have happened since the savepoint was begun. Note
+  that this does _not_ eliminate the targe savepoint, but does abandon any
+  traces that are stored at its level of the stack, resetting to a state as if
+  the savepoint had just been created.
+
+  If no matching savepoint can be found a 'Left' is produced with an error message.
+-}
+rollbackTransactionStackToSavepoint ::
+  O.Savepoint ->
+  TransactionStack trace ->
+  Either String (TransactionStack trace)
+rollbackTransactionStackToSavepoint targetSavepoint =
+  let go :: TransactionStack trace -> Either String (TransactionStack trace)
+      go stack =
+        case stack of
+          TransactionOpened _ ->
+            Left "Tried to rollback savepoint that could not be found in EntityTrace TransactionStack"
+          SavepointCreated currentSavepoint _uncommitedTraces remainingStack ->
+            if currentSavepoint == targetSavepoint
+              then Right (SavepointCreated currentSavepoint DList.empty remainingStack)
+              else go remainingStack
+   in go
+
+{- |
+  INTERNAL: A starting point for 'RecordedTraces' where nothing has been
+  recorded and no transaction stack has been created. This state corresponds to
+  when no transaction has yet been opened by the actions invoked by
+  'runEntityTraceT'. This is not exposed so that 'runEntityTraceT' can ensure
+  that the 'RecordedTraces' and the 'O.OrvilleState' are in sync at the
+  beginning of the traced action.
+-}
+emptyTraceData :: RecordedTraces trace
+emptyTraceData = RecordedTraces mempty Nothing
+
+{- |
+  INTERNAL: A voided version of 'atomicModifyIORef'' since it is not offered
+  as part of 'IORef'
+-}
+atomicModifyIORef'_ :: IORef a -> (a -> a) -> IO ()
+atomicModifyIORef'_ ref f = atomicModifyIORef' ref (\a -> (f a, ()))
+
+{- |
+  INTERNAL: Mutates the 'EntityTraceState' 'IORef' to add some traces to it.
+-}
+addTracesToRecord :: EntityTraceState trace -> [trace] -> IO ()
+addTracesToRecord traceState traces =
+  atomicModifyIORef'_ (_entityTraceStateRef traceState) $ \recorded ->
+    case currentTransactionStack recorded of
+      Just uncommitted ->
+        recorded
+          { currentTransactionStack =
+              Just $ appendTracesAtTopOfStack (DList.fromList traces) uncommitted
+          }
+      Nothing ->
+        recorded
+          { committedTracesDList =
+              committedTracesDList recorded <> DList.fromList traces
+          }
+
+{- |
+  INTERNAL: Responds to an Orville 'O.BeginTransaction' callback by mutating
+  the 'EntityTraceState' to begin a new transaction stack. The 'EntityTraceState'
+  is always expected to be in sync with the transaction state kept by orville,
+  so if there is already a transaction stack open this raises an error.
+-}
+beginTransaction :: EntityTraceState trace -> IO ()
+beginTransaction traceState = do
+  mbError <-
+    atomicModifyIORef' (_entityTraceStateRef traceState) $ \recorded ->
+      case currentTransactionStack recorded of
+        Just _ ->
+          (recorded, Just beginTransactionStateError)
+        Nothing ->
+          ( recorded
+              { currentTransactionStack = Just (TransactionOpened DList.empty)
+              }
+          , Nothing
+          )
+
+  traverse_ Ex.throwIO mbError
+
+{- |
+  INTERNAL: Responds to an Orville 'O.CommitTransaction' callback by mutating
+  the 'EntityTraceState' to commit the current transaction stack. The 'EntityTraceState'
+  is always expected to be in sync with the transaction state kept by orville,
+  so if there is no transaction stack this raises an error.
+-}
+commitTransaction :: EntityTraceState trace -> IO ()
+commitTransaction traceState = do
+  mbError <-
+    atomicModifyIORef' (_entityTraceStateRef traceState) $ \recorded ->
+      case currentTransactionStack recorded of
+        Just stack ->
+          ( recorded
+              { currentTransactionStack = Nothing
+              , committedTracesDList = committedTracesDList recorded <> allTransactionStackTraces stack
+              }
+          , Nothing
+          )
+        Nothing ->
+          (recorded, Just commitTransactionStateError)
+
+  traverse_ Ex.throwIO mbError
+
+{- |
+  INTERNAL: Responds to an Orville 'O.RollbackTransaction' callback by mutating
+  the 'EntityTraceState' to abandon the current transaction stack. The
+  'EntityTraceState' is always expected to be in sync with the transaction
+  state kept by orville, so if there is no transaction stack this raises an
+  error.
+-}
+rollbackTransaction :: EntityTraceState trace -> IO ()
+rollbackTransaction traceState = do
+  mbError <-
+    atomicModifyIORef' (_entityTraceStateRef traceState) $ \recorded ->
+      case currentTransactionStack recorded of
+        Just _ ->
+          (recorded {currentTransactionStack = Nothing}, Nothing)
+        Nothing ->
+          (recorded, Just rollbackTransactionStateError)
+
+  traverse_ Ex.throwIO mbError
+
+{- |
+  INTERNAL: Responds to an Orville 'O.NewSavepoint' callback by mutating the
+  'EntityTraceState' to add a new savpoint to the top with the given
+  identifier. The 'EntityTraceState' is always expected to be in sync with the
+  transaction state kept by orville, so if there is no transaction stack this
+  raises an error.
+-}
+newSavepoint :: O.Savepoint -> EntityTraceState trace -> IO ()
+newSavepoint savepoint traceState = do
+  mbError <-
+    atomicModifyIORef' (_entityTraceStateRef traceState) $ \recorded ->
+      case currentTransactionStack recorded of
+        Just stack ->
+          ( recorded
+              { currentTransactionStack = Just (SavepointCreated savepoint DList.empty stack)
+              }
+          , Nothing
+          )
+        Nothing ->
+          (recorded, Just newSavepointTransactionStateError)
+
+  traverse_ Ex.throwIO mbError
+
+{- |
+  INTERNAL: Responds to an Orville 'O.ReleaseSavepoint' callback by mutating
+  the 'EntityTraceState' to released the savepoint with provided identifier.
+  The 'EntityTraceState' is always expected to be in sync with the transaction
+  state kept by orville, so if there is no transaction stack or no matching
+  savepoint can be found this raises an error.
+-}
+releaseSavepoint :: O.Savepoint -> EntityTraceState trace -> IO ()
+releaseSavepoint savepoint traceState = do
+  mbError <-
+    atomicModifyIORef' (_entityTraceStateRef traceState) $ \recorded ->
+      case currentTransactionStack recorded of
+        Just uncommitted ->
+          case releaseTransactionStackSavepoint savepoint uncommitted of
+            Left _ ->
+              (recorded, Just releaseSavepointNoMatchingSavepointError)
+            Right newStack ->
+              ( recorded
+                  { currentTransactionStack = Just newStack
+                  }
+              , Nothing
+              )
+        Nothing ->
+          (recorded, Just releaseSavepointNoTransactionError)
+
+  traverse_ Ex.throwIO mbError
+
+{- |
+  INTERNAL: Responds to an Orville 'O.RollbackToSavepoint' callback by mutating
+  the 'EntityTraceState' to roll back to the savepoint with provided
+  identifier. The 'EntityTraceState' is always expected to be in sync with the
+  transaction state kept by orville, so if there is no transaction stack or no
+  matching savepoint can be found this raises an error.
+-}
+rollbackToSavepoint :: O.Savepoint -> EntityTraceState trace -> IO ()
+rollbackToSavepoint savepoint traceState = do
+  mbError <-
+    atomicModifyIORef' (_entityTraceStateRef traceState) $ \recorded ->
+      case currentTransactionStack recorded of
+        Just uncommitted ->
+          case rollbackTransactionStackToSavepoint savepoint uncommitted of
+            Left _ ->
+              (recorded, Just rollbackToSavepointNoMatchingSavepointError)
+            Right newStack ->
+              ( recorded
+                  { currentTransactionStack = Just newStack
+                  }
+              , Nothing
+              )
+        Nothing ->
+          (recorded, Just rollbackToSavepointNoTransactionError)
+
+  traverse_ Ex.throwIO mbError
+
+{- |
+  'EntityTraceT' is simply a synonym for 'ReaderT' over an 'EntityTraceState'.
+  The 'EntityTraceState' keeps track of what traces have been recorded,
+  including keeping them in sync with any transaction or savepoint operations
+  that are performed via the 'O.withTransaction' function. I.E. if a
+  transaction or savepoint is rolled-back any traces that had been recorded by
+  'insertEntityTraced', 'updateEntityTrace', or 'deletedEntityTraced' are also
+  rolled-back.
+-}
+type EntityTraceT trace =
+  ReaderT (EntityTraceState trace)
+
+instance O.MonadOrville m => MonadEntityTrace trace (ReaderT (EntityTraceState trace) m) where
+  recordTraces =
+    recordTracesInState ask
+
+  liftOrvilleUntraced untraced =
+    -- The 'untraced' argument must be explict here for GHC 9
+    lift untraced
+
+instance O.MonadOrville m => O.MonadOrville (ReaderT (EntityTraceState trace) m)
+
+{- |
+  INTERNAL: Mutates the 'EntityTraceState' that is returned by the given "ask"
+  operation. We may decide to expose this in the future so that it's possible
+  to build an instance of 'MonadEntityTrace' by tracking an 'EntityTraceState'
+  in a user-provided 'ReaderT' (or other) context, but to do so we would need
+  to provide a relatively safe API for instantiating the 'EntityTraceState' and
+  'O.OrvilleState' together to ensure that the transaction callback is
+  registered and the transaction state between the two is in sync.
+-}
+recordTracesInState ::
+  MonadIO m =>
+  m (EntityTraceState trace) ->
+  [trace] ->
+  m ()
+recordTracesInState askTraceState traces = do
+  recordedTraces <- askTraceState
+  liftIO $ addTracesToRecord recordedTraces traces
+
+{- |
+  'runEntityTraceT' runs an Orville action that has tracing behavior and
+  returns the traces that were committed. Note that there will never be any
+  uncommitted traces at the end because any 'O.withTransaction' block must by
+  contained within the action passed  to 'runEntityTraceT'. This function
+  creates a new 'O.OrvilleState' and passes it to the run function that you
+  provide in order to enforce this.
+
+  Note that if an exception occurs in 'm' and is not caught within the action passed
+  to 'runEntityTraceT', you will lose any traces that may have happened up to
+  the point of the action, including those related to database operations that were
+  successfully committed. If you wish to respond to those traces, you need to catch
+  the exception inside the action given to 'runEntityTraceT' so that it can return
+  the traces to you.
+-}
+runEntityTraceT ::
+  MonadIO n =>
+  O.ErrorDetailLevel ->
+  Pool Conn.Connection ->
+  (O.OrvilleState -> m a -> n a) ->
+  EntityTraceT trace m a ->
+  n (a, [trace])
+runEntityTraceT errorDetailLevel pool runM traceT = do
+  ref <- liftIO $ EntityTraceState <$> newIORef emptyTraceData
+  let mAction =
+        runReaderT traceT ref
+
+      orvilleState =
+        O.addTransactionCallback
+          (trackTransactions ref)
+          (O.newOrvilleState errorDetailLevel pool)
+
+  a <- runM orvilleState mAction
+  traceData <- liftIO (readIORef $ _entityTraceStateRef ref)
+
+  case currentTransactionStack traceData of
+    Nothing ->
+      pure (a, DList.toList $ committedTracesDList traceData)
+    Just _ ->
+      liftIO $ Ex.throwIO transactionStillOpenAtEndError
+
+{- |
+  INTERNAL: This function is registered as the transaction callback on the
+  'O.OrvilleState' to keep the given 'EntityTraceState' transaction stack
+  in sync with operations performed by 'O.withTransaction'.
+-}
+trackTransactions :: EntityTraceState trace -> O.TransactionEvent -> IO ()
+trackTransactions recorded event =
+  case event of
+    O.BeginTransaction -> beginTransaction recorded
+    O.CommitTransaction -> commitTransaction recorded
+    O.RollbackTransaction -> rollbackTransaction recorded
+    O.NewSavepoint savepoint -> newSavepoint savepoint recorded
+    O.ReleaseSavepoint savepoint -> releaseSavepoint savepoint recorded
+    O.RollbackToSavepoint savepoint -> rollbackToSavepoint savepoint recorded
+
+{- |
+  INTERNAL: This error is raised by the transaction callback functions if
+  the 'TransactionStack' is not in the expected state. If this is ever raised
+  it is either a bug in orville, or a user executing transaction sql directly
+  rather than going throw 'O.withTransaction'.
+-}
+newtype EntityTraceTransactionStateError
+  = EntityTraceTransactionStateError String
+  deriving (Show)
+
+beginTransactionStateError :: EntityTraceTransactionStateError
+beginTransactionStateError =
+  EntityTraceTransactionStateError
+    "Got BeginTransaction callback, but the EntityTraceState was already tracking a transaction."
+
+commitTransactionStateError :: EntityTraceTransactionStateError
+commitTransactionStateError =
+  EntityTraceTransactionStateError
+    "Got CommitTransaction callback, but the EntityTraceState was not tracking a transaction."
+
+rollbackTransactionStateError :: EntityTraceTransactionStateError
+rollbackTransactionStateError =
+  EntityTraceTransactionStateError
+    "Got RollbackTransaction callback, but the EntityTraceState was not tracking a transaction."
+
+newSavepointTransactionStateError :: EntityTraceTransactionStateError
+newSavepointTransactionStateError =
+  EntityTraceTransactionStateError
+    "Got NewSavepoint callback, but the EntityTraceState was not tracking a transaction."
+
+releaseSavepointNoTransactionError :: EntityTraceTransactionStateError
+releaseSavepointNoTransactionError =
+  EntityTraceTransactionStateError
+    "Got ReleaseSavepoint callback, but the EntityTraceState was not tracking a transaction."
+
+releaseSavepointNoMatchingSavepointError :: EntityTraceTransactionStateError
+releaseSavepointNoMatchingSavepointError =
+  EntityTraceTransactionStateError
+    "Got ReleaseSavepoint callback, but the EntityTraceState did not have a matching savepoint."
+
+rollbackToSavepointNoTransactionError :: EntityTraceTransactionStateError
+rollbackToSavepointNoTransactionError =
+  EntityTraceTransactionStateError
+    "Got RollbackToSavepoint callback, but the EntityTraceState was not tracking a transaction."
+
+rollbackToSavepointNoMatchingSavepointError :: EntityTraceTransactionStateError
+rollbackToSavepointNoMatchingSavepointError =
+  EntityTraceTransactionStateError
+    "Got RollbackToSavepoint callback, but the EntityTraceState did not have a matching savepoint."
+
+transactionStillOpenAtEndError :: EntityTraceTransactionStateError
+transactionStillOpenAtEndError =
+  EntityTraceTransactionStateError
+    "Finished runEntityTraceT with a transactions still open in the EntityTraceState."
+
+instance Ex.Exception EntityTraceTransactionStateError

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/LimitExpr.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Expr/LimitExpr.hs
@@ -16,4 +16,5 @@ newtype LimitExpr
 limitExpr :: Int -> LimitExpr
 limitExpr limitValue =
   LimitExpr $
-    RawSql.fromString "LIMIT " <> RawSql.parameter (SqlValue.fromInt limitValue)
+    RawSql.fromString "LIMIT "
+      <> RawSql.parameter (SqlValue.fromInt limitValue)

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Insert.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Insert.hs
@@ -22,7 +22,10 @@ import Orville.PostgreSQL.Internal.TableDefinition (TableDefinition, mkInsertExp
   decode the database result set when it is executed.
 -}
 data Insert readEntity returningClause where
-  Insert :: AnnotatedSqlMarshaller writeEntity readEntity -> Expr.InsertExpr -> Insert readEntity NoReturningClause
+  Insert ::
+    AnnotatedSqlMarshaller writeEntity readEntity ->
+    Expr.InsertExpr ->
+    Insert readEntity NoReturningClause
   InsertReturning :: AnnotatedSqlMarshaller writeEntity readEntity -> Expr.InsertExpr -> Insert readEntity ReturningClause
 
 {- |
@@ -37,14 +40,20 @@ insertToInsertExpr (InsertReturning _ expr) = expr
 {- |
   Excutes the database query for the 'Insert' and returns '()'.
 -}
-executeInsert :: MonadOrville.MonadOrville m => Insert readEntity NoReturningClause -> m ()
+executeInsert ::
+  MonadOrville.MonadOrville m =>
+  Insert readEntity NoReturningClause ->
+  m ()
 executeInsert (Insert _ expr) =
   Execute.executeVoid expr
 
 {- | Excutes the database query for the 'Insert' and uses its 'SqlMarshaller' to decode the rows (that
   were just inserted) as returned via a RETURNING clause.
 -}
-executeInsertReturnEntities :: MonadOrville.MonadOrville m => Insert readEntity ReturningClause -> m [readEntity]
+executeInsertReturnEntities ::
+  MonadOrville.MonadOrville m =>
+  Insert readEntity ReturningClause ->
+  m [readEntity]
 executeInsertReturnEntities (InsertReturning marshaller expr) =
   Execute.executeAndDecode expr marshaller
 

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/MonadOrville.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/MonadOrville.hs
@@ -18,6 +18,7 @@ import Orville.PostgreSQL.Internal.OrvilleState
   ( ConnectedState (ConnectedState, connectedConnection, connectedTransaction),
     ConnectionState (Connected, NotConnected),
     HasOrvilleState (askOrvilleState, localOrvilleState),
+    OrvilleState,
     connectState,
     orvilleConnectionPool,
     orvilleConnectionState,
@@ -94,6 +95,8 @@ instance MonadOrvilleControl m => MonadOrvilleControl (ReaderT state m) where
         ioFinally
         (runReaderT action env)
         (runReaderT cleanup env)
+
+instance (MonadOrvilleControl m, MonadIO m) => MonadOrville (ReaderT OrvilleState m)
 
 {- |
   'withConnection' should be used to receive a 'Connection' handle for

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Orville.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Orville.hs
@@ -34,12 +34,11 @@ newtype Orville a = Orville
     , Monad
     , MonadIO
     , MonadOrville.MonadOrvilleControl
+    , MonadOrville.MonadOrville
     , OrvilleState.HasOrvilleState
     , ExSafe.MonadThrow
     , ExSafe.MonadCatch
     )
-
-instance MonadOrville.MonadOrville Orville
 
 {- |
   Runs an 'Orville' operation in the 'IO' monad using the given connection

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/OrvilleState.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/OrvilleState.hs
@@ -26,7 +26,8 @@ module Orville.PostgreSQL.Internal.OrvilleState
   )
 where
 
-import Control.Monad.Trans.Reader (ReaderT, ask, local)
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.Reader (ReaderT, ask, local, mapReaderT)
 import Data.Pool (Pool)
 
 import Orville.PostgreSQL.Connection (Connection)
@@ -145,6 +146,10 @@ class HasOrvilleState m where
 instance Monad m => HasOrvilleState (ReaderT OrvilleState m) where
   askOrvilleState = ask
   localOrvilleState = local
+
+instance {-# OVERLAPS #-} (Monad m, HasOrvilleState m) => HasOrvilleState (ReaderT r m) where
+  askOrvilleState = lift askOrvilleState
+  localOrvilleState f = mapReaderT (localOrvilleState f)
 
 {- |
   Creates a appropriate initial 'OrvilleState' that will use the connection

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Transaction.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Transaction.hs
@@ -1,12 +1,3 @@
-{-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE UndecidableInstances #-}
-
 module Orville.PostgreSQL.Internal.Transaction
   ( withTransaction,
   )

--- a/orville-postgresql-libpq/test/Main.hs
+++ b/orville-postgresql-libpq/test/Main.hs
@@ -13,6 +13,7 @@ import qualified Orville.PostgreSQL.Connection as Connection
 import qualified Test.AutoMigration as AutoMigration
 import qualified Test.Connection as Connection
 import qualified Test.EntityOperations as EntityOperations
+import qualified Test.EntityTrace as EntityTrace
 import qualified Test.Expr.InsertUpdateDelete as ExprInsertUpdateDelete
 import qualified Test.Expr.OrderBy as ExprOrderBy
 import qualified Test.Expr.TableDefinition as ExprTableDefinition
@@ -54,6 +55,7 @@ main = do
       , Plan.planTests pool
       , PgCatalog.pgCatalogTests pool
       , AutoMigration.autoMigrationTests pool
+      , EntityTrace.entityTraceTests pool
       ]
 
   Monad.unless (Property.allPassed summary) SE.exitFailure

--- a/orville-postgresql-libpq/test/Test/Entities/Foo.hs
+++ b/orville-postgresql-libpq/test/Test/Entities/Foo.hs
@@ -5,6 +5,7 @@ module Test.Entities.Foo
     table,
     generate,
     generateFooWithName,
+    generateFooWithId,
     generateFooId,
     generateFooName,
     generateList,
@@ -73,6 +74,12 @@ generate =
   Foo
     <$> generateFooId
     <*> generateFooName
+    <*> generateFooAge
+
+generateFooWithId :: FooId -> HH.Gen Foo
+generateFooWithId knownId =
+  Foo knownId
+    <$> generateFooName
     <*> generateFooAge
 
 generateFooWithName :: FooName -> HH.Gen Foo

--- a/orville-postgresql-libpq/test/Test/EntityTrace.hs
+++ b/orville-postgresql-libpq/test/Test/EntityTrace.hs
@@ -1,0 +1,160 @@
+module Test.EntityTrace
+  ( entityTraceTests,
+  )
+where
+
+import qualified Control.Monad as Monad
+import qualified Data.Pool as Pool
+import qualified Data.String as String
+import Hedgehog ((===))
+import qualified Hedgehog as HH
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+import qualified Orville.PostgreSQL as Orville
+import qualified Orville.PostgreSQL.Connection as Conn
+import qualified Orville.PostgreSQL.EntityTrace as EntityTrace
+
+import qualified Test.Entities.Foo as Foo
+import qualified Test.Property as Property
+import qualified Test.Transaction.Util as TransactionUtil
+
+entityTraceTests :: Pool.Pool Conn.Connection -> Property.Group
+entityTraceTests pool =
+  Property.group "EntityTrace" $
+    [ prop_tracedOperationsAreReported pool
+    , prop_tracesWithinCommittedTransactionsAreKept pool
+    , prop_tracesWithinRolledBackTransactionsAreDropped pool
+    , prop_tracesWithinRolledBackSavepointsAreDropped pool
+    ]
+
+data TestTrace
+  = FooInserted Foo.Foo Foo.Foo
+  | FooUpdated Foo.Foo Foo.Foo (Maybe Foo.Foo)
+  | FooDeleted Foo.FooId (Maybe Foo.Foo)
+  deriving (Eq, Show)
+
+prop_tracedOperationsAreReported :: Property.NamedDBProperty
+prop_tracedOperationsAreReported =
+  Property.singletonNamedDBProperty "Traced operations are reported" $ \pool -> do
+    fooId <- HH.forAll Foo.generateFooId
+    initialFoo <- HH.forAll $ Foo.generateFooWithId fooId
+    updatedFoo <- HH.forAll $ Foo.generateFooWithId fooId
+
+    Foo.withTable pool (pure ())
+
+    ((), fooTraces) <-
+      HH.evalIO $ do
+        EntityTrace.runEntityTraceT Orville.defaultErrorDetailLevel pool Orville.runOrvilleWithState $ do
+          _ <- EntityTrace.insertEntityTraced tracedFooTable initialFoo
+          _ <- EntityTrace.updateEntityTraced tracedFooTable initialFoo updatedFoo
+          _ <- EntityTrace.deleteEntityTraced tracedFooTable fooId
+          pure ()
+
+    fooTraces
+      === [ FooInserted initialFoo initialFoo
+          , FooUpdated initialFoo updatedFoo (Just updatedFoo)
+          , FooDeleted fooId (Just updatedFoo)
+          ]
+
+prop_tracesWithinCommittedTransactionsAreKept :: Property.NamedDBProperty
+prop_tracesWithinCommittedTransactionsAreKept =
+  Property.namedDBProperty "Traces within committed transactions are kept" $ \pool -> do
+    foos <- HH.forAll $ Foo.generateList TransactionUtil.transationNestingLevelRange
+
+    Foo.withTable pool (pure ())
+
+    ((), fooTraces) <-
+      HH.evalIO $ do
+        EntityTrace.runEntityTraceT Orville.defaultErrorDetailLevel pool Orville.runOrvilleWithState $ do
+          TransactionUtil.runNestedTransactionItems foos $ \foo ->
+            Monad.void $ EntityTrace.insertEntityTraced tracedFooTable foo
+
+    fooTraces === map (\foo -> FooInserted foo foo) foos
+
+prop_tracesWithinRolledBackTransactionsAreDropped :: Property.NamedDBProperty
+prop_tracesWithinRolledBackTransactionsAreDropped =
+  Property.namedDBProperty "Traces within rolled-back transactions are dropped" $ \pool -> do
+    foos <- HH.forAll $ Foo.generateList TransactionUtil.transationNestingLevelRange
+
+    Foo.withTable pool (pure ())
+
+    ((), fooTraces) <-
+      HH.evalIO $ do
+        EntityTrace.runEntityTraceT Orville.defaultErrorDetailLevel pool Orville.runOrvilleWithState $ do
+          TransactionUtil.silentlyHandleTestError $
+            TransactionUtil.runNestedTransactionItems foos $ \foo -> do
+              Monad.void $ EntityTrace.insertEntityTraced tracedFooTable foo
+              Monad.when (foo == last foos) TransactionUtil.throwTestError
+
+    fooTraces === []
+
+prop_tracesWithinRolledBackSavepointsAreDropped :: Property.NamedDBProperty
+prop_tracesWithinRolledBackSavepointsAreDropped =
+  Property.namedDBProperty "Traces within inner transactions that rollback are dropped (while outer committed transactions are kept)" $ \pool -> do
+    foos <-
+      HH.forAll $
+        Foo.generateList (fmap (2 *) TransactionUtil.transationNestingLevelRange)
+
+    outerLevels <-
+      HH.forAll $
+        Gen.frequency
+          [ (1, pure 0)
+          , (5, Gen.integral (Range.linear 0 (length foos)))
+          , (1, pure (length foos))
+          ]
+
+    let (outerFoos, innerFoos) =
+          splitAt outerLevels foos
+
+        innerActions =
+          TransactionUtil.runNestedTransactionItems innerFoos $ \foo -> do
+            Monad.void $ EntityTrace.insertEntityTraced tracedFooTable foo
+            Monad.when (foo == last innerFoos) TransactionUtil.throwTestError
+
+        outerActions =
+          if null outerFoos
+            then TransactionUtil.silentlyHandleTestError innerActions
+            else do
+              TransactionUtil.runNestedTransactionItems outerFoos $ \foo -> do
+                Monad.void $ EntityTrace.insertEntityTraced tracedFooTable foo
+                Monad.when (foo == last outerFoos) $
+                  TransactionUtil.silentlyHandleTestError innerActions
+
+    Foo.withTable pool (pure ())
+
+    ((), fooTraces) <-
+      HH.evalIO $
+        EntityTrace.runEntityTraceT Orville.defaultErrorDetailLevel pool Orville.runOrvilleWithState $ do
+          outerActions
+
+    let hasInner = not $ null innerFoos
+        hasOuter = not $ null outerFoos
+
+    HH.cover 5 (String.fromString "With inner transactions") hasInner
+    HH.cover 5 (String.fromString "With outer transactions") hasOuter
+    HH.cover 5 (String.fromString "With both inner and outer transactions") (hasInner && hasOuter)
+    HH.cover 1 (String.fromString "With only inner transactions") (hasInner && not hasOuter)
+    HH.cover 1 (String.fromString "With only outer transactions") (not hasInner && hasOuter)
+
+    fooTraces === map (\foo -> FooInserted foo foo) outerFoos
+
+tracedFooTable :: EntityTrace.TracedTable TestTrace Foo.FooId Foo.Foo Foo.Foo
+tracedFooTable =
+  EntityTrace.addDeleteTrace fooDeleteTrace
+    . EntityTrace.addUpdateTrace fooUpdateTrace
+    . EntityTrace.addInsertTrace fooInsertTrace
+    . EntityTrace.mkTracedTable Foo.fooId
+    $ Foo.table
+
+fooInsertTrace :: Foo.Foo -> Foo.Foo -> [TestTrace]
+fooInsertTrace writeFoo readFoo =
+  [FooInserted writeFoo readFoo]
+
+fooUpdateTrace :: Foo.Foo -> Foo.Foo -> Maybe Foo.Foo -> [TestTrace]
+fooUpdateTrace readFoo writeFoo mbUpdatedFoo =
+  [FooUpdated readFoo writeFoo mbUpdatedFoo]
+
+fooDeleteTrace :: Foo.FooId -> Maybe Foo.Foo -> [TestTrace]
+fooDeleteTrace fooId mbDeletedFoo =
+  [FooDeleted fooId mbDeletedFoo]

--- a/orville-postgresql-libpq/test/Test/Transaction/Util.hs
+++ b/orville-postgresql-libpq/test/Test/Transaction/Util.hs
@@ -1,0 +1,63 @@
+module Test.Transaction.Util
+  ( TestError,
+    throwTestError,
+    silentlyHandleTestError,
+    genNestingLevel,
+    runNestedTransactions,
+    runNestedTransactionItems,
+    transationNestingLevelRange,
+  )
+where
+
+import qualified Control.Exception.Safe as ExSafe
+import qualified Hedgehog as HH
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+import qualified Orville.PostgreSQL as Orville
+
+data TestError
+  = TestError
+  deriving (Show)
+
+instance ExSafe.Exception TestError
+
+runNestedTransactions ::
+  Orville.MonadOrville m =>
+  Int ->
+  (Int -> m ()) ->
+  m ()
+runNestedTransactions maxLevel =
+  runNestedTransactionItems [1 .. maxLevel]
+
+runNestedTransactionItems ::
+  Orville.MonadOrville m =>
+  [a] ->
+  (a -> m ()) ->
+  m ()
+runNestedTransactionItems items doLevel =
+  let go is =
+        case is of
+          [] ->
+            pure ()
+          (item : rest) ->
+            Orville.withTransaction $ do
+              doLevel item
+              go rest
+   in go items
+
+throwTestError :: ExSafe.MonadThrow m => m a
+throwTestError =
+  ExSafe.throw TestError
+
+silentlyHandleTestError :: ExSafe.MonadCatch m => m () -> m ()
+silentlyHandleTestError =
+  ExSafe.handle (\TestError -> pure ())
+
+genNestingLevel :: HH.Gen Int
+genNestingLevel =
+  Gen.integral transationNestingLevelRange
+
+transationNestingLevelRange :: HH.Range Int
+transationNestingLevelRange =
+  Range.linear 0 6


### PR DESCRIPTION
This ports the 'Database.Orville.PostgreSQL.Internal.Trigger' module
from orville 0.9 to libpq as the 'Orville.PostgreSQL.EntityTrace'
module. This is renamed to avoid any confusion that it may be related to
database triggers.

The port involves the following structure changes:

* The trace callbacks are addeded to a `TracedTable` entity rather than
  being implemented via typeclasses
* The transaction state management support savepoints (since libpq
  orville support savepoints for nested transactions).
* `EntityTraceT` is a type-synonym for a `ReaderT` type rather than a
  newtype, which keeps with the pattern of orville libpq not providing
  it's own custom monad transformer newtypes.
* `MonadEntityTrace` includes a `liftOrvilleUntraced` member, allowing
  `insertEntityTraced` et al to not required a `MonadOrville` instance
  directly. This allows a user the option of building a monad that
  implements _only_ `MonadEntityTrace` if they wish to further enforce
  that the `*Traced` functions are used rather than the regular orville
  operations.