### PR TITLE
Introduce TableReferencesList

### DIFF
--- a/orville-postgresql-libpq/orville-postgresql-libpq.cabal
+++ b/orville-postgresql-libpq/orville-postgresql-libpq.cabal
@@ -69,6 +69,7 @@ library
       Orville.PostgreSQL.Expr.SequenceDefinition
       Orville.PostgreSQL.Expr.TableConstraint
       Orville.PostgreSQL.Expr.TableDefinition
+      Orville.PostgreSQL.Expr.TableReferenceList
       Orville.PostgreSQL.Expr.Time
       Orville.PostgreSQL.Expr.Transaction
       Orville.PostgreSQL.Expr.Update

--- a/orville-postgresql-libpq/package.yaml
+++ b/orville-postgresql-libpq/package.yaml
@@ -61,6 +61,7 @@ library:
     - Orville.PostgreSQL.Expr.SequenceDefinition
     - Orville.PostgreSQL.Expr.TableConstraint
     - Orville.PostgreSQL.Expr.TableDefinition
+    - Orville.PostgreSQL.Expr.TableReferenceList
     - Orville.PostgreSQL.Expr.Time
     - Orville.PostgreSQL.Expr.Transaction
     - Orville.PostgreSQL.Expr.Update

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Select.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Select.hs
@@ -110,7 +110,7 @@ selectMarshalledColumns marshaller qualifiedTableName selectOptions =
   rawSelectQueryExpr marshaller $
     SelectOptions.selectOptionsQueryExpr
       (Expr.selectDerivedColumns (marshallerDerivedColumns . unannotatedSqlMarshaller $ marshaller))
-      qualifiedTableName
+      (Expr.referencesTable qualifiedTableName)
       selectOptions
 
 {- |

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/SelectOptions.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/SelectOptions.hs
@@ -244,16 +244,16 @@ groupBy groupByExpr =
 -}
 selectOptionsQueryExpr ::
   Expr.SelectList ->
-  Expr.Qualified Expr.TableName ->
+  Expr.TableReferenceList ->
   SelectOptions ->
   Expr.QueryExpr
-selectOptionsQueryExpr selectList qualifiedTableName selectOptions =
+selectOptionsQueryExpr selectList tableReferenceList selectOptions =
   Expr.queryExpr
     (selectDistinct selectOptions)
     selectList
     ( Just $
         Expr.tableExpr
-          qualifiedTableName
+          tableReferenceList
           (selectWhereClause selectOptions)
           (selectOrderByClause selectOptions)
           (selectGroupByClause selectOptions)

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr.hs
@@ -29,6 +29,7 @@ module Orville.PostgreSQL.Expr
     module Orville.PostgreSQL.Expr.SequenceDefinition,
     module Orville.PostgreSQL.Expr.TableConstraint,
     module Orville.PostgreSQL.Expr.TableDefinition,
+    module Orville.PostgreSQL.Expr.TableReferenceList,
     module Orville.PostgreSQL.Expr.Time,
     module Orville.PostgreSQL.Expr.Transaction,
     module Orville.PostgreSQL.Expr.Update,
@@ -61,6 +62,7 @@ import Orville.PostgreSQL.Expr.Select
 import Orville.PostgreSQL.Expr.SequenceDefinition
 import Orville.PostgreSQL.Expr.TableConstraint
 import Orville.PostgreSQL.Expr.TableDefinition
+import Orville.PostgreSQL.Expr.TableReferenceList
 import Orville.PostgreSQL.Expr.Time
 import Orville.PostgreSQL.Expr.Transaction
 import Orville.PostgreSQL.Expr.Update

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Query.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Query.hs
@@ -23,10 +23,11 @@ import Data.Maybe (catMaybes, fromMaybe)
 
 import Orville.PostgreSQL.Expr.GroupBy (GroupByClause)
 import Orville.PostgreSQL.Expr.LimitExpr (LimitExpr)
-import Orville.PostgreSQL.Expr.Name (ColumnName, Qualified, TableName)
+import Orville.PostgreSQL.Expr.Name (ColumnName)
 import Orville.PostgreSQL.Expr.OffsetExpr (OffsetExpr)
 import Orville.PostgreSQL.Expr.OrderBy (OrderByClause)
 import Orville.PostgreSQL.Expr.Select (SelectClause)
+import Orville.PostgreSQL.Expr.TableReferenceList (TableReferenceList)
 import Orville.PostgreSQL.Expr.ValueExpression (ValueExpression, columnReference)
 import Orville.PostgreSQL.Expr.WhereClause (WhereClause)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
@@ -83,7 +84,7 @@ newtype TableExpr
   deriving (RawSql.SqlExpression)
 
 tableExpr ::
-  Qualified TableName ->
+  TableReferenceList ->
   Maybe WhereClause ->
   Maybe OrderByClause ->
   Maybe GroupByClause ->
@@ -91,7 +92,7 @@ tableExpr ::
   Maybe OffsetExpr ->
   TableExpr
 tableExpr
-  tableName
+  tableReferenceList
   maybeWhereClause
   maybeOrderByClause
   maybeGroupByClause
@@ -99,7 +100,7 @@ tableExpr
   maybeOffsetExpr =
     TableExpr
       . RawSql.intercalate RawSql.space
-      $ (RawSql.toRawSql tableName) :
+      $ RawSql.toRawSql tableReferenceList :
       catMaybes
         [ RawSql.toRawSql <$> maybeWhereClause
         , RawSql.toRawSql <$> maybeOrderByClause

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/TableReferenceList.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/TableReferenceList.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Orville.PostgreSQL.Expr.TableReferenceList
+  ( TableReferenceList,
+    referencesTable,
+  )
+where
+
+import Orville.PostgreSQL.Expr.Name (Qualified, TableName)
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+
+newtype TableReferenceList
+  = TableReferenceList RawSql.RawSql
+  deriving (RawSql.SqlExpression)
+
+referencesTable :: Qualified TableName -> TableReferenceList
+referencesTable qualifiedTableName =
+  TableReferenceList $
+    RawSql.toRawSql qualifiedTableName

--- a/orville-postgresql-libpq/test/Test/Expr/Count.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/Count.hs
@@ -59,7 +59,7 @@ prop_countColumn =
                     (Expr.columnName "count")
                 ]
             )
-            (Just (Expr.tableExpr (Orville.tableName Foo.table) Nothing Nothing Nothing Nothing Nothing))
+            (Just (Expr.tableExpr (Expr.referencesTable $ Orville.tableName Foo.table) Nothing Nothing Nothing Nothing Nothing))
 
         marshaller =
           Orville.annotateSqlMarshallerEmptyAnnotation $

--- a/orville-postgresql-libpq/test/Test/Expr/GroupBy.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/GroupBy.hs
@@ -93,7 +93,7 @@ groupByTest testName test =
           Expr.queryExpr
             (Expr.selectClause $ Expr.selectExpr Nothing)
             (Expr.selectColumns [fooColumn, barColumn])
-            (Just $ Expr.tableExpr testTable Nothing Nothing (groupByClause test) Nothing Nothing)
+            (Just $ Expr.tableExpr (Expr.referencesTable testTable) Nothing Nothing (groupByClause test) Nothing Nothing)
 
       ExecResult.readRows result
 

--- a/orville-postgresql-libpq/test/Test/Expr/OrderBy.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/OrderBy.hs
@@ -131,7 +131,7 @@ orderByTest testName test =
               Expr.queryExpr
                 (Expr.selectClause $ Expr.selectExpr Nothing)
                 (Expr.selectColumns [fooColumn, barColumn])
-                (Just $ Expr.tableExpr fooBarTable Nothing (orderByClause test) Nothing Nothing Nothing)
+                (Just $ Expr.tableExpr (Expr.referencesTable fooBarTable) Nothing (orderByClause test) Nothing Nothing Nothing)
 
           ExecResult.readRows result
 

--- a/orville-postgresql-libpq/test/Test/Expr/TestSchema.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/TestSchema.hs
@@ -73,7 +73,7 @@ findAllFooBars =
   Expr.queryExpr
     (Expr.selectClause $ Expr.selectExpr Nothing)
     (Expr.selectColumns [fooColumn, barColumn])
-    (Just $ Expr.tableExpr fooBarTable Nothing (Just orderByFoo) Nothing Nothing Nothing)
+    (Just $ Expr.tableExpr (Expr.referencesTable fooBarTable) Nothing (Just orderByFoo) Nothing Nothing Nothing)
 
 encodeFooBar :: FooBar -> [(Maybe B8.ByteString, SqlValue.SqlValue)]
 encodeFooBar fooBar =

--- a/orville-postgresql-libpq/test/Test/Expr/Where.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/Where.hs
@@ -211,7 +211,7 @@ whereConditionTest testName test =
               Expr.queryExpr
                 (Expr.selectClause $ Expr.selectExpr Nothing)
                 (Expr.selectColumns [fooColumn, barColumn])
-                (Just $ Expr.tableExpr fooBarTable (whereClause test) Nothing Nothing Nothing Nothing)
+                (Just $ Expr.tableExpr (Expr.referencesTable fooBarTable) (whereClause test) Nothing Nothing Nothing Nothing)
 
           ExecResult.readRows result
 

--- a/orville-postgresql-libpq/test/Test/FieldDefinition.hs
+++ b/orville-postgresql-libpq/test/Test/FieldDefinition.hs
@@ -246,7 +246,7 @@ runRoundTripTest pool testCase = do
         Expr.queryExpr
           (Expr.selectClause $ Expr.selectExpr Nothing)
           (Expr.selectColumns [Marshall.fieldColumnName fieldDef])
-          (Just $ Expr.tableExpr testTable Nothing Nothing Nothing Nothing Nothing)
+          (Just $ Expr.tableExpr (Expr.referencesTable testTable) Nothing Nothing Nothing Nothing Nothing)
 
     Result.readRows result
 
@@ -288,7 +288,7 @@ runNullableRoundTripTest pool testCase = do
         Expr.queryExpr
           (Expr.selectClause $ Expr.selectExpr Nothing)
           (Expr.selectColumns [Marshall.fieldColumnName fieldDef])
-          (Just $ Expr.tableExpr testTable Nothing Nothing Nothing Nothing Nothing)
+          (Just $ Expr.tableExpr (Expr.referencesTable testTable) Nothing Nothing Nothing Nothing Nothing)
 
     Result.readRows result
 
@@ -353,7 +353,7 @@ runDefaultValueFieldDefinitionTest pool testCase mkDefaultValue = do
         Expr.queryExpr
           (Expr.selectClause $ Expr.selectExpr Nothing)
           (Expr.selectColumns [Marshall.fieldColumnName fieldDef])
-          (Just $ Expr.tableExpr testTable Nothing Nothing Nothing Nothing Nothing)
+          (Just $ Expr.tableExpr (Expr.referencesTable testTable) Nothing Nothing Nothing Nothing Nothing)
 
     Result.readRows result
 

--- a/orville-postgresql-libpq/test/Test/SqlType.hs
+++ b/orville-postgresql-libpq/test/Test/SqlType.hs
@@ -528,7 +528,7 @@ runDecodingTest pool test =
           Expr.queryExpr
             (Expr.selectClause $ Expr.selectExpr Nothing)
             Expr.selectStar
-            (Just $ Expr.tableExpr tableName Nothing Nothing Nothing Nothing Nothing)
+            (Just $ Expr.tableExpr (Expr.referencesTable tableName) Nothing Nothing Nothing Nothing Nothing)
 
       ExecutionResult.readRows result
 


### PR DESCRIPTION
Useful for building queries with e.g. JOINs.

Previously, you'd have to put the JOIN clause in a TableName, which isn't right.

Users can migrate to this version by inserting a call to the `referencesTable` function.
