### PR TITLE
Make it possible to use SelectList without SqlMarshaller

### DIFF
--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Select.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Select.hs
@@ -15,7 +15,6 @@ module Orville.PostgreSQL.Execution.Select
     selectToQueryExpr,
     selectTable,
     selectMarshalledColumns,
-    querySelectList,
     rawSelectQueryExpr,
   )
 where
@@ -109,45 +108,10 @@ selectMarshalledColumns ::
   Select readEntity
 selectMarshalledColumns marshaller qualifiedTableName selectOptions =
   rawSelectQueryExpr marshaller $
-    querySelectList
+    SelectOptions.selectOptionsQueryExpr
       (Expr.selectDerivedColumns (marshallerDerivedColumns . unannotatedSqlMarshaller $ marshaller))
       qualifiedTableName
       selectOptions
-
-{- |
-  Builds a 'QueryExpr' that will use the specified 'Expr.SelectList' when building
-  the @SELECT@ statement to execute. It it up to the caller to make sure that
-  the 'Expr.SelectList' expression makes sens for the table being queried, and
-  that the names of the columns in the result set match those expected by the
-  given 'SqlMarshaller', which will be used to decode it.
-
-  This function is useful for building more advanced queries that need to
-  select things other than simple columns from the table, such as using
-  aggregate functions. The 'Expr.SelectList' can be built however the caller
-  desires. If Orville does not support building the 'Expr.SelectList' you need
-  using any of the expression building functions, you can resort to
-  @RawSql.fromRawSql@ as an escape hatch to build the 'Expr.SelectList' here.
-
-@since 0.10.0.0
--}
-querySelectList ::
-  Expr.SelectList ->
-  Expr.Qualified Expr.TableName ->
-  SelectOptions.SelectOptions ->
-  Expr.QueryExpr
-querySelectList selectList qualifiedTableName selectOptions =
-  Expr.queryExpr
-    (SelectOptions.selectDistinct selectOptions)
-    selectList
-    ( Just $
-        Expr.tableExpr
-          qualifiedTableName
-          (SelectOptions.selectWhereClause selectOptions)
-          (SelectOptions.selectOrderByClause selectOptions)
-          (SelectOptions.selectGroupByClause selectOptions)
-          (SelectOptions.selectLimitExpr selectOptions)
-          (SelectOptions.selectOffsetExpr selectOptions)
-    )
 
 {- |
   Builds a 'Select' that will execute the specified query and use the given


### PR DESCRIPTION
If a user wants to use SelectList without a marshaller, there is currently no
way to do that without copying the definition of `selectSelectList`.

This PR makes it possible to do that by, by removing the marshalling related
parts, which can simply be called independently.

I thought I might move it to Expr, since it doesn't actually execute anything,
but I left the function in the current module, since it depends on
SelectOptions, which is in Execution, and I thought it would be bad to have
Expr depend on Execution.
