### PR TITLE
Adds findOneShowVia and findOneWhereShowVia

### DIFF
--- a/orville-postgresql-libpq/orville-postgresql-libpq.cabal
+++ b/orville-postgresql-libpq/orville-postgresql-libpq.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           orville-postgresql-libpq
-version:        0.10.0.0
+version:        0.10.0.1
 synopsis:       ORM
 description:    ORM library for PostgreSQL
 category:       Database

--- a/orville-postgresql-libpq/package.yaml
+++ b/orville-postgresql-libpq/package.yaml
@@ -1,6 +1,6 @@
 ---
 name: orville-postgresql-libpq
-version: '0.10.0.0'
+version: '0.10.0.1'
 synopsis: ORM
 description: ORM library for PostgreSQL
 category: Database

--- a/orville-postgresql/orville-postgresql.cabal
+++ b/orville-postgresql/orville-postgresql.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 671edec7076d0e3f187aef5cb98e6d2bbc5bf0a554eb69945f503117cf8617b5
+-- hash: a69a4ba51007c4d7af950e06da789690d714ed85ef1af99fabe3b70efef0631e
 
 name:           orville-postgresql
-version:        0.9.0.0
+version:        0.9.0.1
 synopsis:       ORM
 description:    ORM library for PostgreSQL
 category:       Database

--- a/orville-postgresql/package.yaml
+++ b/orville-postgresql/package.yaml
@@ -1,5 +1,5 @@
 name: orville-postgresql
-version: '0.9.0.0'
+version: '0.9.0.1'
 synopsis: ORM
 description: ORM library for PostgreSQL
 category: Database


### PR DESCRIPTION
This adds new finder functions to `Plan` so that users can provide their own string conversions to be used when producing error messages about no records being found.

This way we do not have to demand a `Show` instance for all types used as inputs to `Plan` find functions.