### PR TITLE
N/A Fixup some comments and add an export

### DIFF
--- a/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
@@ -20,6 +20,7 @@ module Orville.PostgreSQL
     EntityOperations.findFirstEntityBy,
     EntityOperations.findEntity,
     Connection.createConnectionPool,
+    Connection.NoticeReporting (NoticeReporting,DisableNoticeReporting),
     TableDefinition.TableDefinition,
     TableDefinition.mkTableDefinition,
     TableDefinition.mkTableDefinitionWithoutKey,

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
@@ -20,7 +20,7 @@ module Orville.PostgreSQL
     EntityOperations.findFirstEntityBy,
     EntityOperations.findEntity,
     Connection.createConnectionPool,
-    Connection.NoticeReporting (NoticeReporting,DisableNoticeReporting),
+    Connection.NoticeReporting (EnableNoticeReporting, DisableNoticeReporting),
     TableDefinition.TableDefinition,
     TableDefinition.mkTableDefinition,
     TableDefinition.mkTableDefinitionWithoutKey,

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/FieldDefinition.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/FieldDefinition.hs
@@ -124,7 +124,7 @@ fieldDefaultValue :: FieldDefinition nullability a -> Maybe (DefaultValue a)
 fieldDefaultValue = _fieldDefaultValue
 
 {- |
- A 'FieldNullability is returned by the 'fieldNullability' function, which
+ A 'FieldNullability' is returned by the 'fieldNullability' function, which
  can be used when a function works on both 'Nullable' and 'NotNull' functions
  but needs to deal with each type of field separately. It adds wrapper
  constructors around the 'FieldDefinition' that you can pattern match on to
@@ -469,8 +469,8 @@ asymmetricNullableField field =
   use this function the create 'FieldDefinition's for based on the primitive
   ones provided, but with more specific Haskell types.
 
-  See 'SqlType.convertSqlType' and 'SqlType.maybeConvertSqlType' for functions
-  to create the conversion needed as the firts argument to 'convertField'.
+  See 'SqlType.convertSqlType' and 'SqlType.tryConvertSqlType' for functions
+  to create the conversion needed as the first argument to 'convertField'.
 -}
 convertField ::
   (SqlType.SqlType a -> SqlType.SqlType b) ->

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/SqlType.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/SqlType.hs
@@ -387,7 +387,7 @@ tryConvertSqlType bToA aToB sqlType =
 
 {- |
   'convertSqlType' changes the Haskell type used by a 'SqlType' in the same manner
-  as 'maybeConvertSqlType' in cases where an 'a' can always be converted to a 'b'.
+  as 'tryConvertSqlType' in cases where an 'a' can always be converted to a 'b'.
 -}
 convertSqlType :: (b -> a) -> (a -> b) -> SqlType a -> SqlType b
 convertSqlType bToA aToB =


### PR DESCRIPTION
Replace references to `maybeConvertSqlType` with `tryConvertSqlType` in
a few comments.

Re-export `NoticeReporting` constructors from `Orville.PostgreSQL`
module, since they are needed to use `createConnectionPool`, which was
already exported from there.