### PR TITLE
Compatibility with mtl-2.3 and transformers-0.6 series

### DIFF
--- a/orville-postgresql-libpq/orville-postgresql-libpq.cabal
+++ b/orville-postgresql-libpq/orville-postgresql-libpq.cabal
@@ -142,7 +142,7 @@ library
     , safe-exceptions >=0.1.7
     , text
     , time >=1.5
-    , transformers ==0.5.*
+    , transformers >=0.5 && <0.7
     , uuid
   if flag(ci)
     ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-patterns -Wincomplete-record-updates -Wmissing-local-signatures -Wmissing-export-lists -Wmissing-import-lists -Wnoncanonical-monad-instances -Wredundant-constraints -Wpartial-fields -Wmissed-specialisations -Wno-implicit-prelude -Wno-safe -Wno-unsafe

--- a/orville-postgresql-libpq/package.yaml
+++ b/orville-postgresql-libpq/package.yaml
@@ -86,7 +86,7 @@ library:
     - safe-exceptions >=0.1.7
     - text
     - time >=1.5
-    - transformers >= 0.5 && < 0.6
+    - transformers >= 0.5 && < 0.7
     - uuid
 
 tests:

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Core.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Core.hs
@@ -187,6 +187,7 @@ module Database.Orville.PostgreSQL.Core
   , dropIndexesConcurrently
   ) where
 
+import Control.Monad (void, when)
 import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.State

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/Monad.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/Monad.hs
@@ -12,11 +12,14 @@ License   : MIT
 module Database.Orville.PostgreSQL.Internal.Monad where
 
 import Control.Applicative
+import Control.Monad (MonadPlus)
 import Control.Monad.Base
 import Control.Monad.Catch (MonadCatch, MonadMask(..), MonadThrow)
 import Control.Monad.Except
+import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Reader (ReaderT(..), ask, local, mapReaderT, runReaderT)
 import Control.Monad.State (StateT, mapStateT)
+import Control.Monad.Trans.Class (MonadTrans(lift))
 import Data.Pool
 import Database.HDBC hiding (withTransaction)
 

--- a/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/Types.hs
+++ b/orville-postgresql/src/Database/Orville/PostgreSQL/Internal/Types.hs
@@ -11,6 +11,7 @@ License   : MIT
 module Database.Orville.PostgreSQL.Internal.Types where
 
 import Control.Exception
+import Control.Monad (join)
 import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.State


### PR DESCRIPTION
Tested on GHC-8.6.5, GHC-8.10.7 and GHC-9.2.2.

Using e.g.:

    cabal test --constraint='transformers>=0.6' --constraint='mtl>=2.3' -w ghc-9.2.2