### PR TITLE
Add EntityOperations.findEntities

### DIFF
--- a/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
@@ -20,6 +20,7 @@ module Orville.PostgreSQL
     EntityOperations.findEntitiesBy,
     EntityOperations.findFirstEntityBy,
     EntityOperations.findEntity,
+    EntityOperations.findEntities,
 
     -- * A simple starter monad for running Orville operations
     Orville.Orville,

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/EntityOperations.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/EntityOperations.hs
@@ -21,6 +21,7 @@ module Orville.PostgreSQL.Execution.EntityOperations
     findEntitiesBy,
     findFirstEntityBy,
     findEntity,
+    findEntities,
   )
 where
 
@@ -305,6 +306,23 @@ findEntity entityTable key =
           (Schema.tablePrimaryKey entityTable)
           key
    in findFirstEntityBy entityTable (SelectOptions.where_ primaryKeyCondition)
+
+{- |
+  Finds multiple entities by the table's primary key.
+
+@since 0.10.0.0
+-}
+findEntities ::
+  Monad.MonadOrville m =>
+  Schema.TableDefinition (Schema.HasKey key) writeEntity readEntity ->
+  NonEmpty key ->
+  m [readEntity]
+findEntities entityTable keys =
+  let primaryKeyCondition =
+        Schema.primaryKeyIn
+          (Schema.tablePrimaryKey entityTable)
+          keys
+   in findEntitiesBy entityTable (SelectOptions.where_ primaryKeyCondition)
 
 {- |
   Thrown by 'updateFields' and 'updateFieldsAndReturnEntities' if the

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Schema/PrimaryKey.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Schema/PrimaryKey.hs
@@ -169,10 +169,9 @@ primaryKeyEquals keyDef key =
   primary keys.
 -}
 primaryKeyIn :: PrimaryKey key -> NonEmpty key -> Expr.BooleanExpr
-primaryKeyIn keyDef keys =
-  ExtraNonEmpty.foldl1'
-    Expr.orExpr
-    (primaryKeyEquals keyDef <$> keys)
+primaryKeyIn keyDef =
+  ExtraNonEmpty.foldl1' Expr.orExpr
+    . fmap (primaryKeyEquals keyDef)
 
 {- |
   INTERNAL: builds the where condition for a single part of the key

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Schema/PrimaryKey.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Schema/PrimaryKey.hs
@@ -13,6 +13,7 @@ module Orville.PostgreSQL.Schema.PrimaryKey
     mapPrimaryKeyParts,
     mkPrimaryKeyExpr,
     primaryKeyEquals,
+    primaryKeyIn,
   )
 where
 
@@ -160,6 +161,18 @@ primaryKeyEquals keyDef key =
   ExtraNonEmpty.foldl1'
     Expr.andExpr
     (mapPrimaryKeyParts (partEquals key) keyDef)
+
+{- |
+  'primaryKeyIn' builds a 'Expr.BooleanExpr' that will match rows where
+  the primary key is contained the given list. For single-field primary keys
+  this is equivalent to 'fieldIn', but 'primaryKeyIn' also handles composite
+  primary keys.
+-}
+primaryKeyIn :: PrimaryKey key -> NonEmpty key -> Expr.BooleanExpr
+primaryKeyIn keyDef keys =
+  ExtraNonEmpty.foldl1'
+    Expr.orExpr
+    (primaryKeyEquals keyDef <$> keys)
 
 {- |
   INTERNAL: builds the where condition for a single part of the key

--- a/orville-postgresql-libpq/test/Test/EntityOperations.hs
+++ b/orville-postgresql-libpq/test/Test/EntityOperations.hs
@@ -26,6 +26,7 @@ entityOperationsTests pool =
     , prop_insertEntitiesAffectedRows pool
     , prop_insertEntitiesFindFirstEntityByRoundTrip pool
     , prop_insertEntityFindEntityRoundTrip pool
+    , prop_insertEntityFindEntitiesRoundTrip pool
     , prop_insertAndReturnEntity pool
     , prop_updateEntity pool
     , prop_updateEntityAffectedRows pool
@@ -110,6 +111,18 @@ prop_insertEntityFindEntityRoundTrip =
         Orville.findEntity Foo.table (Foo.fooId originalFoo)
 
     mbRetrievedFoo === Just originalFoo
+
+prop_insertEntityFindEntitiesRoundTrip :: Property.NamedDBProperty
+prop_insertEntityFindEntitiesRoundTrip =
+  Property.singletonNamedDBProperty "insertEntity/findEntities form a round trip" $ \pool -> do
+    foos <- HH.forAll $ Foo.generateNonEmpty (Range.linear 1 5)
+
+    retrievedFoos <-
+      Foo.withTable pool $ do
+        _ <- Orville.insertEntities Foo.table foos
+        Orville.findEntities Foo.table (Foo.fooId <$> foos)
+
+    List.sortOn Foo.fooId retrievedFoos === List.sortOn Foo.fooId (NEL.toList foos)
 
 prop_insertAndReturnEntity :: Property.NamedDBProperty
 prop_insertAndReturnEntity =


### PR DESCRIPTION
A common operation is to find entities given a list of their IDs. This is a generalization of `findEntity`.

The returned list is a list, not a non-empty. This is analogous to how the returned value of `findEntity` is a Maybe.
