### PR TITLE
Add UnliftIO helpers, export Cursor type

### DIFF
--- a/orville-postgresql-libpq/orville-postgresql-libpq.cabal
+++ b/orville-postgresql-libpq/orville-postgresql-libpq.cabal
@@ -144,10 +144,12 @@ library
     , postgresql-libpq >=0.9.4.2 && <0.10
     , random >=1.0 && <2
     , resource-pool
+    , resourcet >=1.2 && <1.4
     , safe-exceptions >=0.1.7
     , text
     , time >=1.9.1
     , transformers >=0.5 && <0.7
+    , unliftio-core >=0.1 && <0.3
     , uuid
   if flag(ci)
     ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-patterns -Wincomplete-record-updates -Wmissing-local-signatures -Wmissing-export-lists -Wmissing-import-lists -Wnoncanonical-monad-instances -Wredundant-constraints -Wpartial-fields -Wmissed-specialisations -Wno-implicit-prelude -Wno-safe -Wno-unsafe

--- a/orville-postgresql-libpq/package.yaml
+++ b/orville-postgresql-libpq/package.yaml
@@ -135,11 +135,13 @@ library:
     - network-uri >= 2.6 && < 2.7
     - random >= 1.0 && <2
     - resource-pool
+    - resourcet >= 1.2 && < 1.4
     - safe-exceptions >=0.1.7
     - text
     - time >=1.9.1
     - transformers >= 0.5 && < 0.7
     - uuid
+    - unliftio-core >= 0.1 && < 0.3
 
 tests:
   spec:

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Cursor.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Cursor.hs
@@ -201,6 +201,19 @@ newCursorName =
         nowAsInteger
         (randomWord :: Word.Word32)
 
+{- |
+  Acquire a @CURSOR@ context with an associated closer.
+
+  The cursor is wrapped in an 'Acquire', which allows for it to be closed
+  automatically in if the 'm' is e.g. also a
+  'Control.Monad.Trans.Resource.MonadResource'.
+
+  See @https://www.postgresql.org/docs/current/sql-declare.html@ for details
+  about the 'Expr.ScrollExpr' and 'Expr.HoldExpr' parameters and how cursor
+  behave in general.
+
+  @since 0.10.0.0
+-}
 acquireCursor ::
   Monad.MonadOrville m =>
   Maybe Expr.ScrollExpr ->
@@ -213,6 +226,22 @@ acquireCursor scrollExpr holdExpr select runInIO =
     (runInIO $ declareCursor scrollExpr holdExpr select)
     (runInIO . closeCursor)
 
+{- |
+  Acquire a @CURSOR@ in a 'MonadUnliftIO' context, with an associated closer.
+
+  The cursor is wrapped in an 'Acquire', which allows for it to be closed
+  automatically in if the 'm' is e.g. also a
+  'Control.Monad.Trans.Resource.MonadResource'.
+
+  This could be used with 'Conduit.allocateAcquire` after lifting to a
+  'Data.Conduit.ConduitT' context.
+
+  See @https://www.postgresql.org/docs/current/sql-declare.html@ for details
+  about the 'Expr.ScrollExpr' and 'Expr.HoldExpr' parameters and how cursor
+  behave in general.
+
+  @since 0.10.0.0
+-}
 acquireCursorUnlift ::
   (MonadUnliftIO m, Monad.MonadOrville m) =>
   Maybe Expr.ScrollExpr ->


### PR DESCRIPTION
These helpers make it easier to use Cursors with UnliftIO, since the cursor can automatically get cleaned up in the case of exceptions.