### PR TITLE
Don't clear transaction stack when clearing traces

### DIFF
--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/EntityTrace.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/EntityTrace.hs
@@ -650,7 +650,7 @@ clearTracesInState askTraceState = do
   liftIO
     . atomicModifyIORef'_ (_entityTraceStateRef traceState)
     $ \recordedTraces ->
-        RecordedTraces mempty
+      RecordedTraces mempty
         . fmap clearUncommittedTraces
         $ currentTransactionStack recordedTraces
 

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/EntityTrace.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/EntityTrace.hs
@@ -636,7 +636,7 @@ clearTracesInState ::
   m ()
 clearTracesInState askTraceState = do
   traceState <- askTraceState
-  liftIO $ atomicModifyIORef'_ (_entityTraceStateRef traceState) (const emptyTraceData)
+  liftIO $ atomicModifyIORef'_ (_entityTraceStateRef traceState) (\x -> x {committedTracesDList = mempty})
 
 {- |
   'runEntityTraceT' runs an Orville action that has tracing behavior and


### PR DESCRIPTION
If we clear the tx stack, an eventual transaction callback like e.g. `commitTransaction` (also in `EntityTrace`) will throw when it finds that there is no stack.
