### PR TITLE
Compatibility with resource-pool 0.3/0.4

### DIFF
--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -45,7 +45,6 @@ We need to tell Cabal how to find Orville:
 ```shell
 cat << EOF > cabal.project
 packages: .
-constraints: resource-pool < 0.3
 source-repository-package
   type: git
   location: https://github.com/flipstone/orville.git

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -18,7 +18,6 @@ cabal init -n --exe
 sed -i -re 's/build-depends:/build-depends: orville-postgresql-libpq, resource-pool, text,/' *.cabal
 cat << 'EOF' > cabal.project
 packages: .
-constraints: resource-pool < 0.3
 source-repository-package
   type: git
   location: https://github.com/flipstone/orville.git

--- a/PLAN.md
+++ b/PLAN.md
@@ -28,7 +28,6 @@ cabal init -n --exe
 sed -i -re 's/build-depends:/build-depends: orville-postgresql-libpq, resource-pool, text,/' *.cabal
 cat << 'EOF' > cabal.project
 packages: .
-constraints: resource-pool < 0.3
 source-repository-package
   type: git
   location: https://github.com/flipstone/orville.git

--- a/SQL-MARSHALLER.md
+++ b/SQL-MARSHALLER.md
@@ -17,7 +17,6 @@ cabal init -n --exe
 sed -i -re 's/build-depends:/build-depends: orville-postgresql-libpq, resource-pool, text,/' *.cabal
 cat << EOF > cabal.project
 packages: .
-constraints: resource-pool < 0.3
 source-repository-package
   type: git
   location: https://github.com/flipstone/orville.git


### PR DESCRIPTION
Now that `Pool.withResource` returns a plain IO, apply the principle of least privilege and extract MonadTest code to outside of `HH.evalIO . Pool.withResource` blocks.

An advantage of this change is that it is now easier to see which parts of the code need `connection`, and which parts don't.

Fixes #259.

See also commercialhaskell/stackage#6852