### PR TITLE
Organizes the Monad-related modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ docker-compose.tools-override.yml
 
 # Ignore local stuff
 .local/
+local-docs
 
 #
 instantclient*

--- a/orville-postgresql-libpq/orville-postgresql-libpq.cabal
+++ b/orville-postgresql-libpq/orville-postgresql-libpq.cabal
@@ -66,7 +66,6 @@ library
       Orville.PostgreSQL.Internal.ErrorDetailLevel
       Orville.PostgreSQL.Internal.ExecutionResult
       Orville.PostgreSQL.Internal.Insert
-      Orville.PostgreSQL.Internal.OrvilleState
       Orville.PostgreSQL.Internal.PgTextFormatValue
       Orville.PostgreSQL.Internal.PgTime
       Orville.PostgreSQL.Internal.RawSql
@@ -83,6 +82,11 @@ library
       Orville.PostgreSQL.Marshall.SqlMarshaller
       Orville.PostgreSQL.Marshall.SqlType
       Orville.PostgreSQL.Marshall.SyntheticField
+      Orville.PostgreSQL.Monad
+      Orville.PostgreSQL.Monad.HasOrvilleState
+      Orville.PostgreSQL.Monad.MonadOrville
+      Orville.PostgreSQL.Monad.Orville
+      Orville.PostgreSQL.OrvilleState
       Orville.PostgreSQL.Plan
       Orville.PostgreSQL.Plan.Explanation
       Orville.PostgreSQL.Plan.Many
@@ -113,8 +117,6 @@ library
       Orville.PostgreSQL.Internal.Execute
       Orville.PostgreSQL.Internal.Extra.NonEmpty
       Orville.PostgreSQL.Internal.MigrationLock
-      Orville.PostgreSQL.Internal.MonadOrville
-      Orville.PostgreSQL.Internal.Orville
       Orville.PostgreSQL.Internal.QueryType
       Orville.PostgreSQL.Internal.RowCountExpectation
       Orville.PostgreSQL.Internal.Sequence

--- a/orville-postgresql-libpq/package.yaml
+++ b/orville-postgresql-libpq/package.yaml
@@ -58,7 +58,6 @@ library:
     - Orville.PostgreSQL.Internal.ErrorDetailLevel
     - Orville.PostgreSQL.Internal.ExecutionResult
     - Orville.PostgreSQL.Internal.Insert
-    - Orville.PostgreSQL.Internal.OrvilleState
     - Orville.PostgreSQL.Internal.PgTextFormatValue
     - Orville.PostgreSQL.Internal.PgTime
     - Orville.PostgreSQL.Internal.RawSql
@@ -75,6 +74,11 @@ library:
     - Orville.PostgreSQL.Marshall.SqlMarshaller
     - Orville.PostgreSQL.Marshall.SqlType
     - Orville.PostgreSQL.Marshall.SyntheticField
+    - Orville.PostgreSQL.Monad
+    - Orville.PostgreSQL.Monad.HasOrvilleState
+    - Orville.PostgreSQL.Monad.MonadOrville
+    - Orville.PostgreSQL.Monad.Orville
+    - Orville.PostgreSQL.OrvilleState
     - Orville.PostgreSQL.Plan
     - Orville.PostgreSQL.Plan.Explanation
     - Orville.PostgreSQL.Plan.Many

--- a/orville-postgresql-libpq/scripts/gen-local-docs.sh
+++ b/orville-postgresql-libpq/scripts/gen-local-docs.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -e
+
+docker-compose run \
+  --no-deps --rm dev \
+  stack --stack-yaml stack-lts-17.0.yml \
+  haddock --force-dirty --no-haddock-deps --haddock-arguments --odir=local-docs

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
@@ -37,7 +37,7 @@ module Orville.PostgreSQL
     MonadOrville.MonadOrville,
     MonadOrville.withConnection,
     MonadOrville.MonadOrvilleControl (liftWithConnection, liftFinally, liftBracket),
-    OrvilleState.HasOrvilleState (askOrvilleState, localOrvilleState),
+    HasOrvilleState.HasOrvilleState (askOrvilleState, localOrvilleState),
     OrvilleState.OrvilleState,
     OrvilleState.newOrvilleState,
     OrvilleState.resetOrvilleState,
@@ -326,9 +326,6 @@ import qualified Orville.PostgreSQL.Internal.DefaultValue as DefaultValue
 import qualified Orville.PostgreSQL.Internal.EntityOperations as EntityOperations
 import qualified Orville.PostgreSQL.Internal.ErrorDetailLevel as ErrorDetailLevel
 import qualified Orville.PostgreSQL.Internal.Execute as Execute
-import qualified Orville.PostgreSQL.Internal.MonadOrville as MonadOrville
-import qualified Orville.PostgreSQL.Internal.Orville as Orville
-import qualified Orville.PostgreSQL.Internal.OrvilleState as OrvilleState
 import qualified Orville.PostgreSQL.Internal.QueryType as QueryType
 import qualified Orville.PostgreSQL.Internal.SelectOptions as SelectOptions
 import qualified Orville.PostgreSQL.Internal.Sequence as Sequence
@@ -338,6 +335,10 @@ import qualified Orville.PostgreSQL.Marshall.FieldDefinition as FieldDefinition
 import qualified Orville.PostgreSQL.Marshall.SqlMarshaller as SqlMarshaller
 import qualified Orville.PostgreSQL.Marshall.SqlType as SqlType
 import qualified Orville.PostgreSQL.Marshall.SyntheticField as SyntheticField
+import qualified Orville.PostgreSQL.Monad.HasOrvilleState as HasOrvilleState
+import qualified Orville.PostgreSQL.Monad.MonadOrville as MonadOrville
+import qualified Orville.PostgreSQL.Monad.Orville as Orville
+import qualified Orville.PostgreSQL.OrvilleState as OrvilleState
 import qualified Orville.PostgreSQL.Schema.ConstraintDefinition as ConstraintDefinition
 import qualified Orville.PostgreSQL.Schema.IndexDefinition as IndexDefinition
 import qualified Orville.PostgreSQL.Schema.PrimaryKey as PrimaryKey

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Cursor.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Cursor.hs
@@ -35,10 +35,10 @@ import qualified Text.Printf as Printf
 
 import qualified Orville.PostgreSQL.Expr as Expr
 import qualified Orville.PostgreSQL.Internal.Execute as Execute
-import qualified Orville.PostgreSQL.Internal.MonadOrville as MonadOrville
 import qualified Orville.PostgreSQL.Internal.QueryType as QueryType
 import Orville.PostgreSQL.Internal.Select (Select, useSelect)
 import Orville.PostgreSQL.Marshall (AnnotatedSqlMarshaller)
+import qualified Orville.PostgreSQL.Monad as Monad
 
 {- |
   A 'Cursor' allows you to fetch rows incrementally from PostgreSQL. Using
@@ -69,14 +69,14 @@ data Cursor readEntity where
   yourself and can do so safely.
 -}
 withCursor ::
-  MonadOrville.MonadOrville m =>
+  Monad.MonadOrville m =>
   Maybe Expr.ScrollExpr ->
   Maybe Expr.HoldExpr ->
   Select readEntity ->
   (Cursor readEntity -> m a) ->
   m a
 withCursor scrollExpr holdExpr select useCursor =
-  MonadOrville.liftBracket
+  Monad.liftBracket
     bracket
     (declareCursor scrollExpr holdExpr select)
     closeCursor
@@ -93,7 +93,7 @@ withCursor scrollExpr holdExpr select useCursor =
   behave in general.
 -}
 declareCursor ::
-  MonadOrville.MonadOrville m =>
+  Monad.MonadOrville m =>
   Maybe Expr.ScrollExpr ->
   Maybe Expr.HoldExpr ->
   Select readEntity ->
@@ -115,7 +115,7 @@ declareCursor scrollExpr holdExpr =
   opened cursor are closed in the event of an exception.
 -}
 closeCursor ::
-  MonadOrville.MonadOrville m =>
+  Monad.MonadOrville m =>
   Cursor readEntity ->
   m ()
 closeCursor (Cursor _ cursorName) =
@@ -130,7 +130,7 @@ closeCursor (Cursor _ cursorName) =
   effect of fetch and the meanings of cursor directions to PostgreSQL.
 -}
 fetch ::
-  MonadOrville.MonadOrville m =>
+  Monad.MonadOrville m =>
   Maybe Expr.CursorDirection ->
   Cursor readEntity ->
   m [readEntity]
@@ -146,7 +146,7 @@ fetch direction (Cursor marshaller cursorName) =
   effect of move and the meanings of cursor directions to PostgreSQL.
 -}
 move ::
-  MonadOrville.MonadOrville m =>
+  Monad.MonadOrville m =>
   Maybe Expr.CursorDirection ->
   Cursor readEntity ->
   m ()

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Delete.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Delete.hs
@@ -19,10 +19,10 @@ where
 
 import qualified Orville.PostgreSQL.Expr as Expr
 import qualified Orville.PostgreSQL.Internal.Execute as Execute
-import qualified Orville.PostgreSQL.Internal.MonadOrville as MonadOrville
 import qualified Orville.PostgreSQL.Internal.QueryType as QueryType
 import Orville.PostgreSQL.Internal.ReturningOption (NoReturningClause, ReturningClause, ReturningOption (WithReturning, WithoutReturning))
 import Orville.PostgreSQL.Marshall.SqlMarshaller (AnnotatedSqlMarshaller)
+import qualified Orville.PostgreSQL.Monad as Monad
 import Orville.PostgreSQL.Schema (TableDefinition, mkTableReturningClause, tableMarshaller, tableName)
 
 {- | Represents a @DELETE@ statement that can be executed against a database. A 'Delete' has a
@@ -49,7 +49,7 @@ deleteFromDeleteExpr (DeleteReturning _ expr) = expr
   rows affected by the query.
 -}
 executeDelete ::
-  MonadOrville.MonadOrville m =>
+  Monad.MonadOrville m =>
   Delete readEntity NoReturningClause ->
   m Int
 executeDelete (Delete expr) =
@@ -59,7 +59,7 @@ executeDelete (Delete expr) =
   were just deleteed) as returned via a RETURNING clause.
 -}
 executeDeleteReturnEntities ::
-  MonadOrville.MonadOrville m =>
+  Monad.MonadOrville m =>
   Delete readEntity ReturningClause ->
   m [readEntity]
 executeDeleteReturnEntities (DeleteReturning marshaller expr) =

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/EntityOperations.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/EntityOperations.hs
@@ -30,11 +30,11 @@ import Data.Maybe (listToMaybe)
 import qualified Orville.PostgreSQL.Expr as Expr
 import qualified Orville.PostgreSQL.Internal.Delete as Delete
 import qualified Orville.PostgreSQL.Internal.Insert as Insert
-import qualified Orville.PostgreSQL.Internal.MonadOrville as MonadOrville
 import qualified Orville.PostgreSQL.Internal.RowCountExpectation as RowCountExpectation
 import qualified Orville.PostgreSQL.Internal.Select as Select
 import qualified Orville.PostgreSQL.Internal.SelectOptions as SelectOptions
 import qualified Orville.PostgreSQL.Internal.Update as Update
+import qualified Orville.PostgreSQL.Monad as Monad
 import qualified Orville.PostgreSQL.Schema as Schema
 
 {- |
@@ -42,7 +42,7 @@ import qualified Orville.PostgreSQL.Schema as Schema
   affected by the query.
 -}
 insertEntity ::
-  MonadOrville.MonadOrville m =>
+  Monad.MonadOrville m =>
   Schema.TableDefinition key writeEntity readEntity ->
   writeEntity ->
   m Int
@@ -57,7 +57,7 @@ insertEntity entityTable entity =
   database, such as auto-incrementing ids.
 -}
 insertAndReturnEntity ::
-  MonadOrville.MonadOrville m =>
+  Monad.MonadOrville m =>
   Schema.TableDefinition key writeEntity readEntity ->
   writeEntity ->
   m readEntity
@@ -73,7 +73,7 @@ insertAndReturnEntity entityTable entity = do
   number of rows affected by the query.
 -}
 insertEntities ::
-  MonadOrville.MonadOrville m =>
+  Monad.MonadOrville m =>
   Schema.TableDefinition key writeEntity readEntity ->
   NonEmpty writeEntity ->
   m Int
@@ -88,7 +88,7 @@ insertEntities tableDef =
   database, such as auto-incrementing ids.
 -}
 insertAndReturnEntities ::
-  MonadOrville.MonadOrville m =>
+  Monad.MonadOrville m =>
   Schema.TableDefinition key writeEntity readEntity ->
   NonEmpty writeEntity ->
   m [readEntity]
@@ -100,7 +100,7 @@ insertAndReturnEntities tableDef =
   Returns the number of rows affected by the query.
 -}
 updateEntity ::
-  MonadOrville.MonadOrville m =>
+  Monad.MonadOrville m =>
   Schema.TableDefinition (Schema.HasKey key) writeEntity readEntity ->
   key ->
   writeEntity ->
@@ -121,7 +121,7 @@ updateEntity tableDef key writeEntity =
   during update, including columns with triggers attached to them.
 -}
 updateAndReturnEntity ::
-  MonadOrville.MonadOrville m =>
+  Monad.MonadOrville m =>
   Schema.TableDefinition (Schema.HasKey key) writeEntity readEntity ->
   key ->
   writeEntity ->
@@ -143,7 +143,7 @@ updateAndReturnEntity tableDef key writeEntity =
   Returns the number of rows affected by the query.
 -}
 updateFields ::
-  MonadOrville.MonadOrville m =>
+  Monad.MonadOrville m =>
   Schema.TableDefinition (Schema.HasKey key) writeEntity readEntity ->
   NonEmpty Expr.SetClause ->
   Maybe Expr.BooleanExpr ->
@@ -157,7 +157,7 @@ updateFields tableDef setClauses mbWhereCondition =
   version of any rows that were affected by the update.
 -}
 updateFieldsAndReturnEntities ::
-  MonadOrville.MonadOrville m =>
+  Monad.MonadOrville m =>
   Schema.TableDefinition (Schema.HasKey key) writeEntity readEntity ->
   NonEmpty Expr.SetClause ->
   Maybe Expr.BooleanExpr ->
@@ -171,7 +171,7 @@ updateFieldsAndReturnEntities tableDef setClauses mbWhereCondition =
   by the query.
 -}
 deleteEntity ::
-  MonadOrville.MonadOrville m =>
+  Monad.MonadOrville m =>
   Schema.TableDefinition (Schema.HasKey key) writeEntity readEntity ->
   key ->
   m Int
@@ -188,7 +188,7 @@ deleteEntity entityTable key =
   If no row matches the given key, 'Nothing' is returned.
 -}
 deleteAndReturnEntity ::
-  MonadOrville.MonadOrville m =>
+  Monad.MonadOrville m =>
   Schema.TableDefinition (Schema.HasKey key) writeEntity readEntity ->
   key ->
   m (Maybe readEntity)
@@ -209,7 +209,7 @@ deleteAndReturnEntity entityTable key = do
   the number of rows affected by the query.
 -}
 deleteEntities ::
-  MonadOrville.MonadOrville m =>
+  Monad.MonadOrville m =>
   Schema.TableDefinition key writeEntity readEntity ->
   Maybe Expr.BooleanExpr ->
   m Int
@@ -222,7 +222,7 @@ deleteEntities entityTable whereCondition =
   the rows that were deleted.
 -}
 deleteAndReturnEntities ::
-  MonadOrville.MonadOrville m =>
+  Monad.MonadOrville m =>
   Schema.TableDefinition key writeEntity readEntity ->
   Maybe Expr.BooleanExpr ->
   m [readEntity]
@@ -236,7 +236,7 @@ deleteAndReturnEntities entityTable whereCondition =
   match, ordering specifications, etc.
 -}
 findEntitiesBy ::
-  MonadOrville.MonadOrville m =>
+  Monad.MonadOrville m =>
   Schema.TableDefinition key writeEntity readEntity ->
   SelectOptions.SelectOptions ->
   m [readEntity]
@@ -251,7 +251,7 @@ findEntitiesBy entityTable selectOptions =
   database will not guarantee ordering.
 -}
 findFirstEntityBy ::
-  MonadOrville.MonadOrville m =>
+  Monad.MonadOrville m =>
   Schema.TableDefinition key writeEntity readEntity ->
   SelectOptions.SelectOptions ->
   m (Maybe readEntity)
@@ -263,7 +263,7 @@ findFirstEntityBy entityTable selectOptions =
   Finds a single entity by the table's primary key value.
 -}
 findEntity ::
-  MonadOrville.MonadOrville m =>
+  Monad.MonadOrville m =>
   Schema.TableDefinition (Schema.HasKey key) writeEntity readEntity ->
   key ->
   m (Maybe readEntity)

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Execute.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Execute.hs
@@ -15,13 +15,13 @@ import Control.Monad.IO.Class (liftIO)
 import qualified Database.PostgreSQL.LibPQ as LibPQ
 
 import Orville.PostgreSQL.Connection (Connection)
-import Orville.PostgreSQL.Internal.MonadOrville (MonadOrville, withConnection)
-import Orville.PostgreSQL.Internal.OrvilleState (OrvilleState, askOrvilleState, orvilleErrorDetailLevel, orvilleSqlCommenterAttributes, orvilleSqlExecutionCallback)
 import Orville.PostgreSQL.Internal.QueryType (QueryType)
 import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
 import qualified Orville.PostgreSQL.Internal.SqlCommenter as SqlCommenter
 import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
 import qualified Orville.PostgreSQL.Marshall.SqlMarshaller as SqlMarshaller
+import Orville.PostgreSQL.Monad (MonadOrville, askOrvilleState, withConnection)
+import Orville.PostgreSQL.OrvilleState (OrvilleState, orvilleErrorDetailLevel, orvilleSqlCommenterAttributes, orvilleSqlExecutionCallback)
 
 {- |
   Executes a SQL query and decodes the result set using the provided

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Insert.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Insert.hs
@@ -21,10 +21,10 @@ import Data.List.NonEmpty (NonEmpty)
 
 import qualified Orville.PostgreSQL.Expr as Expr
 import qualified Orville.PostgreSQL.Internal.Execute as Execute
-import qualified Orville.PostgreSQL.Internal.MonadOrville as MonadOrville
 import qualified Orville.PostgreSQL.Internal.QueryType as QueryType
 import Orville.PostgreSQL.Internal.ReturningOption (NoReturningClause, ReturningClause, ReturningOption (WithReturning, WithoutReturning))
 import Orville.PostgreSQL.Marshall.SqlMarshaller (AnnotatedSqlMarshaller)
+import qualified Orville.PostgreSQL.Monad as Monad
 import Orville.PostgreSQL.Schema (TableDefinition, mkInsertExpr, tableMarshaller)
 
 {- | Represents an @INSERT@ statement that can be executed against a database. An 'Insert' has a
@@ -52,7 +52,7 @@ insertToInsertExpr (InsertReturning _ expr) = expr
   affected by the query
 -}
 executeInsert ::
-  MonadOrville.MonadOrville m =>
+  Monad.MonadOrville m =>
   Insert readEntity NoReturningClause ->
   m Int
 executeInsert (Insert _ expr) =
@@ -62,7 +62,7 @@ executeInsert (Insert _ expr) =
   were just inserted) as returned via a RETURNING clause.
 -}
 executeInsertReturnEntities ::
-  MonadOrville.MonadOrville m =>
+  Monad.MonadOrville m =>
   Insert readEntity ReturningClause ->
   m [readEntity]
 executeInsertReturnEntities (InsertReturning marshaller expr) =

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/MigrationLock.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/MigrationLock.hs
@@ -12,14 +12,14 @@ import qualified Control.Monad.IO.Class as MIO
 import Data.Int (Int32)
 
 import qualified Orville.PostgreSQL.Internal.Execute as Execute
-import qualified Orville.PostgreSQL.Internal.MonadOrville as MonadOrville
 import qualified Orville.PostgreSQL.Internal.QueryType as QueryType
 import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
 import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
 import qualified Orville.PostgreSQL.Internal.Transaction as Transaction
 import qualified Orville.PostgreSQL.Marshall as Marshall
+import qualified Orville.PostgreSQL.Monad as Monad
 
-withLockedTransaction :: forall m a. MonadOrville.MonadOrville m => m a -> m a
+withLockedTransaction :: forall m a. Monad.MonadOrville m => m a -> m a
 withLockedTransaction action = do
   go 0
   where

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Select.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Select.hs
@@ -15,10 +15,10 @@ where
 
 import qualified Orville.PostgreSQL.Expr as Expr
 import qualified Orville.PostgreSQL.Internal.Execute as Execute
-import qualified Orville.PostgreSQL.Internal.MonadOrville as MonadOrville
 import qualified Orville.PostgreSQL.Internal.QueryType as QueryType
 import qualified Orville.PostgreSQL.Internal.SelectOptions as SelectOptions
 import Orville.PostgreSQL.Marshall.SqlMarshaller (AnnotatedSqlMarshaller, marshallerDerivedColumns, unannotatedSqlMarshaller)
+import qualified Orville.PostgreSQL.Monad as Monad
 import Orville.PostgreSQL.Schema (TableDefinition, tableMarshaller, tableName)
 
 {- |
@@ -41,7 +41,7 @@ selectToQueryExpr (Select _ query) = query
   Excutes the database query for the 'Select' and uses its 'SqlMarshaller' to
   decode the result set.
 -}
-executeSelect :: MonadOrville.MonadOrville m => Select row -> m [row]
+executeSelect :: Monad.MonadOrville m => Select row -> m [row]
 executeSelect =
   useSelect (Execute.executeAndDecode QueryType.SelectQuery)
 

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Sequence.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Sequence.hs
@@ -9,16 +9,16 @@ import Data.Int (Int64)
 
 import qualified Orville.PostgreSQL.Expr as Expr
 import qualified Orville.PostgreSQL.Internal.Execute as Execute
-import qualified Orville.PostgreSQL.Internal.MonadOrville as MonadOrville
 import qualified Orville.PostgreSQL.Internal.QueryType as QueryType
 import qualified Orville.PostgreSQL.Internal.RowCountExpectation as RowCountExpectation
 import qualified Orville.PostgreSQL.Marshall as Marshall
+import qualified Orville.PostgreSQL.Monad as Monad
 import Orville.PostgreSQL.Schema (SequenceDefinition, sequenceName)
 
 {- |
   Fetches the next value from a sequence via the PostgreSQL @nextval@ function.
 -}
-sequenceNextValue :: MonadOrville.MonadOrville m => SequenceDefinition -> m Int64
+sequenceNextValue :: Monad.MonadOrville m => SequenceDefinition -> m Int64
 sequenceNextValue sequenceDef =
   selectInt64Value
     "sequenceNextValue"
@@ -27,7 +27,7 @@ sequenceNextValue sequenceDef =
 {- |
   Fetches the current value from a sequence via the PostgreSQL @currval@ function.
 -}
-sequenceCurrentValue :: MonadOrville.MonadOrville m => SequenceDefinition -> m Int64
+sequenceCurrentValue :: Monad.MonadOrville m => SequenceDefinition -> m Int64
 sequenceCurrentValue sequenceDef =
   selectInt64Value
     "sequenceCurrentValue"
@@ -36,13 +36,13 @@ sequenceCurrentValue sequenceDef =
 {- |
   Sets the current value from a sequence via the PostgreSQL @setval@ function.
 -}
-sequenceSetValue :: MonadOrville.MonadOrville m => SequenceDefinition -> Int64 -> m Int64
+sequenceSetValue :: Monad.MonadOrville m => SequenceDefinition -> Int64 -> m Int64
 sequenceSetValue sequenceDef newValue =
   selectInt64Value
     "sequenceSetValue"
     (Expr.setVal (sequenceName sequenceDef) newValue)
 
-selectInt64Value :: MonadOrville.MonadOrville m => String -> Expr.ValueExpression -> m Int64
+selectInt64Value :: Monad.MonadOrville m => String -> Expr.ValueExpression -> m Int64
 selectInt64Value caller valueExpression = do
   let queryExpr =
         Expr.queryExpr

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Update.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Update.hs
@@ -17,10 +17,10 @@ import Data.List.NonEmpty (NonEmpty, nonEmpty)
 
 import qualified Orville.PostgreSQL.Expr as Expr
 import qualified Orville.PostgreSQL.Internal.Execute as Execute
-import qualified Orville.PostgreSQL.Internal.MonadOrville as MonadOrville
 import qualified Orville.PostgreSQL.Internal.QueryType as QueryType
 import Orville.PostgreSQL.Internal.ReturningOption (NoReturningClause, ReturningClause, ReturningOption (WithReturning, WithoutReturning))
 import Orville.PostgreSQL.Marshall (AnnotatedSqlMarshaller, marshallEntityToSetClauses, unannotatedSqlMarshaller)
+import qualified Orville.PostgreSQL.Monad as Monad
 import Orville.PostgreSQL.Schema (HasKey, TableDefinition, mkTableReturningClause, primaryKeyEquals, tableMarshaller, tableName, tablePrimaryKey)
 
 {- |
@@ -45,7 +45,7 @@ updateToUpdateExpr (UpdateReturning _ expr) = expr
   Executes the database query for the 'Update' and returns the number of
   affected rows
 -}
-executeUpdate :: MonadOrville.MonadOrville m => Update readEntity returningClause -> m Int
+executeUpdate :: Monad.MonadOrville m => Update readEntity returningClause -> m Int
 executeUpdate =
   Execute.executeAndReturnAffectedRows QueryType.UpdateQuery . updateToUpdateExpr
 
@@ -54,7 +54,7 @@ executeUpdate =
   'AnnotatedSqlMarshaller' to decode any rows that were just updated, as
   returned via a RETURNING clause.
 -}
-executeUpdateReturnEntities :: MonadOrville.MonadOrville m => Update readEntity ReturningClause -> m [readEntity]
+executeUpdateReturnEntities :: Monad.MonadOrville m => Update readEntity ReturningClause -> m [readEntity]
 executeUpdateReturnEntities (UpdateReturning marshaller expr) =
   Execute.executeAndDecode QueryType.UpdateQuery expr marshaller
 

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Monad.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Monad.hs
@@ -1,0 +1,15 @@
+{-# OPTIONS_GHC -Wno-missing-import-lists #-}
+
+module Orville.PostgreSQL.Monad
+  ( module Orville.PostgreSQL.Monad.Orville,
+    module Orville.PostgreSQL.Monad.HasOrvilleState,
+    module Orville.PostgreSQL.Monad.MonadOrville,
+  )
+where
+
+-- Note: we list the re-exports explicity above to control the order that they
+-- appear in the generated haddock documentation.
+
+import Orville.PostgreSQL.Monad.HasOrvilleState
+import Orville.PostgreSQL.Monad.MonadOrville
+import Orville.PostgreSQL.Monad.Orville

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Monad/HasOrvilleState.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Monad/HasOrvilleState.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Orville.PostgreSQL.Monad.HasOrvilleState
+  ( HasOrvilleState (askOrvilleState, localOrvilleState),
+  )
+where
+
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.Reader (ReaderT, ask, local, mapReaderT)
+
+import Orville.PostgreSQL.OrvilleState (OrvilleState)
+
+{- |
+  'HasOrvilleState' is the typeclass that Orville uses to access and manange
+  the connection pool and state tracking when it is being executed inside an
+  unknown Monad. It is a specialized version of the Reader interface so that it
+  can easily implemented by application Monads that already have a Reader
+  context and want to simply add 'OrvilleState' as an attribute to that
+  context, like so
+
+  @
+    data MyApplicationState =
+      MyApplicationState
+        { appConfig :: MyAppConfig
+        , appOrvilleState :: OrvilleState
+        }
+
+    newtype MyApplicationMonad a =
+      MyApplicationMonad (ReaderT MyApplicationState IO) a
+
+    instance HasOrvilleState MyApplicationMonad where
+      askOrvilleState =
+        MyApplicationMonad (asks appOrvilleState)
+
+      localOrvilleState f (MyApplicationMonad reader) =
+        MyApplicationMonad $
+          local
+            (\state -> state { appOrvilleState = f (appOrvilleState state))
+            reader
+  @
+
+  An instance for 'ReaderT OrvilleState m' is provided as a convenience in
+  the case that your application has no extra context to track.
+-}
+class HasOrvilleState m where
+  {-
+    Fetches the current 'OrvilleState' from the host Monad context. The
+    equivalent of 'ask' for 'ReaderT OrvilleState'
+  -}
+  askOrvilleState :: m OrvilleState
+
+  {-
+    Applies a modification to the 'OrvilleState' that is local to the given
+    monad operation. Calls to 'askOrvilleState' made within the 'm a' provided
+    must return the modified state. The modified state must only apply to
+    the given 'm a' and not persisted beyond it. The equivalent of 'local'
+    for 'ReaderT OrvilleState'
+  -}
+  localOrvilleState ::
+    -- | The function to modify the 'OrvilleState'
+    (OrvilleState -> OrvilleState) ->
+    -- | The monad operation to execute with the modified state
+    m a ->
+    m a
+
+instance Monad m => HasOrvilleState (ReaderT OrvilleState m) where
+  askOrvilleState = ask
+  localOrvilleState = local
+
+instance {-# OVERLAPS #-} (Monad m, HasOrvilleState m) => HasOrvilleState (ReaderT r m) where
+  askOrvilleState = lift askOrvilleState
+  localOrvilleState f = mapReaderT (localOrvilleState f)

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Monad/MonadOrville.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Monad/MonadOrville.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE RankNTypes #-}
 
-module Orville.PostgreSQL.Internal.MonadOrville
+module Orville.PostgreSQL.Monad.MonadOrville
   ( MonadOrville,
     MonadOrvilleControl (liftWithConnection, liftFinally, liftBracket),
     withConnection,
@@ -14,10 +14,10 @@ import Control.Monad.Trans.Reader (ReaderT (ReaderT), runReaderT)
 import Data.Pool (withResource)
 
 import Orville.PostgreSQL.Connection (Connection)
-import Orville.PostgreSQL.Internal.OrvilleState
+import Orville.PostgreSQL.Monad.HasOrvilleState (HasOrvilleState (askOrvilleState, localOrvilleState))
+import Orville.PostgreSQL.OrvilleState
   ( ConnectedState (ConnectedState, connectedConnection, connectedTransaction),
     ConnectionState (Connected, NotConnected),
-    HasOrvilleState (askOrvilleState, localOrvilleState),
     OrvilleState,
     connectState,
     orvilleConnectionPool,

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Monad/Orville.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Monad/Orville.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
-module Orville.PostgreSQL.Internal.Orville
+module Orville.PostgreSQL.Monad.Orville
   ( Orville,
     runOrville,
     runOrvilleWithState,
@@ -14,8 +14,9 @@ import Data.Pool (Pool)
 
 import Orville.PostgreSQL.Connection (Connection)
 import qualified Orville.PostgreSQL.Internal.ErrorDetailLevel as ErrorDetailLevel
-import qualified Orville.PostgreSQL.Internal.MonadOrville as MonadOrville
-import qualified Orville.PostgreSQL.Internal.OrvilleState as OrvilleState
+import qualified Orville.PostgreSQL.Monad.HasOrvilleState as HasOrvilleState
+import qualified Orville.PostgreSQL.Monad.MonadOrville as MonadOrville
+import qualified Orville.PostgreSQL.OrvilleState as OrvilleState
 
 {- |
   The 'Orville' Monad provides a easy starter implementation of 'MonadOrville'
@@ -35,7 +36,7 @@ newtype Orville a = Orville
     , MonadIO
     , MonadOrville.MonadOrvilleControl
     , MonadOrville.MonadOrville
-    , OrvilleState.HasOrvilleState
+    , HasOrvilleState.HasOrvilleState
     , ExSafe.MonadThrow
     , ExSafe.MonadCatch
     )

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/OrvilleState.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/OrvilleState.hs
@@ -1,7 +1,6 @@
-{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE RankNTypes #-}
 
-module Orville.PostgreSQL.Internal.OrvilleState
+module Orville.PostgreSQL.OrvilleState
   ( OrvilleState,
     newOrvilleState,
     resetOrvilleState,
@@ -15,7 +14,6 @@ module Orville.PostgreSQL.Internal.OrvilleState
     openTransactionEvent,
     rollbackTransactionEvent,
     transactionSuccessEvent,
-    HasOrvilleState (askOrvilleState, localOrvilleState),
     ConnectionState (NotConnected, Connected),
     ConnectedState (ConnectedState, connectedConnection, connectedTransaction),
     connectState,
@@ -34,8 +32,6 @@ module Orville.PostgreSQL.Internal.OrvilleState
   )
 where
 
-import Control.Monad.Trans.Class (lift)
-import Control.Monad.Trans.Reader (ReaderT, ask, local, mapReaderT)
 import qualified Data.Map.Strict as Map
 import Data.Pool (Pool)
 
@@ -113,67 +109,6 @@ addTransactionCallback newCallback state =
         originalCallback event
         newCallback event
    in state {_orvilleTransactionCallback = wrappedCallback}
-
-{- |
-  'HasOrvilleState' is the typeclass that Orville uses to access and manange
-  the connection pool and state tracking when it is being executed inside an
-  unknown Monad. It is a specialized version of the Reader interface so that it
-  can easily implemented by application Monads that already have a Reader
-  context and want to simply add 'OrvilleState' as an attribute to that
-  context, like so
-
-  @
-    data MyApplicationState =
-      MyApplicationState
-        { appConfig :: MyAppConfig
-        , appOrvilleState :: OrvilleState
-        }
-
-    newtype MyApplicationMonad a =
-      MyApplicationMonad (ReaderT MyApplicationState IO) a
-
-    instance HasOrvilleState MyApplicationMonad where
-      askOrvilleState =
-        MyApplicationMonad (asks appOrvilleState)
-
-      localOrvilleState f (MyApplicationMonad reader) =
-        MyApplicationMonad $
-          local
-            (\state -> state { appOrvilleState = f (appOrvilleState state))
-            reader
-  @
-
-  An instance for 'ReaderT OrvilleState m' is provided as a convenience in
-  the case that your application has no extra context to track.
--}
-class HasOrvilleState m where
-  {-
-    Fetches the current 'OrvilleState' from the host Monad context. The
-    equivalent of 'ask' for 'ReaderT OrvilleState'
-  -}
-  askOrvilleState :: m OrvilleState
-
-  {-
-    Applies a modification to the 'OrvilleState' that is local to the given
-    monad operation. Calls to 'askOrvilleState' made within the 'm a' provided
-    must return the modified state. The modified state must only apply to
-    the given 'm a' and not persisted beyond it. The equivalent of 'local'
-    for 'ReaderT OrvilleState'
-  -}
-  localOrvilleState ::
-    -- | The function to modify the 'OrvilleState'
-    (OrvilleState -> OrvilleState) ->
-    -- | The monad operation to execute with the modified state
-    m a ->
-    m a
-
-instance Monad m => HasOrvilleState (ReaderT OrvilleState m) where
-  askOrvilleState = ask
-  localOrvilleState = local
-
-instance {-# OVERLAPS #-} (Monad m, HasOrvilleState m) => HasOrvilleState (ReaderT r m) where
-  askOrvilleState = lift askOrvilleState
-  localOrvilleState f = mapReaderT (localOrvilleState f)
 
 {- |
   Creates a appropriate initial 'OrvilleState' that will use the connection

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Plan.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Plan.hs
@@ -48,9 +48,9 @@ import Data.Either (partitionEithers)
 import qualified Data.List.NonEmpty as NEL
 
 import qualified Orville.PostgreSQL.Expr as Expr
-import qualified Orville.PostgreSQL.Internal.MonadOrville as MonadOrville
 import Orville.PostgreSQL.Internal.Select (Select)
 import qualified Orville.PostgreSQL.Marshall as Marshall
+import qualified Orville.PostgreSQL.Monad as Monad
 import qualified Orville.PostgreSQL.Plan.Explanation as Exp
 import Orville.PostgreSQL.Plan.Many (Many)
 import qualified Orville.PostgreSQL.Plan.Many as Many
@@ -509,7 +509,7 @@ assert assertion aPlan =
   'execute'.
 -}
 execute ::
-  MonadOrville.MonadOrville m =>
+  Monad.MonadOrville m =>
   Plan Execute param result ->
   param ->
   m result
@@ -521,7 +521,7 @@ execute plan param =
   'scope' type to ensure all 'Planned' values are built with 'PlannedOne'.
 -}
 executeOne ::
-  MonadOrville.MonadOrville m =>
+  Monad.MonadOrville m =>
   Plan Execute param result ->
   param ->
   m result
@@ -563,7 +563,7 @@ executeOne plan param =
   @scope@ type to ensure all 'Planned' values are built with 'PlannedMany'.
 -}
 executeMany ::
-  MonadOrville.MonadOrville m =>
+  Monad.MonadOrville m =>
   Plan ExecuteMany param result ->
   [param] ->
   m (Many.Many param result)

--- a/orville-postgresql-libpq/test/Test/Transaction.hs
+++ b/orville-postgresql-libpq/test/Test/Transaction.hs
@@ -15,8 +15,8 @@ import qualified Hedgehog.Gen as Gen
 import qualified Orville.PostgreSQL as Orville
 import qualified Orville.PostgreSQL.Connection as Conn
 import qualified Orville.PostgreSQL.Expr as Expr
-import qualified Orville.PostgreSQL.Internal.OrvilleState as OrvilleState
 import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+import qualified Orville.PostgreSQL.OrvilleState as OrvilleState
 
 import qualified Test.Property as Property
 import qualified Test.TestTable as TestTable


### PR DESCRIPTION
I split `HasOrvilleState` to its own file because putting `OrvilleState`
in with the monad things didn't really feel right. Instead I simply put
it directly under `Orville.PostgreSQL`.
