### PR TITLE
Adjusts `BooleanExpr` construction to be more re-useable

### DIFF
--- a/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
@@ -160,6 +160,7 @@ module Orville.PostgreSQL
     FieldDefinition.localTimestampField,
     FieldDefinition.fieldOfType,
     FieldDefinition.fieldColumnName,
+    FieldDefinition.fieldColumnReference,
     FieldDefinition.fieldName,
     FieldDefinition.fieldDescription,
     FieldDefinition.setFieldDescription,

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/FieldDefinition.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/FieldDefinition.hs
@@ -18,9 +18,11 @@ module Orville.PostgreSQL.Internal.FieldDefinition
     setField,
     (.:=),
     FieldNullability (..),
+    fieldValueToExpression,
     fieldValueToSqlValue,
     fieldValueFromSqlValue,
     fieldColumnName,
+    fieldColumnReference,
     fieldColumnDefinition,
     FieldName,
     stringToFieldName,
@@ -177,6 +179,15 @@ fieldIsNotNullable field =
 
 {- |
   Mashalls a Haskell value to be stored in the field to its 'SqlValue'
+  representation and packages the resul as a 'Expr.ValueExression' so that
+  it can be easily used with other @Expr@ functions.
+-}
+fieldValueToExpression :: FieldDefinition nullability a -> a -> Expr.ValueExpression
+fieldValueToExpression field =
+  Expr.valueExpression . fieldValueToSqlValue field
+
+{- |
+  Mashalls a Haskell value to be stored in the field to its 'SqlValue'
   representation.
 -}
 fieldValueToSqlValue :: FieldDefinition nullability a -> a -> SqlValue.SqlValue
@@ -198,6 +209,14 @@ fieldValueFromSqlValue =
 fieldColumnName :: FieldDefinition nullability a -> Expr.ColumnName
 fieldColumnName =
   fieldNameToColumnName . fieldName
+
+{- |
+  Constructs the 'Expr.ValueExpression for a field for use in SQL expressions
+  from the 'Expr' module.
+-}
+fieldColumnReference :: FieldDefinition nullability a -> Expr.ValueExpression
+fieldColumnReference =
+  Expr.columnReference . fieldColumnName
 
 {- |
   Constructions the equivalant 'Expr.FieldDefinition' as a SQL expression,

--- a/orville-postgresql-libpq/test/Test/Expr/InsertUpdateDelete.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/InsertUpdateDelete.hs
@@ -14,7 +14,7 @@ import qualified Orville.PostgreSQL.Internal.Expr as Expr
 import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
 import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
 
-import Test.Expr.TestSchema (assertEqualFooBarRows, barColumn, dropAndRecreateTestTable, findAllFooBars, fooBarTable, fooColumn, insertFooBarSource, mkFooBar)
+import Test.Expr.TestSchema (assertEqualFooBarRows, barColumn, barColumnRef, dropAndRecreateTestTable, findAllFooBars, fooBarTable, fooColumn, insertFooBarSource, mkFooBar)
 import qualified Test.Property as Property
 
 insertUpdateDeleteTests :: Pool.Pool Conn.Connection -> Property.Group
@@ -111,7 +111,7 @@ prop_updateExprWithWhere =
           Expr.updateExpr
             fooBarTable
             (Expr.setClauseList (Expr.setColumn barColumn (SqlValue.fromText (T.pack "ferret")) :| []))
-            (Just (Expr.whereClause (Expr.columnEquals barColumn (SqlValue.fromText (T.pack "dog")))))
+            (Just (Expr.whereClause (Expr.equals barColumnRef (Expr.valueExpression (SqlValue.fromText (T.pack "dog"))))))
             Nothing
 
     rows <-
@@ -193,7 +193,7 @@ prop_deleteExprWithWhere =
         deleteDogs =
           Expr.deleteExpr
             fooBarTable
-            (Just (Expr.whereClause (Expr.columnEquals barColumn (SqlValue.fromText (T.pack "dog")))))
+            (Just (Expr.whereClause (Expr.equals barColumnRef (Expr.valueExpression (SqlValue.fromText (T.pack "dog"))))))
             Nothing
 
     rows <-

--- a/orville-postgresql-libpq/test/Test/Expr/TestSchema.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/TestSchema.hs
@@ -4,7 +4,9 @@ module Test.Expr.TestSchema
     findAllFooBars,
     fooBarTable,
     fooColumn,
+    fooColumnRef,
     barColumn,
+    barColumnRef,
     encodeFooBar,
     orderByFoo,
     insertFooBarSource,
@@ -47,9 +49,17 @@ fooColumn :: Expr.ColumnName
 fooColumn =
   Expr.columnName "foo"
 
+fooColumnRef :: Expr.ValueExpression
+fooColumnRef =
+  Expr.columnReference fooColumn
+
 barColumn :: Expr.ColumnName
 barColumn =
   Expr.columnName "bar"
+
+barColumnRef :: Expr.ValueExpression
+barColumnRef =
+  Expr.columnReference barColumn
 
 orderByFoo :: Expr.OrderByClause
 orderByFoo =


### PR DESCRIPTION
This changes a number of the Expr functions to take `ValueExpression` rather than `ColumnName` or `SqlValue` because it allows users to use them to construct more generic expressions.

The field-definition wrappers for these functions (such as `fieldEquals`) still have the same type the used to. The implementations have been adjust accordingly.