### PR TITLE
Organizes the remaining modules

### DIFF
--- a/orville-postgresql-libpq/orville-postgresql-libpq.cabal
+++ b/orville-postgresql-libpq/orville-postgresql-libpq.cabal
@@ -31,7 +31,6 @@ library
   exposed-modules:
       Orville.PostgreSQL
       Orville.PostgreSQL.AutoMigration
-      Orville.PostgreSQL.Connection
       Orville.PostgreSQL.EntityTrace
       Orville.PostgreSQL.Execution
       Orville.PostgreSQL.Execution.Cursor
@@ -47,6 +46,7 @@ library
       Orville.PostgreSQL.Execution.Sequence
       Orville.PostgreSQL.Execution.Transaction
       Orville.PostgreSQL.Execution.Update
+      Orville.PostgreSQL.ErrorDetailLevel
       Orville.PostgreSQL.Expr
       Orville.PostgreSQL.Expr.BinaryOperator
       Orville.PostgreSQL.Expr.ColumnDefinition
@@ -74,14 +74,8 @@ library
       Orville.PostgreSQL.Expr.Update
       Orville.PostgreSQL.Expr.ValueExpression
       Orville.PostgreSQL.Expr.WhereClause
-      Orville.PostgreSQL.Internal.DefaultValue
-      Orville.PostgreSQL.Internal.ErrorDetailLevel
-      Orville.PostgreSQL.Internal.PgTextFormatValue
-      Orville.PostgreSQL.Internal.PgTime
-      Orville.PostgreSQL.Internal.RawSql
-      Orville.PostgreSQL.Internal.SqlCommenter
-      Orville.PostgreSQL.Internal.SqlValue
       Orville.PostgreSQL.Marshall
+      Orville.PostgreSQL.Marshall.DefaultValue
       Orville.PostgreSQL.Marshall.FieldDefinition
       Orville.PostgreSQL.Marshall.MarshallError
       Orville.PostgreSQL.Marshall.SqlMarshaller
@@ -98,6 +92,12 @@ library
       Orville.PostgreSQL.Plan.Operation
       Orville.PostgreSQL.Plan.Syntax
       Orville.PostgreSQL.PgCatalog
+      Orville.PostgreSQL.Raw.Connection
+      Orville.PostgreSQL.Raw.PgTextFormatValue
+      Orville.PostgreSQL.Raw.PgTime
+      Orville.PostgreSQL.Raw.RawSql
+      Orville.PostgreSQL.Raw.SqlCommenter
+      Orville.PostgreSQL.Raw.SqlValue
       Orville.PostgreSQL.Schema
       Orville.PostgreSQL.Schema.ConstraintDefinition
       Orville.PostgreSQL.Schema.IndexDefinition

--- a/orville-postgresql-libpq/package.yaml
+++ b/orville-postgresql-libpq/package.yaml
@@ -23,7 +23,6 @@ library:
   exposed-modules:
     - Orville.PostgreSQL
     - Orville.PostgreSQL.AutoMigration
-    - Orville.PostgreSQL.Connection
     - Orville.PostgreSQL.EntityTrace
     - Orville.PostgreSQL.Execution
     - Orville.PostgreSQL.Execution.Cursor
@@ -39,6 +38,7 @@ library:
     - Orville.PostgreSQL.Execution.Sequence
     - Orville.PostgreSQL.Execution.Transaction
     - Orville.PostgreSQL.Execution.Update
+    - Orville.PostgreSQL.ErrorDetailLevel
     - Orville.PostgreSQL.Expr
     - Orville.PostgreSQL.Expr.BinaryOperator
     - Orville.PostgreSQL.Expr.ColumnDefinition
@@ -66,14 +66,8 @@ library:
     - Orville.PostgreSQL.Expr.Update
     - Orville.PostgreSQL.Expr.ValueExpression
     - Orville.PostgreSQL.Expr.WhereClause
-    - Orville.PostgreSQL.Internal.DefaultValue
-    - Orville.PostgreSQL.Internal.ErrorDetailLevel
-    - Orville.PostgreSQL.Internal.PgTextFormatValue
-    - Orville.PostgreSQL.Internal.PgTime
-    - Orville.PostgreSQL.Internal.RawSql
-    - Orville.PostgreSQL.Internal.SqlCommenter
-    - Orville.PostgreSQL.Internal.SqlValue
     - Orville.PostgreSQL.Marshall
+    - Orville.PostgreSQL.Marshall.DefaultValue
     - Orville.PostgreSQL.Marshall.FieldDefinition
     - Orville.PostgreSQL.Marshall.MarshallError
     - Orville.PostgreSQL.Marshall.SqlMarshaller
@@ -90,6 +84,12 @@ library:
     - Orville.PostgreSQL.Plan.Operation
     - Orville.PostgreSQL.Plan.Syntax
     - Orville.PostgreSQL.PgCatalog
+    - Orville.PostgreSQL.Raw.Connection
+    - Orville.PostgreSQL.Raw.PgTextFormatValue
+    - Orville.PostgreSQL.Raw.PgTime
+    - Orville.PostgreSQL.Raw.RawSql
+    - Orville.PostgreSQL.Raw.SqlCommenter
+    - Orville.PostgreSQL.Raw.SqlValue
     - Orville.PostgreSQL.Schema
     - Orville.PostgreSQL.Schema.ConstraintDefinition
     - Orville.PostgreSQL.Schema.IndexDefinition

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
@@ -27,6 +27,8 @@ module Orville.PostgreSQL
 
     -- * Creating a connection pool
     Connection.createConnectionPool,
+    Connection.Connection,
+    Connection.Pool,
     Connection.NoticeReporting (EnableNoticeReporting, DisableNoticeReporting),
 
     -- * Opening transactions and savepoints
@@ -319,7 +321,7 @@ module Orville.PostgreSQL
   )
 where
 
-import qualified Orville.PostgreSQL.Connection as Connection
+import qualified Orville.PostgreSQL.ErrorDetailLevel as ErrorDetailLevel
 import qualified Orville.PostgreSQL.Execution.EntityOperations as EntityOperations
 import qualified Orville.PostgreSQL.Execution.Execute as Execute
 import qualified Orville.PostgreSQL.Execution.QueryType as QueryType
@@ -327,9 +329,7 @@ import qualified Orville.PostgreSQL.Execution.SelectOptions as SelectOptions
 import qualified Orville.PostgreSQL.Execution.Sequence as Sequence
 import qualified Orville.PostgreSQL.Execution.Transaction as Transaction
 import qualified Orville.PostgreSQL.Expr as Expr
-import qualified Orville.PostgreSQL.Internal.DefaultValue as DefaultValue
-import qualified Orville.PostgreSQL.Internal.ErrorDetailLevel as ErrorDetailLevel
-import qualified Orville.PostgreSQL.Internal.SqlCommenter as SqlCommenter
+import qualified Orville.PostgreSQL.Marshall.DefaultValue as DefaultValue
 import qualified Orville.PostgreSQL.Marshall.FieldDefinition as FieldDefinition
 import qualified Orville.PostgreSQL.Marshall.SqlMarshaller as SqlMarshaller
 import qualified Orville.PostgreSQL.Marshall.SqlType as SqlType
@@ -338,6 +338,8 @@ import qualified Orville.PostgreSQL.Monad.HasOrvilleState as HasOrvilleState
 import qualified Orville.PostgreSQL.Monad.MonadOrville as MonadOrville
 import qualified Orville.PostgreSQL.Monad.Orville as Orville
 import qualified Orville.PostgreSQL.OrvilleState as OrvilleState
+import qualified Orville.PostgreSQL.Raw.Connection as Connection
+import qualified Orville.PostgreSQL.Raw.SqlCommenter as SqlCommenter
 import qualified Orville.PostgreSQL.Schema.ConstraintDefinition as ConstraintDefinition
 import qualified Orville.PostgreSQL.Schema.IndexDefinition as IndexDefinition
 import qualified Orville.PostgreSQL.Schema.PrimaryKey as PrimaryKey

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/AutoMigration.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/AutoMigration.hs
@@ -29,8 +29,8 @@ import qualified Database.PostgreSQL.LibPQ as LibPQ
 import qualified Orville.PostgreSQL as Orville
 import qualified Orville.PostgreSQL.Expr as Expr
 import qualified Orville.PostgreSQL.Internal.MigrationLock as MigrationLock
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
 import qualified Orville.PostgreSQL.PgCatalog as PgCatalog
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 {- |
   A 'SchemaItem' represents a single item in a database schema such as a table,

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/EntityTrace.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/EntityTrace.hs
@@ -29,10 +29,8 @@ import Control.Monad.Trans.Reader (ReaderT, ask, runReaderT)
 import qualified Data.DList as DList
 import Data.Foldable (traverse_)
 import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef)
-import Data.Pool (Pool)
 
 import qualified Orville.PostgreSQL as O
-import qualified Orville.PostgreSQL.Connection as Conn
 
 {- |
  'MonadEntityTrace' provides the interface used by functions such as
@@ -614,7 +612,7 @@ recordTracesInState askTraceState traces = do
 runEntityTraceT ::
   MonadIO n =>
   O.ErrorDetailLevel ->
-  Pool Conn.Connection ->
+  O.Pool O.Connection ->
   (O.OrvilleState -> m a -> n a) ->
   EntityTraceT trace m a ->
   n (a, [trace])

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/ErrorDetailLevel.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/ErrorDetailLevel.hs
@@ -1,4 +1,4 @@
-module Orville.PostgreSQL.Internal.ErrorDetailLevel
+module Orville.PostgreSQL.ErrorDetailLevel
   ( ErrorDetailLevel (ErrorDetailLevel, includeErrorMessage, includeSchemaNames, includeRowIdentifierValues, includeNonIdentifierValues),
     defaultErrorDetailLevel,
     minimalErrorDetailLevel,

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Execute.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Execute.hs
@@ -14,14 +14,14 @@ import Control.Monad (void)
 import Control.Monad.IO.Class (liftIO)
 import qualified Database.PostgreSQL.LibPQ as LibPQ
 
-import Orville.PostgreSQL.Connection (Connection)
 import Orville.PostgreSQL.Execution.QueryType (QueryType)
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
-import qualified Orville.PostgreSQL.Internal.SqlCommenter as SqlCommenter
-import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
 import qualified Orville.PostgreSQL.Marshall.SqlMarshaller as SqlMarshaller
 import Orville.PostgreSQL.Monad (MonadOrville, askOrvilleState, withConnection)
 import Orville.PostgreSQL.OrvilleState (OrvilleState, orvilleErrorDetailLevel, orvilleSqlCommenterAttributes, orvilleSqlExecutionCallback)
+import Orville.PostgreSQL.Raw.Connection (Connection)
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.SqlCommenter as SqlCommenter
+import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 {- |
   Executes a SQL query and decodes the result set using the provided

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/ExecutionResult.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/ExecutionResult.hs
@@ -19,8 +19,8 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Maybe as Maybe
 import qualified Database.PostgreSQL.LibPQ as LibPQ
 
-import Orville.PostgreSQL.Internal.SqlValue (SqlValue)
-import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
+import Orville.PostgreSQL.Raw.SqlValue (SqlValue)
+import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 {- |
   A trivial wrapper for `Int` to help keep track of column vs row number

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Transaction.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Transaction.hs
@@ -11,9 +11,9 @@ import qualified Data.IORef as IORef
 import qualified Orville.PostgreSQL.Execution.Execute as Execute
 import qualified Orville.PostgreSQL.Execution.QueryType as QueryType
 import qualified Orville.PostgreSQL.Expr as Expr
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
 import qualified Orville.PostgreSQL.Monad as Monad
 import qualified Orville.PostgreSQL.OrvilleState as OrvilleState
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 {- |
   Performs an action in an Orville monad within a database transaction. The transaction

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/BinaryOperator.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/BinaryOperator.hs
@@ -33,7 +33,7 @@ module Orville.PostgreSQL.Expr.BinaryOperator
 where
 
 import Orville.PostgreSQL.Expr.ValueExpression (ValueExpression)
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 newtype BinaryOperator
   = BinaryOperator RawSql.RawSql

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/ColumnDefinition.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/ColumnDefinition.hs
@@ -20,7 +20,7 @@ import qualified Data.Maybe as Maybe
 import Orville.PostgreSQL.Expr.DataType (DataType)
 import Orville.PostgreSQL.Expr.Name (ColumnName)
 import Orville.PostgreSQL.Expr.ValueExpression (ValueExpression)
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 newtype ColumnDefinition
   = ColumnDefinition RawSql.RawSql

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Count.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Count.hs
@@ -8,7 +8,7 @@ where
 
 import Orville.PostgreSQL.Expr.Name (ColumnName, FunctionName, functionName)
 import Orville.PostgreSQL.Expr.ValueExpression (ValueExpression, columnReference, functionCall)
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 countFunction :: FunctionName
 countFunction = functionName "count"

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Cursor.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Cursor.hs
@@ -44,7 +44,7 @@ import Prelude (Either, Int, Maybe (Just), either, fmap, ($), (.), (<>))
 
 import Orville.PostgreSQL.Expr.Name (CursorName)
 import Orville.PostgreSQL.Expr.Query (QueryExpr)
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 newtype DeclareExpr
   = DeclareExpr RawSql.RawSql

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/DataType.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/DataType.hs
@@ -27,7 +27,7 @@ where
 
 import Data.Int (Int32)
 
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 newtype DataType
   = DataType RawSql.RawSql

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Delete.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Delete.hs
@@ -11,7 +11,7 @@ import Data.Maybe (catMaybes)
 import Orville.PostgreSQL.Expr.Name (Qualified, TableName)
 import Orville.PostgreSQL.Expr.ReturningExpr (ReturningExpr)
 import Orville.PostgreSQL.Expr.WhereClause (WhereClause)
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 newtype DeleteExpr
   = DeleteExpr RawSql.RawSql

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/GroupBy.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/GroupBy.hs
@@ -17,7 +17,7 @@ where
 import Data.List.NonEmpty (NonEmpty)
 
 import Orville.PostgreSQL.Expr.Name (ColumnName)
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 newtype GroupByClause
   = GroupByClause RawSql.RawSql

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/IfExists.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/IfExists.hs
@@ -6,7 +6,7 @@ module Orville.PostgreSQL.Expr.IfExists
   )
 where
 
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 newtype IfExists
   = IfExists RawSql.RawSql

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Index.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Index.hs
@@ -13,7 +13,7 @@ where
 import Data.List.NonEmpty (NonEmpty)
 
 import Orville.PostgreSQL.Expr.Name (ColumnName, IndexName, Qualified, TableName)
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 newtype CreateIndexExpr
   = CreateIndexExpr RawSql.RawSql

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Insert.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Insert.hs
@@ -20,8 +20,8 @@ import Data.Maybe (catMaybes)
 
 import Orville.PostgreSQL.Expr.Name (ColumnName, Qualified, TableName)
 import Orville.PostgreSQL.Expr.ReturningExpr (ReturningExpr)
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
-import Orville.PostgreSQL.Internal.SqlValue (SqlValue)
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+import Orville.PostgreSQL.Raw.SqlValue (SqlValue)
 
 newtype InsertExpr
   = InsertExpr RawSql.RawSql

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/ColumnName.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/ColumnName.hs
@@ -11,7 +11,7 @@ module Orville.PostgreSQL.Expr.Internal.Name.ColumnName
 where
 
 import Orville.PostgreSQL.Expr.Internal.Name.Identifier (Identifier, IdentifierExpression, identifier)
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 newtype ColumnName
   = ColumnName Identifier

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/ConstraintName.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/ConstraintName.hs
@@ -11,7 +11,7 @@ module Orville.PostgreSQL.Expr.Internal.Name.ConstraintName
 where
 
 import Orville.PostgreSQL.Expr.Internal.Name.Identifier (Identifier, IdentifierExpression, identifier)
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 newtype ConstraintName
   = ConstraintName Identifier

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/CursorName.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/CursorName.hs
@@ -11,7 +11,7 @@ module Orville.PostgreSQL.Expr.Internal.Name.CursorName
 where
 
 import Orville.PostgreSQL.Expr.Internal.Name.Identifier (Identifier, IdentifierExpression, identifier)
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 newtype CursorName
   = CursorName Identifier

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/FunctionName.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/FunctionName.hs
@@ -11,7 +11,7 @@ module Orville.PostgreSQL.Expr.Internal.Name.FunctionName
 where
 
 import Orville.PostgreSQL.Expr.Internal.Name.Identifier (Identifier, IdentifierExpression, identifier)
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 newtype FunctionName
   = FunctionName Identifier

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/Identifier.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/Identifier.hs
@@ -15,7 +15,7 @@ module Orville.PostgreSQL.Expr.Internal.Name.Identifier
 where
 
 import qualified Data.ByteString.Char8 as B8
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 newtype Identifier
   = Identifier RawSql.RawSql

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/IndexName.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/IndexName.hs
@@ -11,7 +11,7 @@ module Orville.PostgreSQL.Expr.Internal.Name.IndexName
 where
 
 import Orville.PostgreSQL.Expr.Internal.Name.Identifier (Identifier, IdentifierExpression, identifier)
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 newtype IndexName
   = IndexName Identifier

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/Qualified.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/Qualified.hs
@@ -12,7 +12,7 @@ where
 
 import Orville.PostgreSQL.Expr.Internal.Name.Identifier (IdentifierExpression (toIdentifier))
 import Orville.PostgreSQL.Expr.Internal.Name.SchemaName (SchemaName)
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 newtype Qualified name
   = Qualified RawSql.RawSql

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/SavepointName.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/SavepointName.hs
@@ -11,7 +11,7 @@ module Orville.PostgreSQL.Expr.Internal.Name.SavepointName
 where
 
 import Orville.PostgreSQL.Expr.Internal.Name.Identifier (Identifier, IdentifierExpression, identifier)
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 newtype SavepointName
   = SavepointName Identifier

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/SchemaName.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/SchemaName.hs
@@ -11,7 +11,7 @@ module Orville.PostgreSQL.Expr.Internal.Name.SchemaName
 where
 
 import Orville.PostgreSQL.Expr.Internal.Name.Identifier (Identifier, IdentifierExpression, identifier)
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 newtype SchemaName
   = SchemaName Identifier

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/SequenceName.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/SequenceName.hs
@@ -11,7 +11,7 @@ module Orville.PostgreSQL.Expr.Internal.Name.SequenceName
 where
 
 import Orville.PostgreSQL.Expr.Internal.Name.Identifier (Identifier, IdentifierExpression, identifier)
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 newtype SequenceName
   = SequenceName Identifier

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/TableName.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/TableName.hs
@@ -11,7 +11,7 @@ module Orville.PostgreSQL.Expr.Internal.Name.TableName
 where
 
 import Orville.PostgreSQL.Expr.Internal.Name.Identifier (Identifier, IdentifierExpression, identifier)
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 newtype TableName
   = TableName Identifier

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/LimitExpr.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/LimitExpr.hs
@@ -6,8 +6,8 @@ module Orville.PostgreSQL.Expr.LimitExpr
   )
 where
 
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
-import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 newtype LimitExpr
   = LimitExpr RawSql.RawSql

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/OffsetExpr.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/OffsetExpr.hs
@@ -6,8 +6,8 @@ module Orville.PostgreSQL.Expr.OffsetExpr
   )
 where
 
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
-import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 newtype OffsetExpr
   = OffsetExpr RawSql.RawSql

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/OrderBy.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/OrderBy.hs
@@ -25,7 +25,7 @@ import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
 
 import Orville.PostgreSQL.Expr.Name (ColumnName)
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 newtype OrderByClause
   = OrderByClause RawSql.RawSql

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Query.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Query.hs
@@ -29,7 +29,7 @@ import Orville.PostgreSQL.Expr.OrderBy (OrderByClause)
 import Orville.PostgreSQL.Expr.Select (SelectClause)
 import Orville.PostgreSQL.Expr.ValueExpression (ValueExpression, columnReference)
 import Orville.PostgreSQL.Expr.WhereClause (WhereClause)
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 -- This is a rough model of "query specification" see https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#_7_16_query_specification for more detail than you probably want
 newtype QueryExpr

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/ReturningExpr.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/ReturningExpr.hs
@@ -7,7 +7,7 @@ module Orville.PostgreSQL.Expr.ReturningExpr
 where
 
 import Orville.PostgreSQL.Expr.Query (SelectList)
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 newtype ReturningExpr
   = ReturningExpr RawSql.RawSql

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Select.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Select.hs
@@ -13,7 +13,7 @@ module Orville.PostgreSQL.Expr.Select
   )
 where
 
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 newtype SelectClause
   = SelectClause RawSql.RawSql

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/SequenceDefinition.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/SequenceDefinition.hs
@@ -41,8 +41,8 @@ import Data.Maybe (catMaybes)
 import Orville.PostgreSQL.Expr.IfExists (IfExists)
 import Orville.PostgreSQL.Expr.Name (FunctionName, Qualified, SequenceName, functionName)
 import Orville.PostgreSQL.Expr.ValueExpression (ValueExpression, functionCall, valueExpression)
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
-import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 {-
    From https://www.postgresql.org/docs/15/sql-createsequence.html

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/TableConstraint.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/TableConstraint.hs
@@ -19,7 +19,7 @@ where
 import Data.List.NonEmpty (NonEmpty)
 
 import Orville.PostgreSQL.Expr.Name (ColumnName, Qualified, TableName)
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 newtype TableConstraint
   = TableConstraint RawSql.RawSql

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/TableDefinition.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/TableDefinition.hs
@@ -34,7 +34,7 @@ import Orville.PostgreSQL.Expr.DataType (DataType)
 import Orville.PostgreSQL.Expr.IfExists (IfExists)
 import Orville.PostgreSQL.Expr.Name (ColumnName, ConstraintName, Qualified, TableName)
 import Orville.PostgreSQL.Expr.TableConstraint (TableConstraint)
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 newtype CreateTableExpr
   = CreateTableExpr RawSql.RawSql

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Time.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Time.hs
@@ -16,7 +16,7 @@ where
 
 import Orville.PostgreSQL.Expr.Name (functionName)
 import Orville.PostgreSQL.Expr.ValueExpression (ParameterName, ValueExpression, functionCall, functionCallNamedParams)
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 now :: ValueExpression
 now = functionCall (functionName "now") []

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Transaction.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Transaction.hs
@@ -29,7 +29,7 @@ where
 import Data.Maybe (maybeToList)
 
 import qualified Orville.PostgreSQL.Expr.Name as Name
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 newtype BeginTransactionExpr
   = BeginTransactionExpr RawSql.RawSql

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Update.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Update.hs
@@ -21,8 +21,8 @@ import Data.Maybe (catMaybes)
 import Orville.PostgreSQL.Expr.Name (ColumnName, Qualified, TableName)
 import Orville.PostgreSQL.Expr.ReturningExpr (ReturningExpr)
 import Orville.PostgreSQL.Expr.WhereClause (WhereClause)
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
-import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 newtype UpdateExpr
   = UpdateExpr RawSql.RawSql

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/ValueExpression.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/ValueExpression.hs
@@ -20,8 +20,8 @@ import qualified Data.List.NonEmpty as NE
 
 import Orville.PostgreSQL.Expr.DataType (DataType)
 import Orville.PostgreSQL.Expr.Name (ColumnName, FunctionName)
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
-import Orville.PostgreSQL.Internal.SqlValue (SqlValue)
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+import Orville.PostgreSQL.Raw.SqlValue (SqlValue)
 
 newtype ValueExpression = ValueExpression RawSql.RawSql
   deriving (RawSql.SqlExpression)

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/WhereClause.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/WhereClause.hs
@@ -38,7 +38,7 @@ import qualified Data.List.NonEmpty as NE
 
 import Orville.PostgreSQL.Expr.BinaryOperator (andOp, binaryOpExpression, equalsOp, greaterThanOp, greaterThanOrEqualsOp, iLikeOp, lessThanOp, lessThanOrEqualsOp, likeOp, notEqualsOp, orOp)
 import Orville.PostgreSQL.Expr.ValueExpression (ValueExpression, rowValueConstructor)
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 newtype WhereClause
   = WhereClause RawSql.RawSql

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/MigrationLock.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/MigrationLock.hs
@@ -12,10 +12,10 @@ import qualified Control.Monad.IO.Class as MIO
 import Data.Int (Int32)
 
 import qualified Orville.PostgreSQL.Execution as Exec
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
-import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
 import qualified Orville.PostgreSQL.Marshall as Marshall
 import qualified Orville.PostgreSQL.Monad as Monad
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 withLockedTransaction :: forall m a. Monad.MonadOrville m => m a -> m a
 withLockedTransaction action = do

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Marshall.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Marshall.hs
@@ -3,6 +3,7 @@
 module Orville.PostgreSQL.Marshall
   ( module Orville.PostgreSQL.Marshall.SqlMarshaller,
     module Orville.PostgreSQL.Marshall.FieldDefinition,
+    module Orville.PostgreSQL.Marshall.DefaultValue,
     module Orville.PostgreSQL.Marshall.SyntheticField,
     module Orville.PostgreSQL.Marshall.MarshallError,
     module Orville.PostgreSQL.Marshall.SqlType,
@@ -12,6 +13,7 @@ where
 -- Note: we list the re-exports explicity above to control the order that they
 -- appear in the generated haddock documentation.
 
+import Orville.PostgreSQL.Marshall.DefaultValue
 import Orville.PostgreSQL.Marshall.FieldDefinition
 import Orville.PostgreSQL.Marshall.MarshallError
 import Orville.PostgreSQL.Marshall.SqlMarshaller

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Marshall/DefaultValue.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Marshall/DefaultValue.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
-module Orville.PostgreSQL.Internal.DefaultValue
+module Orville.PostgreSQL.Marshall.DefaultValue
   ( DefaultValue,
     integerDefault,
     smallIntegerDefault,
@@ -30,8 +30,8 @@ import qualified Data.Time as Time
 import qualified Numeric as Numeric
 
 import qualified Orville.PostgreSQL.Expr as Expr
-import qualified Orville.PostgreSQL.Internal.PgTime as PgTime
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.PgTime as PgTime
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 {- |
   A 'DefaultValue' is a SQL expression that can be attached to a

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Marshall/MarshallError.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Marshall/MarshallError.hs
@@ -15,9 +15,9 @@ import qualified Data.ByteString.Char8 as B8
 import qualified Data.List as List
 import qualified Data.Set as Set
 
-import Orville.PostgreSQL.Internal.ErrorDetailLevel (ErrorDetailLevel, redactErrorMessage, redactIdentifierValue, redactNonIdentifierValue, redactSchemaName)
-import qualified Orville.PostgreSQL.Internal.PgTextFormatValue as PgTextFormatValue
-import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
+import Orville.PostgreSQL.ErrorDetailLevel (ErrorDetailLevel, redactErrorMessage, redactIdentifierValue, redactNonIdentifierValue, redactSchemaName)
+import qualified Orville.PostgreSQL.Raw.PgTextFormatValue as PgTextFormatValue
+import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 {- |
   A 'MarshallError' may be returned from 'marshallResultFromSql' when a row being

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Marshall/SqlMarshaller.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Marshall/SqlMarshaller.hs
@@ -45,14 +45,14 @@ import qualified Data.Map.Strict as Map
 import Data.Maybe (catMaybes)
 import qualified Data.Set as Set
 
+import Orville.PostgreSQL.ErrorDetailLevel (ErrorDetailLevel)
 import Orville.PostgreSQL.Execution.ExecutionResult (Column (Column), ExecutionResult, Row (Row))
 import qualified Orville.PostgreSQL.Execution.ExecutionResult as Result
 import qualified Orville.PostgreSQL.Expr as Expr
-import Orville.PostgreSQL.Internal.ErrorDetailLevel (ErrorDetailLevel)
-import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
 import Orville.PostgreSQL.Marshall.FieldDefinition (FieldDefinition, FieldName, FieldNullability (NotNullField, NullableField), asymmetricNullableField, fieldColumnName, fieldName, fieldNameToByteString, fieldNameToColumnName, fieldNullability, fieldValueFromSqlValue, nullableField, prefixField, setField)
 import qualified Orville.PostgreSQL.Marshall.MarshallError as MarshallError
 import Orville.PostgreSQL.Marshall.SyntheticField (SyntheticField, nullableSyntheticField, prefixSyntheticField, syntheticFieldAlias, syntheticFieldExpression, syntheticFieldValueFromSqlValue)
+import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 {- |
   An 'AnnotatedSqlMarshaller' is a 'SqlMarshaller' that contains extra

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Marshall/SqlType.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Marshall/SqlType.hs
@@ -48,8 +48,8 @@ import qualified Database.PostgreSQL.LibPQ as LibPQ
 import qualified Foreign.C.Types as CTypes
 
 import qualified Orville.PostgreSQL.Expr as Expr
-import Orville.PostgreSQL.Internal.SqlValue (SqlValue)
-import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
+import Orville.PostgreSQL.Raw.SqlValue (SqlValue)
+import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 {- |
   SqlType defines the mapping of a Haskell type (`a`) to a SQL column type in the

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Marshall/SyntheticField.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Marshall/SyntheticField.hs
@@ -13,8 +13,8 @@ where
 
 import qualified Data.ByteString.Char8 as B8
 import qualified Orville.PostgreSQL.Expr as Expr
-import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
 import Orville.PostgreSQL.Marshall.FieldDefinition (FieldName, byteStringToFieldName, fieldNameToByteString, stringToFieldName)
+import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 {- |
   A 'SyntheticField' can be used to evaluate a SQL expression based on the

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Monad/MonadOrville.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Monad/MonadOrville.hs
@@ -13,7 +13,6 @@ import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Trans.Reader (ReaderT (ReaderT), runReaderT)
 import Data.Pool (withResource)
 
-import Orville.PostgreSQL.Connection (Connection)
 import Orville.PostgreSQL.Monad.HasOrvilleState (HasOrvilleState (askOrvilleState, localOrvilleState))
 import Orville.PostgreSQL.OrvilleState
   ( ConnectedState (ConnectedState, connectedConnection, connectedTransaction),
@@ -23,6 +22,7 @@ import Orville.PostgreSQL.OrvilleState
     orvilleConnectionPool,
     orvilleConnectionState,
   )
+import Orville.PostgreSQL.Raw.Connection (Connection)
 
 {- |
   'MonadOrville' is the typeclass that most Orville operations require to

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Monad/Orville.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Monad/Orville.hs
@@ -12,11 +12,11 @@ import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Trans.Reader (ReaderT, runReaderT)
 import Data.Pool (Pool)
 
-import Orville.PostgreSQL.Connection (Connection)
-import qualified Orville.PostgreSQL.Internal.ErrorDetailLevel as ErrorDetailLevel
+import qualified Orville.PostgreSQL.ErrorDetailLevel as ErrorDetailLevel
 import qualified Orville.PostgreSQL.Monad.HasOrvilleState as HasOrvilleState
 import qualified Orville.PostgreSQL.Monad.MonadOrville as MonadOrville
 import qualified Orville.PostgreSQL.OrvilleState as OrvilleState
+import Orville.PostgreSQL.Raw.Connection (Connection)
 
 {- |
   The 'Orville' Monad provides a easy starter implementation of 'MonadOrville'

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/OrvilleState.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/OrvilleState.hs
@@ -35,12 +35,12 @@ where
 import qualified Data.Map.Strict as Map
 import Data.Pool (Pool)
 
-import Orville.PostgreSQL.Connection (Connection)
+import Orville.PostgreSQL.ErrorDetailLevel (ErrorDetailLevel)
 import Orville.PostgreSQL.Execution.QueryType (QueryType)
 import qualified Orville.PostgreSQL.Expr as Expr
-import Orville.PostgreSQL.Internal.ErrorDetailLevel (ErrorDetailLevel)
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
-import qualified Orville.PostgreSQL.Internal.SqlCommenter as SqlCommenter
+import Orville.PostgreSQL.Raw.Connection (Connection)
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.SqlCommenter as SqlCommenter
 
 {- |
   'OrvilleState' is used to manange opening connections to the database,

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/PgCatalog/PgAttributeDefault.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/PgCatalog/PgAttributeDefault.hs
@@ -9,10 +9,10 @@ import qualified Data.Text as T
 import qualified Database.PostgreSQL.LibPQ as LibPQ
 
 import qualified Orville.PostgreSQL as Orville
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
-import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
 import Orville.PostgreSQL.PgCatalog.OidField (oidField, oidTypeField)
 import Orville.PostgreSQL.PgCatalog.PgAttribute (AttributeNumber, attributeNumberTypeField)
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 {- |
   The Haskell representation of data read from the @pg_catalog.pg_attrdef@

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Plan/Operation.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Plan/Operation.hs
@@ -30,12 +30,12 @@ import qualified Data.Text as T
 
 import qualified Orville.PostgreSQL.Execution as Exec
 import qualified Orville.PostgreSQL.Expr as Expr
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
 import qualified Orville.PostgreSQL.Marshall as Marshall
 import qualified Orville.PostgreSQL.Monad as Monad
 import qualified Orville.PostgreSQL.Plan.Explanation as Exp
 import Orville.PostgreSQL.Plan.Many (Many)
 import qualified Orville.PostgreSQL.Plan.Many as Many
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import qualified Orville.PostgreSQL.Schema as Schema
 
 {- |

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Raw/Connection.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Raw/Connection.hs
@@ -4,7 +4,7 @@
 Copyright : Flipstone Technology Partners 2016-2021
 License   : MIT
 -}
-module Orville.PostgreSQL.Connection
+module Orville.PostgreSQL.Raw.Connection
   ( Connection,
     Pool,
     ConnectionUsedAfterCloseError,
@@ -30,7 +30,7 @@ import qualified Data.Text.Encoding as Enc
 import Data.Time (NominalDiffTime)
 import qualified Database.PostgreSQL.LibPQ as LibPQ
 
-import Orville.PostgreSQL.Internal.PgTextFormatValue (NULByteFoundError (NULByteFoundError), PgTextFormatValue, toBytesForLibPQ)
+import Orville.PostgreSQL.Raw.PgTextFormatValue (NULByteFoundError (NULByteFoundError), PgTextFormatValue, toBytesForLibPQ)
 
 {- |
   An option for 'createConnectionPool' than indicates whether the LibPQ should

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Raw/PgTextFormatValue.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Raw/PgTextFormatValue.hs
@@ -1,4 +1,4 @@
-module Orville.PostgreSQL.Internal.PgTextFormatValue
+module Orville.PostgreSQL.Raw.PgTextFormatValue
   ( PgTextFormatValue,
     NULByteFoundError (NULByteFoundError),
     unsafeFromByteString,

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Raw/PgTime.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Raw/PgTime.hs
@@ -1,4 +1,4 @@
-module Orville.PostgreSQL.Internal.PgTime
+module Orville.PostgreSQL.Raw.PgTime
   ( dayToPostgreSQL,
     day,
     utcTimeToPostgreSQL,

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Raw/RawSql.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Raw/RawSql.hs
@@ -6,7 +6,7 @@ License   : MIT
 The funtions in this module are named with the intent that it is imported
 qualified as 'RawSql'.
 -}
-module Orville.PostgreSQL.Internal.RawSql
+module Orville.PostgreSQL.Raw.RawSql
   ( RawSql,
     parameter,
     fromString,
@@ -60,11 +60,10 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as TextEnc
 import qualified Database.PostgreSQL.LibPQ as LibPQ
 
-import Orville.PostgreSQL.Connection (Connection)
-import qualified Orville.PostgreSQL.Connection as Conn
-import Orville.PostgreSQL.Internal.PgTextFormatValue (PgTextFormatValue)
-import Orville.PostgreSQL.Internal.SqlValue (SqlValue)
-import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
+import qualified Orville.PostgreSQL.Raw.Connection as Conn
+import Orville.PostgreSQL.Raw.PgTextFormatValue (PgTextFormatValue)
+import Orville.PostgreSQL.Raw.SqlValue (SqlValue)
+import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 {- |
   'RawSql' provides a type for efficiently constructing raw sql statements
@@ -96,10 +95,10 @@ instance SqlExpression RawSql where
   unsafeFromRawSql = id
 
 {- |
-  Provides procedures for escaping parts of a raw SQL query so that they
-  can be safely executed. Escaping may be done in some 'Monad' m, allowing
-  for the use of escaping operations provided by 'Connection', which operate
-  in the 'IO' monad.
+  Provides procedures for escaping parts of a raw SQL query so that they can be
+  safely executed. Escaping may be done in some 'Monad' m, allowing for the use
+  of escaping operations provided by 'Conn.Connection', which operates in the
+  'IO' monad.
 
   See 'connectionEscaping' and 'exampleEscaping'.
 -}
@@ -150,7 +149,7 @@ isEscapedChar c =
   If you don't have a connection available and are only planning on using
   the SQL for explanatory or example purposes, see 'exampleEscaping'.
 -}
-connectionEscaping :: Connection -> Escaping IO
+connectionEscaping :: Conn.Connection -> Escaping IO
 connectionEscaping connection =
   Escaping
     { escapeStringLiteral = Conn.escapeStringLiteral connection
@@ -329,7 +328,7 @@ intercalate separator =
   Note that because this is done in 'IO' no callback functions are available to
   be called.
 -}
-execute :: SqlExpression sql => Connection -> sql -> IO LibPQ.Result
+execute :: SqlExpression sql => Conn.Connection -> sql -> IO LibPQ.Result
 execute connection sql = do
   (sqlBytes, params) <- toBytesAndParams (connectionEscaping connection) sql
   Conn.executeRaw connection sqlBytes params
@@ -342,7 +341,7 @@ execute connection sql = do
   Note that because this is done in 'IO' no callback functions are available to
   be called.
 -}
-executeVoid :: SqlExpression sql => Connection -> sql -> IO ()
+executeVoid :: SqlExpression sql => Conn.Connection -> sql -> IO ()
 executeVoid connection sql = do
   void $ execute connection sql
 

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Raw/SqlCommenter.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Raw/SqlCommenter.hs
@@ -8,7 +8,7 @@ Stability : unstable
 This module provides the very basics for [sqlcommenter](https://google.github.io/sqlcommenter)
 support.
 -}
-module Orville.PostgreSQL.Internal.SqlCommenter
+module Orville.PostgreSQL.Raw.SqlCommenter
   ( SqlCommenterAttributes,
     addSqlCommenterAttributes,
   )
@@ -19,7 +19,7 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import qualified Network.URI as URI
 
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 {- | The representation of 'T.Text' key/value pairs for supporting the sqlcommenter specification.
   This allows you to attach key/values of 'T.Text' that supporting systems can use for advanced

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Raw/SqlValue.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Raw/SqlValue.hs
@@ -4,9 +4,9 @@ Copyright : Flipstone Technology Partners 2016-2021
 License   : MIT
 
 The funtions in this module are named with the intent that it is imported
-qualified as 'SqlValue.
+qualified as 'SqlValue'.
 -}
-module Orville.PostgreSQL.Internal.SqlValue
+module Orville.PostgreSQL.Raw.SqlValue
   ( SqlValue,
     isSqlNull,
     sqlNull,
@@ -61,9 +61,9 @@ import qualified Data.Time as Time
 import qualified Data.Typeable as Typeable
 import Data.Word (Word16, Word32, Word64, Word8)
 
-import Orville.PostgreSQL.Internal.PgTextFormatValue (PgTextFormatValue)
-import qualified Orville.PostgreSQL.Internal.PgTextFormatValue as PgTextFormatValue
-import qualified Orville.PostgreSQL.Internal.PgTime as PgTime
+import Orville.PostgreSQL.Raw.PgTextFormatValue (PgTextFormatValue)
+import qualified Orville.PostgreSQL.Raw.PgTextFormatValue as PgTextFormatValue
+import qualified Orville.PostgreSQL.Raw.PgTime as PgTime
 
 data SqlValue
   = SqlValue PgTextFormatValue

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Schema/IndexDefinition.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Schema/IndexDefinition.hs
@@ -19,8 +19,8 @@ import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NEL
 
 import qualified Orville.PostgreSQL.Expr as Expr
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
 import qualified Orville.PostgreSQL.Marshall.FieldDefinition as FieldDefinition
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 {- |
   Defines an index that can be added to a 'Orville.PostgreSQL.TableDefinition'.

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Schema/PrimaryKey.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Schema/PrimaryKey.hs
@@ -21,8 +21,8 @@ import Data.List.NonEmpty (NonEmpty ((:|)), toList)
 
 import qualified Orville.PostgreSQL.Expr as Expr
 import qualified Orville.PostgreSQL.Internal.Extra.NonEmpty as ExtraNonEmpty
-import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
 import Orville.PostgreSQL.Marshall.FieldDefinition (FieldDefinition, FieldName, NotNull, fieldColumnName, fieldEquals, fieldName, fieldNameToString, fieldValueToSqlValue)
+import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 {- |
   A Haskell description of the 'FieldDefinition's that make up the primary

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Schema/TableDefinition.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Schema/TableDefinition.hs
@@ -35,9 +35,9 @@ import qualified Data.Set as Set
 
 import Orville.PostgreSQL.Execution.ReturningOption (ReturningOption (WithReturning, WithoutReturning))
 import qualified Orville.PostgreSQL.Expr as Expr
-import Orville.PostgreSQL.Internal.SqlValue (SqlValue)
 import Orville.PostgreSQL.Marshall.FieldDefinition (fieldColumnDefinition, fieldColumnName, fieldValueToSqlValue)
 import Orville.PostgreSQL.Marshall.SqlMarshaller (AnnotatedSqlMarshaller, MarshallerField (Natural, Synthetic), ReadOnlyColumnOption (ExcludeReadOnlyColumns, IncludeReadOnlyColumns), SqlMarshaller, annotateSqlMarshaller, annotateSqlMarshallerEmptyAnnotation, collectFromField, foldMarshallerFields, mapSqlMarshaller, marshallerDerivedColumns, unannotatedSqlMarshaller)
+import Orville.PostgreSQL.Raw.SqlValue (SqlValue)
 import Orville.PostgreSQL.Schema.ConstraintDefinition (ConstraintDefinition, ConstraintMigrationKey, constraintMigrationKey, constraintSqlExpr)
 import Orville.PostgreSQL.Schema.IndexDefinition (IndexDefinition, IndexMigrationKey, indexMigrationKey)
 import Orville.PostgreSQL.Schema.PrimaryKey (PrimaryKey, mkPrimaryKeyExpr, primaryKeyFieldNames)

--- a/orville-postgresql-libpq/test/Main.hs
+++ b/orville-postgresql-libpq/test/Main.hs
@@ -10,7 +10,7 @@ import qualified Hedgehog as HH
 import qualified System.Environment as Env
 import qualified System.Exit as SE
 
-import qualified Orville.PostgreSQL.Connection as Connection
+import qualified Orville.PostgreSQL as Orville
 
 import qualified Test.AutoMigration as AutoMigration
 import qualified Test.Connection as Connection
@@ -84,10 +84,10 @@ main = do
 
   Monad.unless (Property.allPassed summary) SE.exitFailure
 
-createTestConnectionPool :: IO (Connection.Pool Connection.Connection)
+createTestConnectionPool :: IO (Orville.Pool Orville.Connection)
 createTestConnectionPool = do
   connStr <- lookupConnStr
-  Connection.createConnectionPool Connection.DisableNoticeReporting 1 10 1 connStr
+  Orville.createConnectionPool Orville.DisableNoticeReporting 1 10 1 connStr
 
 recheckDBProperty :: HH.Size -> HH.Seed -> Property.NamedDBProperty -> IO ()
 recheckDBProperty size seed namedProperty = do

--- a/orville-postgresql-libpq/test/Test/AutoMigration.hs
+++ b/orville-postgresql-libpq/test/Test/AutoMigration.hs
@@ -15,7 +15,6 @@ import Data.List ((\\))
 import qualified Data.List as List
 import qualified Data.List.NonEmpty as NEL
 import qualified Data.Maybe as Maybe
-import qualified Data.Pool as Pool
 import qualified Data.String as String
 import Hedgehog ((===))
 import qualified Hedgehog as HH
@@ -24,10 +23,10 @@ import qualified Hedgehog.Range as Range
 
 import qualified Orville.PostgreSQL as Orville
 import qualified Orville.PostgreSQL.AutoMigration as AutoMigration
-import qualified Orville.PostgreSQL.Connection as Conn
 import qualified Orville.PostgreSQL.Expr as Expr
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
 import qualified Orville.PostgreSQL.PgCatalog as PgCatalog
+import qualified Orville.PostgreSQL.Raw.Connection as Conn
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import qualified Orville.PostgreSQL.Schema as Schema
 
 import qualified Test.Entities.Foo as Foo
@@ -36,7 +35,7 @@ import qualified Test.PgGen as PgGen
 import qualified Test.Property as Property
 import qualified Test.TestTable as TestTable
 
-autoMigrationTests :: Pool.Pool Conn.Connection -> Property.Group
+autoMigrationTests :: Orville.Pool Orville.Connection -> Property.Group
 autoMigrationTests pool =
   Property.group
     "AutoMigration"
@@ -345,7 +344,7 @@ prop_respectsImplicitDefaultOnSerialFields =
     map RawSql.toExampleBytes secondTimeSteps === []
 
 assertDefaultValuesMigrateProperly ::
-  Pool.Pool Conn.Connection ->
+  Orville.Pool Orville.Connection ->
   HH.Gen SomeField ->
   HH.PropertyT IO ()
 assertDefaultValuesMigrateProperly pool genSomeField = do
@@ -745,7 +744,7 @@ prop_altersModifiedSequences =
 
 assertSequenceExistsMatching ::
   (HH.MonadTest m, MIO.MonadIO m) =>
-  Pool.Pool Conn.Connection ->
+  Orville.Pool Orville.Connection ->
   Orville.SequenceDefinition ->
   m ()
 assertSequenceExistsMatching pool sequenceDef = do
@@ -795,7 +794,7 @@ prop_arbitrarySchemaInitialMigration =
 
 assertTableStructure ::
   (HH.MonadTest m, MIO.MonadIO m) =>
-  Conn.Pool Conn.Connection ->
+  Orville.Pool Orville.Connection ->
   TestTable ->
   m ()
 assertTableStructure pool testTable = do

--- a/orville-postgresql-libpq/test/Test/Connection.hs
+++ b/orville-postgresql-libpq/test/Test/Connection.hs
@@ -15,8 +15,8 @@ import qualified Database.PostgreSQL.LibPQ as LibPQ
 import qualified Hedgehog as HH
 import qualified Hedgehog.Range as Range
 
-import qualified Orville.PostgreSQL.Connection as Connection
-import qualified Orville.PostgreSQL.Internal.PgTextFormatValue as PgTextFormatValue
+import qualified Orville.PostgreSQL.Raw.Connection as Connection
+import qualified Orville.PostgreSQL.Raw.PgTextFormatValue as PgTextFormatValue
 
 import qualified Test.PgGen as PgGen
 import qualified Test.Property as Property

--- a/orville-postgresql-libpq/test/Test/Cursor.hs
+++ b/orville-postgresql-libpq/test/Test/Cursor.hs
@@ -6,20 +6,18 @@ where
 import qualified Data.List as List
 import qualified Data.List.NonEmpty as NEL
 import qualified Data.Ord as Ord
-import qualified Data.Pool as Pool
 import Hedgehog ((===))
 import qualified Hedgehog as HH
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 import qualified Orville.PostgreSQL as Orville
-import qualified Orville.PostgreSQL.Connection as Conn
 import qualified Orville.PostgreSQL.Execution as Exec
 
 import qualified Test.Entities.Foo as Foo
 import qualified Test.Property as Property
 
-cursorTests :: Pool.Pool Conn.Connection -> Property.Group
+cursorTests :: Orville.Pool Orville.Connection -> Property.Group
 cursorTests pool =
   Property.group "Cursor" $
     [ prop_withCursorFetch pool

--- a/orville-postgresql-libpq/test/Test/Entities/Bar.hs
+++ b/orville-postgresql-libpq/test/Test/Entities/Bar.hs
@@ -17,7 +17,6 @@ import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 import qualified Orville.PostgreSQL as Orville
-import Orville.PostgreSQL.Connection (Connection)
 
 import qualified Test.PgGen as PgGen
 import qualified Test.TestTable as TestTable
@@ -61,7 +60,7 @@ generateList :: HH.Range Int -> HH.Gen [BarWrite]
 generateList range =
   (Gen.list range generate)
 
-withTable :: MonadIO m => Pool Connection -> Orville.Orville a -> m a
+withTable :: MonadIO m => Pool Orville.Connection -> Orville.Orville a -> m a
 withTable pool operation =
   liftIO $ do
     withResource pool $ \connection ->

--- a/orville-postgresql-libpq/test/Test/Entities/Foo.hs
+++ b/orville-postgresql-libpq/test/Test/Entities/Foo.hs
@@ -32,7 +32,6 @@ import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 import qualified Orville.PostgreSQL as Orville
-import Orville.PostgreSQL.Connection (Connection)
 
 import qualified Test.PgGen as PgGen
 import qualified Test.TestTable as TestTable
@@ -133,7 +132,7 @@ generateNonEmpty range =
     (NEL.nubBy ((==) `on` fooId))
     (Gen.nonEmpty range generate)
 
-withTable :: MonadIO m => Pool Connection -> Orville.Orville a -> m a
+withTable :: MonadIO m => Pool Orville.Connection -> Orville.Orville a -> m a
 withTable pool operation =
   liftIO $ do
     withResource pool $ \connection ->

--- a/orville-postgresql-libpq/test/Test/Entities/FooChild.hs
+++ b/orville-postgresql-libpq/test/Test/Entities/FooChild.hs
@@ -14,12 +14,11 @@ import Control.Monad.IO.Class (MonadIO (liftIO))
 import Data.Function (on)
 import Data.Int (Int32)
 import qualified Data.List as List
-import Data.Pool (Pool, withResource)
+import Data.Pool (withResource)
 import qualified Hedgehog as HH
 import qualified Hedgehog.Gen as Gen
 
 import qualified Orville.PostgreSQL as Orville
-import Orville.PostgreSQL.Connection (Connection)
 
 import qualified Test.Entities.Foo as Foo
 import qualified Test.PgGen as PgGen
@@ -67,7 +66,7 @@ generateList range foos =
     (List.nubBy ((==) `on` fooChildId))
     (Gen.list range $ generate foos)
 
-withTables :: MonadIO m => Pool Connection -> Orville.Orville a -> m a
+withTables :: MonadIO m => Orville.Pool Orville.Connection -> Orville.Orville a -> m a
 withTables pool operation =
   liftIO $ do
     withResource pool $ \connection -> do

--- a/orville-postgresql-libpq/test/Test/EntityOperations.hs
+++ b/orville-postgresql-libpq/test/Test/EntityOperations.hs
@@ -7,7 +7,6 @@ import qualified Data.List as List
 import Data.List.NonEmpty (NonEmpty ((:|)))
 import qualified Data.List.NonEmpty as NEL
 import qualified Data.Maybe as Maybe
-import qualified Data.Pool as Pool
 import qualified Data.String as String
 import qualified Data.Text as T
 import Hedgehog ((===))
@@ -16,12 +15,11 @@ import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 import qualified Orville.PostgreSQL as Orville
-import qualified Orville.PostgreSQL.Connection as Connection
 
 import qualified Test.Entities.Foo as Foo
 import qualified Test.Property as Property
 
-entityOperationsTests :: Pool.Pool Connection.Connection -> Property.Group
+entityOperationsTests :: Orville.Pool Orville.Connection -> Property.Group
 entityOperationsTests pool =
   Property.group "EntityOperations" $
     [ prop_insertEntitiesFindEntitiesByRoundTrip pool

--- a/orville-postgresql-libpq/test/Test/EntityTrace.hs
+++ b/orville-postgresql-libpq/test/Test/EntityTrace.hs
@@ -4,7 +4,6 @@ module Test.EntityTrace
 where
 
 import qualified Control.Monad as Monad
-import qualified Data.Pool as Pool
 import qualified Data.String as String
 import Hedgehog ((===))
 import qualified Hedgehog as HH
@@ -12,14 +11,13 @@ import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 import qualified Orville.PostgreSQL as Orville
-import qualified Orville.PostgreSQL.Connection as Conn
 import qualified Orville.PostgreSQL.EntityTrace as EntityTrace
 
 import qualified Test.Entities.Foo as Foo
 import qualified Test.Property as Property
 import qualified Test.Transaction.Util as TransactionUtil
 
-entityTraceTests :: Pool.Pool Conn.Connection -> Property.Group
+entityTraceTests :: Orville.Pool Orville.Connection -> Property.Group
 entityTraceTests pool =
   Property.group "EntityTrace" $
     [ prop_tracedOperationsAreReported pool

--- a/orville-postgresql-libpq/test/Test/Execution.hs
+++ b/orville-postgresql-libpq/test/Test/Execution.hs
@@ -5,16 +5,14 @@ where
 
 import qualified Data.ByteString as BS
 import qualified Data.IORef as IORef
-import qualified Data.Pool as Pool
 import Hedgehog ((===))
 import qualified Hedgehog as HH
 
 import qualified Orville.PostgreSQL as Orville
-import qualified Orville.PostgreSQL.Connection as Conn
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import qualified Test.Property as Property
 
-executionTests :: Pool.Pool Conn.Connection -> Property.Group
+executionTests :: Orville.Pool Orville.Connection -> Property.Group
 executionTests pool =
   Property.group
     "Execution"

--- a/orville-postgresql-libpq/test/Test/Expr/Count.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/Count.hs
@@ -6,19 +6,17 @@ where
 import qualified Data.Foldable as Fold
 import qualified Data.List as List
 import qualified Data.List.NonEmpty as NEL
-import qualified Data.Pool as Pool
 import Hedgehog ((===))
 import qualified Hedgehog as HH
 import qualified Hedgehog.Range as Range
 
 import qualified Orville.PostgreSQL as Orville
-import qualified Orville.PostgreSQL.Connection as Conn
 import qualified Orville.PostgreSQL.Expr as Expr
 
 import qualified Test.Entities.Foo as Foo
 import qualified Test.Property as Property
 
-countTests :: Pool.Pool Conn.Connection -> Property.Group
+countTests :: Orville.Pool Orville.Connection -> Property.Group
 countTests pool =
   Property.group
     "Expr - Count"

--- a/orville-postgresql-libpq/test/Test/Expr/Cursor.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/Cursor.hs
@@ -11,16 +11,17 @@ import qualified Data.Pool as Pool
 import Hedgehog ((===))
 import qualified Hedgehog as HH
 
-import qualified Orville.PostgreSQL.Connection as Conn
+import qualified Orville.PostgreSQL as Orville
 import qualified Orville.PostgreSQL.Execution.ExecutionResult as ExecResult
 import qualified Orville.PostgreSQL.Expr as Expr
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
-import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
+import qualified Orville.PostgreSQL.Raw.Connection as Conn
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 import Test.Expr.TestSchema (FooBar, assertEqualFooBarRows, findAllFooBars, mkFooBar, withFooBarData)
 import qualified Test.Property as Property
 
-cursorTests :: Pool.Pool Conn.Connection -> Property.Group
+cursorTests :: Orville.Pool Orville.Connection -> Property.Group
 cursorTests pool =
   Property.group
     "Expr - Cursor"
@@ -275,7 +276,7 @@ row :: Int.Int32 -> FooBar
 row n = mkFooBar n ("row " <> show n)
 
 runFetchDirectionsOnData ::
-  Pool.Pool Conn.Connection ->
+  Orville.Pool Orville.Connection ->
   Maybe Expr.ScrollExpr ->
   [FooBar] ->
   [Expr.CursorDirection] ->
@@ -289,7 +290,7 @@ runFetchDirectionsOnData pool scroll fooBars directions =
        in traverse runDirection directions
 
 withTestCursor ::
-  Conn.Connection ->
+  Orville.Connection ->
   Maybe Expr.ScrollExpr ->
   Maybe Expr.HoldExpr ->
   Expr.QueryExpr ->
@@ -307,7 +308,7 @@ withTestCursor connection scroll hold query action =
         RawSql.executeVoid connection $ Expr.close (Right cursorName)
    in ExSafe.bracket_ declare close (action cursorName)
 
-withTestTransaction :: Conn.Connection -> IO a -> IO a
+withTestTransaction :: Orville.Connection -> IO a -> IO a
 withTestTransaction connection action =
   let begin =
         RawSql.executeVoid connection $ Expr.beginTransaction Nothing

--- a/orville-postgresql-libpq/test/Test/Expr/GroupBy.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/GroupBy.hs
@@ -10,11 +10,11 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Pool as Pool
 import qualified Data.Text as T
 
-import qualified Orville.PostgreSQL.Connection as Conn
+import qualified Orville.PostgreSQL as Orville
 import qualified Orville.PostgreSQL.Execution.ExecutionResult as ExecResult
 import qualified Orville.PostgreSQL.Expr as Expr
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
-import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 import Test.Expr.TestSchema (assertEqualSqlRows)
 import qualified Test.Property as Property
@@ -24,7 +24,7 @@ data FooBar = FooBar
   , bar :: String
   }
 
-groupByTests :: Pool.Pool Conn.Connection -> Property.Group
+groupByTests :: Orville.Pool Orville.Connection -> Property.Group
 groupByTests pool =
   Property.group
     "Expr - GroupBy"
@@ -111,7 +111,7 @@ barColumn :: Expr.ColumnName
 barColumn =
   Expr.columnName "bar"
 
-dropAndRecreateTestTable :: Conn.Connection -> IO ()
+dropAndRecreateTestTable :: Orville.Connection -> IO ()
 dropAndRecreateTestTable connection = do
   RawSql.executeVoid connection (RawSql.fromString "DROP TABLE IF EXISTS " <> RawSql.toRawSql testTable)
   RawSql.executeVoid connection (RawSql.fromString "CREATE TABLE " <> RawSql.toRawSql testTable <> RawSql.fromString "(foo INTEGER, bar TEXT)")

--- a/orville-postgresql-libpq/test/Test/Expr/InsertUpdateDelete.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/InsertUpdateDelete.hs
@@ -8,16 +8,16 @@ import Data.List.NonEmpty (NonEmpty ((:|)))
 import qualified Data.Pool as Pool
 import qualified Data.Text as T
 
-import qualified Orville.PostgreSQL.Connection as Conn
+import qualified Orville.PostgreSQL as Orville
 import qualified Orville.PostgreSQL.Execution.ExecutionResult as ExecResult
 import qualified Orville.PostgreSQL.Expr as Expr
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
-import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 import Test.Expr.TestSchema (assertEqualFooBarRows, barColumn, barColumnRef, dropAndRecreateTestTable, findAllFooBars, fooBarTable, fooColumn, insertFooBarSource, mkFooBar)
 import qualified Test.Property as Property
 
-insertUpdateDeleteTests :: Pool.Pool Conn.Connection -> Property.Group
+insertUpdateDeleteTests :: Orville.Pool Orville.Connection -> Property.Group
 insertUpdateDeleteTests pool =
   Property.group
     "Expr - Insert/Update/Delete"

--- a/orville-postgresql-libpq/test/Test/Expr/Math.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/Math.hs
@@ -6,7 +6,6 @@ where
 import Data.Bits ((.&.), (.|.))
 import qualified Data.Bits as Bits
 import Data.Int (Int32)
-import qualified Data.Pool as Pool
 import GHC.Stack (withFrozenCallStack)
 import Hedgehog ((===))
 import qualified Hedgehog as HH
@@ -14,13 +13,12 @@ import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 import qualified Orville.PostgreSQL as Orville
-import qualified Orville.PostgreSQL.Connection as Conn
 import qualified Orville.PostgreSQL.Expr as Expr
-import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
+import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 import qualified Test.Property as Property
 
-mathTests :: Pool.Pool Conn.Connection -> Property.Group
+mathTests :: Orville.Pool Orville.Connection -> Property.Group
 mathTests pool =
   Property.group
     "Expr - Math"
@@ -185,7 +183,7 @@ intExpression n =
   Expr.cast (Expr.valueExpression (SqlValue.fromInt n)) Expr.int
 
 evaluateIntegerExpression ::
-  Conn.Pool Conn.Connection ->
+  Orville.Pool Orville.Connection ->
   Expr.ValueExpression ->
   HH.PropertyT IO Int32
 evaluateIntegerExpression pool expression = do

--- a/orville-postgresql-libpq/test/Test/Expr/OrderBy.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/OrderBy.hs
@@ -7,15 +7,15 @@ import qualified Control.Monad.IO.Class as MIO
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Pool as Pool
 
-import qualified Orville.PostgreSQL.Connection as Conn
+import qualified Orville.PostgreSQL as Orville
 import qualified Orville.PostgreSQL.Execution.ExecutionResult as ExecResult
 import qualified Orville.PostgreSQL.Expr as Expr
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 import Test.Expr.TestSchema (FooBar (..), assertEqualFooBarRows, barColumn, dropAndRecreateTestTable, fooBarTable, fooColumn, insertFooBarSource, mkFooBar)
 import qualified Test.Property as Property
 
-orderByTests :: Pool.Pool Conn.Connection -> Property.Group
+orderByTests :: Orville.Pool Orville.Connection -> Property.Group
 orderByTests pool =
   Property.group
     "Expr - OrderBy"

--- a/orville-postgresql-libpq/test/Test/Expr/SequenceDefinition.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/SequenceDefinition.hs
@@ -4,18 +4,16 @@ module Test.Expr.SequenceDefinition
 where
 
 import qualified Control.Monad.IO.Class as MIO
-import qualified Data.Pool as Pool
 import Hedgehog ((===))
 
 import qualified Orville.PostgreSQL as Orville
-import qualified Orville.PostgreSQL.Connection as Conn
 import qualified Orville.PostgreSQL.Expr as Expr
 import qualified Orville.PostgreSQL.PgCatalog as PgCatalog
 
 import qualified Test.PgAssert as PgAssert
 import qualified Test.Property as Property
 
-sequenceDefinitionTests :: Pool.Pool Conn.Connection -> Property.Group
+sequenceDefinitionTests :: Orville.Pool Orville.Connection -> Property.Group
 sequenceDefinitionTests pool =
   Property.group
     "Expr - SequenceDefinition"

--- a/orville-postgresql-libpq/test/Test/Expr/TableDefinition.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/TableDefinition.hs
@@ -5,16 +5,14 @@ where
 
 import qualified Control.Monad.IO.Class as MIO
 import Data.List.NonEmpty (NonEmpty ((:|)))
-import qualified Data.Pool as Pool
 
 import qualified Orville.PostgreSQL as Orville
-import qualified Orville.PostgreSQL.Connection as Conn
 import qualified Orville.PostgreSQL.Expr as Expr
 
 import qualified Test.PgAssert as PgAssert
 import qualified Test.Property as Property
 
-tableDefinitionTests :: Pool.Pool Conn.Connection -> Property.Group
+tableDefinitionTests :: Orville.Pool Orville.Connection -> Property.Group
 tableDefinitionTests pool =
   Property.group
     "Expr - TableDefinition"

--- a/orville-postgresql-libpq/test/Test/Expr/TestSchema.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/TestSchema.hs
@@ -27,10 +27,10 @@ import GHC.Stack (HasCallStack, withFrozenCallStack)
 import Hedgehog ((===))
 import qualified Hedgehog as HH
 
-import qualified Orville.PostgreSQL.Connection as Connection
+import qualified Orville.PostgreSQL as Orville
 import qualified Orville.PostgreSQL.Expr as Expr
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
-import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 data FooBar = FooBar
   { foo :: Maybe Int.Int32
@@ -93,9 +93,9 @@ nullOr :: (a -> SqlValue.SqlValue) -> Maybe a -> SqlValue.SqlValue
 nullOr = maybe SqlValue.sqlNull
 
 withFooBarData ::
-  Pool.Pool Connection.Connection ->
+  Pool.Pool Orville.Connection ->
   [FooBar] ->
-  (Connection.Connection -> IO a) ->
+  (Orville.Connection -> IO a) ->
   HH.PropertyT IO a
 withFooBarData pool fooBars action =
   MIO.liftIO $
@@ -107,7 +107,7 @@ withFooBarData pool fooBars action =
 
       action connection
 
-dropAndRecreateTestTable :: Connection.Connection -> IO ()
+dropAndRecreateTestTable :: Orville.Connection -> IO ()
 dropAndRecreateTestTable connection = do
   RawSql.executeVoid connection (RawSql.fromString "DROP TABLE IF EXISTS " <> RawSql.toRawSql fooBarTable)
   RawSql.executeVoid connection (RawSql.fromString "CREATE TABLE " <> RawSql.toRawSql fooBarTable <> RawSql.fromString "(foo INTEGER, bar TEXT)")

--- a/orville-postgresql-libpq/test/Test/Expr/Time.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/Time.hs
@@ -6,7 +6,6 @@ where
 import qualified Data.ByteString.Char8 as B8
 import Data.Int (Int32)
 import qualified Data.Maybe as Maybe
-import qualified Data.Pool as Pool
 import qualified Data.Text as T
 import qualified Data.Time as Time
 import Hedgehog ((===))
@@ -16,14 +15,13 @@ import qualified Hedgehog.Range as Range
 import qualified Text.Printf as Printf
 
 import qualified Orville.PostgreSQL as Orville
-import qualified Orville.PostgreSQL.Connection as Conn
 import qualified Orville.PostgreSQL.Expr as Expr
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
-import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 import qualified Test.Property as Property
 
-timeTests :: Pool.Pool Conn.Connection -> Property.Group
+timeTests :: Orville.Pool Orville.Connection -> Property.Group
 timeTests pool =
   Property.group
     "Expr - Time"

--- a/orville-postgresql-libpq/test/Test/Expr/Where.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/Where.hs
@@ -9,16 +9,16 @@ import Data.List.NonEmpty (NonEmpty ((:|)))
 import qualified Data.Pool as Pool
 import qualified Data.Text as T
 
-import qualified Orville.PostgreSQL.Connection as Connection
+import qualified Orville.PostgreSQL as Orville
 import qualified Orville.PostgreSQL.Execution.ExecutionResult as ExecResult
 import qualified Orville.PostgreSQL.Expr as Expr
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
-import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 import Test.Expr.TestSchema (FooBar (..), assertEqualFooBarRows, barColumn, barColumnRef, dropAndRecreateTestTable, fooBarTable, fooColumn, fooColumnRef, insertFooBarSource, mkFooBar)
 import qualified Test.Property as Property
 
-whereTests :: Pool.Pool Connection.Connection -> Property.Group
+whereTests :: Orville.Pool Orville.Connection -> Property.Group
 whereTests pool =
   Property.group "Expr - WhereClause" $
     [ prop_noWhereClauseSpecified pool

--- a/orville-postgresql-libpq/test/Test/FieldDefinition.hs
+++ b/orville-postgresql-libpq/test/Test/FieldDefinition.hs
@@ -15,19 +15,19 @@ import qualified Hedgehog as HH
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
-import qualified Orville.PostgreSQL.Connection as Connection
+import qualified Orville.PostgreSQL as Orville
 import qualified Orville.PostgreSQL.Execution.ExecutionResult as Result
 import qualified Orville.PostgreSQL.Expr as Expr
-import qualified Orville.PostgreSQL.Internal.DefaultValue as DefaultValue
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
-import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
-import qualified Orville.PostgreSQL.Marshall.FieldDefinition as FieldDef
+import qualified Orville.PostgreSQL.Marshall as Marshall
+import qualified Orville.PostgreSQL.Raw.Connection as Conn
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 import Test.Expr.TestSchema (sqlRowsToText)
 import qualified Test.PgGen as PgGen
 import qualified Test.Property as Property
 
-fieldDefinitionTests :: Pool.Pool Connection.Connection -> Property.Group
+fieldDefinitionTests :: Orville.Pool Orville.Connection -> Property.Group
 fieldDefinitionTests pool =
   Property.group "FieldDefinition" $
     integerField pool
@@ -43,126 +43,126 @@ fieldDefinitionTests pool =
       <> utcTimestampField pool
       <> localTimestampField pool
 
-integerField :: Pool.Pool Connection.Connection -> [(HH.PropertyName, HH.Property)]
+integerField :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
 integerField pool =
   testFieldProperties pool "integerField" $
     FieldDefinitionTest
-      { roundTripFieldDef = FieldDef.integerField "foo"
-      , roundTripDefaultValueTests = [RoundTripDefaultTest DefaultValue.integerDefault]
+      { roundTripFieldDef = Marshall.integerField "foo"
+      , roundTripDefaultValueTests = [RoundTripDefaultTest Marshall.integerDefault]
       , roundTripGen = PgGen.pgInt32
       }
 
-bigIntegerField :: Pool.Pool Connection.Connection -> [(HH.PropertyName, HH.Property)]
+bigIntegerField :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
 bigIntegerField pool =
   testFieldProperties pool "bigIntegerField" $
     FieldDefinitionTest
-      { roundTripFieldDef = FieldDef.bigIntegerField "foo"
-      , roundTripDefaultValueTests = [RoundTripDefaultTest DefaultValue.bigIntegerDefault]
+      { roundTripFieldDef = Marshall.bigIntegerField "foo"
+      , roundTripDefaultValueTests = [RoundTripDefaultTest Marshall.bigIntegerDefault]
       , roundTripGen = Gen.integral (Range.linearFrom 0 minBound maxBound)
       }
 
-doubleField :: Pool.Pool Connection.Connection -> [(HH.PropertyName, HH.Property)]
+doubleField :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
 doubleField pool =
   testFieldProperties pool "doubleField" $
     FieldDefinitionTest
-      { roundTripFieldDef = FieldDef.doubleField "foo"
-      , roundTripDefaultValueTests = [RoundTripDefaultTest DefaultValue.doubleDefault]
+      { roundTripFieldDef = Marshall.doubleField "foo"
+      , roundTripDefaultValueTests = [RoundTripDefaultTest Marshall.doubleDefault]
       , roundTripGen = PgGen.pgDouble
       }
 
-booleanField :: Pool.Pool Connection.Connection -> [(HH.PropertyName, HH.Property)]
+booleanField :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
 booleanField pool =
   testFieldProperties pool "booleanField" $
     FieldDefinitionTest
-      { roundTripFieldDef = FieldDef.booleanField "foo"
-      , roundTripDefaultValueTests = [RoundTripDefaultTest DefaultValue.booleanDefault]
+      { roundTripFieldDef = Marshall.booleanField "foo"
+      , roundTripDefaultValueTests = [RoundTripDefaultTest Marshall.booleanDefault]
       , roundTripGen = Gen.bool
       }
 
-unboundedTextField :: Pool.Pool Connection.Connection -> [(HH.PropertyName, HH.Property)]
+unboundedTextField :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
 unboundedTextField pool =
   testFieldProperties pool "unboundedTextField" $
     FieldDefinitionTest
-      { roundTripFieldDef = FieldDef.unboundedTextField "foo"
-      , roundTripDefaultValueTests = [RoundTripDefaultTest DefaultValue.textDefault]
+      { roundTripFieldDef = Marshall.unboundedTextField "foo"
+      , roundTripDefaultValueTests = [RoundTripDefaultTest Marshall.textDefault]
       , roundTripGen = PgGen.pgText (Range.constant 0 1024)
       }
 
-boundedTextField :: Pool.Pool Connection.Connection -> [(HH.PropertyName, HH.Property)]
+boundedTextField :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
 boundedTextField pool =
   testFieldProperties pool "boundedTextField" $
     FieldDefinitionTest
-      { roundTripFieldDef = FieldDef.boundedTextField "foo" 4
-      , roundTripDefaultValueTests = [RoundTripDefaultTest DefaultValue.textDefault]
+      { roundTripFieldDef = Marshall.boundedTextField "foo" 4
+      , roundTripDefaultValueTests = [RoundTripDefaultTest Marshall.textDefault]
       , roundTripGen = PgGen.pgText (Range.constant 0 4)
       }
 
-fixedTextField :: Pool.Pool Connection.Connection -> [(HH.PropertyName, HH.Property)]
+fixedTextField :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
 fixedTextField pool =
   testFieldProperties pool "fixedTextField" $
     FieldDefinitionTest
-      { roundTripFieldDef = FieldDef.fixedTextField "foo" 4
-      , roundTripDefaultValueTests = [RoundTripDefaultTest DefaultValue.textDefault]
+      { roundTripFieldDef = Marshall.fixedTextField "foo" 4
+      , roundTripDefaultValueTests = [RoundTripDefaultTest Marshall.textDefault]
       , roundTripGen = PgGen.pgText (Range.constant 4 4)
       }
 
-textSearchVectorField :: Pool.Pool Connection.Connection -> [(HH.PropertyName, HH.Property)]
+textSearchVectorField :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
 textSearchVectorField pool =
   testFieldProperties pool "textSearchVectorField" $
     FieldDefinitionTest
-      { roundTripFieldDef = FieldDef.textSearchVectorField "foo"
+      { roundTripFieldDef = Marshall.textSearchVectorField "foo"
       , roundTripDefaultValueTests = []
       , roundTripGen = tsVectorGen
       }
 
-uuidField :: Pool.Pool Connection.Connection -> [(HH.PropertyName, HH.Property)]
+uuidField :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
 uuidField pool =
   testFieldProperties pool "uuidField" $
     FieldDefinitionTest
-      { roundTripFieldDef = FieldDef.uuidField "foo"
+      { roundTripFieldDef = Marshall.uuidField "foo"
       , roundTripDefaultValueTests = []
       , roundTripGen = uuidGen
       }
 
-dateField :: Pool.Pool Connection.Connection -> [(HH.PropertyName, HH.Property)]
+dateField :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
 dateField pool =
   testFieldProperties pool "dateField" $
     FieldDefinitionTest
-      { roundTripFieldDef = FieldDef.dateField "foo"
+      { roundTripFieldDef = Marshall.dateField "foo"
       , roundTripDefaultValueTests =
-          [ RoundTripDefaultTest DefaultValue.dateDefault
-          , InsertOnlyDefaultTest DefaultValue.currentDateDefault
+          [ RoundTripDefaultTest Marshall.dateDefault
+          , InsertOnlyDefaultTest Marshall.currentDateDefault
           ]
       , roundTripGen = PgGen.pgDay
       }
 
-utcTimestampField :: Pool.Pool Connection.Connection -> [(HH.PropertyName, HH.Property)]
+utcTimestampField :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
 utcTimestampField pool =
   testFieldProperties pool "utcTimestampField" $
     FieldDefinitionTest
-      { roundTripFieldDef = FieldDef.utcTimestampField "foo"
+      { roundTripFieldDef = Marshall.utcTimestampField "foo"
       , roundTripDefaultValueTests =
-          [ RoundTripDefaultTest DefaultValue.utcTimestampDefault
-          , InsertOnlyDefaultTest DefaultValue.currentUTCTimestampDefault
+          [ RoundTripDefaultTest Marshall.utcTimestampDefault
+          , InsertOnlyDefaultTest Marshall.currentUTCTimestampDefault
           ]
       , roundTripGen = PgGen.pgUTCTime
       }
 
-localTimestampField :: Pool.Pool Connection.Connection -> [(HH.PropertyName, HH.Property)]
+localTimestampField :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
 localTimestampField pool =
   testFieldProperties pool "localTimestampField" $
     FieldDefinitionTest
-      { roundTripFieldDef = FieldDef.localTimestampField "foo"
+      { roundTripFieldDef = Marshall.localTimestampField "foo"
       , roundTripDefaultValueTests =
-          [ RoundTripDefaultTest DefaultValue.localTimestampDefault
-          , InsertOnlyDefaultTest DefaultValue.currentLocalTimestampDefault
+          [ RoundTripDefaultTest Marshall.localTimestampDefault
+          , InsertOnlyDefaultTest Marshall.currentLocalTimestampDefault
           ]
       , roundTripGen = PgGen.pgLocalTime
       }
 
 testFieldProperties ::
   (Show a, Eq a) =>
-  Pool.Pool Connection.Connection ->
+  Orville.Pool Orville.Connection ->
   String ->
   FieldDefinitionTest a ->
   [(HH.PropertyName, HH.Property)]
@@ -181,7 +181,7 @@ testFieldProperties pool fieldDefName roundTripTest =
 
 testDefaultValueProperties ::
   (Show a, Eq a) =>
-  Pool.Pool Connection.Connection ->
+  Orville.Pool Orville.Connection ->
   String ->
   FieldDefinitionTest a ->
   DefaultValueTest a ->
@@ -217,16 +217,16 @@ uuidGen =
     <*> Gen.word32 Range.linearBounded
 
 data FieldDefinitionTest a = FieldDefinitionTest
-  { roundTripFieldDef :: FieldDef.FieldDefinition FieldDef.NotNull a
+  { roundTripFieldDef :: Marshall.FieldDefinition Marshall.NotNull a
   , roundTripDefaultValueTests :: [DefaultValueTest a]
   , roundTripGen :: HH.Gen a
   }
 
 data DefaultValueTest a
-  = RoundTripDefaultTest (a -> DefaultValue.DefaultValue a)
-  | InsertOnlyDefaultTest (DefaultValue.DefaultValue a)
+  = RoundTripDefaultTest (a -> Marshall.DefaultValue a)
+  | InsertOnlyDefaultTest (Marshall.DefaultValue a)
 
-runRoundTripTest :: (Show a, Eq a) => Pool.Pool Connection.Connection -> FieldDefinitionTest a -> HH.PropertyT IO ()
+runRoundTripTest :: (Show a, Eq a) => Orville.Pool Orville.Connection -> FieldDefinitionTest a -> HH.PropertyT IO ()
 runRoundTripTest pool testCase = do
   let fieldDef = roundTripFieldDef testCase
 
@@ -238,14 +238,14 @@ runRoundTripTest pool testCase = do
       Expr.insertExpr
         testTable
         Nothing
-        (Expr.insertSqlValues [[FieldDef.fieldValueToSqlValue fieldDef value]])
+        (Expr.insertSqlValues [[Marshall.fieldValueToSqlValue fieldDef value]])
         Nothing
 
     result <-
       RawSql.execute connection $
         Expr.queryExpr
           (Expr.selectClause $ Expr.selectExpr Nothing)
-          (Expr.selectColumns [FieldDef.fieldColumnName fieldDef])
+          (Expr.selectColumns [Marshall.fieldColumnName fieldDef])
           (Just $ Expr.tableExpr testTable Nothing Nothing Nothing Nothing Nothing)
 
     Result.readRows result
@@ -253,15 +253,15 @@ runRoundTripTest pool testCase = do
   let roundTripResult =
         case rows of
           [[(_, sqlValue)]] ->
-            FieldDef.fieldValueFromSqlValue fieldDef sqlValue
+            Marshall.fieldValueFromSqlValue fieldDef sqlValue
           _ ->
             Left ("Expected one row with one value in results, but got: " ++ show (sqlRowsToText rows))
 
   roundTripResult === Right value
 
-runNullableRoundTripTest :: (Show a, Eq a) => Pool.Pool Connection.Connection -> FieldDefinitionTest a -> HH.PropertyT IO ()
+runNullableRoundTripTest :: (Show a, Eq a) => Orville.Pool Orville.Connection -> FieldDefinitionTest a -> HH.PropertyT IO ()
 runNullableRoundTripTest pool testCase = do
-  let fieldDef = FieldDef.nullableField (roundTripFieldDef testCase)
+  let fieldDef = Marshall.nullableField (roundTripFieldDef testCase)
 
   value <-
     HH.forAll $
@@ -280,14 +280,14 @@ runNullableRoundTripTest pool testCase = do
       Expr.insertExpr
         testTable
         Nothing
-        (Expr.insertSqlValues [[FieldDef.fieldValueToSqlValue fieldDef value]])
+        (Expr.insertSqlValues [[Marshall.fieldValueToSqlValue fieldDef value]])
         Nothing
 
     result <-
       RawSql.execute connection $
         Expr.queryExpr
           (Expr.selectClause $ Expr.selectExpr Nothing)
-          (Expr.selectColumns [FieldDef.fieldColumnName fieldDef])
+          (Expr.selectColumns [Marshall.fieldColumnName fieldDef])
           (Just $ Expr.tableExpr testTable Nothing Nothing Nothing Nothing Nothing)
 
     Result.readRows result
@@ -295,13 +295,13 @@ runNullableRoundTripTest pool testCase = do
   let roundTripResult =
         case rows of
           [[(_, sqlValue)]] ->
-            FieldDef.fieldValueFromSqlValue fieldDef sqlValue
+            Marshall.fieldValueFromSqlValue fieldDef sqlValue
           _ ->
             Left ("Expected one row with one value in results, but got: " ++ show (sqlRowsToText rows))
 
   roundTripResult === Right value
 
-runNullCounterExampleTest :: Pool.Pool Connection.Connection -> FieldDefinitionTest a -> HH.PropertyT IO ()
+runNullCounterExampleTest :: Orville.Pool Orville.Connection -> FieldDefinitionTest a -> HH.PropertyT IO ()
 runNullCounterExampleTest pool testCase = do
   result <- HH.evalIO . Pool.withResource pool $ \connection -> do
     let fieldDef = roundTripFieldDef testCase
@@ -318,16 +318,16 @@ runNullCounterExampleTest pool testCase = do
 
   case result of
     Left err ->
-      Connection.sqlExecutionErrorSqlState err === Just (B8.pack "23502")
+      Conn.sqlExecutionErrorSqlState err === Just (B8.pack "23502")
     Right _ -> do
       HH.footnote "Expected insert query to fail, but it did not"
       HH.failure
 
 runDefaultValueFieldDefinitionTest ::
   (Show a, Eq a) =>
-  Pool.Pool Connection.Connection ->
+  Orville.Pool Orville.Connection ->
   FieldDefinitionTest a ->
-  (a -> DefaultValue.DefaultValue a) ->
+  (a -> Marshall.DefaultValue a) ->
   HH.PropertyT IO ()
 runDefaultValueFieldDefinitionTest pool testCase mkDefaultValue = do
   value <- HH.forAll (roundTripGen testCase)
@@ -336,7 +336,7 @@ runDefaultValueFieldDefinitionTest pool testCase mkDefaultValue = do
         mkDefaultValue value
 
       fieldDef =
-        FieldDef.setDefaultValue defaultValue $ roundTripFieldDef testCase
+        Marshall.setDefaultValue defaultValue $ roundTripFieldDef testCase
 
   rows <- HH.evalIO . Pool.withResource pool $ \connection -> do
     dropAndRecreateTestTable fieldDef connection
@@ -352,7 +352,7 @@ runDefaultValueFieldDefinitionTest pool testCase mkDefaultValue = do
       RawSql.execute connection $
         Expr.queryExpr
           (Expr.selectClause $ Expr.selectExpr Nothing)
-          (Expr.selectColumns [FieldDef.fieldColumnName fieldDef])
+          (Expr.selectColumns [Marshall.fieldColumnName fieldDef])
           (Just $ Expr.tableExpr testTable Nothing Nothing Nothing Nothing Nothing)
 
     Result.readRows result
@@ -360,21 +360,21 @@ runDefaultValueFieldDefinitionTest pool testCase mkDefaultValue = do
   let roundTripResult =
         case rows of
           [[(_, sqlValue)]] ->
-            FieldDef.fieldValueFromSqlValue fieldDef sqlValue
+            Marshall.fieldValueFromSqlValue fieldDef sqlValue
           _ ->
             Left ("Expected one row with one value in results, but got: " ++ show (sqlRowsToText rows))
 
   roundTripResult === Right value
 
 runDefaultValueInsertOnlyTest ::
-  Pool.Pool Connection.Connection ->
+  Orville.Pool Orville.Connection ->
   FieldDefinitionTest a ->
-  DefaultValue.DefaultValue a ->
+  Marshall.DefaultValue a ->
   HH.PropertyT IO ()
 runDefaultValueInsertOnlyTest pool testCase defaultValue =
   HH.evalIO . Pool.withResource pool $ \connection -> do
     let fieldDef =
-          FieldDef.setDefaultValue defaultValue $ roundTripFieldDef testCase
+          Marshall.setDefaultValue defaultValue $ roundTripFieldDef testCase
 
     dropAndRecreateTestTable fieldDef connection
 
@@ -389,9 +389,9 @@ testTable :: Expr.Qualified Expr.TableName
 testTable =
   Expr.qualified Nothing (Expr.tableName "field_definition_test")
 
-dropAndRecreateTestTable :: FieldDef.FieldDefinition nullability a -> Connection.Connection -> IO ()
+dropAndRecreateTestTable :: Marshall.FieldDefinition nullability a -> Orville.Connection -> IO ()
 dropAndRecreateTestTable fieldDef connection = do
   RawSql.executeVoid connection (RawSql.fromString "DROP TABLE IF EXISTS " <> RawSql.toRawSql testTable)
 
   RawSql.executeVoid connection $
-    Expr.createTableExpr testTable [FieldDef.fieldColumnDefinition fieldDef] Nothing []
+    Expr.createTableExpr testTable [Marshall.fieldColumnDefinition fieldDef] Nothing []

--- a/orville-postgresql-libpq/test/Test/MarshallError.hs
+++ b/orville-postgresql-libpq/test/Test/MarshallError.hs
@@ -5,7 +5,6 @@ where
 
 import qualified Control.Exception as E
 import qualified Data.ByteString.Char8 as B8
-import qualified Data.Pool as Pool
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import Hedgehog ((===))
@@ -13,15 +12,14 @@ import qualified Hedgehog as HH
 import qualified Hedgehog.Gen as Gen
 
 import qualified Orville.PostgreSQL as Orville
-import qualified Orville.PostgreSQL.Connection as Connection
-import qualified Orville.PostgreSQL.Internal.ErrorDetailLevel as ErrorDetailLevel
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
-import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
+import qualified Orville.PostgreSQL.ErrorDetailLevel as ErrorDetailLevel
 import qualified Orville.PostgreSQL.Marshall.MarshallError as MarshallError
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 import qualified Test.Property as Property
 
-marshallErrorTests :: Pool.Pool Connection.Connection -> Property.Group
+marshallErrorTests :: Orville.Pool Orville.Connection -> Property.Group
 marshallErrorTests pool =
   Property.group
     "MarshallError"

--- a/orville-postgresql-libpq/test/Test/PgAssert.hs
+++ b/orville-postgresql-libpq/test/Test/PgAssert.hs
@@ -24,7 +24,6 @@ import qualified Control.Monad.IO.Class as MIO
 import qualified Data.List as List
 import qualified Data.List.NonEmpty as NEL
 import qualified Data.Map.Strict as Map
-import qualified Data.Pool as Pool
 import qualified Data.String as String
 import qualified Data.Text.Encoding as Enc
 import GHC.Stack (HasCallStack, withFrozenCallStack)
@@ -32,13 +31,12 @@ import Hedgehog ((===))
 import qualified Hedgehog as HH
 
 import qualified Orville.PostgreSQL as Orville
-import qualified Orville.PostgreSQL.Connection as Conn
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
 import qualified Orville.PostgreSQL.PgCatalog as PgCatalog
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 assertTableExists ::
   (HH.MonadTest m, MIO.MonadIO m, HasCallStack) =>
-  Pool.Pool Conn.Connection ->
+  Orville.Pool Orville.Connection ->
   String ->
   m PgCatalog.RelationDescription
 assertTableExists pool =
@@ -46,7 +44,7 @@ assertTableExists pool =
 
 assertTableDoesNotExist ::
   (HH.MonadTest m, MIO.MonadIO m, HasCallStack) =>
-  Pool.Pool Conn.Connection ->
+  Orville.Pool Orville.Connection ->
   String ->
   m ()
 assertTableDoesNotExist pool =
@@ -54,7 +52,7 @@ assertTableDoesNotExist pool =
 
 assertTableExistsInSchema ::
   (HH.MonadTest m, MIO.MonadIO m, HasCallStack) =>
-  Pool.Pool Conn.Connection ->
+  Orville.Pool Orville.Connection ->
   String ->
   String ->
   m PgCatalog.RelationDescription
@@ -63,7 +61,7 @@ assertTableExistsInSchema pool schemaName tableName =
 
 assertTableDoesNotExistInSchema ::
   (HH.MonadTest m, MIO.MonadIO m, HasCallStack) =>
-  Pool.Pool Conn.Connection ->
+  Orville.Pool Orville.Connection ->
   String ->
   String ->
   m ()
@@ -72,7 +70,7 @@ assertTableDoesNotExistInSchema pool schemaName tableName =
 
 assertSequenceExists ::
   (HH.MonadTest m, MIO.MonadIO m, HasCallStack) =>
-  Pool.Pool Conn.Connection ->
+  Orville.Pool Orville.Connection ->
   String ->
   m PgCatalog.RelationDescription
 assertSequenceExists pool =
@@ -80,7 +78,7 @@ assertSequenceExists pool =
 
 assertSequenceDoesNotExist ::
   (HH.MonadTest m, MIO.MonadIO m, HasCallStack) =>
-  Pool.Pool Conn.Connection ->
+  Orville.Pool Orville.Connection ->
   String ->
   m ()
 assertSequenceDoesNotExist pool =
@@ -88,7 +86,7 @@ assertSequenceDoesNotExist pool =
 
 assertSequenceExistsInSchema ::
   (HH.MonadTest m, MIO.MonadIO m, HasCallStack) =>
-  Pool.Pool Conn.Connection ->
+  Orville.Pool Orville.Connection ->
   String ->
   String ->
   m PgCatalog.RelationDescription
@@ -97,7 +95,7 @@ assertSequenceExistsInSchema pool schemaName sequenceName =
 
 assertSequenceDoesNotExistInSchema ::
   (HH.MonadTest m, MIO.MonadIO m, HasCallStack) =>
-  Pool.Pool Conn.Connection ->
+  Orville.Pool Orville.Connection ->
   String ->
   String ->
   m ()
@@ -119,7 +117,7 @@ assertRelationHasPgSequence relationDesc =
 
 assertRelationExistsInSchema ::
   (HH.MonadTest m, MIO.MonadIO m, HasCallStack) =>
-  Pool.Pool Conn.Connection ->
+  Orville.Pool Orville.Connection ->
   String ->
   String ->
   PgCatalog.RelationKind ->
@@ -142,7 +140,7 @@ assertRelationExistsInSchema pool schemaName relationName relationKind = do
 
 assertRelationDoesNotExistInSchema ::
   (HH.MonadTest m, MIO.MonadIO m, HasCallStack) =>
-  Pool.Pool Conn.Connection ->
+  Orville.Pool Orville.Connection ->
   String ->
   String ->
   PgCatalog.RelationKind ->

--- a/orville-postgresql-libpq/test/Test/PgCatalog.hs
+++ b/orville-postgresql-libpq/test/Test/PgCatalog.hs
@@ -5,7 +5,6 @@ where
 
 import qualified Control.Monad.IO.Class as MIO
 import qualified Data.Map.Strict as Map
-import qualified Data.Pool as Pool
 import qualified Data.Set as Set
 import qualified Data.String as String
 import qualified Data.Text as T
@@ -13,14 +12,13 @@ import Hedgehog ((===))
 import qualified Hedgehog as HH
 
 import qualified Orville.PostgreSQL as Orville
-import qualified Orville.PostgreSQL.Connection as Conn
 import qualified Orville.PostgreSQL.PgCatalog as PgCatalog
 
 import qualified Test.Entities.Foo as Foo
 import qualified Test.Property as Property
 import qualified Test.TestTable as TestTable
 
-pgCatalogTests :: Pool.Pool Conn.Connection -> Property.Group
+pgCatalogTests :: Orville.Pool Orville.Connection -> Property.Group
 pgCatalogTests pool =
   Property.group
     "PgCatalog"

--- a/orville-postgresql-libpq/test/Test/PgTime.hs
+++ b/orville-postgresql-libpq/test/Test/PgTime.hs
@@ -4,17 +4,16 @@ module Test.PgTime
 where
 
 import Data.Attoparsec.ByteString (parseOnly)
-import qualified Data.Pool as Pool
 import qualified Data.String as String
 import Data.Time (UTCTime (..), fromGregorian)
 import qualified Hedgehog as HH
 
-import qualified Orville.PostgreSQL.Connection as Conn
-import qualified Orville.PostgreSQL.Internal.PgTime as PgTime
+import qualified Orville.PostgreSQL as Orville
+import qualified Orville.PostgreSQL.Raw.PgTime as PgTime
 
 import qualified Test.Property as Property
 
-pgTimeTests :: Pool.Pool Conn.Connection -> Property.Group
+pgTimeTests :: Orville.Pool Orville.Connection -> Property.Group
 pgTimeTests _pool =
   Property.group "PgTime" $
     [

--- a/orville-postgresql-libpq/test/Test/Plan.hs
+++ b/orville-postgresql-libpq/test/Test/Plan.hs
@@ -16,7 +16,6 @@ import qualified Data.Either as Either
 import Data.Foldable (traverse_)
 import qualified Data.List as List
 import qualified Data.List.NonEmpty as NEL
-import qualified Data.Pool as Pool
 import qualified Data.String as String
 import Hedgehog ((===))
 import qualified Hedgehog as HH
@@ -24,7 +23,6 @@ import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 import qualified Orville.PostgreSQL as Orville
-import qualified Orville.PostgreSQL.Connection as Connection
 import qualified Orville.PostgreSQL.Plan as Plan
 import qualified Orville.PostgreSQL.Plan.Many as Many
 
@@ -39,8 +37,8 @@ import qualified Test.Entities.FooChild as FooChild
 import qualified Test.Property as Property
 
 {- ORMOLU_DISABLE -}
-{- disable formatting so fourmolu doesn't go haywire with te cpp within the list -}
-planTests :: Pool.Pool Connection.Connection -> Property.Group
+{- disable formatting so fourmolu doesn't go haywire with the cpp within the list -}
+planTests :: Orville.Pool Orville.Connection -> Property.Group
 planTests pool =
   Property.group "Plan" $
     [ prop_askParam pool

--- a/orville-postgresql-libpq/test/Test/PostgreSQLAxioms.hs
+++ b/orville-postgresql-libpq/test/Test/PostgreSQLAxioms.hs
@@ -6,17 +6,16 @@ where
 import qualified Control.Exception.Safe as ExSafe
 import qualified Control.Monad.IO.Class as MIO
 import qualified Data.ByteString.Char8 as B8
-import qualified Data.Pool as Pool
 import Hedgehog ((===))
 import qualified Hedgehog as HH
 
 import qualified Orville.PostgreSQL as Orville
-import qualified Orville.PostgreSQL.Connection as Conn
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
 import qualified Orville.PostgreSQL.Marshall.SqlType as SqlType
+import qualified Orville.PostgreSQL.Raw.Connection as Conn
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import qualified Test.Property as Property
 
-postgreSQLAxiomTests :: Pool.Pool Conn.Connection -> Property.Group
+postgreSQLAxiomTests :: Orville.Pool Orville.Connection -> Property.Group
 postgreSQLAxiomTests pool =
   Property.group
     "PostgreSQL Axioms"
@@ -45,7 +44,7 @@ prop_bigIntegerBounds =
 
 assertPostgreSQLMinValueMatchesHaskell ::
   (Eq a, Show a, Bounded a, HH.MonadTest m, MIO.MonadIO m, ExSafe.MonadCatch m) =>
-  Pool.Pool Conn.Connection ->
+  Orville.Pool Orville.Connection ->
   SqlType.SqlType a ->
   m ()
 assertPostgreSQLMinValueMatchesHaskell pool sqlType = do
@@ -60,7 +59,7 @@ assertPostgreSQLMinValueMatchesHaskell pool sqlType = do
 
 assertPostgreSQLMaxValueMatchesHaskell ::
   (Eq a, Show a, Bounded a, HH.MonadTest m, MIO.MonadIO m, ExSafe.MonadCatch m) =>
-  Pool.Pool Conn.Connection ->
+  Orville.Pool Orville.Connection ->
   SqlType.SqlType a ->
   m ()
 assertPostgreSQLMaxValueMatchesHaskell pool sqlType = do
@@ -82,7 +81,7 @@ evalEitherMLeft =
 
 selectValue ::
   (HH.MonadTest m, MIO.MonadIO m) =>
-  Pool.Pool Conn.Connection ->
+  Orville.Pool Orville.Connection ->
   a ->
   SqlType.SqlType a ->
   m (Either Conn.SqlExecutionError a)
@@ -91,7 +90,7 @@ selectValue pool inputValue sqlType =
 
 selectValueWithModifier ::
   (HH.MonadTest m, MIO.MonadIO m) =>
-  Pool.Pool Conn.Connection ->
+  Orville.Pool Orville.Connection ->
   a ->
   RawSql.RawSql ->
   SqlType.SqlType a ->

--- a/orville-postgresql-libpq/test/Test/Property.hs
+++ b/orville-postgresql-libpq/test/Test/Property.hs
@@ -24,11 +24,10 @@ import qualified Hedgehog.Internal.Report as Report
 import qualified Hedgehog.Internal.Runner as Runner
 import qualified Hedgehog.Internal.Seed as Seed
 
-import qualified Data.Pool as Pool
-import qualified Orville.PostgreSQL.Connection as Connection
+import qualified Orville.PostgreSQL as Orville
 
 type NamedProperty = (HH.PropertyName, HH.Property)
-type NamedDBProperty = Pool.Pool Connection.Connection -> NamedProperty
+type NamedDBProperty = Orville.Pool Orville.Connection -> NamedProperty
 
 namedProperty :: String -> HH.PropertyT IO () -> NamedProperty
 namedProperty nameString propertyT =
@@ -43,14 +42,14 @@ singletonNamedProperty nameString property =
 
 namedDBProperty ::
   String ->
-  (Pool.Pool Connection.Connection -> HH.PropertyT IO ()) ->
+  (Orville.Pool Orville.Connection -> HH.PropertyT IO ()) ->
   NamedDBProperty
 namedDBProperty nameString dbProperty pool =
   namedProperty nameString (dbProperty pool)
 
 singletonNamedDBProperty ::
   String ->
-  (Pool.Pool Connection.Connection -> HH.PropertyT IO ()) ->
+  (Orville.Pool Orville.Connection -> HH.PropertyT IO ()) ->
   NamedDBProperty
 singletonNamedDBProperty nameString dbProperty pool =
   HH.withTests 1 <$> namedProperty nameString (dbProperty pool)

--- a/orville-postgresql-libpq/test/Test/RawSql.hs
+++ b/orville-postgresql-libpq/test/Test/RawSql.hs
@@ -8,9 +8,9 @@ import Data.Functor.Identity (runIdentity)
 import qualified Data.Text as T
 import qualified Hedgehog as HH
 
-import qualified Orville.PostgreSQL.Internal.PgTextFormatValue as PgTextFormatValue
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
-import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
+import qualified Orville.PostgreSQL.Raw.PgTextFormatValue as PgTextFormatValue
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 import qualified Test.Property as Property
 

--- a/orville-postgresql-libpq/test/Test/ReservedWords.hs
+++ b/orville-postgresql-libpq/test/Test/ReservedWords.hs
@@ -9,13 +9,12 @@ import qualified Data.String as String
 import qualified Hedgehog as HH
 
 import qualified Orville.PostgreSQL as Orville
-import qualified Orville.PostgreSQL.Connection as Conn
 
 import qualified Test.Entities.User as User
 import qualified Test.Property as Property
 import qualified Test.TestTable as TestTable
 
-reservedWordsTests :: Pool.Pool Conn.Connection -> Property.Group
+reservedWordsTests :: Orville.Pool Orville.Connection -> Property.Group
 reservedWordsTests pool =
   Property.group "ReservedWords" $
     [

--- a/orville-postgresql-libpq/test/Test/SelectOptions.hs
+++ b/orville-postgresql-libpq/test/Test/SelectOptions.hs
@@ -13,8 +13,8 @@ import qualified Hedgehog as HH
 import Orville.PostgreSQL ((.&&), (./=), (.<), (.<-), (.</-), (.<=), (.==), (.>), (.>=), (.||))
 import qualified Orville.PostgreSQL as O
 import qualified Orville.PostgreSQL.Expr as Expr
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
 import qualified Orville.PostgreSQL.Marshall.FieldDefinition as FieldDef
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import qualified Test.Property as Property
 
 selectOptionsTests :: Property.Group

--- a/orville-postgresql-libpq/test/Test/Sequence.hs
+++ b/orville-postgresql-libpq/test/Test/Sequence.hs
@@ -4,16 +4,14 @@ module Test.Sequence
 where
 
 import qualified Control.Monad.IO.Class as MIO
-import qualified Data.Pool as Pool
 import Hedgehog ((===))
 
 import qualified Orville.PostgreSQL as Orville
-import qualified Orville.PostgreSQL.Connection as Conn
 import qualified Orville.PostgreSQL.Expr as Expr
 
 import qualified Test.Property as Property
 
-sequenceTests :: Pool.Pool Conn.Connection -> Property.Group
+sequenceTests :: Orville.Pool Orville.Connection -> Property.Group
 sequenceTests pool =
   Property.group
     "Sequence"

--- a/orville-postgresql-libpq/test/Test/SqlCommenter.hs
+++ b/orville-postgresql-libpq/test/Test/SqlCommenter.hs
@@ -13,11 +13,10 @@ import Hedgehog ((===))
 import qualified Hedgehog as HH
 
 import qualified Orville.PostgreSQL as Orville
-import qualified Orville.PostgreSQL.Connection as Conn
 import qualified Orville.PostgreSQL.Execution.ExecutionResult as ExecResult
 import qualified Orville.PostgreSQL.Expr as Expr
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
-import qualified Orville.PostgreSQL.Internal.SqlCommenter as SqlCommenter
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.SqlCommenter as SqlCommenter
 
 import Test.Expr.TestSchema
   ( assertEqualFooBarRows,
@@ -29,7 +28,7 @@ import Test.Expr.TestSchema
   )
 import qualified Test.Property as Property
 
-sqlCommenterTests :: Pool.Pool Conn.Connection -> Property.Group
+sqlCommenterTests :: Orville.Pool Orville.Connection -> Property.Group
 sqlCommenterTests pool =
   Property.group
     "SqlCommenterAttributes"

--- a/orville-postgresql-libpq/test/Test/SqlMarshaller.hs
+++ b/orville-postgresql-libpq/test/Test/SqlMarshaller.hs
@@ -16,10 +16,10 @@ import qualified Hedgehog as HH
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
+import qualified Orville.PostgreSQL.ErrorDetailLevel as ErrorDetailLevel
 import qualified Orville.PostgreSQL.Execution.ExecutionResult as Result
-import qualified Orville.PostgreSQL.Internal.ErrorDetailLevel as ErrorDetailLevel
-import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
 import qualified Orville.PostgreSQL.Marshall as Marshall
+import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 import Test.Expr.TestSchema (assertEqualSqlRows)
 import qualified Test.PgGen as PgGen

--- a/orville-postgresql-libpq/test/Test/SqlType.hs
+++ b/orville-postgresql-libpq/test/Test/SqlType.hs
@@ -13,16 +13,16 @@ import qualified Data.Time as Time
 import Hedgehog ((===))
 import qualified Hedgehog as HH
 
-import qualified Orville.PostgreSQL.Connection as Connection
+import qualified Orville.PostgreSQL as Orville
 import qualified Orville.PostgreSQL.Execution.ExecutionResult as ExecutionResult
 import qualified Orville.PostgreSQL.Expr as Expr
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
-import qualified Orville.PostgreSQL.Internal.SqlValue as SqlValue
 import qualified Orville.PostgreSQL.Marshall.SqlType as SqlType
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 import qualified Test.Property as Property
 
-sqlTypeTests :: Pool.Pool Connection.Connection -> Property.Group
+sqlTypeTests :: Orville.Pool Orville.Connection -> Property.Group
 sqlTypeTests pool =
   Property.group "SqlType" $
     integerTests pool
@@ -39,7 +39,7 @@ sqlTypeTests pool =
       <> dateTests pool
       <> timestampTests pool
 
-integerTests :: Pool.Pool Connection.Connection -> [(HH.PropertyName, HH.Property)]
+integerTests :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
 integerTests pool =
   [
     ( String.fromString "Testing the decode of INTEGER with value 0"
@@ -73,7 +73,7 @@ integerTests pool =
     )
   ]
 
-smallIntegerTests :: Pool.Pool Connection.Connection -> [(HH.PropertyName, HH.Property)]
+smallIntegerTests :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
 smallIntegerTests pool =
   [
     ( String.fromString "Testing the decode of SMALLINT with value 0"
@@ -107,7 +107,7 @@ smallIntegerTests pool =
     )
   ]
 
-bigIntegerTests :: Pool.Pool Connection.Connection -> [(HH.PropertyName, HH.Property)]
+bigIntegerTests :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
 bigIntegerTests pool =
   [
     ( String.fromString "Testing the decode of BIGINT with value 0"
@@ -131,7 +131,7 @@ bigIntegerTests pool =
     )
   ]
 
-serialTests :: Pool.Pool Connection.Connection -> [(HH.PropertyName, HH.Property)]
+serialTests :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
 serialTests pool =
   [
     ( String.fromString "Testing the decode of SERIAL with value 0"
@@ -165,7 +165,7 @@ serialTests pool =
     )
   ]
 
-bigSerialTests :: Pool.Pool Connection.Connection -> [(HH.PropertyName, HH.Property)]
+bigSerialTests :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
 bigSerialTests pool =
   [
     ( String.fromString "Testing the decode of BIGSERIAL with value 0"
@@ -189,7 +189,7 @@ bigSerialTests pool =
     )
   ]
 
-doubleTests :: Pool.Pool Connection.Connection -> [(HH.PropertyName, HH.Property)]
+doubleTests :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
 doubleTests pool =
   [
     ( String.fromString "Testing the decode of DOUBLE PRECISION with value 0"
@@ -213,7 +213,7 @@ doubleTests pool =
     )
   ]
 
-boolTests :: Pool.Pool Connection.Connection -> [(HH.PropertyName, HH.Property)]
+boolTests :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
 boolTests pool =
   [
     ( String.fromString "Testing the decode of BOOL with value False"
@@ -237,7 +237,7 @@ boolTests pool =
     )
   ]
 
-unboundedTextTests :: Pool.Pool Connection.Connection -> [(HH.PropertyName, HH.Property)]
+unboundedTextTests :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
 unboundedTextTests pool =
   [
     ( String.fromString "Testing the decode of TEXT with value abcde"
@@ -251,7 +251,7 @@ unboundedTextTests pool =
     )
   ]
 
-fixedTextTests :: Pool.Pool Connection.Connection -> [(HH.PropertyName, HH.Property)]
+fixedTextTests :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
 fixedTextTests pool =
   [
     ( String.fromString "Testing the decode of CHAR(5) with value 'abcde'"
@@ -275,7 +275,7 @@ fixedTextTests pool =
     )
   ]
 
-boundedTextTests :: Pool.Pool Connection.Connection -> [(HH.PropertyName, HH.Property)]
+boundedTextTests :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
 boundedTextTests pool =
   [
     ( String.fromString "Testing the decode of VARCHAR(5) with value 'abcde'"
@@ -299,7 +299,7 @@ boundedTextTests pool =
     )
   ]
 
-textSearchVectorTests :: Pool.Pool Connection.Connection -> [(HH.PropertyName, HH.Property)]
+textSearchVectorTests :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
 textSearchVectorTests pool =
   [
     ( String.fromString "Testing the decode of TSVECTOR with value 'abcde'"
@@ -323,7 +323,7 @@ textSearchVectorTests pool =
     )
   ]
 
-dateTests :: Pool.Pool Connection.Connection -> [(HH.PropertyName, HH.Property)]
+dateTests :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
 dateTests pool =
   [
     ( String.fromString "Testing the decode of DATE with value 2020-12-21"
@@ -357,7 +357,7 @@ dateTests pool =
     )
   ]
 
-timestampTests :: Pool.Pool Connection.Connection -> [(HH.PropertyName, HH.Property)]
+timestampTests :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
 timestampTests pool =
   [
     ( String.fromString "Testing the decode of TIMESTAMP WITH TIME ZONE with value '2020-12-21 00:00:32-00'"
@@ -508,7 +508,7 @@ data DecodingTest a = DecodingTest
   , expectedValue :: a
   }
 
-runDecodingTest :: (Show a, Eq a) => Pool.Pool Connection.Connection -> DecodingTest a -> HH.Property
+runDecodingTest :: (Show a, Eq a) => Orville.Pool Orville.Connection -> DecodingTest a -> HH.Property
 runDecodingTest pool test =
   Property.singletonProperty $ do
     rows <- MIO.liftIO . Pool.withResource pool $ \connection -> do
@@ -536,7 +536,7 @@ runDecodingTest pool test =
 
     actual === [Right $ expectedValue test]
 
-dropAndRecreateTable :: Connection.Connection -> String -> String -> IO ()
+dropAndRecreateTable :: Orville.Connection -> String -> String -> IO ()
 dropAndRecreateTable connection tableName columnTypeDDL = do
   RawSql.executeVoid connection (RawSql.fromString $ "DROP TABLE IF EXISTS " <> tableName)
   RawSql.executeVoid connection (RawSql.fromString $ "CREATE TABLE " <> tableName <> "(foo " <> columnTypeDDL <> ")")

--- a/orville-postgresql-libpq/test/Test/TableDefinition.hs
+++ b/orville-postgresql-libpq/test/Test/TableDefinition.hs
@@ -13,10 +13,10 @@ import Hedgehog ((===))
 import qualified Hedgehog as HH
 
 import qualified Orville.PostgreSQL as Orville
-import qualified Orville.PostgreSQL.Connection as Conn
 import qualified Orville.PostgreSQL.Execution.ReturningOption as ReturningOption
 import qualified Orville.PostgreSQL.Execution.Select as Select
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.Connection as Conn
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import qualified Orville.PostgreSQL.Schema.TableDefinition as TableDefinition
 
 import qualified Test.Entities.Bar as Bar
@@ -24,7 +24,7 @@ import qualified Test.Entities.Foo as Foo
 import qualified Test.Property as Property
 import qualified Test.TestTable as TestTable
 
-tableDefinitionTests :: Pool.Pool Conn.Connection -> Property.Group
+tableDefinitionTests :: Pool.Pool Orville.Connection -> Property.Group
 tableDefinitionTests pool =
   Property.group
     "TableDefinition"

--- a/orville-postgresql-libpq/test/Test/TestTable.hs
+++ b/orville-postgresql-libpq/test/Test/TestTable.hs
@@ -6,9 +6,9 @@ module Test.TestTable
   )
 where
 
-import Orville.PostgreSQL.Connection (Connection)
 import qualified Orville.PostgreSQL.Expr as Expr
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
+import Orville.PostgreSQL.Raw.Connection (Connection)
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import Orville.PostgreSQL.Schema (TableDefinition, mkCreateTableExpr, tableName)
 
 dropTableDef ::

--- a/orville-postgresql-libpq/test/Test/Transaction.hs
+++ b/orville-postgresql-libpq/test/Test/Transaction.hs
@@ -13,16 +13,15 @@ import qualified Hedgehog as HH
 import qualified Hedgehog.Gen as Gen
 
 import qualified Orville.PostgreSQL as Orville
-import qualified Orville.PostgreSQL.Connection as Conn
 import qualified Orville.PostgreSQL.Expr as Expr
-import qualified Orville.PostgreSQL.Internal.RawSql as RawSql
 import qualified Orville.PostgreSQL.OrvilleState as OrvilleState
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 import qualified Test.Property as Property
 import qualified Test.TestTable as TestTable
 import qualified Test.Transaction.Util as TransactionUtil
 
-transactionTests :: Pool.Pool Conn.Connection -> Property.Group
+transactionTests :: Orville.Pool Orville.Connection -> Property.Group
 transactionTests pool =
   Property.group "Transaction" $
     [ prop_transactionsWithoutExceptionsCommit pool
@@ -161,7 +160,7 @@ prop_usesCustomBeginTransactionSql =
           ]
 
 captureTransactionCallbackEvents ::
-  Pool.Pool Conn.Connection ->
+  Orville.Pool Orville.Connection ->
   Orville.Orville () ->
   HH.PropertyT IO [Orville.TransactionEvent]
 captureTransactionCallbackEvents pool actions = do
@@ -210,7 +209,7 @@ tracerMarshaller =
     <$> Orville.marshallField (const $ T.pack "tracer") (Orville.unboundedTextField "tracer")
 
 captureSqlTrace ::
-  Pool.Pool Conn.Connection ->
+  Orville.Pool Orville.Connection ->
   Orville.Orville () ->
   HH.PropertyT IO [(Orville.QueryType, BS.ByteString)]
 captureSqlTrace pool actions = do


### PR DESCRIPTION
* Moved a number of modules to a new `Raw` section to represent the
  lowest-level API we expose. I included `Connection` is this because
  it exposes `executeRaw`, but added a couple more re-exports from
  `Connection` in `Orville.PostgreSQL` to allow most users to avoid
  importing `Raw.Connection` directly. I deliberately omitted creating
  an `Orville.PostgreSQL.Raw` module to re-export all of these as
  they to do really form a cohensive API as a group.

* `ErrorDetailLevel` moved out if internal to no particular subgrouping.
  It it used across a number of subgroups with no obvious preference for
  living in a particular one.

* `DefaultValue` moved next to `Marshall.FieldDefinition`
  (the only place it is directly imported)
