### PR TITLE
Use more general type for runEntityTraceT

### DIFF
--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/EntityTrace.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/EntityTrace.hs
@@ -648,9 +648,9 @@ runEntityTraceT ::
   MonadIO n =>
   O.ErrorDetailLevel ->
   O.Pool O.Connection ->
-  (O.OrvilleState -> m a -> n a) ->
+  (O.OrvilleState -> m a -> n b) ->
   EntityTraceT trace m a ->
-  n (a, [trace])
+  n (b, [trace])
 runEntityTraceT errorDetailLevel pool runM traceT = do
   ref <- liftIO $ EntityTraceState <$> newIORef emptyTraceData
   let mAction =


### PR DESCRIPTION
The callback passed to `runEntityTraceT` would previously (before this PR)
require the `a` in `m a` to be the same type, before and after converting.

Let's say you have a `StateT` in your monad stack, the result of `runStateT` is
a pair, which then, if you want to pass it back, would mean that the `a`
becomes `(a, newState)`, which wouldn't work if the types are required to be
the same.

This PR adds an additional type quantifier to the function, such that a
callback that modifies the `a` is now permitted. This is a genaralization of
the previous behavior.

Co-authored-by: @OwenGraves 
