### PR TITLE
Adds/updates Haddocks to more modules

### DIFF
--- a/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
@@ -317,7 +317,7 @@ module Orville.PostgreSQL
     Execute.executeVoid,
     QueryType.QueryType (SelectQuery, InsertQuery, UpdateQuery, DeleteQuery, DDLQuery, OtherQuery),
 
-    -- * [sqlcommenter](https://google.github.io/sqlcommenter/) support.
+    -- * [sqlcommenter](https://google.github.io/sqlcommenter/) support
     SqlCommenter.SqlCommenterAttributes,
   )
 where

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/AutoMigration.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/AutoMigration.hs
@@ -9,6 +9,8 @@ Stability : Stable
 
 Facilities for performing some database migrations automatically.
 See 'autoMigrateSchema' as a primary, high level entry point.
+
+@since 0.10.0.0
 -}
 module Orville.PostgreSQL.AutoMigration
   ( autoMigrateSchema,
@@ -45,6 +47,8 @@ import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
   index or constraint. The constructor functions below can be used to create
   items from other types (such as 'Orville.TableDefinition') to put them into
   a list to be used with 'autoMigrateSchema'.
+
+@since 0.10.0.0
 -}
 data SchemaItem where
   -- |
@@ -76,6 +80,8 @@ data SchemaItem where
 
   For example, a 'SchemaItem' constructed via 'schemaTable' gives @Table <table
   name>@.
+
+@since 0.10.0.0
 -}
 schemaItemSummary :: SchemaItem -> String
 schemaItemSummary item =
@@ -93,14 +99,21 @@ schemaItemSummary item =
   A single SQL statement that will be executed in order to migrate the database
   to the desired result. You can use 'generateMigrationSteps' to get a list
   of these yourself for inspection and debugging.
+
+@since 0.10.0.0
 -}
 newtype MigrationStep
   = MigrationStep RawSql.RawSql
-  deriving (RawSql.SqlExpression)
+  deriving
+    ( -- | @since 0.10.0.0
+      RawSql.SqlExpression
+    )
 
 {- |
   This type is used internally by Orville to order the migration steps after
   they have been created. It is not exposed outside this module.
+
+@since 0.10.0.0
 -}
 data MigrationStepWithType = MigrationStepWithType
   { migrationStepType :: StepType
@@ -123,6 +136,8 @@ mkMigrationStepWithType stepType sql =
   that the steps can be ordered in a sequence that is guaranteed to succeed.
   The order of the constructors below indicates the order in which steps will
   be run.
+
+@since 0.10.0.0
 -}
 data StepType
   = DropForeignKeys
@@ -132,17 +147,28 @@ data StepType
   | AddIndexes
   | AddUniqueConstraints
   | AddForeignKeys
-  deriving (Eq, Ord)
+  deriving
+    ( -- | @since 0.10.0.0
+      Eq
+    , -- | @since 0.10.0.0
+      Ord
+    )
 
 {- |
   A 'MigrationDataError' will be thrown from the migration functions if data
   necessary for migration cannot be found.
+
+@since 0.10.0.0
 -}
 data MigrationDataError
   = UnableToDiscoverCurrentSchema String
   | PgCatalogInvariantViolated String
-  deriving (Show)
+  deriving
+    ( -- | @since 0.10.0.0
+      Show
+    )
 
+-- | @since 0.10.0.0
 instance Exception MigrationDataError
 
 {- |
@@ -151,6 +177,8 @@ instance Exception MigrationDataError
   necessary.  If any changes need to be made, this function executes. You can
   call 'generateMigrationSteps' and 'executeMigrationSteps' yourself if you
   want to have more control over the process.
+
+@since 0.10.0.0
 -}
 autoMigrateSchema :: Orville.MonadOrville m => [SchemaItem] -> m ()
 autoMigrateSchema schemaItems = do
@@ -165,6 +193,8 @@ autoMigrateSchema schemaItems = do
 
   You can execute the 'MigrationStep's yourself using 'Orville.executeVoid',
   or use the 'executeMigrationSteps' convenience function.
+
+@since 0.10.0.0
 -}
 generateMigrationSteps :: Orville.MonadOrville m => [SchemaItem] -> m [MigrationStep]
 generateMigrationSteps =
@@ -191,6 +221,8 @@ generateMigrationStepsWithoutTransaction schemaItems = do
 {- |
   A convenience function for executing a list of 'MigrationStep's that has
   be previously devised via 'generateMigrationSteps'.
+
+@since 0.10.0.0
 -}
 executeMigrationSteps :: Orville.MonadOrville m => [MigrationStep] -> m ()
 executeMigrationSteps =
@@ -274,6 +306,8 @@ calculateMigrationSteps currentNamespace dbDesc schemaItem =
   the table already exists in its schema. Multiple steps may be required to
   create the table if foreign keys exist to that reference other tables, which
   may not have been created yet.
+
+@since 0.10.0.0
 -}
 mkCreateTableSteps ::
   PgCatalog.NamespaceName ->
@@ -313,6 +347,8 @@ mkCreateTableSteps currentNamespace tableDef =
   This function uses the given relation description to determine what
   alterations need to be performed. If there is nothing to do, an empty list
   will be returned.
+
+@since 0.10.0.0
 -}
 mkAlterTableSteps ::
   PgCatalog.NamespaceName ->
@@ -399,6 +435,8 @@ mkAlterTableSteps currentNamespace relationDesc tableDef =
   dropping constraints) into migration steps based on their 'StepType'. Actions
   with the same 'StepType' will be performed togethir in a single @ALTER TABLE@
   statement.
+
+@since 0.10.0.0
 -}
 mkConstraintSteps ::
   Expr.Qualified Expr.TableName ->
@@ -421,6 +459,8 @@ mkConstraintSteps tableName actions =
 {- |
   If there are any alter table actions for adding or removing columns, creates a migration
   step to perform them. Otherwise returns an empty list.
+
+@since 0.10.0.0
 -}
 mkAlterColumnSteps ::
   Expr.Qualified Expr.TableName ->
@@ -437,6 +477,8 @@ mkAlterColumnSteps tableName actionExprs =
   Builds 'Expr.AlterTableAction' expressions to bring the database schema in
   line with the given 'Orville.FieldDefinition', or none if no change is
   required.
+
+@since 0.10.0.0
 -}
 mkAddAlterColumnActions ::
   PgCatalog.RelationDescription ->
@@ -531,6 +573,8 @@ mkAddAlterColumnActions relationDesc fieldDef =
   is only responsible for handling cases where the attribute does not have a
   correspending 'Orville.FieldDefinition'. See 'mkFieldActions' for those
   cases.
+
+@since 0.10.0.0
 -}
 mkDropColumnActions ::
   Orville.TableDefinition key readEntity writeEntity ->
@@ -550,6 +594,8 @@ mkDropColumnActions tableDef attr = do
   to discover whether a constraint from a table definition matches a constraint
   found to already exist in the database because constraints in the database
   always have schema names included with them.
+
+@since 0.10.0.0
 -}
 setDefaultSchemaNameOnConstraintKey ::
   PgCatalog.NamespaceName ->
@@ -575,6 +621,8 @@ setDefaultSchemaNameOnConstraintKey currentNamespace constraintKey =
 {- |
   Builds 'Expr.AlterTableAction' expressions to create the given table
   constraint if it does not exist.
+
+@since 0.10.0.0
 -}
 mkAddConstraintActions ::
   PgCatalog.NamespaceName ->
@@ -597,6 +645,8 @@ mkAddConstraintActions currentNamespace existingConstraints constraintDef =
 {- |
   Builds 'Expr.AlterTableAction' expressions to drop the given table
   constraint if it should not exist.
+
+@since 0.10.0.0
 -}
 mkDropConstraintActions ::
   Set.Set Orville.ConstraintMigrationKey ->
@@ -632,6 +682,8 @@ mkDropConstraintActions constraintsToKeep constraint =
 
   If the description is for a kind of constraint that Orville does not support,
   'Nothing' is returned.
+
+@since 0.10.0.0
 -}
 pgConstraintMigrationKey ::
   PgCatalog.ConstraintDescription ->
@@ -687,6 +739,8 @@ pgConstraintMigrationKey constraintDesc =
 
 {- |
   Builds migration steps to create an index if it does not exist.
+
+@since 0.10.0.0
 -}
 mkAddIndexSteps ::
   Set.Set Orville.IndexMigrationKey ->
@@ -702,6 +756,8 @@ mkAddIndexSteps existingIndexes tableName indexDef =
 
 {- |
   Builds migration steps to drop an index if it should not exist.
+
+@since 0.10.0.0
 -}
 mkDropIndexSteps ::
   Set.Set Orville.IndexMigrationKey ->
@@ -738,6 +794,8 @@ mkDropIndexSteps indexesToKeep systemIndexOids indexDesc =
   Foreign key constraints also have a supporting index OID in @pg_catalog@, but
   this index is not automatically created due to the constraint, so we don't
   return the index's OID for that case.
+
+@since 0.10.0.0
 -}
 pgConstraintImpliedIndexOid :: PgCatalog.PgConstraint -> Maybe LibPQ.Oid
 pgConstraintImpliedIndexOid pgConstraint =
@@ -761,6 +819,8 @@ pgConstraintImpliedIndexOid pgConstraint =
 
   If the description includes expressions as members of the index rather than
   simple attributes, 'Nothing' is returned.
+
+@since 0.10.0.0
 -}
 pgIndexMigrationKeys ::
   PgCatalog.IndexDescription ->
@@ -909,7 +969,7 @@ currentNamespaceQuery =
             -- current_schema is a special reserved word in postgresql. If you
             -- put it in quotes it tries to treat it as a regular column name,
             -- which then can't be found as a column in the query.
-            (RawSql.unsafeFromRawSql $ RawSql.fromString "current_schema")
+            (RawSql.unsafeSqlExpression "current_schema")
             (Orville.fieldColumnName PgCatalog.namespaceNameField)
         ]
     )

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/ErrorDetailLevel.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/ErrorDetailLevel.hs
@@ -2,6 +2,8 @@
 Copyright : Flipstone Technology Partners 2023
 License   : MIT
 Stability : Stable
+
+@since 0.10.0.0
 -}
 module Orville.PostgreSQL.ErrorDetailLevel
   ( ErrorDetailLevel (ErrorDetailLevel, includeErrorMessage, includeSchemaNames, includeRowIdentifierValues, includeNonIdentifierValues),
@@ -24,6 +26,8 @@ where
 
   Information will be redacted from error messages for any of the fields
   that are set to @False@.
+
+@since 0.10.0.0
 -}
 data ErrorDetailLevel = ErrorDetailLevel
   { includeErrorMessage :: Bool
@@ -31,11 +35,16 @@ data ErrorDetailLevel = ErrorDetailLevel
   , includeRowIdentifierValues :: Bool
   , includeNonIdentifierValues :: Bool
   }
-  deriving (Show)
+  deriving
+    ( -- | @since 0.10.0.0
+      Show
+    )
 
 {- |
   A minimal 'ErrorDetailLevel' where everything all information (including
   any situationally-specific error message!) is redacted from error messages.
+
+@since 0.10.0.0
 -}
 minimalErrorDetailLevel :: ErrorDetailLevel
 minimalErrorDetailLevel =
@@ -51,6 +60,8 @@ minimalErrorDetailLevel =
   information such as the error message, schema names and row identifiers, but
   avoids untentionally leaking non-identifier values from the database by
   redacting them.
+
+@since 0.10.0.0
 -}
 defaultErrorDetailLevel :: ErrorDetailLevel
 defaultErrorDetailLevel =
@@ -66,6 +77,8 @@ defaultErrorDetailLevel =
   messages. Error messages will include values from the database for any
   columns are involved in a decoding failure, including some which you may
   not have intended to expose through error message. Use with caution.
+
+@since 0.10.0.0
 -}
 maximalErrorDetailLevel :: ErrorDetailLevel
 maximalErrorDetailLevel =
@@ -79,6 +92,8 @@ maximalErrorDetailLevel =
 {- |
   Redacts given the error message string if the 'ErrorDetailLevel' indicates
   that error messages should be redacted.
+
+@since 0.10.0.0
 -}
 redactErrorMessage :: ErrorDetailLevel -> String -> String
 redactErrorMessage detailLevel message =
@@ -89,6 +104,8 @@ redactErrorMessage detailLevel message =
 {- |
   Redacts given the schema name string if the 'ErrorDetailLevel' indicates
   that schema names should be redacted.
+
+@since 0.10.0.0
 -}
 redactSchemaName :: ErrorDetailLevel -> String -> String
 redactSchemaName detailLevel schemaName =
@@ -99,6 +116,8 @@ redactSchemaName detailLevel schemaName =
 {- |
   Redacts given the identifier value string if the 'ErrorDetailLevel' indicates
   that identifier values should be redacted.
+
+@since 0.10.0.0
 -}
 redactIdentifierValue :: ErrorDetailLevel -> String -> String
 redactIdentifierValue detailLevel idValue =
@@ -109,6 +128,8 @@ redactIdentifierValue detailLevel idValue =
 {- |
   Redacts given the non-identifier value string if the 'ErrorDetailLevel' indicates
   that non-identifier values should be redacted.
+
+@since 0.10.0.0
 -}
 redactNonIdentifierValue :: ErrorDetailLevel -> String -> String
 redactNonIdentifierValue detailLevel nonIdValue =

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution.hs
@@ -4,6 +4,8 @@
 Copyright : Flipstone Technology Partners 2023
 License   : MIT
 Stability : Stable
+
+@since 0.10.0.0
 -}
 module Orville.PostgreSQL.Execution
   ( -- * High level modules for most common tasks
@@ -12,9 +14,7 @@ module Orville.PostgreSQL.Execution
     module Orville.PostgreSQL.Execution.Sequence,
     module Orville.PostgreSQL.Execution.Transaction,
 
-    -- * Mid-level modules with more flexibility for handling less common
-
-    -- queries
+    -- * Mid-level modules with more flexibility for handling less common queries
     module Orville.PostgreSQL.Execution.Select,
     module Orville.PostgreSQL.Execution.Insert,
     module Orville.PostgreSQL.Execution.Update,

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Cursor.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Cursor.hs
@@ -4,6 +4,8 @@
 Copyright : Flipstone Technology Partners 2023
 License   : MIT
 Stability : Stable
+
+@since 0.10.0.0
 -}
 module Orville.PostgreSQL.Execution.Cursor
   ( withCursor,
@@ -53,6 +55,8 @@ import qualified Orville.PostgreSQL.Monad as Monad
 
   See 'withCursor', 'fetch' and 'move' for details on creating and using
   'Cursor' values.
+
+@since 0.10.0.0
 -}
 data Cursor readEntity where
   Cursor ::
@@ -72,6 +76,8 @@ data Cursor readEntity where
   We recommend you use this instead of 'declareCursor' and 'closeCursor'
   unless you need to control the cursor resource acquisition and release
   yourself and can do so safely.
+
+@since 0.10.0.0
 -}
 withCursor ::
   Monad.MonadOrville m =>
@@ -96,6 +102,8 @@ withCursor scrollExpr holdExpr select useCursor =
   See @https://www.postgresql.org/docs/current/sql-declare.html@ for details
   about the 'Expr.ScrollExpr' and 'Expr.HoldExpr' parameters and how cursor
   behave in general.
+
+@since 0.10.0.0
 -}
 declareCursor ::
   Monad.MonadOrville m =>
@@ -118,6 +126,8 @@ declareCursor scrollExpr holdExpr =
   This should be used to close any cursors you open via 'declareCursor',
   thought we recommend you use 'withCursor' instead to ensure that any
   opened cursor are closed in the event of an exception.
+
+@since 0.10.0.0
 -}
 closeCursor ::
   Monad.MonadOrville m =>
@@ -133,6 +143,8 @@ closeCursor (Cursor _ cursorName) =
   Fetch rows from a cursor according to the 'Expr.CursorDirection' given. See
   @https://www.postgresql.org/docs/current/sql-fetch.html@ for details about
   effect of fetch and the meanings of cursor directions to PostgreSQL.
+
+@since 0.10.0.0
 -}
 fetch ::
   Monad.MonadOrville m =>
@@ -149,6 +161,8 @@ fetch direction (Cursor marshaller cursorName) =
   Moves a cursor according to the 'Expr.CursorDirection' given. See
   @https://www.postgresql.org/docs/current/sql-fetch.html@ for details about
   effect of move and the meanings of cursor directions to PostgreSQL.
+
+@since 0.10.0.0
 -}
 move ::
   Monad.MonadOrville m =>

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Delete.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Delete.hs
@@ -4,6 +4,8 @@
 Copyright : Flipstone Technology Partners 2021-2023
 License   : MIT
 Stability : Stable
+
+@since 0.10.0.0
 -}
 module Orville.PostgreSQL.Execution.Delete
   ( Delete,
@@ -27,6 +29,8 @@ import Orville.PostgreSQL.Schema (TableDefinition, mkTableReturningClause, table
 {- | Represents a @DELETE@ statement that can be executed against a database. A 'Delete' has a
   'SqlMarshaller' bound to it that, when the delete returns data from the database, will be used to
   decode the database result set when it is executed.
+
+@since 0.10.0.0
 -}
 data Delete readEntity returningClause where
   Delete ::
@@ -38,6 +42,8 @@ data Delete readEntity returningClause where
   Extracts the query that will be run when the delete is executed. Normally you
   don't want to extract the query and run it yourself, but this function is
   useful to view the query for debugging or query explanation.
+
+@since 0.10.0.0
 -}
 deleteFromDeleteExpr :: Delete readEntity returningClause -> Expr.DeleteExpr
 deleteFromDeleteExpr (Delete expr) = expr
@@ -46,6 +52,8 @@ deleteFromDeleteExpr (DeleteReturning _ expr) = expr
 {- |
   Excutes the database query for the 'Delete' and returns the number of
   rows affected by the query.
+
+@since 0.10.0.0
 -}
 executeDelete ::
   Monad.MonadOrville m =>
@@ -56,6 +64,8 @@ executeDelete (Delete expr) =
 
 {- | Excutes the database query for the 'Delete' and uses its 'SqlMarshaller' to decode the rows (that
   were just deleteed) as returned via a RETURNING clause.
+
+@since 0.10.0.0
 -}
 executeDeleteReturnEntities ::
   Monad.MonadOrville m =>
@@ -67,6 +77,8 @@ executeDeleteReturnEntities (DeleteReturning marshaller expr) =
 {- |
   Builds a 'Delete' that will delete all of the writeable columns described in the
   'TableDefinition' without returning the data as seen by the database.
+
+@since 0.10.0.0
 -}
 deleteFromTable ::
   TableDefinition key writeEntity readEntity ->
@@ -79,6 +91,8 @@ deleteFromTable =
   Builds a 'Delete' that will delete all of the writeable columns described in the
   'TableDefinition' and returning the data as seen by the database. This is useful for getting
   database managed columns such as auto-incrementing identifiers and sequences.
+
+@since 0.10.0.0
 -}
 deleteFromTableReturning ::
   TableDefinition key writeEntity readEntity ->
@@ -112,6 +126,8 @@ deleteTable returningOption tableDef whereCondition =
   a raw 'Expr.DeleteExpr'. It is expected that the 'ReturningOption' given matches the
   'Expr.DeleteExpr'. This level of interface does not provide an automatic enforcement of the
   expectation, however failure is likely if that is not met.
+
+@since 0.10.0.0
 -}
 rawDeleteExpr :: ReturningOption returningClause -> AnnotatedSqlMarshaller writeEntity readEntity -> Expr.DeleteExpr -> Delete readEntity returningClause
 rawDeleteExpr WithReturning marshaller = DeleteReturning marshaller

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/EntityOperations.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/EntityOperations.hs
@@ -2,6 +2,8 @@
 Copyright : Flipstone Technology Partners 2021-2023
 License   : MIT
 Stability : Stable
+
+@since 0.10.0.0
 -}
 module Orville.PostgreSQL.Execution.EntityOperations
   ( insertEntity,
@@ -40,6 +42,8 @@ import qualified Orville.PostgreSQL.Schema as Schema
 {- |
   Inserts a entity into the specified table. Returns the number of rows
   affected by the query.
+
+@since 0.10.0.0
 -}
 insertEntity ::
   Monad.MonadOrville m =>
@@ -55,6 +59,8 @@ insertEntity entityTable entity =
 
   You can use this function to obtain any column values filled in by the
   database, such as auto-incrementing ids.
+
+@since 0.10.0.0
 -}
 insertAndReturnEntity ::
   Monad.MonadOrville m =>
@@ -71,6 +77,8 @@ insertAndReturnEntity entityTable entity = do
 {- |
   Inserts a non-empty list of entities into the specified table. Returns the
   number of rows affected by the query.
+
+@since 0.10.0.0
 -}
 insertEntities ::
   Monad.MonadOrville m =>
@@ -86,6 +94,8 @@ insertEntities tableDef =
 
   You can use this function to obtain any column values filled in by the
   database, such as auto-incrementing ids.
+
+@since 0.10.0.0
 -}
 insertAndReturnEntities ::
   Monad.MonadOrville m =>
@@ -98,6 +108,8 @@ insertAndReturnEntities tableDef =
 {- |
   Updates the row with the given key in with the data given by 'writeEntity'.
   Returns the number of rows affected by the query.
+
+@since 0.10.0.0
 -}
 updateEntity ::
   Monad.MonadOrville m =>
@@ -119,6 +131,8 @@ updateEntity tableDef key writeEntity =
 
   You can use this function to obtain any column values computer by the database
   during update, including columns with triggers attached to them.
+
+@since 0.10.0.0
 -}
 updateAndReturnEntity ::
   Monad.MonadOrville m =>
@@ -141,6 +155,8 @@ updateAndReturnEntity tableDef key writeEntity =
   given where condition. The easiest way to construct a 'Expr.SetClause' is
   via the 'Orville.Postgresql.setField' function (also exported as @.:=@).
   Returns the number of rows affected by the query.
+
+@since 0.10.0.0
 -}
 updateFields ::
   Monad.MonadOrville m =>
@@ -155,6 +171,8 @@ updateFields tableDef setClauses mbWhereCondition =
 {- |
   Like 'updateFields', but uses a @RETURNING@ clause to return the updated
   version of any rows that were affected by the update.
+
+@since 0.10.0.0
 -}
 updateFieldsAndReturnEntities ::
   Monad.MonadOrville m =>
@@ -169,6 +187,8 @@ updateFieldsAndReturnEntities tableDef setClauses mbWhereCondition =
 {- |
   Deletes the row with the given key. Returns the number of rows affected
   by the query.
+
+@since 0.10.0.0
 -}
 deleteEntity ::
   Monad.MonadOrville m =>
@@ -186,6 +206,8 @@ deleteEntity entityTable key =
 {- |
   Deletes the row with the given key, returning the row that was deleted.
   If no row matches the given key, 'Nothing' is returned.
+
+@since 0.10.0.0
 -}
 deleteAndReturnEntity ::
   Monad.MonadOrville m =>
@@ -207,6 +229,8 @@ deleteAndReturnEntity entityTable key = do
 {- |
   Deletes all rows in the given table that match the where condition. Returns
   the number of rows affected by the query.
+
+@since 0.10.0.0
 -}
 deleteEntities ::
   Monad.MonadOrville m =>
@@ -220,6 +244,8 @@ deleteEntities entityTable whereCondition =
 {- |
   Deletes all rows in the given table that match the where condition, returning
   the rows that were deleted.
+
+@since 0.10.0.0
 -}
 deleteAndReturnEntities ::
   Monad.MonadOrville m =>
@@ -234,6 +260,8 @@ deleteAndReturnEntities entityTable whereCondition =
   Finds all the entities in the given table according to the specified
   'SelectOptions.SelectOptions', which may include where conditions to
   match, ordering specifications, etc.
+
+@since 0.10.0.0
 -}
 findEntitiesBy ::
   Monad.MonadOrville m =>
@@ -249,6 +277,8 @@ findEntitiesBy entityTable selectOptions =
   the first item from the list. Usually when you use this you will want to
   provide an order by clause in the 'SelectOptions.SelectOptions' because the
   database will not guarantee ordering.
+
+@since 0.10.0.0
 -}
 findFirstEntityBy ::
   Monad.MonadOrville m =>
@@ -261,6 +291,8 @@ findFirstEntityBy entityTable selectOptions =
 
 {- |
   Finds a single entity by the table's primary key value.
+
+@since 0.10.0.0
 -}
 findEntity ::
   Monad.MonadOrville m =>
@@ -277,14 +309,18 @@ findEntity entityTable key =
 {- |
   Thrown by 'updateFields' and 'updateFieldsAndReturnEntities' if the
   'Schema.TableDefinition' they are given has no columns to update.
+
+@since 0.10.0.0
 -}
 newtype EmptyUpdateError
   = EmptyUpdateError Schema.TableIdentifier
 
+-- | @since 0.10.0.0
 instance Show EmptyUpdateError where
   show (EmptyUpdateError tableId) =
     "EmptyUdateError: "
       <> Schema.tableIdToString tableId
       <> " has no columns to update."
 
+-- | @since 0.10.0.0
 instance Exception EmptyUpdateError

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Execute.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Execute.hs
@@ -2,6 +2,8 @@
 Copyright : Flipstone Technology Partners 2021-2023
 License   : MIT
 Stability : Stable
+
+@since 0.10.0.0
 -}
 module Orville.PostgreSQL.Execution.Execute
   ( executeAndDecode,
@@ -35,6 +37,8 @@ import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
   If the query fails or if any row is unable to be decoded by the marshaller,
   an exception will be raised.
+
+@since 0.10.0.0
 -}
 executeAndDecode ::
   (MonadOrville m, RawSql.SqlExpression sql) =>
@@ -58,6 +62,8 @@ executeAndDecode queryType sql marshaller = do
   wil be raised after the query is executed when the result is read.
 
   If the query fails an exception will be raised.
+
+@since 0.10.0.0
 -}
 executeAndReturnAffectedRows ::
   (MonadOrville m, RawSql.SqlExpression sql) =>
@@ -73,6 +79,8 @@ executeAndReturnAffectedRows queryType sql = do
   that have been added to the 'OrvilleState' will be called.
 
   If the query fails an exception will be raised.
+
+@since 0.10.0.0
 -}
 executeVoid ::
   (MonadOrville m, RawSql.SqlExpression sql) =>
@@ -90,6 +98,8 @@ executeVoid queryType sql = do
 
   If the query fails or if any row is unable to be decoded by the marshaller,
   an exception will be raised.
+
+@since 0.10.0.0
 -}
 executeAndDecodeIO ::
   RawSql.SqlExpression sql =>
@@ -128,6 +138,8 @@ executeAndDecodeIO queryType sql marshaller orvilleState conn = do
   wil be raised after the query is executed when the result is read.
 
   If the query fails an exception will be raised.
+
+@since 0.10.0.0
 -}
 executeAndReturnAffectedRowsIO ::
   RawSql.SqlExpression sql =>
@@ -156,6 +168,8 @@ executeAndReturnAffectedRowsIO queryType sql orvilleState conn = do
   that have been added to the 'OrvilleState' will be called.
 
   If the query fails an exception will be raised.
+
+@since 0.10.0.0
 -}
 executeVoidIO ::
   RawSql.SqlExpression sql =>
@@ -191,9 +205,15 @@ executeWithCallbacksIO queryType sql orvilleState conn =
   Thrown by 'executeAndReturnAffectedRows' and 'executeAndReturnAffectedRowsIO'
   if the number of affected rows cannot be successfully read from the LibPQ
   command result.
+
+@since 0.10.0.0
 -}
 newtype AffectedRowsDecodingError
   = AffectedRowsDecodingError String
-  deriving (Show)
+  deriving
+    ( -- | @since 0.10.0.0
+      Show
+    )
 
+-- | @since 0.10.0.0
 instance Exception AffectedRowsDecodingError

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/ExecutionResult.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/ExecutionResult.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2016-2023
+Copyright : Flipstone Technology Partners 2021-2023
 License   : MIT
 Stability : Stable
+
+@since 0.10.0.0
 -}
 module Orville.PostgreSQL.Execution.ExecutionResult
   ( ExecutionResult (..),
@@ -25,17 +27,35 @@ import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 {- |
   A trivial wrapper for `Int` to help keep track of column vs row number
+
+@since 0.10.0.0
 -}
 newtype Column
   = Column Int
-  deriving (Eq, Ord, Enum)
+  deriving
+    ( -- | @since 0.10.0.0
+      Eq
+    , -- | @since 0.10.0.0
+      Ord
+    , -- | @since 0.10.0.0
+      Enum
+    )
 
 {- |
   A trivial wrapper for `Int` to help keep track of column vs row number
+
+@since 0.10.0.0
 -}
 newtype Row
   = Row Int
-  deriving (Eq, Ord, Enum)
+  deriving
+    ( -- | @since 0.10.0.0
+      Eq
+    , -- | @since 0.10.0.0
+      Ord
+    , -- | @since 0.10.0.0
+      Enum
+    )
 
 {- |
   `ExecutionResult` is a common interface for types that represent a result
@@ -44,6 +64,8 @@ newtype Row
   may be useful as well if you are writing custom code for decoding result
   sets and want to test aspects of the decoding that don't require a real
   database.
+
+@since 0.10.0.0
 -}
 class ExecutionResult result where
   maxRowNumber :: result -> IO (Maybe Row)
@@ -51,6 +73,7 @@ class ExecutionResult result where
   columnName :: result -> Column -> IO (Maybe BS.ByteString)
   getValue :: result -> Row -> Column -> IO SqlValue
 
+-- | @since 0.10.0.0
 instance ExecutionResult LibPQ.Result where
   maxRowNumber result = do
     rowCount <- fmap fromEnum (LibPQ.ntuples result)
@@ -78,6 +101,8 @@ instance ExecutionResult LibPQ.Result where
   `ExecutionResult`.  This is mostly useful for writing automated tests that
   can assume a result set has been loaded and just need to test decoding the
   results.
+
+@since 0.10.0.0
 -}
 data FakeLibPQResult = FakeLibPQResult
   { fakeLibPQColumns :: Map.Map Column BS.ByteString
@@ -89,6 +114,8 @@ data FakeLibPQResult = FakeLibPQResult
   the values for each row by their position in list. Any missing values (e.g.
   because a row is shorter than the heeader list) are treated as a SQL Null
   value.
+
+@since 0.10.0.0
 -}
 mkFakeLibPQResult ::
   -- | The column names for the result set
@@ -126,6 +153,7 @@ fakeLibPQMaxColumn result =
         _ ->
           Just (maximum maxColumnsByRow)
 
+-- | @since 0.10.0.0
 instance ExecutionResult FakeLibPQResult where
   maxRowNumber = pure . fakeLibPQMaxRow
   maxColumnNumber = pure . fakeLibPQMaxColumn
@@ -144,6 +172,8 @@ fakeLibPQGetValue result rowNumber columnNumber =
 
 {- | 'readRows' will consume the 'LibPQ.Result', resulting in the collection of name for the field and
   'SqlValue' for each field in a row and for each row.
+
+@since 0.10.0.0
 -}
 readRows :: LibPQ.Result -> IO [[(Maybe BS.ByteString, SqlValue)]]
 readRows res = do

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Insert.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Insert.hs
@@ -5,6 +5,8 @@
 Copyright : Flipstone Technology Partners 2021
 License   : MIT
 Stability : Stable
+
+@since 0.10.0.0
 -}
 module Orville.PostgreSQL.Execution.Insert
   ( Insert,
@@ -30,6 +32,8 @@ import Orville.PostgreSQL.Schema (TableDefinition, mkInsertExpr, tableMarshaller
 {- | Represents an @INSERT@ statement that can be executed against a database. An 'Insert' has a
   'SqlMarshaller' bound to it that, when the insert returns data from the database, will be used to
   decode the database result set when it is executed.
+
+@since 0.10.0.0
 -}
 data Insert readEntity returningClause where
   Insert ::
@@ -42,6 +46,8 @@ data Insert readEntity returningClause where
   Extracts the query that will be run when the insert is executed. Normally you
   don't want to extract the query and run it yourself, but this function is
   useful to view the query for debugging or query explanation.
+
+@since 0.10.0.0
 -}
 insertToInsertExpr :: Insert readEntity returningClause -> Expr.InsertExpr
 insertToInsertExpr (Insert _ expr) = expr
@@ -49,7 +55,9 @@ insertToInsertExpr (InsertReturning _ expr) = expr
 
 {- |
   Excutes the database query for the 'Insert' and returns the number of rows
-  affected by the query
+  affected by the query.
+
+@since 0.10.0.0
 -}
 executeInsert ::
   Monad.MonadOrville m =>
@@ -60,6 +68,8 @@ executeInsert (Insert _ expr) =
 
 {- | Excutes the database query for the 'Insert' and uses its 'SqlMarshaller' to decode the rows (that
   were just inserted) as returned via a RETURNING clause.
+
+@since 0.10.0.0
 -}
 executeInsertReturnEntities ::
   Monad.MonadOrville m =>
@@ -71,6 +81,8 @@ executeInsertReturnEntities (InsertReturning marshaller expr) =
 {- |
   Builds an 'Insert' that will insert all of the writeable columns described in the
   'TableDefinition' without returning the data as seen by the database.
+
+@since 0.10.0.0
 -}
 insertToTable ::
   TableDefinition key writeEntity readEntity ->
@@ -83,6 +95,8 @@ insertToTable =
   Builds an 'Insert' that will insert all of the writeable columns described in the
   'TableDefinition' and returning the data as seen by the database. This is useful for getting
   database managed columns such as auto-incrementing identifiers and sequences.
+
+@since 0.10.0.0
 -}
 insertToTableReturning ::
   TableDefinition key writeEntity readEntity ->
@@ -111,6 +125,8 @@ insertTable returningOption tableDef entities =
   a raw 'Expr.InsertExpr'. It is expected that the 'ReturningOption' given matches the
   'Expr.InsertExpr'. This level of interface does not provide an automatic enforcement of the
   expectation, however failure is likely if that is not met.
+
+@since 0.10.0.0
 -}
 rawInsertExpr :: ReturningOption returningClause -> AnnotatedSqlMarshaller writeEntity readEntity -> Expr.InsertExpr -> Insert readEntity returningClause
 rawInsertExpr WithReturning = InsertReturning

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/QueryType.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/QueryType.hs
@@ -2,6 +2,8 @@
 Copyright : Flipstone Technology Partners 2023
 License   : MIT
 Stability : Stable
+
+@since 0.10.0.0
 -}
 module Orville.PostgreSQL.Execution.QueryType
   ( QueryType (SelectQuery, InsertQuery, UpdateQuery, DeleteQuery, DDLQuery, CursorQuery, OtherQuery),
@@ -13,6 +15,8 @@ where
   user callbacks about what kind of query is being run.
 
   See 'Orville.PostgreSQL.addSqlExecutionCallback'
+
+@since 0.10.0.0
 -}
 data QueryType
   = SelectQuery
@@ -22,4 +26,17 @@ data QueryType
   | DDLQuery
   | CursorQuery
   | OtherQuery
-  deriving (Ord, Eq, Enum, Bounded, Show, Read)
+  deriving
+    ( -- | @since 0.10.0.0
+      Ord
+    , -- | @since 0.10.0.0
+      Eq
+    , -- | @since 0.10.0.0
+      Enum
+    , -- | @since 0.10.0.0
+      Bounded
+    , -- | @since 0.10.0.0
+      Show
+    , -- | @since 0.10.0.0
+      Read
+    )

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/ReturningOption.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/ReturningOption.hs
@@ -4,6 +4,8 @@
 Copyright : Flipstone Technology Partners 2023
 License   : MIT
 Stability : Stable
+
+@since 0.10.0.0
 -}
 module Orville.PostgreSQL.Execution.ReturningOption
   ( ReturningOption (..),
@@ -12,16 +14,23 @@ module Orville.PostgreSQL.Execution.ReturningOption
   )
 where
 
--- | A tag, used with 'ReturningOption' to indicate a SQL Returning clause.
+{- | A tag, used with 'ReturningOption' to indicate a SQL Returning clause.
+
+@since 0.10.0.0
+-}
 data ReturningClause
 
--- | A tag, used with 'ReturningOption' to indicate no SQL Returning clause.
+{- | A tag, used with 'ReturningOption' to indicate no SQL Returning clause.
+
+@since 0.10.0.0
+-}
 data NoReturningClause
 
 {- |
   Specifies whether or not a @RETURNING@ clause should be included when a
   query expression is built. This type is found as a parameter on a number
   of the query building functions related to 'TableDefinition'.
+@since 0.10.0.0
 -}
 data ReturningOption clause where
   WithReturning :: ReturningOption ReturningClause

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Select.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Select.hs
@@ -5,6 +5,8 @@
 Copyright : Flipstone Technology Partners 2023
 License   : MIT
 Stability : Stable
+
+@since 0.10.0.0
 -}
 module Orville.PostgreSQL.Execution.Select
   ( Select,
@@ -30,6 +32,8 @@ import Orville.PostgreSQL.Schema (TableDefinition, tableMarshaller, tableName)
   Represents a @SELECT@ statement that can be executed against a database. A
   'Select' has a 'SqlMarshaller' bound to it that will be used to decode the
   database result set when it is executed.
+
+@since 0.10.0.0
 -}
 data Select readEntity where
   Select :: AnnotatedSqlMarshaller writeEntity readEntity -> Expr.QueryExpr -> Select readEntity
@@ -38,6 +42,8 @@ data Select readEntity where
   Extracts the query that will be run when the select is executed. Normally you
   don't want to extract the query and run it yourself, but this function is
   useful to view the query for debugging or query explanation.
+
+@since 0.10.0.0
 -}
 selectToQueryExpr :: Select readEntity -> Expr.QueryExpr
 selectToQueryExpr (Select _ query) = query
@@ -45,6 +51,8 @@ selectToQueryExpr (Select _ query) = query
 {- |
   Excutes the database query for the 'Select' and uses its 'SqlMarshaller' to
   decode the result set.
+
+@since 0.10.0.0
 -}
 executeSelect :: Monad.MonadOrville m => Select row -> m [row]
 executeSelect =
@@ -54,6 +62,8 @@ executeSelect =
   Runs a function allowing it to use the data elements containted within the
   'Select' it pleases. The marshaller that the function is provided can be use
   to decode results from the query.
+
+@since 0.10.0.0
 -}
 useSelect ::
   ( forall writeEntity.
@@ -72,6 +82,8 @@ useSelect f (Select marshaller query) =
   name and columns are all read from the 'TableDefinition'. If the table is
   being managed with Orville auto migrations, this will match the schema in the
   database.
+
+@since 0.10.0.0
 -}
 selectTable ::
   TableDefinition key writeEntity readEntity ->
@@ -87,6 +99,8 @@ selectTable tableDef =
 
   This function is useful for query a subset of table columns using a custom
   marshaller.
+
+@since 0.10.0.0
 -}
 selectMarshalledColumns ::
   AnnotatedSqlMarshaller writeEntity readEntity ->
@@ -111,6 +125,8 @@ selectMarshalledColumns marshaller =
   desires. If Orville does not support building the 'Expr.SelectList' you need
   using any of the expression building functions, you can resort to
   @RawSql.fromRawSql@ as an escape hatch to build the 'Expr.SelectList' here.
+
+@since 0.10.0.0
 -}
 selectSelectList ::
   Expr.SelectList ->
@@ -142,6 +158,8 @@ selectSelectList selectList marshaller qualifiedTableName selectOptions =
   This is the lowest level of escape hatch available for 'Select'. The caller
   can build any query that Orville supports using the expression building
   functions, or use @RawSql.fromRawSql@ to build a raw 'Expr.QueryExpr'.
+
+@since 0.10.0.0
 -}
 rawSelectQueryExpr ::
   AnnotatedSqlMarshaller writeEntity readEntity ->

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/SelectOptions.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/SelectOptions.hs
@@ -2,6 +2,8 @@
 Copyright : Flipstone Technology Partners 2023
 License   : MIT
 Stability : Stable
+
+@since 0.10.0.0
 -}
 module Orville.PostgreSQL.Execution.SelectOptions
   ( SelectOptions,
@@ -31,6 +33,8 @@ import qualified Orville.PostgreSQL.Expr as Expr
    a basic query function works by adding 'WHERE', 'ORDER BY', 'GROUP BY', etc.
    Functions are provided to construct 'SelectOptions' for individual options,
    which may then be combined via '<>' (also exposed as 'appendSelectOptions').
+
+@since 0.10.0.0
 -}
 data SelectOptions = SelectOptions
   { i_distinct :: First Bool
@@ -41,14 +45,18 @@ data SelectOptions = SelectOptions
   , i_groupByExpr :: Maybe Expr.GroupByExpr
   }
 
+-- | @since 0.10.0.0
 instance Semigroup SelectOptions where
   (<>) = appendSelectOptions
 
+-- | @since 0.10.0.0
 instance Monoid SelectOptions where
   mempty = emptySelectOptions
 
 {- |
   A set of empty 'SelectOptions' that will not change how a query is run.
+
+@since 0.10.0.0
 -}
 emptySelectOptions :: SelectOptions
 emptySelectOptions =
@@ -65,6 +73,8 @@ emptySelectOptions =
   Combines multple select options together, unioning the options together where
   possible. For options where this is not possible, (e.g. 'LIMIT'), the one
   on the left is preferred.
+
+@since 0.10.0.0
 -}
 appendSelectOptions :: SelectOptions -> SelectOptions -> SelectOptions
 appendSelectOptions left right =
@@ -87,6 +97,8 @@ unionMaybeWith f mbLeft mbRight =
 {- |
   Builds the 'Expr.SelectClause' that should be used to include the
   'distinct's from the 'SelectOptions' on a query.
+
+@since 0.10.0.0
 -}
 selectDistinct :: SelectOptions -> Expr.SelectClause
 selectDistinct selectOptions =
@@ -98,6 +110,8 @@ selectDistinct selectOptions =
   Builds the 'Expr.WhereClause' that should be used to include the
   'WhereCondition's from the 'SelectOptions' on a query. This will be 'Nothing'
   where no 'WhereCondition's have been specified.
+
+@since 0.10.0.0
 -}
 selectWhereClause :: SelectOptions -> Maybe Expr.WhereClause
 selectWhereClause =
@@ -105,6 +119,8 @@ selectWhereClause =
 
 {- |
   Constructs a 'SelectOptions' with just 'distinct' set to 'True'.
+
+@since 0.10.0.0
 -}
 distinct :: SelectOptions
 distinct =
@@ -116,6 +132,8 @@ distinct =
   Builds the 'Expr.OrderByClause' that should be used to include the
   'OrderByClause's from the 'SelectOptions' on a query. This will be 'Nothing'
   where no 'OrderByClause's have been specified.
+
+@since 0.10.0.0
 -}
 selectOrderByClause :: SelectOptions -> Maybe Expr.OrderByClause
 selectOrderByClause =
@@ -125,6 +143,8 @@ selectOrderByClause =
   Builds the 'Expr.GroupByClause' that should be used to include the
   'GroupByClause's from the 'SelectOptions' on a query. This will be 'Nothing'
   where no 'GroupByClause's have been specified.
+
+@since 0.10.0.0
 -}
 selectGroupByClause :: SelectOptions -> Maybe Expr.GroupByClause
 selectGroupByClause =
@@ -133,6 +153,8 @@ selectGroupByClause =
 {- |
   Builds a 'Expr.LimitExpr' that will limit the query results to the
   number specified in the 'SelectOptions' (if any)
+
+@since 0.10.0.0
 -}
 selectLimitExpr :: SelectOptions -> Maybe Expr.LimitExpr
 selectLimitExpr =
@@ -141,6 +163,8 @@ selectLimitExpr =
 {- |
   Builds a 'Expr.OffsetExpr' that will limit the query results to the
   number specified in the 'SelectOptions' (if any)
+
+@since 0.10.0.0
 -}
 selectOffsetExpr :: SelectOptions -> Maybe Expr.OffsetExpr
 selectOffsetExpr =
@@ -148,6 +172,8 @@ selectOffsetExpr =
 
 {- |
   Constructs a 'SelectOptions' with just the given 'WhereCondition'.
+
+@since 0.10.0.0
 -}
 where_ :: Expr.BooleanExpr -> SelectOptions
 where_ condition =
@@ -157,6 +183,8 @@ where_ condition =
 
 {- |
   Constructs a 'SelectOptions' with just the given 'Expr.OrderByExpr'.
+
+@since 0.10.0.0
 -}
 orderBy :: Expr.OrderByExpr -> SelectOptions
 orderBy order =
@@ -165,7 +193,9 @@ orderBy order =
     }
 
 {- |
-  Constructs a 'SelectOptions' that will apply the given limit
+  Constructs a 'SelectOptions' that will apply the given limit.
+
+@since 0.10.0.0
 -}
 limit :: Int -> SelectOptions
 limit limitValue =
@@ -174,7 +204,9 @@ limit limitValue =
     }
 
 {- |
-  Constructs a 'SelectOptions' that will apply the given offset
+  Constructs a 'SelectOptions' that will apply the given offset.
+
+@since 0.10.0.0
 -}
 offset :: Int -> SelectOptions
 offset offsetValue =
@@ -184,6 +216,8 @@ offset offsetValue =
 
 {- |
   Constructs a 'SelectOptions' with just the given 'GroupByClause'.
+
+@since 0.10.0.0
 -}
 groupBy :: Expr.GroupByExpr -> SelectOptions
 groupBy groupByExpr =

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr.hs
@@ -1,8 +1,11 @@
 {-# OPTIONS_GHC -Wno-missing-import-lists #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2016-2021
+Copyright : Flipstone Technology Partners 2021-2023
 License   : MIT
+Stability : Stable
+
+@since 0.10.0.0
 -}
 module Orville.PostgreSQL.Expr
   ( module Orville.PostgreSQL.Expr.BinaryOperator,

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/BinaryOperator.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/BinaryOperator.hs
@@ -3,6 +3,9 @@
 {- |
 Copyright : Flipstone Technology Partners 2016-2023
 License   : MIT
+Stability : Stable
+
+@since 0.10.0.0
 -}
 module Orville.PostgreSQL.Expr.BinaryOperator
   ( BinaryOperator,
@@ -35,98 +38,212 @@ where
 import Orville.PostgreSQL.Expr.ValueExpression (ValueExpression)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
+{- | Type to represent any SQL operator of two arguments.
+
+There is an low level escape hatch included here, by means of the instance of
+'RawSql.SqlExpression'. This is intended to be used when some functionality is required but not
+already included. The exension mechanism provided does require care in use as no guarantees are
+provided for correctness in usage.
+
+For example, if one wanted to have a binary operator corresponding to the fictional SQL operator
+MY_OPERATOR, that could be done as
+
+ > RawSql.unsafeSqlExpression "MY_OPERATOR"
+
+@since 0.10.0.0
+-}
 newtype BinaryOperator
   = BinaryOperator RawSql.RawSql
-  deriving (RawSql.SqlExpression)
+  deriving
+    ( -- | @since 0.10.0.0
+      RawSql.SqlExpression
+    )
 
+{- | Construct a binary operator, note that this does not include any check to determine if the
+operator is valid either by being a native SQL operator, or a custom defined operator in the
+database.
+
+@since 0.10.0.0
+-}
 binaryOperator :: String -> BinaryOperator
 binaryOperator =
   BinaryOperator . RawSql.fromString
 
+{- | The SQL equal binary operator.
+
+@since 0.10.0.0
+-}
 equalsOp :: BinaryOperator
 equalsOp =
   binaryOperator "="
 
+{- | The SQL not equal binary operator.
+
+@since 0.10.0.0
+-}
 notEqualsOp :: BinaryOperator
 notEqualsOp =
   binaryOperator "<>"
 
+{- | The SQL strictly greater than binary operator.
+
+@since 0.10.0.0
+-}
 greaterThanOp :: BinaryOperator
 greaterThanOp =
   binaryOperator ">"
 
+{- | The SQL strictly less than binary operator.
+
+@since 0.10.0.0
+-}
 lessThanOp :: BinaryOperator
 lessThanOp =
   binaryOperator "<"
 
+{- | The SQL greater than or equal binary operator.
+
+@since 0.10.0.0
+-}
 greaterThanOrEqualsOp :: BinaryOperator
 greaterThanOrEqualsOp =
   binaryOperator ">="
 
+{- | The SQL less than or equal binary operator.
+
+@since 0.10.0.0
+-}
 lessThanOrEqualsOp :: BinaryOperator
 lessThanOrEqualsOp =
   binaryOperator "<="
 
+{- | The SQL LIKE binary operator.
+
+@since 0.10.0.0
+-}
 likeOp :: BinaryOperator
 likeOp =
   binaryOperator "LIKE"
 
+{- | The SQL ILIKE binary operator.
+
+@since 0.10.0.0
+-}
 iLikeOp :: BinaryOperator
 iLikeOp =
   binaryOperator "ILIKE"
 
+{- | The SQL logical or binary operator.
+
+@since 0.10.0.0
+-}
 orOp :: BinaryOperator
 orOp =
   binaryOperator "OR"
 
+{- | The SQL logical and binary operator.
+
+@since 0.10.0.0
+-}
 andOp :: BinaryOperator
 andOp =
   binaryOperator "AND"
 
+{- | The SQL + binary operator.
+
+@since 0.10.0.0
+-}
 plusOp :: BinaryOperator
 plusOp =
   binaryOperator "+"
 
+{- | The SQL - binary operator.
+
+@since 0.10.0.0
+-}
 minusOp :: BinaryOperator
 minusOp =
   binaryOperator "-"
 
+{- | The SQL * binary operator.
+
+@since 0.10.0.0
+-}
 multiplicationOp :: BinaryOperator
 multiplicationOp =
   binaryOperator "*"
 
+{- | The SQL / binary operator.
+
+@since 0.10.0.0
+-}
 divisionOp :: BinaryOperator
 divisionOp =
   binaryOperator "/"
 
+{- | The SQL % binary operator.
+
+@since 0.10.0.0
+-}
 moduloOp :: BinaryOperator
 moduloOp =
   binaryOperator "%"
 
+{- | The SQL ^ binary operator.
+
+@since 0.10.0.0
+-}
 exponentiationOp :: BinaryOperator
 exponentiationOp =
   binaryOperator "^"
 
+{- | The SQL bitwise and (a.k.a &) binary operator.
+
+@since 0.10.0.0
+-}
 bitwiseAndOp :: BinaryOperator
 bitwiseAndOp =
   binaryOperator "&"
 
+{- | The SQL bitwise or (a.k.a |) binary operator.
+
+@since 0.10.0.0
+-}
 bitwiseOrOp :: BinaryOperator
 bitwiseOrOp =
   binaryOperator "|"
 
+{- | The SQL bitwise exclusive or (a.k.a #) binary operator.
+
+@since 0.10.0.0
+-}
 bitwiseXorOp :: BinaryOperator
 bitwiseXorOp =
   binaryOperator "#"
 
+{- | The SQL bitwise left shift (a.k.a <<) binary operator.
+
+@since 0.10.0.0
+-}
 bitwiseShiftLeftOp :: BinaryOperator
 bitwiseShiftLeftOp =
   binaryOperator "<<"
 
+{- | The SQL bitwise right shift (a.k.a >>) binary operator.
+
+@since 0.10.0.0
+-}
 bitwiseShiftRightOp :: BinaryOperator
 bitwiseShiftRightOp =
   binaryOperator ">>"
 
+{- | Apply a binary operator to two 'ValueExpression's resulting in some
+ 'RawSql.SqlExpression'. Note that this does *NOT* extend typechecking to the 'ValueExpression's
+ being used with the 'BinaryOperator'. It is left to the caller to ensure that the operator makes
+ sense with the arguments being passed.
+
+@since 0.10.0.0
+-}
 binaryOpExpression ::
   RawSql.SqlExpression sql =>
   BinaryOperator ->

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/ColumnDefinition.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/ColumnDefinition.hs
@@ -1,8 +1,11 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2016-2021
+Copyright : Flipstone Technology Partners 2021-2023
 License   : MIT
+Stability : Stable
+
+@since 0.10.0.0
 -}
 module Orville.PostgreSQL.Expr.ColumnDefinition
   ( ColumnDefinition,
@@ -22,42 +25,112 @@ import Orville.PostgreSQL.Expr.Name (ColumnName)
 import Orville.PostgreSQL.Expr.ValueExpression (ValueExpression)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
+{- | Represent a complete definition of a column.
+
+There is an low level escape hatch included here, by means of the instance of
+'RawSql.SqlExpression'. This is intended to be used when some functionality is required but not
+already included. The exension mechanism provided does require care in use as no guarantees are
+provided for correctness in usage.
+
+For example, if one wanted to have a column named FOO of type INT, that could be done as
+
+ > RawSql.unsafeSqlExpression "FOO INT"
+
+@since 0.10.0.0
+-}
 newtype ColumnDefinition
   = ColumnDefinition RawSql.RawSql
-  deriving (RawSql.SqlExpression)
+  deriving
+    ( -- | @since 0.10.0.0
+      RawSql.SqlExpression
+    )
 
+{- | Smart constructor for ensuring a 'ColumnDefinition' is setup correctly.
+
+@since 0.10.0.0
+-}
 columnDefinition ::
+  -- | The name the resulting column should have.
   ColumnName ->
+  -- | The SQL type of the column
   DataType ->
+  -- | The constraint on the column if any
   Maybe ColumnConstraint ->
+  -- | The default value for the column if any
   Maybe ColumnDefault ->
   ColumnDefinition
 columnDefinition columnName dataType maybeColumnConstraint maybeColumnDefault =
-  ColumnDefinition $
-    RawSql.intercalate RawSql.space $
-      Maybe.catMaybes
-        [ Just $ RawSql.toRawSql columnName
-        , Just $ RawSql.toRawSql dataType
-        , fmap RawSql.toRawSql maybeColumnConstraint
-        , fmap RawSql.toRawSql maybeColumnDefault
-        ]
+  ColumnDefinition
+    . RawSql.intercalate RawSql.space
+    $ Maybe.catMaybes
+      [ Just $ RawSql.toRawSql columnName
+      , Just $ RawSql.toRawSql dataType
+      , fmap RawSql.toRawSql maybeColumnConstraint
+      , fmap RawSql.toRawSql maybeColumnDefault
+      ]
 
+{- | Represent constraints, such as nullability, on a column.
+
+There is an low level escape hatch included here, by means of the instance of
+'RawSql.SqlExpression'. This is intended to be used when some functionality is required but not
+already included. The exension mechanism provided does require care in use as no guarantees are
+provided for correctness in usage.
+
+For example, if one wanted to have a constraint of NOT NULL, that could be done as
+
+ > RawSql.unsafeSqlExpression "NOT NULL"
+
+@since 0.10.0.0
+-}
 newtype ColumnConstraint
   = ColumnConstraint RawSql.RawSql
-  deriving (RawSql.SqlExpression)
+  deriving
+    ( -- | @since 0.10.0.0
+      RawSql.SqlExpression
+    )
 
+{- | Express that a column may not contain NULL.
+
+@since 0.10.0.0
+-}
 notNullConstraint :: ColumnConstraint
 notNullConstraint =
   ColumnConstraint (RawSql.fromString "NOT NULL")
 
+{- | Express that a column may contain NULL.
+
+@since 0.10.0.0
+-}
 nullConstraint :: ColumnConstraint
 nullConstraint =
   ColumnConstraint (RawSql.fromString "NULL")
 
+{- | Represent the default value of a column.
+
+There is an low level escape hatch included here, by means of the instance of
+'RawSql.SqlExpression'. This is intended to be used when some functionality is required but not
+already included. The exension mechanism provided does require care in use as no guarantees are
+provided for correctness in usage.
+
+For example, if one wanted to have a default of FOO, that could be done as
+
+ > RawSql.unsafeSqlExpression "FOO"
+
+@since 0.10.0.0
+-}
 newtype ColumnDefault
   = ColumnDefault RawSql.RawSql
-  deriving (RawSql.SqlExpression)
+  deriving
+    ( -- | @since 0.10.0.0
+      RawSql.SqlExpression
+    )
 
+{- | Given a 'ValueExpression' use that as a 'ColumnDefault'. This is the preferred path to creating a
+   column default. Note that it is up to the caller to ensure the 'ValueExpression' makes sense for
+   the resulting 'ColumnDefinition' this will be a part of.
+
+@since 0.10.0.0
+-}
 columnDefault ::
   ValueExpression ->
   ColumnDefault

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Count.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Count.hs
@@ -1,3 +1,10 @@
+{- |
+Copyright : Flipstone Technology Partners 2023
+License   : MIT
+Stability : Stable
+
+@since 0.10.0.0
+-}
 module Orville.PostgreSQL.Expr.Count
   ( count,
     countFunction,
@@ -10,17 +17,33 @@ import Orville.PostgreSQL.Expr.Name (ColumnName, FunctionName, functionName)
 import Orville.PostgreSQL.Expr.ValueExpression (ValueExpression, columnReference, functionCall)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
+{- | The SQL @count@ function
+
+@since 0.10.0.0
+-}
 countFunction :: FunctionName
 countFunction = functionName "count"
 
+{- | Given a 'ValueExpression', use it as the argument to the SQL @count@
+
+@since 0.10.0.0
+-}
 count :: ValueExpression -> ValueExpression
 count value =
   functionCall countFunction [value]
 
+{- | The SQL @count(1)@
+
+@since 0.10.0.0
+-}
 count1 :: ValueExpression
 count1 =
   count . RawSql.unsafeFromRawSql . RawSql.intDecLiteral $ 1
 
+{- | Use a given column as the argument to the SQL @count@
+
+@since 0.10.0.0
+-}
 countColumn :: ColumnName -> ValueExpression
 countColumn =
   count . columnReference

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Cursor.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Cursor.hs
@@ -1,8 +1,11 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2022
+Copyright : Flipstone Technology Partners 2022-2023
 License   : MIT
+Stability : Stable
+
+@since 0.10.0.0
 -}
 module Orville.PostgreSQL.Expr.Cursor
   ( DeclareExpr,
@@ -46,10 +49,35 @@ import Orville.PostgreSQL.Expr.Name (CursorName)
 import Orville.PostgreSQL.Expr.Query (QueryExpr)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
+{- | 'DeclareExpr' corresponds to the SQL DECLARE statement, for declaring and opening cursors.
+
+See PostgreSQL [cursor declare
+documentation](https://www.postgresql.org/docs/current/sql-declare.html) for more information.
+
+There is an low level escape hatch included here, by means of the instance of
+'RawSql.SqlExpression'. This is intended to be used when some functionality is required but not
+already included. The exension mechanism provided does require care in use as no guarantees are
+provided for correctness in usage.
+
+For example, if one wanted to have a cusor named FOO, with a query of select * from BAR, that could
+be done as
+
+ > RawSql.unsafeSqlExpression "DECLARE FOO CURSOR FOR SELECT * FROM BAR"
+
+@since 0.10.0.0
+-}
 newtype DeclareExpr
   = DeclareExpr RawSql.RawSql
-  deriving (RawSql.SqlExpression)
+  deriving
+    ( -- | @since 0.10.0.0
+      RawSql.SqlExpression
+    )
 
+{- | A smart constructor for setting up a 'DeclareExpr'. This, along with other functions provided
+   allow to more safely declare a cursor.
+
+@since 0.10.0.0
+-}
 declare ::
   CursorName ->
   Maybe ScrollExpr ->
@@ -69,52 +97,197 @@ declare cursorName maybeScrollExpr maybeHoldExpr queryExpr =
         , Just $ RawSql.toRawSql queryExpr
         ]
 
+{- | 'ScrollExpr' is used to determine if a cursor should be able to fetch nonsequentially.
+
+Note that the default in at least PostgreSQL versions 11-15 is to allow nonsequential fetches under
+some, but not all, circumstances.
+
+See PostgreSQL [cursor declare
+documentation](https://www.postgresql.org/docs/current/sql-declare.html) for more information.
+
+There is an low level escape hatch included here, by means of the instance of
+'RawSql.SqlExpression'. This is intended to be used when some functionality is required but not
+already included. The exension mechanism provided does require care in use as no guarantees are
+provided for correctness in usage.
+
+For example, if one wanted to allow only sequential fetches, that could be done as
+
+ > RawSql.unsafeSqlExpression "NO SCROLL"
+
+The above is provided as a built-in, 'noScroll'.
+@since 0.10.0.0
+-}
 newtype ScrollExpr
   = ScrollExpr RawSql.RawSql
-  deriving (RawSql.SqlExpression)
+  deriving
+    ( -- | @since 0.10.0.0
+      RawSql.SqlExpression
+    )
 
+{- | Allow a cursor to be used to fetch rows nonsequentially.
+
+@since 0.10.0.0
+-}
 scroll :: ScrollExpr
 scroll =
   ScrollExpr . RawSql.fromString $ "SCROLL"
 
+{- | Only allow a cursor to be used to fetch rows sequentially.
+
+@since 0.10.0.0
+-}
 noScroll :: ScrollExpr
 noScroll =
   ScrollExpr . RawSql.fromString $ "NO SCROLL"
 
+{- | 'HoldExpr' is used to determine if a cursor should be available for use after the transaction
+   that created it has been comitted.
+
+See PostgreSQL [cursor documentation](https://www.postgresql.org/docs/current/sql-declare.html) for
+more information.
+
+There is an low level escape hatch included here, by means of the instance of
+'RawSql.SqlExpression'. This is intended to be used when some functionality is required but not
+already included. The exension mechanism provided does require care in use as no guarantees are
+provided for correctness in usage.
+
+For example, if one wanted to have a cursor available after the transaction creating it commits,
+that could be done as
+
+ > RawSql.unsafeSqlExpression "WITH HOLD"
+
+The above is provided as a built-in, 'withHold'.
+
+@since 0.10.0.0
+-}
 newtype HoldExpr
   = HoldExpr RawSql.RawSql
-  deriving (RawSql.SqlExpression)
+  deriving
+    ( -- | @since 0.10.0.0
+      RawSql.SqlExpression
+    )
 
+{- | Allow a cursor to be used after the transaction creating it is committed.
+
+@since 0.10.0.0
+-}
 withHold :: HoldExpr
 withHold =
   HoldExpr . RawSql.fromString $ "WITH HOLD"
 
+{- | Do not allow a cursor to be used after the transaction creating it is committed.
+
+@since 0.10.0.0
+-}
 withoutHold :: HoldExpr
 withoutHold =
   HoldExpr . RawSql.fromString $ "WITHOUT HOLD"
 
+{- | 'CloseExpr' corresponds to the SQL CLOSE statement.
+
+See PostgreSQL [close documentation](https://www.postgresql.org/docs/current/sql-close.html) for
+more information.
+
+There is an low level escape hatch included here, by means of the instance of
+'RawSql.SqlExpression'. This is intended to be used when some functionality is required but not
+already included. The exension mechanism provided does require care in use as no guarantees are
+provided for correctness in usage.
+
+For example, if one wanted to close all cursors, that could be done as
+
+> RawSql.unsafeSqlExpression "CLOSE ALL"
+
+The above is available via built-ins as,
+
+> close (Left allCursors)
+
+@since 0.10.0.0
+-}
 newtype CloseExpr
   = CloseExpr RawSql.RawSql
-  deriving (RawSql.SqlExpression)
+  deriving
+    ( -- | @since 0.10.0.0
+      RawSql.SqlExpression
+    )
 
+{- | A smart constructor for setting up a 'CloseExpr' either closing all cursors or the given named
+   cursor.
+
+@since 0.10.0.0
+-}
 close :: Either AllCursors CursorName -> CloseExpr
 close allOrCursorName =
   CloseExpr $
     RawSql.fromString "CLOSE "
       <> either RawSql.toRawSql RawSql.toRawSql allOrCursorName
 
+{- | 'AllCursors' corresponds to the ALL keyword in a CLOSE statement.
+
+See PostgreSQL [close documentation](https://www.postgresql.org/docs/current/sql-close.html) for
+more information.
+
+There is an low level escape hatch included here, by means of the instance of
+'RawSql.SqlExpression'. This is intended to be used when some functionality is required but not
+already included. The exension mechanism provided does require care in use as no guarantees are
+provided for correctness in usage.
+
+For example, this could be done as
+
+> RawSql.unsafeSqlExpression "ALL"
+
+The above is available as a built-in, 'allCursors'
+
+@since 0.10.0.0
+-}
 newtype AllCursors
   = AllCursors RawSql.RawSql
-  deriving (RawSql.SqlExpression)
+  deriving
+    ( -- | @since 0.10.0.0
+      RawSql.SqlExpression
+    )
 
+{- | Specify closing all open cursors, for use with a 'CloseExpr'
+
+@since 0.10.0.0
+-}
 allCursors :: AllCursors
 allCursors =
   AllCursors . RawSql.fromString $ "ALL"
 
+{- | 'FetchExpr' corresponds to the SQL FETCH statement, for retrieving rows from a previously created
+   cursor.
+
+See PostgreSQL [fetch documentation](https://www.postgresql.org/docs/current/sql-fetch.html) for
+more information.
+
+There is an low level escape hatch included here, by means of the instance of
+'RawSql.SqlExpression'. This is intended to be used when some functionality is required but not
+already included. The exension mechanism provided does require care in use as no guarantees are
+provided for correctness in usage.
+
+For example, if one wanted to use a cusor named FOO, to get the next row, that could
+be done as
+
+ > RawSql.unsafeSqlExpression "FETCH NEXT FOO"
+
+The above is available via built-ins, given you have previously created the cursor and named it foo
+as,
+
+> fetch (Just next) foo
+
+@since 0.10.0.0
+-}
 newtype FetchExpr
   = FetchExpr RawSql.RawSql
-  deriving (RawSql.SqlExpression)
+  deriving
+    ( -- | @since 0.10.0.0
+      RawSql.SqlExpression
+    )
 
+{- | Construct a 'FetchExpr', for a given cursor and optionally a direction to fetch.
+
+@since 0.10.0.0
+-}
 fetch :: Maybe CursorDirection -> CursorName -> FetchExpr
 fetch maybeDirection cursorName =
   FetchExpr $
@@ -125,40 +298,128 @@ fetch maybeDirection cursorName =
         , Just $ RawSql.toRawSql cursorName
         ]
 
+{- | 'MoveExpr' corresponds to the SQL MOVE statement, for positioning a previously created cursor,
+   /without/ retrieving any rows.
+
+See PostgreSQL [move
+documentation](https://www.postgresql.org/docs/current/sql-move.html) for more information.
+
+There is an low level escape hatch included here, by means of the instance of
+'RawSql.SqlExpression'. This is intended to be used when some functionality is required but not
+already included. The exension mechanism provided does require care in use as no guarantees are
+provided for correctness in usage.
+
+For example, if one wanted to use a cusor named FOO, and position on next row, that could
+be done as
+
+ > RawSql.unsafeSqlExpression "MOVE NEXT FOO"
+
+The above is available via built-ins, given you have previously created the cursor and named it foo
+as,
+
+> move (Just next) foo
+
+@since 0.10.0.0
+-}
 newtype MoveExpr
   = MoveExpr RawSql.RawSql
-  deriving (RawSql.SqlExpression)
+  deriving
+    ( -- | @since 0.10.0.0
+      RawSql.SqlExpression
+    )
 
+{- | Construct a 'MoveExpr', for a given cursor and optionally a direction to move.
+
+@since 0.10.0.0
+-}
 move :: Maybe CursorDirection -> CursorName -> MoveExpr
 move maybeDirection cursorName =
-  MoveExpr $
-    RawSql.intercalate RawSql.space $
-      catMaybes
-        [ Just $ RawSql.fromString "MOVE"
-        , fmap RawSql.toRawSql maybeDirection
-        , Just $ RawSql.toRawSql cursorName
-        ]
+  MoveExpr
+    . RawSql.intercalate RawSql.space
+    $ catMaybes
+      [ Just $ RawSql.fromString "MOVE"
+      , fmap RawSql.toRawSql maybeDirection
+      , Just $ RawSql.toRawSql cursorName
+      ]
 
+{- | 'CursorDirection' corresponds to the direction argument to the SQL FETCH and MOVE statements.
+
+See PostgreSQL [fetch documentation](https://www.postgresql.org/docs/current/sql-fetch.html) for
+more information.
+
+There is an low level escape hatch included here, by means of the instance of
+'RawSql.SqlExpression'. This is intended to be used when some functionality is required but not
+already included. The exension mechanism provided does require care in use as no guarantees are
+provided for correctness in usage.
+
+For example, if one wanted to specify a backwards direction for use in a 'FetchExpr' or 'MoveExpr',
+this could be done as
+
+> RawSql.unsafeSqlExpression "BACKWARD"
+
+The above is available as a built-in, 'backward'
+
+@since 0.10.0.0
+-}
 newtype CursorDirection
   = CursorDirection RawSql.RawSql
-  deriving (RawSql.SqlExpression)
+  deriving
+    ( -- | @since 0.10.0.0
+      RawSql.SqlExpression
+    )
 
+{- | Specify a direction of the next single row. Primarily for use with 'fetch' or 'move'.
+
+See PostgreSQL [fetch documentation](https://www.postgresql.org/docs/current/sql-fetch.html) for
+more information.
+
+@since 0.10.0.0
+-}
 next :: CursorDirection
 next =
   CursorDirection . RawSql.fromString $ "NEXT"
 
+{- | Specify a direction of the prior single row. Primarily for use with 'fetch' or 'move'.
+
+See PostgreSQL [fetch documentation](https://www.postgresql.org/docs/current/sql-fetch.html) for
+more information.
+
+@since 0.10.0.0
+-}
 prior :: CursorDirection
 prior =
   CursorDirection . RawSql.fromString $ "PRIOR"
 
+{- | Specify a direction of the first single row. Primarily for use with 'fetch' or 'move'.
+
+See PostgreSQL [fetch documentation](https://www.postgresql.org/docs/current/sql-fetch.html) for
+more information.
+
+@since 0.10.0.0
+-}
 first :: CursorDirection
 first =
   CursorDirection . RawSql.fromString $ "FIRST"
 
+{- | Specify a direction of the last single row. Primarily for use with 'fetch' or 'move'.
+
+See PostgreSQL [fetch documentation](https://www.postgresql.org/docs/current/sql-fetch.html) for
+more information.
+
+@since 0.10.0.0
+-}
 last :: CursorDirection
 last =
   CursorDirection . RawSql.fromString $ "LAST"
 
+{- | Specify a direction of the single row at an absolute position within the cursor. Primarily for
+   use with 'fetch' or 'move'.
+
+See PostgreSQL [fetch documentation](https://www.postgresql.org/docs/current/sql-fetch.html) for
+more information.
+
+@since 0.10.0.0
+-}
 absolute :: Int -> CursorDirection
 absolute countParam =
   -- postgresql won't let us pass the count as a parameter.
@@ -169,6 +430,14 @@ absolute countParam =
     RawSql.fromString "ABSOLUTE "
       <> RawSql.intDecLiteral countParam
 
+{- | Specify a direction of the single row relative to the cursor's current position. Primarily for
+   use with 'fetch' or 'move'.
+
+See PostgreSQL [fetch documentation](https://www.postgresql.org/docs/current/sql-fetch.html) for
+more information.
+
+@since 0.10.0.0
+-}
 relative :: Int -> CursorDirection
 relative countParam =
   CursorDirection $
@@ -180,6 +449,13 @@ relative countParam =
       --  LINE 1: FETCH RELATIVE $1 \"testcursor\"
       RawSql.intDecLiteral countParam
 
+{- | Specify a direction of the next n rows. Primarily for use with 'fetch' or 'move'.
+
+See PostgreSQL [fetch documentation](https://www.postgresql.org/docs/current/sql-fetch.html) for
+more information.
+
+@since 0.10.0.0
+-}
 rowCount :: Int -> CursorDirection
 rowCount countParam =
   -- postgresql won't let us pass the count as a parameter.
@@ -189,14 +465,35 @@ rowCount countParam =
   CursorDirection $
     RawSql.intDecLiteral countParam
 
+{- | Specify a direction of all the next rows. Primarily for use with 'fetch' or 'move'.
+
+See PostgreSQL [fetch documentation](https://www.postgresql.org/docs/current/sql-fetch.html) for
+more information.
+
+@since 0.10.0.0
+-}
 fetchAll :: CursorDirection
 fetchAll =
   CursorDirection . RawSql.fromString $ "ALL"
 
+{- | Specify a direction of the next single row. Primarily for use with 'fetch' or 'move'.
+
+See PostgreSQL [fetch documentation](https://www.postgresql.org/docs/current/sql-fetch.html) for
+more information.
+
+@since 0.10.0.0
+-}
 forward :: CursorDirection
 forward =
   CursorDirection . RawSql.fromString $ "FORWARD"
 
+{- | Specify a direction of the next n rows. Primarily for use with 'fetch' or 'move'.
+
+See PostgreSQL [fetch documentation](https://www.postgresql.org/docs/current/sql-fetch.html) for
+more information.
+
+@since 0.10.0.0
+-}
 forwardCount :: Int -> CursorDirection
 forwardCount countParam =
   -- postgresql won't let us pass the count as a parameter.
@@ -207,14 +504,35 @@ forwardCount countParam =
     RawSql.fromString "FORWARD "
       <> RawSql.intDecLiteral countParam
 
+{- | Specify a direction of all the next rows. Primarily for use with 'fetch' or 'move'.
+
+See PostgreSQL [fetch documentation](https://www.postgresql.org/docs/current/sql-fetch.html) for
+more information.
+
+@since 0.10.0.0
+-}
 forwardAll :: CursorDirection
 forwardAll =
   CursorDirection . RawSql.fromString $ "FORWARD ALL"
 
+{- | Specify a direction of the prior single row. Primarily for use with 'fetch' or 'move'.
+
+See PostgreSQL [fetch documentation](https://www.postgresql.org/docs/current/sql-fetch.html) for
+more information.
+
+@since 0.10.0.0
+-}
 backward :: CursorDirection
 backward =
   CursorDirection . RawSql.fromString $ "BACKWARD"
 
+{- | Specify a direction of the prior n rows. Primarily for use with 'fetch' or 'move'.
+
+See PostgreSQL [fetch documentation](https://www.postgresql.org/docs/current/sql-fetch.html) for
+more information.
+
+@since 0.10.0.0
+-}
 backwardCount :: Int -> CursorDirection
 backwardCount countParam =
   -- postgresql won't let us pass the count as a parameter.
@@ -225,6 +543,13 @@ backwardCount countParam =
     RawSql.fromString "BACKWARD "
       <> RawSql.intDecLiteral countParam
 
+{- | Specify a direction of all the prior rows. Primarily for use with 'fetch' or 'move'.
+
+See PostgreSQL [fetch documentation](https://www.postgresql.org/docs/current/sql-fetch.html) for
+more information.
+
+@since 0.10.0.0
+-}
 backwardAll :: CursorDirection
 backwardAll =
   CursorDirection . RawSql.fromString $ "BACKWARD ALL"

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Query.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Query.hs
@@ -72,7 +72,7 @@ deriveColumn =
 
 deriveColumnAs :: ValueExpression -> ColumnName -> DerivedColumn
 deriveColumnAs valueExpr asColumn =
-  DerivedColumn $
+  DerivedColumn
     ( RawSql.toRawSql valueExpr
         <> RawSql.fromString " AS "
         <> RawSql.toRawSql asColumn
@@ -97,13 +97,13 @@ tableExpr
   maybeGroupByClause
   maybeLimitExpr
   maybeOffsetExpr =
-    TableExpr $
-      RawSql.intercalate RawSql.space $
-        (RawSql.toRawSql tableName) :
-        catMaybes
-          [ RawSql.toRawSql <$> maybeWhereClause
-          , RawSql.toRawSql <$> maybeOrderByClause
-          , RawSql.toRawSql <$> maybeGroupByClause
-          , RawSql.toRawSql <$> maybeLimitExpr
-          , RawSql.toRawSql <$> maybeOffsetExpr
-          ]
+    TableExpr
+      . RawSql.intercalate RawSql.space
+      $ (RawSql.toRawSql tableName) :
+      catMaybes
+        [ RawSql.toRawSql <$> maybeWhereClause
+        , RawSql.toRawSql <$> maybeOrderByClause
+        , RawSql.toRawSql <$> maybeGroupByClause
+        , RawSql.toRawSql <$> maybeLimitExpr
+        , RawSql.toRawSql <$> maybeOffsetExpr
+        ]

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Time.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Time.hs
@@ -33,7 +33,7 @@ newtype IntervalArgument
 
 unsafeIntervalArg :: String -> IntervalArgument
 unsafeIntervalArg =
-  IntervalArgument . RawSql.unsafeFromRawSql . RawSql.fromString
+  IntervalArgument . RawSql.unsafeSqlExpression
 
 years :: IntervalArgument
 years = unsafeIntervalArg "years"

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Marshall/DefaultValue.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Marshall/DefaultValue.hs
@@ -118,7 +118,7 @@ booleanDefault bool =
         case bool of
           True -> "true"
           False -> "false"
-   in DefaultValue . RawSql.unsafeFromRawSql . RawSql.fromString $ pgString
+   in DefaultValue $ RawSql.unsafeSqlExpression pgString
 
 {- |
   Builds a default value from a 'T.Text', for use with unbounded, bounded
@@ -173,10 +173,7 @@ utcTimestampDefault utcTime =
 -}
 currentUTCTimestampDefault :: DefaultValue Time.UTCTime
 currentUTCTimestampDefault =
-  DefaultValue
-    . RawSql.unsafeFromRawSql
-    . RawSql.fromString
-    $ "now()"
+  DefaultValue $ RawSql.unsafeSqlExpression "now()"
 
 {- |
   Builds a default value from a 'Time.LocalTime' for use with local timestamp fields.
@@ -201,10 +198,7 @@ localTimestampDefault localTime =
 -}
 currentLocalTimestampDefault :: DefaultValue Time.LocalTime
 currentLocalTimestampDefault =
-  DefaultValue
-    . RawSql.unsafeFromRawSql
-    . RawSql.fromString
-    $ "('now'::text)::timestamp without time zone"
+  DefaultValue $ RawSql.unsafeSqlExpression "('now'::text)::timestamp without time zone"
 
 {- |
   Coerce's a 'DefaultValue' so that it can be used with field definitions of

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Marshall/SqlMarshaller.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Marshall/SqlMarshaller.hs
@@ -710,7 +710,7 @@ marshallField accessor fieldDef =
   atLeast21Field :: SyntheticField Bool
   atLeast21Field =
     SyntheticField
-      { syntheticFieldExpression = RawSql.unsafeFromRawSql $ RawSql.fromString "age >= 21"
+      { syntheticFieldExpression = RawSql.unsafeSqlExpression "age >= 21"
       , syntheticFieldAlias = Orville.stringToFieldName "over21"
       , syntheticFieldValueFromSqlValue = SqlValue.toBool
       }

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/PgCatalog/PgAttributeDefault.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/PgCatalog/PgAttributeDefault.hs
@@ -74,6 +74,6 @@ attributeDefaultAttributeNumberField =
 attributeDefaultExpressionField :: Orville.SyntheticField T.Text
 attributeDefaultExpressionField =
   Orville.syntheticField
-    (RawSql.unsafeFromRawSql $ RawSql.fromString "pg_get_expr(adbin,adrelid)")
+    (RawSql.unsafeSqlExpression "pg_get_expr(adbin,adrelid)")
     "expression"
     SqlValue.toText

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Raw/RawSql.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Raw/RawSql.hs
@@ -1,6 +1,6 @@
 {- |
 
-Copyright : Flipstone Technology Partners 2016-2021
+Copyright : Flipstone Technology Partners 2016-2023
 License   : MIT
 
 The funtions in this module are named with the intent that it is imported
@@ -39,6 +39,7 @@ module Orville.PostgreSQL.Raw.RawSql
 
     -- * Generic interface for generating sql
     SqlExpression (toRawSql, unsafeFromRawSql),
+    unsafeSqlExpression,
     toBytesAndParams,
     toExampleBytes,
     Quoting (Quoting, quoteStringLiteral, quoteIdentifier),
@@ -71,6 +72,8 @@ import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
   from smaller parts and then executing them. It also supports using placeholder
   values to pass parameters with a query without having to interpolate them
   as part of the actual sql state and being exposed to sql injection.
+
+@since 0.10.0.0
 -}
 data RawSql
   = SqlSection BSB.Builder
@@ -95,6 +98,14 @@ class SqlExpression a where
 instance SqlExpression RawSql where
   toRawSql = id
   unsafeFromRawSql = id
+
+{- | A conveinence function for creating an arbitrary 'SqlExpression' from a 'String'. Great care should be exercised in use of this function as it cannot provide any sort of correctness guarantee.
+
+@since 0.10.0.2
+-}
+unsafeSqlExpression :: SqlExpression a => String -> a
+unsafeSqlExpression =
+  unsafeFromRawSql . fromString
 
 {- |
   Provides procedures for quoting parts of a raw SQL query so that they can be

--- a/orville-postgresql-libpq/test/Test/Expr/Cursor.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/Cursor.hs
@@ -75,9 +75,9 @@ prop_cursorCloseAll =
           cursorName = Expr.fromIdentifier $ Expr.identifier "testcursor"
 
           declare =
-            RawSql.executeVoid connection $
-              Expr.declare cursorName Nothing (Just Expr.withHold) $
-                RawSql.unsafeFromRawSql $ RawSql.fromString "SELECT 1"
+            RawSql.executeVoid connection
+              . Expr.declare cursorName Nothing (Just Expr.withHold)
+              $ RawSql.unsafeSqlExpression "SELECT 1"
 
           close =
             RawSql.executeVoid connection $ Expr.close (Left Expr.allCursors)

--- a/orville-postgresql-libpq/test/Test/FieldDefinition.hs
+++ b/orville-postgresql-libpq/test/Test/FieldDefinition.hs
@@ -345,7 +345,7 @@ runDefaultValueFieldDefinitionTest pool testCase mkDefaultValue = do
       Expr.insertExpr
         testTable
         Nothing
-        (RawSql.unsafeFromRawSql (RawSql.fromString "VALUES(DEFAULT)"))
+        (RawSql.unsafeSqlExpression "VALUES(DEFAULT)")
         Nothing
 
     result <-
@@ -382,7 +382,7 @@ runDefaultValueInsertOnlyTest pool testCase defaultValue =
       Expr.insertExpr
         testTable
         Nothing
-        (RawSql.unsafeFromRawSql (RawSql.fromString "VALUES(DEFAULT)"))
+        (RawSql.unsafeSqlExpression "VALUES(DEFAULT)")
         Nothing
 
 testTable :: Expr.Qualified Expr.TableName


### PR DESCRIPTION
Notably, I've made sure the @since is included in everything that I've gone through thus far, so the docs will show when functionality, including typeclass instances were added. Thus far everything is since 0.10.0.0, as even if they existed prior, given the major rewrite that is 0.10.0.0 it seems certain some change was in effect. Additionally it is much easier, to state them uniformly this way.

This also adds a new helper `unsafeSqlExpression` that eases going from string literals to something implementing the SqlExpression class. Previous usages of unsafeFromRawSql combined with fromString are replaced with this helper to show it's usage.

Still cutting in rather arbitrary places to keep individual reviews smaller in size.