### PR TITLE
Export Cursor type

### DIFF
--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Cursor.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Cursor.hs
@@ -8,7 +8,8 @@ Stability : Stable
 @since 0.10.0.0
 -}
 module Orville.PostgreSQL.Execution.Cursor
-  ( withCursor,
+  ( Cursor,
+    withCursor,
     declareCursor,
     closeCursor,
     newCursorName,


### PR DESCRIPTION
As requested in #290, this just exports the Cursor type.