### PR TITLE
Adds Haddocks to several modules.

### DIFF
--- a/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
@@ -1,6 +1,7 @@
 {- |
-Copyright : Flipstone Technology Partners 2020-2021
+Copyright : Flipstone Technology Partners 2020-2023
 License   : MIT
+Stability : Stable
 -}
 module Orville.PostgreSQL
   ( -- * Basic operations on entities in tables

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/AutoMigration.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/AutoMigration.hs
@@ -2,6 +2,14 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RankNTypes #-}
 
+{- |
+Copyright : Flipstone Technology Partners 2023
+License   : MIT
+Stability : Stable
+
+Facilities for performing some database migrations automatically.
+See 'autoMigrateSchema' as a primary, high level entry point.
+-}
 module Orville.PostgreSQL.AutoMigration
   ( autoMigrateSchema,
     generateMigrationSteps,
@@ -230,7 +238,7 @@ calculateMigrationSteps currentNamespace dbDesc schemaItem =
               (Orville.sequenceIdentifier sequenceDef)
        in case PgCatalog.lookupRelationOfKind PgCatalog.Sequence (schemaName, sequenceName) dbDesc of
             Nothing ->
-              Right $
+              Right
                 [ mkMigrationStepWithType
                     AddRemoveTablesAndColumns
                     (Orville.mkCreateSequenceExpr sequenceDef)

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/EntityTrace.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/EntityTrace.hs
@@ -1,10 +1,15 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
 
+{- |
+Copyright : Flipstone Technology Partners 2023
+License   : MIT
+Stability : Stable
+
+Run various actions with user supplied tracing.
+-}
 module Orville.PostgreSQL.EntityTrace
   ( EntityTraceT,
     EntityTraceState,

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/ErrorDetailLevel.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/ErrorDetailLevel.hs
@@ -1,3 +1,8 @@
+{- |
+Copyright : Flipstone Technology Partners 2023
+License   : MIT
+Stability : Stable
+-}
 module Orville.PostgreSQL.ErrorDetailLevel
   ( ErrorDetailLevel (ErrorDetailLevel, includeErrorMessage, includeSchemaNames, includeRowIdentifierValues, includeNonIdentifierValues),
     defaultErrorDetailLevel,

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution.hs
@@ -1,5 +1,10 @@
 {-# OPTIONS_GHC -Wno-missing-import-lists #-}
 
+{- |
+Copyright : Flipstone Technology Partners 2023
+License   : MIT
+Stability : Stable
+-}
 module Orville.PostgreSQL.Execution
   ( -- * High level modules for most common tasks
     module Orville.PostgreSQL.Execution.EntityOperations,

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Cursor.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Cursor.hs
@@ -1,5 +1,10 @@
 {-# LANGUAGE GADTs #-}
 
+{- |
+Copyright : Flipstone Technology Partners 2023
+License   : MIT
+Stability : Stable
+-}
 module Orville.PostgreSQL.Execution.Cursor
   ( withCursor,
     declareCursor,

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Delete.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Delete.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE GADTs #-}
 
 {- |
-
-Copyright : Flipstone Technology Partners 2021
+Copyright : Flipstone Technology Partners 2021-2023
 License   : MIT
+Stability : Stable
 -}
 module Orville.PostgreSQL.Execution.Delete
   ( Delete,

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/EntityOperations.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/EntityOperations.hs
@@ -1,6 +1,7 @@
 {- |
-Copyright : Flipstone Technology Partners 2021
+Copyright : Flipstone Technology Partners 2021-2023
 License   : MIT
+Stability : Stable
 -}
 module Orville.PostgreSQL.Execution.EntityOperations
   ( insertEntity,

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Execute.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Execute.hs
@@ -1,3 +1,8 @@
+{- |
+Copyright : Flipstone Technology Partners 2021-2023
+License   : MIT
+Stability : Stable
+-}
 module Orville.PostgreSQL.Execution.Execute
   ( executeAndDecode,
     executeAndReturnAffectedRows,

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/ExecutionResult.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/ExecutionResult.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2016-2021
+Copyright : Flipstone Technology Partners 2016-2023
 License   : MIT
+Stability : Stable
 -}
 module Orville.PostgreSQL.Execution.ExecutionResult
   ( ExecutionResult (..),
@@ -141,6 +142,9 @@ fakeLibPQGetValue result rowNumber columnNumber =
     row <- Map.lookup rowNumber (fakeLibPQRows result)
     Map.lookup columnNumber row
 
+{- | 'readRows' will consume the 'LibPQ.Result', resulting in the collection of name for the field and
+  'SqlValue' for each field in a row and for each row.
+-}
 readRows :: LibPQ.Result -> IO [[(Maybe BS.ByteString, SqlValue)]]
 readRows res = do
   nrows <- LibPQ.ntuples res

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Insert.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Insert.hs
@@ -4,6 +4,7 @@
 
 Copyright : Flipstone Technology Partners 2021
 License   : MIT
+Stability : Stable
 -}
 module Orville.PostgreSQL.Execution.Insert
   ( Insert,

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/QueryType.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/QueryType.hs
@@ -1,3 +1,8 @@
+{- |
+Copyright : Flipstone Technology Partners 2023
+License   : MIT
+Stability : Stable
+-}
 module Orville.PostgreSQL.Execution.QueryType
   ( QueryType (SelectQuery, InsertQuery, UpdateQuery, DeleteQuery, DDLQuery, CursorQuery, OtherQuery),
   )

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/ReturningOption.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/ReturningOption.hs
@@ -1,5 +1,10 @@
 {-# LANGUAGE GADTs #-}
 
+{- |
+Copyright : Flipstone Technology Partners 2023
+License   : MIT
+Stability : Stable
+-}
 module Orville.PostgreSQL.Execution.ReturningOption
   ( ReturningOption (..),
     ReturningClause,
@@ -7,7 +12,10 @@ module Orville.PostgreSQL.Execution.ReturningOption
   )
 where
 
+-- | A tag, used with 'ReturningOption' to indicate a SQL Returning clause.
 data ReturningClause
+
+-- | A tag, used with 'ReturningOption' to indicate no SQL Returning clause.
 data NoReturningClause
 
 {- |

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Select.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Select.hs
@@ -1,6 +1,11 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
 
+{- |
+Copyright : Flipstone Technology Partners 2023
+License   : MIT
+Stability : Stable
+-}
 module Orville.PostgreSQL.Execution.Select
   ( Select,
     executeSelect,

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/SelectOptions.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/SelectOptions.hs
@@ -1,3 +1,8 @@
+{- |
+Copyright : Flipstone Technology Partners 2023
+License   : MIT
+Stability : Stable
+-}
 module Orville.PostgreSQL.Execution.SelectOptions
   ( SelectOptions,
     emptySelectOptions,

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Sequence.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Sequence.hs
@@ -1,3 +1,8 @@
+{- |
+Copyright : Flipstone Technology Partners 2023
+License   : MIT
+Stability : Stable
+-}
 module Orville.PostgreSQL.Execution.Sequence
   ( sequenceNextValue,
     sequenceCurrentValue,

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Transaction.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Transaction.hs
@@ -1,3 +1,8 @@
+{- |
+Copyright : Flipstone Technology Partners 2023
+License   : MIT
+Stability : Stable
+-}
 module Orville.PostgreSQL.Execution.Transaction
   ( withTransaction,
   )

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Update.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Update.hs
@@ -1,5 +1,10 @@
 {-# LANGUAGE GADTs #-}
 
+{- |
+Copyright : Flipstone Technology Partners 2023
+License   : MIT
+Stability : Stable
+-}
 module Orville.PostgreSQL.Execution.Update
   ( Update,
     updateToUpdateExpr,


### PR DESCRIPTION
Haddocks, primarily module headers, are added to AutoMigration, EntityTrace, ErrorDetailLevel, and Execution/*. This includes a module description, which is short, but shows the general pattern for doing so. I suspect that we will want to expand that pattern going forward.

This is a somewhat arbitrary place to cut this work, and more is to follow.