### PR TITLE
Adds a `MonadOrville` level API for Cursors

### DIFF
--- a/orville-postgresql-libpq/orville-postgresql-libpq.cabal
+++ b/orville-postgresql-libpq/orville-postgresql-libpq.cabal
@@ -33,6 +33,7 @@ library
       Orville.PostgreSQL.AutoMigration
       Orville.PostgreSQL.Connection
       Orville.PostgreSQL.EntityTrace
+      Orville.PostgreSQL.Internal.Cursor
       Orville.PostgreSQL.Internal.DefaultValue
       Orville.PostgreSQL.Internal.Delete
       Orville.PostgreSQL.Internal.ErrorDetailLevel
@@ -142,6 +143,7 @@ library
     , containers ==0.6.*
     , dlist >=0.8 && <1.1
     , postgresql-libpq >=0.9.4.2 && <0.10
+    , random >=1.0 && <2
     , resource-pool
     , safe-exceptions >=0.1.7
     , text
@@ -160,6 +162,7 @@ test-suite spec
   other-modules:
       Test.AutoMigration
       Test.Connection
+      Test.Cursor
       Test.Entities.Bar
       Test.Entities.Foo
       Test.Entities.FooChild

--- a/orville-postgresql-libpq/package.yaml
+++ b/orville-postgresql-libpq/package.yaml
@@ -25,6 +25,7 @@ library:
     - Orville.PostgreSQL.AutoMigration
     - Orville.PostgreSQL.Connection
     - Orville.PostgreSQL.EntityTrace
+    - Orville.PostgreSQL.Internal.Cursor
     - Orville.PostgreSQL.Internal.DefaultValue
     - Orville.PostgreSQL.Internal.Delete
     - Orville.PostgreSQL.Internal.ErrorDetailLevel
@@ -85,6 +86,7 @@ library:
     - dlist >= 0.8 && < 1.1
     - postgresql-libpq >= 0.9.4.2 && <0.10
     - containers >= 0.6 && < 0.7
+    - random >= 1.0 && <2
     - resource-pool
     - safe-exceptions >=0.1.7
     - text

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
@@ -4,7 +4,8 @@ Copyright : Flipstone Technology Partners 2020-2021
 License   : MIT
 -}
 module Orville.PostgreSQL
-  ( EntityOperations.insertEntity,
+  ( -- * Basic operations on entities in tables
+    EntityOperations.insertEntity,
     EntityOperations.insertAndReturnEntity,
     EntityOperations.insertEntities,
     EntityOperations.insertAndReturnEntities,
@@ -19,8 +20,38 @@ module Orville.PostgreSQL
     EntityOperations.findEntitiesBy,
     EntityOperations.findFirstEntityBy,
     EntityOperations.findEntity,
+
+    -- * A simple starter monad for running Orville operations
+    Orville.Orville,
+    Orville.runOrville,
+    Orville.runOrvilleWithState,
+
+    -- * Creating a connection pool
     Connection.createConnectionPool,
     Connection.NoticeReporting (EnableNoticeReporting, DisableNoticeReporting),
+
+    -- * Opening transactions and savepoints
+    Transaction.withTransaction,
+
+    -- * Types for incorporating Orville into other Monads
+    MonadOrville.MonadOrville,
+    MonadOrville.withConnection,
+    MonadOrville.MonadOrvilleControl (liftWithConnection, liftFinally, liftBracket),
+    OrvilleState.HasOrvilleState (askOrvilleState, localOrvilleState),
+    OrvilleState.OrvilleState,
+    OrvilleState.newOrvilleState,
+    OrvilleState.resetOrvilleState,
+    OrvilleState.addTransactionCallback,
+    OrvilleState.TransactionEvent (BeginTransaction, NewSavepoint, ReleaseSavepoint, RollbackToSavepoint, CommitTransaction, RollbackTransaction),
+    OrvilleState.Savepoint,
+    OrvilleState.addSqlExecutionCallback,
+    OrvilleState.setBeginTransactionExpr,
+    ErrorDetailLevel.ErrorDetailLevel (ErrorDetailLevel, includeErrorMessage, includeSchemaNames, includeRowIdentifierValues, includeNonIdentifierValues),
+    ErrorDetailLevel.defaultErrorDetailLevel,
+    ErrorDetailLevel.minimalErrorDetailLevel,
+    ErrorDetailLevel.maximalErrorDetailLevel,
+
+    -- * Functions for defining a database schema
     TableDefinition.TableDefinition,
     TableDefinition.mkTableDefinition,
     TableDefinition.mkTableDefinitionWithoutKey,
@@ -150,26 +181,10 @@ module Orville.PostgreSQL
     DefaultValue.coerceDefaultValue,
     DefaultValue.defaultValueExpression,
     DefaultValue.rawSqlDefault,
-    Orville.Orville,
-    Orville.runOrville,
-    Orville.runOrvilleWithState,
-    MonadOrville.MonadOrville,
-    MonadOrville.withConnection,
-    Transaction.withTransaction,
-    MonadOrville.MonadOrvilleControl (liftWithConnection),
-    OrvilleState.HasOrvilleState (askOrvilleState, localOrvilleState),
-    OrvilleState.OrvilleState,
-    OrvilleState.newOrvilleState,
-    OrvilleState.resetOrvilleState,
-    OrvilleState.addTransactionCallback,
-    OrvilleState.TransactionEvent (BeginTransaction, NewSavepoint, ReleaseSavepoint, RollbackToSavepoint, CommitTransaction, RollbackTransaction),
-    OrvilleState.Savepoint,
-    OrvilleState.addSqlExecutionCallback,
-    OrvilleState.setBeginTransactionExpr,
-    ErrorDetailLevel.ErrorDetailLevel (ErrorDetailLevel, includeErrorMessage, includeSchemaNames, includeRowIdentifierValues, includeNonIdentifierValues),
-    ErrorDetailLevel.defaultErrorDetailLevel,
-    ErrorDetailLevel.minimalErrorDetailLevel,
-    ErrorDetailLevel.maximalErrorDetailLevel,
+
+    -- * Functions and operators for putting where clauses, order by clauses
+
+    -- and limits on selects
     SelectOptions.SelectOptions,
     SelectOptions.distinct,
     SelectOptions.groupBy,
@@ -218,16 +233,6 @@ module Orville.PostgreSQL
     SelectOptions.appendOrderBy,
     SelectOptions.orderByToClause,
     SelectOptions.orderByToExpr,
-    SqlType.SqlType
-      ( SqlType.SqlType,
-        SqlType.sqlTypeExpr,
-        SqlType.sqlTypeReferenceExpr,
-        SqlType.sqlTypeOid,
-        SqlType.sqlTypeMaximumLength,
-        SqlType.sqlTypeToSql,
-        SqlType.sqlTypeFromSql,
-        SqlType.sqlTypeDontDropImplicitDefaultDuringMigrate
-      ),
 
     -- * numeric types
     SqlType.integer,
@@ -247,10 +252,21 @@ module Orville.PostgreSQL
     -- * date types
     SqlType.date,
     SqlType.timestamp,
-    -- type conversions
+
+    -- * type conversions
     SqlType.foreignRefType,
     SqlType.convertSqlType,
     SqlType.tryConvertSqlType,
+    SqlType.SqlType
+      ( SqlType.SqlType,
+        SqlType.sqlTypeExpr,
+        SqlType.sqlTypeReferenceExpr,
+        SqlType.sqlTypeOid,
+        SqlType.sqlTypeMaximumLength,
+        SqlType.sqlTypeToSql,
+        SqlType.sqlTypeFromSql,
+        SqlType.sqlTypeDontDropImplicitDefaultDuringMigrate
+      ),
     Expr.QueryExpr,
     Execute.executeAndDecode,
     Execute.executeVoid,

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Cursor.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Cursor.hs
@@ -1,0 +1,177 @@
+{-# LANGUAGE GADTs #-}
+
+module Orville.PostgreSQL.Internal.Cursor
+  ( withCursor,
+    declareCursor,
+    closeCursor,
+    newCursorName,
+    fetch,
+    move,
+    Expr.CursorDirection,
+    Expr.next,
+    Expr.prior,
+    Expr.first,
+    Expr.last,
+    Expr.absolute,
+    Expr.relative,
+    Expr.count,
+    Expr.fetchAll,
+    Expr.forward,
+    Expr.forwardCount,
+    Expr.forwardAll,
+    Expr.backward,
+    Expr.backwardCount,
+    Expr.backwardAll,
+  )
+where
+
+import Control.Exception (bracket)
+import Control.Monad.IO.Class (MonadIO (liftIO))
+import qualified Data.Time as Time
+import qualified Data.Time.Clock.POSIX as POSIXTime
+import qualified Data.Word as Word
+import qualified System.Random as Random
+import qualified Text.Printf as Printf
+
+import qualified Orville.PostgreSQL.Internal.Execute as Execute
+import qualified Orville.PostgreSQL.Internal.Expr as Expr
+import qualified Orville.PostgreSQL.Internal.MonadOrville as MonadOrville
+import qualified Orville.PostgreSQL.Internal.QueryType as QueryType
+import Orville.PostgreSQL.Internal.Select (Select, useSelect)
+import Orville.PostgreSQL.Internal.SqlMarshaller (AnnotatedSqlMarshaller)
+
+{- |
+  A 'Cursor' allows you to fetch rows incrementally from PostgreSQL. Using
+  a cursor will allow you to execute a query that returns a very large
+  result set without the entire result set being loaded in memory in your
+  application and instead pulling rows as you're able to process them.
+
+  See 'withCursor', 'fetch' and 'move' for details on creating and using
+  'Cursor' values.
+-}
+data Cursor readEntity where
+  Cursor ::
+    AnnotatedSqlMarshaller writeEntity readEntity ->
+    Expr.CursorName ->
+    Cursor readEntity
+
+{- |
+  Declares a @CURSOR@ in PostgreSQL that is available for the duration of the
+  action passed to 'withCursor' and closes the cursor when that action
+  completes (or raises an exception).
+
+  See @https://www.postgresql.org/docs/current/sql-declare.html@ for details
+  about the 'Expr.ScrollExpr' and 'Expr.HoldExpr' parameters and how cursor
+  behave in general.
+
+  We recommend you use this instead of 'declareCursor' and 'closeCursor'
+  unless you need to control the cursor resource acquisition and release
+  yourself and can do so safely.
+-}
+withCursor ::
+  MonadOrville.MonadOrville m =>
+  Maybe Expr.ScrollExpr ->
+  Maybe Expr.HoldExpr ->
+  Select readEntity ->
+  (Cursor readEntity -> m a) ->
+  m a
+withCursor scrollExpr holdExpr select useCursor =
+  MonadOrville.liftBracket
+    bracket
+    (declareCursor scrollExpr holdExpr select)
+    closeCursor
+    useCursor
+
+{- |
+  Declares a @CURSOR@ in PostgreSQL and returns it for you to use. The cursor
+  must be closed via 'closeCursor' (or another means) when you are done using
+  it. Generally you should use 'withCursor' instead of 'declareCursor' to
+  ensure that the cursor gets closed properly.
+
+  See @https://www.postgresql.org/docs/current/sql-declare.html@ for details
+  about the 'Expr.ScrollExpr' and 'Expr.HoldExpr' parameters and how cursor
+  behave in general.
+-}
+declareCursor ::
+  MonadOrville.MonadOrville m =>
+  Maybe Expr.ScrollExpr ->
+  Maybe Expr.HoldExpr ->
+  Select readEntity ->
+  m (Cursor readEntity)
+declareCursor scrollExpr holdExpr =
+  useSelect $ \queryExpr marshaller -> do
+    cursorName <- newCursorName
+
+    let declareExpr =
+          Expr.declare cursorName scrollExpr holdExpr queryExpr
+
+    _ <- Execute.executeVoid QueryType.CursorQuery declareExpr
+    pure (Cursor marshaller cursorName)
+
+{- |
+  Closes a @CURSOR@ in PostgreSQL that was previously declared.
+  This should be used to close any cursors you open via 'declareCursor',
+  thought we recommend you use 'withCursor' instead to ensure that any
+  opened cursor are closed in the event of an exception.
+-}
+closeCursor ::
+  MonadOrville.MonadOrville m =>
+  Cursor readEntity ->
+  m ()
+closeCursor (Cursor _ cursorName) =
+  Execute.executeVoid QueryType.CursorQuery
+    . Expr.close
+    . Right
+    $ cursorName
+
+{- |
+  Fetch rows from a cursor according to the 'Expr.CursorDirection' given. See
+  @https://www.postgresql.org/docs/current/sql-fetch.html@ for details about
+  effect of fetch and the meanings of cursor directions to PostgreSQL.
+-}
+fetch ::
+  MonadOrville.MonadOrville m =>
+  Maybe Expr.CursorDirection ->
+  Cursor readEntity ->
+  m [readEntity]
+fetch direction (Cursor marshaller cursorName) =
+  Execute.executeAndDecode
+    QueryType.CursorQuery
+    (Expr.fetch direction cursorName)
+    marshaller
+
+{- |
+  Moves a cursor according to the 'Expr.CursorDirection' given. See
+  @https://www.postgresql.org/docs/current/sql-fetch.html@ for details about
+  effect of move and the meanings of cursor directions to PostgreSQL.
+-}
+move ::
+  MonadOrville.MonadOrville m =>
+  Maybe Expr.CursorDirection ->
+  Cursor readEntity ->
+  m ()
+move direction (Cursor _ cursorName) =
+  Execute.executeVoid
+    QueryType.CursorQuery
+    (Expr.move direction cursorName)
+
+{- |
+  INTERNAL - Generates a unique (or very nearly guaranteed to be) cursor name.
+  Cursor names only need to be unique among the currently open cursors on the
+  current connection, so using POSIX time plus a 32 bit random tag should be
+  more than sufficient to ensure conflicts are not seen in practice.
+-}
+newCursorName :: MonadIO m => m Expr.CursorName
+newCursorName =
+  liftIO $ do
+    now <- POSIXTime.getPOSIXTime
+    randomWord <- Random.randomIO
+
+    let nowAsInteger =
+          fromEnum . Time.nominalDiffTimeToSeconds $ now
+
+    pure . Expr.cursorName $
+      Printf.printf
+        "orville_cursor_%x_%08x"
+        nowAsInteger
+        (randomWord :: Word.Word32)

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/QueryType.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/QueryType.hs
@@ -1,5 +1,5 @@
 module Orville.PostgreSQL.Internal.QueryType
-  ( QueryType (SelectQuery, InsertQuery, UpdateQuery, DeleteQuery, DDLQuery, OtherQuery),
+  ( QueryType (SelectQuery, InsertQuery, UpdateQuery, DeleteQuery, DDLQuery, CursorQuery, OtherQuery),
   )
 where
 
@@ -15,5 +15,6 @@ data QueryType
   | UpdateQuery
   | DeleteQuery
   | DDLQuery
+  | CursorQuery
   | OtherQuery
   deriving (Ord, Eq, Enum, Bounded, Show, Read)

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Transaction.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Transaction.hs
@@ -16,7 +16,7 @@ import qualified Orville.PostgreSQL.Internal.QueryType as QueryType
 import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
 
 {- |
-  Performs a an action in an Orville monad within a database transaction. The transaction
+  Performs an action in an Orville monad within a database transaction. The transaction
   in begun before the action is called. If the action completes without raising an exception,
   the transaction will be committed. If the action raises an exception, the transaction will
   rollback.

--- a/orville-postgresql-libpq/test/Main.hs
+++ b/orville-postgresql-libpq/test/Main.hs
@@ -12,6 +12,7 @@ import qualified System.Exit as SE
 import qualified Orville.PostgreSQL.Connection as Connection
 import qualified Test.AutoMigration as AutoMigration
 import qualified Test.Connection as Connection
+import qualified Test.Cursor as Cursor
 import qualified Test.EntityOperations as EntityOperations
 import qualified Test.EntityTrace as EntityTrace
 import qualified Test.Execution as Execution
@@ -60,6 +61,7 @@ main = do
       , PgCatalog.pgCatalogTests pool
       , AutoMigration.autoMigrationTests pool
       , EntityTrace.entityTraceTests pool
+      , Cursor.cursorTests pool
       ]
 
   Monad.unless (Property.allPassed summary) SE.exitFailure

--- a/orville-postgresql-libpq/test/Test/Cursor.hs
+++ b/orville-postgresql-libpq/test/Test/Cursor.hs
@@ -1,0 +1,84 @@
+module Test.Cursor
+  ( cursorTests,
+  )
+where
+
+import qualified Data.List as List
+import qualified Data.List.NonEmpty as NEL
+import qualified Data.Ord as Ord
+import qualified Data.Pool as Pool
+import Hedgehog ((===))
+import qualified Hedgehog as HH
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+import qualified Orville.PostgreSQL as Orville
+import qualified Orville.PostgreSQL.Connection as Conn
+import qualified Orville.PostgreSQL.Internal.Cursor as Cursor
+import qualified Orville.PostgreSQL.Internal.Select as Select
+
+import qualified Test.Entities.Foo as Foo
+import qualified Test.Property as Property
+
+cursorTests :: Pool.Pool Conn.Connection -> Property.Group
+cursorTests pool =
+  Property.group "Cursor" $
+    [ prop_withCursorFetch pool
+    , prop_withCursorMove pool
+    ]
+
+prop_withCursorFetch :: Property.NamedDBProperty
+prop_withCursorFetch =
+  Property.namedDBProperty "withCursor - fetch" $ \pool -> do
+    foos <- HH.forAll (Foo.generateNonEmpty (Range.linear 1 20))
+    -- A fetch count of 0 has the special meaning of "current row" in
+    -- PostgreSQL so we avoid generating 0 for the fetch count in this test
+    numToFetch <- HH.forAll (Gen.integral (Range.linear 1 (length foos)))
+
+    let expectedRows =
+          take numToFetch
+            . List.sortBy (Ord.comparing Foo.fooId)
+            . NEL.toList
+            $ foos
+
+    actualRows <-
+      Foo.withTable pool $ do
+        Orville.withTransaction $ do
+          Orville.insertEntities Foo.table foos
+          Cursor.withCursor Nothing Nothing selectAllFoosOrderedById $ \cursor ->
+            Cursor.fetch (Just $ Cursor.forwardCount numToFetch) cursor
+
+    expectedRows === actualRows
+
+prop_withCursorMove :: Property.NamedDBProperty
+prop_withCursorMove =
+  Property.namedDBProperty "withCursor - move" $ \pool -> do
+    foos <- HH.forAll (Foo.generateNonEmpty (Range.linear 1 20))
+    -- A fetch count of 0 has the special meaning of "current row" in
+    -- PostgreSQL so we avoid generating any scenario that would give us a
+    -- fetch count of 0 in this test
+    numToSkip <- HH.forAll (Gen.integral (Range.linear 0 (length foos - 1)))
+    numToFetch <- HH.forAll (Gen.integral (Range.linear 1 (length foos - numToSkip)))
+
+    let expectedRows =
+          take numToFetch
+            . drop numToSkip
+            . List.sortBy (Ord.comparing Foo.fooId)
+            . NEL.toList
+            $ foos
+
+    actualRows <-
+      Foo.withTable pool $ do
+        Orville.withTransaction $ do
+          Orville.insertEntities Foo.table foos
+          Cursor.withCursor Nothing Nothing selectAllFoosOrderedById $ \cursor -> do
+            Cursor.move (Just $ Cursor.forwardCount numToSkip) cursor
+            Cursor.fetch (Just $ Cursor.forwardCount numToFetch) cursor
+
+    expectedRows === actualRows
+
+selectAllFoosOrderedById :: Select.Select Foo.Foo
+selectAllFoosOrderedById =
+  Select.selectTable
+    Foo.table
+    (Orville.orderBy $ Orville.orderByField Foo.fooIdField Orville.ascendingOrder)


### PR DESCRIPTION
This provides a more convenient API for declaring and using cursors than the lower-level `Expr` + raw execute API