### PR TITLE
Fix UTC offset sign

### DIFF
--- a/orville-postgresql-libpq/orville-postgresql-libpq.cabal
+++ b/orville-postgresql-libpq/orville-postgresql-libpq.cabal
@@ -44,6 +44,7 @@ library
       Orville.PostgreSQL.Internal.MarshallError
       Orville.PostgreSQL.Internal.OrvilleState
       Orville.PostgreSQL.Internal.PgTextFormatValue
+      Orville.PostgreSQL.Internal.PgTime
       Orville.PostgreSQL.Internal.PrimaryKey
       Orville.PostgreSQL.Internal.RawSql
       Orville.PostgreSQL.Internal.ReturningOption
@@ -130,7 +131,6 @@ library
       Orville.PostgreSQL.Internal.MigrationLock
       Orville.PostgreSQL.Internal.MonadOrville
       Orville.PostgreSQL.Internal.Orville
-      Orville.PostgreSQL.Internal.PgTime
       Orville.PostgreSQL.Internal.QueryType
       Orville.PostgreSQL.Internal.RowCountExpectation
       Orville.PostgreSQL.Internal.Sequence
@@ -198,6 +198,7 @@ test-suite spec
       Test.PgAssert
       Test.PgCatalog
       Test.PgGen
+      Test.PgTime
       Test.Plan
       Test.PostgreSQLAxioms
       Test.Property
@@ -217,7 +218,8 @@ test-suite spec
       test
   ghc-options: -j -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wmissing-local-signatures -Wmissing-export-lists -Wno-implicit-prelude -Wno-safe -Wno-unsafe -Wnoncanonical-monad-instances -Wredundant-constraints -Wpartial-fields -Wmissed-specialisations -Woverflowed-literals
   build-depends:
-      base
+      attoparsec
+    , base
     , bytestring
     , containers
     , hedgehog

--- a/orville-postgresql-libpq/package.yaml
+++ b/orville-postgresql-libpq/package.yaml
@@ -36,6 +36,7 @@ library:
     - Orville.PostgreSQL.Internal.MarshallError
     - Orville.PostgreSQL.Internal.OrvilleState
     - Orville.PostgreSQL.Internal.PgTextFormatValue
+    - Orville.PostgreSQL.Internal.PgTime
     - Orville.PostgreSQL.Internal.PrimaryKey
     - Orville.PostgreSQL.Internal.RawSql
     - Orville.PostgreSQL.Internal.ReturningOption
@@ -104,6 +105,7 @@ tests:
     source-dirs: test
     main: Main.hs
     dependencies:
+      - attoparsec
       - base
       - bytestring
       - containers

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/PgTime.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/PgTime.hs
@@ -71,7 +71,7 @@ utcTime = do
     else do
       hour <- twoDigits
       minute <- AttoB8.option 0 $ AttoB8.choice [AttoB8.char ':' *> twoDigits, twoDigits]
-      let offset = minute + hour * 60 * if sign == '-' then (-1) else 1
+      let offset = (minute + hour * 60) * if sign == '-' then (-1) else 1
       pure $ Time.localTimeToUTC (Time.minutesToTimeZone offset) lt
 
 {- |

--- a/orville-postgresql-libpq/test/Main.hs
+++ b/orville-postgresql-libpq/test/Main.hs
@@ -30,6 +30,7 @@ import qualified Test.Expr.Where as ExprWhere
 import qualified Test.FieldDefinition as FieldDefinition
 import qualified Test.MarshallError as MarshallError
 import qualified Test.PgCatalog as PgCatalog
+import qualified Test.PgTime as PgTime
 import qualified Test.Plan as Plan
 import qualified Test.PostgreSQLAxioms as PostgreSQLAxioms
 import qualified Test.Property as Property
@@ -78,6 +79,7 @@ main = do
       , EntityTrace.entityTraceTests pool
       , Cursor.cursorTests pool
       , SqlCommenter.sqlCommenterTests pool
+      , PgTime.pgTimeTests pool
       ]
 
   Monad.unless (Property.allPassed summary) SE.exitFailure

--- a/orville-postgresql-libpq/test/Test/PgTime.hs
+++ b/orville-postgresql-libpq/test/Test/PgTime.hs
@@ -1,0 +1,26 @@
+module Test.PgTime
+  ( pgTimeTests
+  )
+where
+
+import           Data.Attoparsec.ByteString (parseOnly)
+import qualified Data.Pool as Pool
+import qualified Data.String as String
+import           Data.Time (UTCTime(..), fromGregorian)
+import qualified Hedgehog as HH
+
+import qualified Orville.PostgreSQL.Connection as Conn
+import qualified Orville.PostgreSQL.Internal.PgTime as PgTime
+
+import qualified Test.Property as Property
+
+pgTimeTests :: Pool.Pool Conn.Connection -> Property.Group
+pgTimeTests _pool =
+  Property.group "PgTime" $
+    [
+      ( String.fromString "Ignores seconds in UTC offset correctly"
+      , Property.singletonProperty $
+          parseOnly PgTime.utcTime (String.fromString "1971-01-01 00:00:00-00:44:30")
+            HH.=== Right (UTCTime (fromGregorian 1971 1 1) (44 * 60))
+      )
+    ]

--- a/orville-postgresql-libpq/test/Test/PgTime.hs
+++ b/orville-postgresql-libpq/test/Test/PgTime.hs
@@ -1,12 +1,12 @@
 module Test.PgTime
-  ( pgTimeTests
+  ( pgTimeTests,
   )
 where
 
-import           Data.Attoparsec.ByteString (parseOnly)
+import Data.Attoparsec.ByteString (parseOnly)
 import qualified Data.Pool as Pool
 import qualified Data.String as String
-import           Data.Time (UTCTime(..), fromGregorian)
+import Data.Time (UTCTime (..), fromGregorian)
 import qualified Hedgehog as HH
 
 import qualified Orville.PostgreSQL.Connection as Conn


### PR DESCRIPTION
Precedence confusion in the UTC time parser was causing nonsensical negation of only the hour, but not the minute component. Fixed in this PR.

An upcoming PR will add seconds support, if I can manage to do it, which I am not sure of, since ISO 8601 doesn't support the seconds, and that might mean doing too much time infrastructure ourselves.