### PR TITLE
Require time >=1.9.1

### DIFF
--- a/orville-postgresql-libpq/orville-postgresql-libpq.cabal
+++ b/orville-postgresql-libpq/orville-postgresql-libpq.cabal
@@ -145,7 +145,7 @@ library
     , resource-pool
     , safe-exceptions >=0.1.7
     , text
-    , time >=1.5
+    , time >=1.9.1
     , transformers >=0.5 && <0.7
     , uuid
   if flag(ci)

--- a/orville-postgresql-libpq/package.yaml
+++ b/orville-postgresql-libpq/package.yaml
@@ -136,7 +136,7 @@ library:
     - resource-pool
     - safe-exceptions >=0.1.7
     - text
-    - time >=1.5
+    - time >=1.9.1
     - transformers >= 0.5 && < 0.7
     - uuid
 


### PR DESCRIPTION
The use of [nominalDiffTimeToSeconds](https://hackage.haskell.org/package/time-1.12.2/docs/Data-Time-Clock.html#v:nominalDiffTimeToSeconds)
means that the code won't compile on versions before time-1.9.1.
