### PR TITLE
Allow new HDBC-postgresql

### DIFF
--- a/cabal.config
+++ b/cabal.config
@@ -1,1 +1,0 @@
-constraints: HDBC-postgresql ==2.3.2.4


### PR DESCRIPTION
Undoes https://github.com/flipstone/orville/pull/76/commits/aeb275937a72e847258a3cb5987808e14861f140 by @onslaughtq 

Newer versions of HDBC-postgresql seem to work fine.

If a specific release of HDBC-postgresql doesn't work, it would be best to ask David Johnson (who maintains the library) to revise the release to make it not get chosen by the solver (setting `base < 0`) or having the Hackage trustees do that. Setting the HDBC-postgresql version here could be confusing since `cabal.config` is not in the source distribution, and as such, it will only affect people checking out the git repo of Orville, which could get confusing since the constraint solver is not likely to choose the version in `cabal.config`.

If we want to constrain the HDBC-postgresql version, it seems better to do it in the cabal file. But I don't really think it is necessary, as HDBC-postgresql is barely changing.