### PR TITLE
Decode seconds in UTC offset

### DIFF
--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/PgTime.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/PgTime.hs
@@ -71,8 +71,13 @@ utcTime = do
     else do
       hour <- twoDigits
       minute <- AttoB8.option 0 $ AttoB8.choice [AttoB8.char ':' *> twoDigits, twoDigits]
-      let offset = (minute + hour * 60) * if sign == '-' then (-1) else 1
-      pure $ Time.localTimeToUTC (Time.minutesToTimeZone offset) lt
+      second <- AttoB8.option 0 $ AttoB8.char ':' *> twoDigits
+      let offsetSeconds :: Int
+          offsetSeconds = (second + minute * 60 + hour * 3600) * if sign == '+' then (-1) else 1
+          offsetNominalDiffTime = fromIntegral offsetSeconds
+          diffTime = Time.timeOfDayToTime (Time.localTimeOfDay lt)
+          utcTimeWithoutOffset = Time.UTCTime (Time.localDay lt) diffTime
+      pure $ Time.addUTCTime offsetNominalDiffTime utcTimeWithoutOffset
 
 {- |
   Renders a 'Time.LocalTime value to a textual representation for PostgreSQL

--- a/orville-postgresql-libpq/test/Test/PgTime.hs
+++ b/orville-postgresql-libpq/test/Test/PgTime.hs
@@ -23,7 +23,8 @@ pgTimeTests _pool =
           parseOnly PgTime.utcTime (String.fromString "1971-01-01 00:00:00-00:44:30")
             HH.=== Right (UTCTime (fromGregorian 1971 1 1) (44 * 60 + 30))
       )
-    , ( String.fromString "Handles far future"
+    ,
+      ( String.fromString "Handles far future"
       , Property.singletonProperty $
           -- https://github.com/postgres/postgres/blob/b5737efea00717173c0cc889ebd115966abd8c8c/src/test/regress/sql/timestamptz.sql#L175
           parseOnly PgTime.utcTime (String.fromString "294276-12-31 23:59:59+00")

--- a/orville-postgresql-libpq/test/Test/PgTime.hs
+++ b/orville-postgresql-libpq/test/Test/PgTime.hs
@@ -18,9 +18,15 @@ pgTimeTests :: Pool.Pool Conn.Connection -> Property.Group
 pgTimeTests _pool =
   Property.group "PgTime" $
     [
-      ( String.fromString "Ignores seconds in UTC offset correctly"
+      ( String.fromString "Handles seconds in UTC offset correctly"
       , Property.singletonProperty $
           parseOnly PgTime.utcTime (String.fromString "1971-01-01 00:00:00-00:44:30")
-            HH.=== Right (UTCTime (fromGregorian 1971 1 1) (44 * 60))
+            HH.=== Right (UTCTime (fromGregorian 1971 1 1) (44 * 60 + 30))
+      )
+    , ( String.fromString "Handles far future"
+      , Property.singletonProperty $
+          -- https://github.com/postgres/postgres/blob/b5737efea00717173c0cc889ebd115966abd8c8c/src/test/regress/sql/timestamptz.sql#L175
+          parseOnly PgTime.utcTime (String.fromString "294276-12-31 23:59:59+00")
+            HH.=== Right (UTCTime (fromGregorian 294276 12 31) (23 * 3600 + 59 * 60 + 59))
       )
     ]


### PR DESCRIPTION
This doesn't handle leap seconds well, `NominalDiffTime` mentions that explicitly as a drawback. But leap seconds aren't handled well, since we don't have anywhere to source when they occur, anyway.