### PR TITLE
Require attoparsec >=0.10

### DIFF
--- a/orville-postgresql-libpq/orville-postgresql-libpq.cabal
+++ b/orville-postgresql-libpq/orville-postgresql-libpq.cabal
@@ -134,7 +134,7 @@ library
   hs-source-dirs:
       src
   build-depends:
-      attoparsec
+      attoparsec >=0.10
     , base >=4.8 && <5
     , bytestring
     , containers ==0.6.*

--- a/orville-postgresql-libpq/package.yaml
+++ b/orville-postgresql-libpq/package.yaml
@@ -126,7 +126,7 @@ library:
           - -fwarn-incomplete-record-updates
   dependencies:
     - base >=4.8 && <5
-    - attoparsec
+    - attoparsec >=0.10
     - bytestring
     - dlist >= 0.8 && < 1.1
     - postgresql-libpq >= 0.9.4.2 && <0.10


### PR DESCRIPTION
The use of the `Data.Attoparsec.Bytestring` module means that the code will not compile before attoparsec 0.10. It is [not available in 0.9.1.2](https://hackage.haskell.org/package/attoparsec-0.9.1.2).