### PR TITLE
Fix incorrect ordering of order by and group by

### DIFF
--- a/orville-postgresql-libpq/orville-postgresql-libpq.cabal
+++ b/orville-postgresql-libpq/orville-postgresql-libpq.cabal
@@ -172,6 +172,7 @@ test-suite spec
       Test.Expr.Count
       Test.Expr.Cursor
       Test.Expr.GroupBy
+      Test.Expr.GroupByOrderBy
       Test.Expr.InsertUpdateDelete
       Test.Expr.Math
       Test.Expr.OrderBy

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/SelectOptions.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/SelectOptions.hs
@@ -255,8 +255,8 @@ selectOptionsQueryExpr selectList tableReferenceList selectOptions =
         Expr.tableExpr
           tableReferenceList
           (selectWhereClause selectOptions)
-          (selectOrderByClause selectOptions)
           (selectGroupByClause selectOptions)
+          (selectOrderByClause selectOptions)
           (selectLimitExpr selectOptions)
           (selectOffsetExpr selectOptions)
     )

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Query.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Query.hs
@@ -86,16 +86,16 @@ newtype TableExpr
 tableExpr ::
   TableReferenceList ->
   Maybe WhereClause ->
-  Maybe OrderByClause ->
   Maybe GroupByClause ->
+  Maybe OrderByClause ->
   Maybe LimitExpr ->
   Maybe OffsetExpr ->
   TableExpr
 tableExpr
   tableReferenceList
   maybeWhereClause
-  maybeOrderByClause
   maybeGroupByClause
+  maybeOrderByClause
   maybeLimitExpr
   maybeOffsetExpr =
     TableExpr

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Query.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Query.hs
@@ -103,8 +103,8 @@ tableExpr
       $ RawSql.toRawSql tableReferenceList :
       catMaybes
         [ RawSql.toRawSql <$> maybeWhereClause
-        , RawSql.toRawSql <$> maybeOrderByClause
         , RawSql.toRawSql <$> maybeGroupByClause
+        , RawSql.toRawSql <$> maybeOrderByClause
         , RawSql.toRawSql <$> maybeLimitExpr
         , RawSql.toRawSql <$> maybeOffsetExpr
         ]

--- a/orville-postgresql-libpq/test/Main.hs
+++ b/orville-postgresql-libpq/test/Main.hs
@@ -20,6 +20,7 @@ import qualified Test.EntityTrace as EntityTrace
 import qualified Test.Execution as Execution
 import qualified Test.Expr.Count as ExprCount
 import qualified Test.Expr.Cursor as ExprCursor
+import qualified Test.Expr.GroupByOrderBy as ExprGroupByOrderBy
 import qualified Test.Expr.InsertUpdateDelete as ExprInsertUpdateDelete
 import qualified Test.Expr.Math as ExprMath
 import qualified Test.Expr.OrderBy as ExprOrderBy
@@ -58,6 +59,7 @@ main = do
       , ExprInsertUpdateDelete.insertUpdateDeleteTests pool
       , ExprWhere.whereTests pool
       , ExprOrderBy.orderByTests pool
+      , ExprGroupByOrderBy.groupByOrderByTests pool
       , ExprTableDefinition.tableDefinitionTests pool
       , ExprSequenceDefinition.sequenceDefinitionTests pool
       , ExprCursor.cursorTests pool

--- a/orville-postgresql-libpq/test/Main.hs
+++ b/orville-postgresql-libpq/test/Main.hs
@@ -20,6 +20,7 @@ import qualified Test.EntityTrace as EntityTrace
 import qualified Test.Execution as Execution
 import qualified Test.Expr.Count as ExprCount
 import qualified Test.Expr.Cursor as ExprCursor
+import qualified Test.Expr.GroupBy as ExprGroupBy
 import qualified Test.Expr.GroupByOrderBy as ExprGroupByOrderBy
 import qualified Test.Expr.InsertUpdateDelete as ExprInsertUpdateDelete
 import qualified Test.Expr.Math as ExprMath
@@ -59,6 +60,7 @@ main = do
       , ExprInsertUpdateDelete.insertUpdateDeleteTests pool
       , ExprWhere.whereTests pool
       , ExprOrderBy.orderByTests pool
+      , ExprGroupBy.groupByTests pool
       , ExprGroupByOrderBy.groupByOrderByTests pool
       , ExprTableDefinition.tableDefinitionTests pool
       , ExprSequenceDefinition.sequenceDefinitionTests pool

--- a/orville-postgresql-libpq/test/Test/Expr/GroupBy.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/GroupBy.hs
@@ -93,7 +93,7 @@ groupByTest testName test =
           Expr.queryExpr
             (Expr.selectClause $ Expr.selectExpr Nothing)
             (Expr.selectColumns [fooColumn, barColumn])
-            (Just $ Expr.tableExpr (Expr.referencesTable testTable) Nothing Nothing (groupByClause test) Nothing Nothing)
+            (Just $ Expr.tableExpr (Expr.referencesTable testTable) Nothing (groupByClause test) Nothing Nothing Nothing)
 
       ExecResult.readRows result
 

--- a/orville-postgresql-libpq/test/Test/Expr/GroupBy.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/GroupBy.hs
@@ -37,7 +37,7 @@ prop_groupByColumnsExpr =
   groupByTest "groupByColumnsExpr groups by columns" $
     GroupByTest
       { groupByValuesToInsert = [FooBar 1 "dog", FooBar 2 "dingo", FooBar 3 "dog"]
-      , groupByExpectedQueryResults = [FooBar 2 "dingo", FooBar 3 "dog", FooBar 1 "dog"]
+      , groupByExpectedQueryResults = [FooBar 3 "dog", FooBar 2 "dingo", FooBar 1 "dog"]
       , groupByClause =
           Just . Expr.groupByClause $
             Expr.groupByColumnsExpr $
@@ -49,7 +49,7 @@ prop_appendGroupByExpr =
   groupByTest "appendGroupByExpr causes grouping on both clauses" $
     GroupByTest
       { groupByValuesToInsert = [FooBar 1 "dog", FooBar 2 "dingo", FooBar 1 "dog", FooBar 3 "dingo", FooBar 1 "dog", FooBar 2 "dingo"]
-      , groupByExpectedQueryResults = [FooBar 1 "dog", FooBar 3 "dingo", FooBar 2 "dingo"]
+      , groupByExpectedQueryResults = [FooBar 2 "dingo", FooBar 1 "dog", FooBar 3 "dingo"]
       , groupByClause =
           Just . Expr.groupByClause $
             Expr.appendGroupByExpr

--- a/orville-postgresql-libpq/test/Test/Expr/GroupByOrderBy.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/GroupByOrderBy.hs
@@ -1,0 +1,107 @@
+module Test.Expr.GroupByOrderBy
+  ( groupByOrderByTests,
+  )
+where
+
+import qualified Control.Monad.IO.Class as MIO
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.Int as Int
+import qualified Data.Pool as Pool
+import qualified Data.Text as T
+
+import qualified Orville.PostgreSQL as Orville
+import qualified Orville.PostgreSQL.Execution.ExecutionResult as ExecResult
+import qualified Orville.PostgreSQL.Expr as Expr
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
+
+import Test.Expr.TestSchema (assertEqualSqlRows)
+import qualified Test.Property as Property
+
+data FooBar = FooBar
+  { foo :: Int.Int32
+  , bar :: String
+  }
+
+groupByOrderByTests :: Orville.Pool Orville.Connection -> Property.Group
+groupByOrderByTests pool =
+  Property.group
+    "Expr - GroupBy and OrderBy"
+    [ prop_groupByOrderByExpr pool
+    ]
+
+prop_groupByOrderByExpr :: Property.NamedDBProperty
+prop_groupByOrderByExpr =
+  groupByOrderByTest "GroupBy and OrderBy clauses can be used together" $
+    GroupByOrderByTest
+      { valuesToInsert = [FooBar 1 "shiba", FooBar 2 "dingo", FooBar 1 "dog", FooBar 2 "dingo", FooBar 1 "shiba"]
+      , expectedQueryResults = [FooBar 2 "dingo", FooBar 1 "dog", FooBar 1 "shiba"]
+      , groupByClause =
+          Just . Expr.groupByClause $
+            Expr.appendGroupByExpr
+              (Expr.groupByExpr $ RawSql.toRawSql barColumn)
+              (Expr.groupByExpr $ RawSql.toRawSql fooColumn)
+      , orderByClause =
+          Just . Expr.orderByClause $
+            Expr.orderByExpr (RawSql.toRawSql barColumn) Expr.ascendingOrder
+      }
+
+data GroupByOrderByTest = GroupByOrderByTest
+  { valuesToInsert :: [FooBar]
+  , groupByClause :: Maybe Expr.GroupByClause
+  , orderByClause :: Maybe Expr.OrderByClause
+  , expectedQueryResults :: [FooBar]
+  }
+
+mkGroupByOrderByTestInsertSource :: GroupByOrderByTest -> Expr.InsertSource
+mkGroupByOrderByTestInsertSource test =
+  let mkRow foobar =
+        [ SqlValue.fromInt32 (foo foobar)
+        , SqlValue.fromText (T.pack $ bar foobar)
+        ]
+   in Expr.insertSqlValues (map mkRow $ valuesToInsert test)
+
+mkGroupByOrderByTestExpectedRows :: GroupByOrderByTest -> [[(Maybe B8.ByteString, SqlValue.SqlValue)]]
+mkGroupByOrderByTestExpectedRows test =
+  let mkRow foobar =
+        [ (Just (B8.pack "foo"), SqlValue.fromInt32 (foo foobar))
+        , (Just (B8.pack "bar"), SqlValue.fromText (T.pack $ bar foobar))
+        ]
+   in fmap mkRow (expectedQueryResults test)
+
+groupByOrderByTest :: String -> GroupByOrderByTest -> Property.NamedDBProperty
+groupByOrderByTest testName test =
+  Property.singletonNamedDBProperty testName $ \pool -> do
+    rows <- MIO.liftIO . Pool.withResource pool $ \connection -> do
+      dropAndRecreateTestTable connection
+
+      RawSql.executeVoid connection $
+        Expr.insertExpr testTable Nothing (mkGroupByOrderByTestInsertSource test) Nothing
+
+      result <-
+        RawSql.execute connection $
+          Expr.queryExpr
+            (Expr.selectClause $ Expr.selectExpr Nothing)
+            (Expr.selectColumns [fooColumn, barColumn])
+            (Just $ Expr.tableExpr (Expr.referencesTable testTable) Nothing (groupByClause test) (orderByClause test) Nothing Nothing)
+
+      ExecResult.readRows result
+
+    rows `assertEqualSqlRows` mkGroupByOrderByTestExpectedRows test
+
+testTable :: Expr.Qualified Expr.TableName
+testTable =
+  Expr.qualified Nothing (Expr.tableName "expr_test")
+
+fooColumn :: Expr.ColumnName
+fooColumn =
+  Expr.columnName "foo"
+
+barColumn :: Expr.ColumnName
+barColumn =
+  Expr.columnName "bar"
+
+dropAndRecreateTestTable :: Orville.Connection -> IO ()
+dropAndRecreateTestTable connection = do
+  RawSql.executeVoid connection (RawSql.fromString "DROP TABLE IF EXISTS " <> RawSql.toRawSql testTable)
+  RawSql.executeVoid connection (RawSql.fromString "CREATE TABLE " <> RawSql.toRawSql testTable <> RawSql.fromString "(foo INTEGER, bar TEXT)")

--- a/orville-postgresql-libpq/test/Test/Expr/OrderBy.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/OrderBy.hs
@@ -131,7 +131,7 @@ orderByTest testName test =
               Expr.queryExpr
                 (Expr.selectClause $ Expr.selectExpr Nothing)
                 (Expr.selectColumns [fooColumn, barColumn])
-                (Just $ Expr.tableExpr (Expr.referencesTable fooBarTable) Nothing (orderByClause test) Nothing Nothing Nothing)
+                (Just $ Expr.tableExpr (Expr.referencesTable fooBarTable) Nothing Nothing (orderByClause test) Nothing Nothing)
 
           ExecResult.readRows result
 

--- a/orville-postgresql-libpq/test/Test/Expr/TestSchema.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/TestSchema.hs
@@ -73,7 +73,7 @@ findAllFooBars =
   Expr.queryExpr
     (Expr.selectClause $ Expr.selectExpr Nothing)
     (Expr.selectColumns [fooColumn, barColumn])
-    (Just $ Expr.tableExpr (Expr.referencesTable fooBarTable) Nothing (Just orderByFoo) Nothing Nothing Nothing)
+    (Just $ Expr.tableExpr (Expr.referencesTable fooBarTable) Nothing Nothing (Just orderByFoo) Nothing Nothing)
 
 encodeFooBar :: FooBar -> [(Maybe B8.ByteString, SqlValue.SqlValue)]
 encodeFooBar fooBar =


### PR DESCRIPTION
This fixes a malformed syntax error which occurs when you try to write a query which uses both a `GROUP BY` and `ORDER BY` clause. I've added tests verifying that the clauses can be used together.

I also noticed the group by tests were not added to the test suite, but they didn't work because the order of the expected result was incorrect. I fixed this by correcting the order, but since the order in SQL is technically undefined when a sort has not been specified, I don't think this is the best fix. I attempted changing the tests to use a `Set` instead, but that necessitated a change to `assertEqualSqlRows` too, so I decided not to do that to keep the PR limited in size.