### PR TITLE
Implement a Date parser in attoparsec

### DIFF
--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/SqlValue.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/SqlValue.hs
@@ -348,7 +348,7 @@ fromDay =
 -}
 toDay :: SqlValue -> Either String Time.Day
 toDay =
-  toBytesValue PgTime.dayFromPostgreSQL
+  toParsedValue PgTime.day
 
 {- |
   Encodes a 'Time.UTCTime' in ISO 8601 format for usage with the database.

--- a/orville-postgresql-libpq/test/Test/SqlType.hs
+++ b/orville-postgresql-libpq/test/Test/SqlType.hs
@@ -335,6 +335,26 @@ dateTests pool =
           , expectedValue = Time.fromGregorian 2020 12 21
           }
     )
+  ,
+    ( String.fromString "Testing the decode of DATE with value 0001-12-21"
+    , runDecodingTest pool $
+        DecodingTest
+          { sqlTypeDDL = "DATE"
+          , rawSqlValue = Just $ B8.pack "'0001-12-21'"
+          , sqlType = SqlType.date
+          , expectedValue = Time.fromGregorian 1 12 21
+          }
+    )
+  ,
+    ( String.fromString "Testing the decode of DATE with value 10000-12-21"
+    , runDecodingTest pool $
+        DecodingTest
+          { sqlTypeDDL = "DATE"
+          , rawSqlValue = Just $ B8.pack "'10000-12-21'"
+          , sqlType = SqlType.date
+          , expectedValue = Time.fromGregorian 10000 12 21
+          }
+    )
   ]
 
 timestampTests :: Pool.Pool Connection.Connection -> [(HH.PropertyName, HH.Property)]


### PR DESCRIPTION
The date parser has a small amount of leniency when it comes to
parsing years, the ISO spec states that years should not be less
than 4 digits and the parser allows for smaller years. Postgres
should not give us a date like that, and adding support for that
would mean reimplementing the `decimal` function, so I chose to
allow the leniency.

I added a couple more cases for Date tests.