### PR TITLE
Fixes async exceptions interfering with transaction callback sequences

### DIFF
--- a/orville-postgresql-libpq/orville-postgresql-libpq.cabal
+++ b/orville-postgresql-libpq/orville-postgresql-libpq.cabal
@@ -120,6 +120,7 @@ library
       Orville.PostgreSQL.Expr.Internal.Name.SchemaName
       Orville.PostgreSQL.Expr.Internal.Name.SequenceName
       Orville.PostgreSQL.Expr.Internal.Name.TableName
+      Orville.PostgreSQL.Internal.Bracket
       Orville.PostgreSQL.Internal.Extra.NonEmpty
       Orville.PostgreSQL.Internal.MigrationLock
       Orville.PostgreSQL.Internal.RowCountExpectation

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
@@ -39,7 +39,7 @@ module Orville.PostgreSQL
     -- * Types for incorporating Orville into other Monads
   , MonadOrville.MonadOrville
   , MonadOrville.withConnection
-  , MonadOrville.MonadOrvilleControl (liftWithConnection, liftFinally, liftBracket)
+  , MonadOrville.MonadOrvilleControl (liftWithConnection, liftCatch, liftMask)
   , HasOrvilleState.HasOrvilleState (askOrvilleState, localOrvilleState)
   , OrvilleState.OrvilleState
   , OrvilleState.newOrvilleState

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Cursor.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/Cursor.hs
@@ -33,7 +33,6 @@ module Orville.PostgreSQL.Execution.Cursor
   )
 where
 
-import Control.Exception (bracket)
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import qualified Data.Time as Time
 import qualified Data.Time.Clock.POSIX as POSIXTime
@@ -45,6 +44,7 @@ import qualified Orville.PostgreSQL.Execution.Execute as Execute
 import qualified Orville.PostgreSQL.Execution.QueryType as QueryType
 import Orville.PostgreSQL.Execution.Select (Select, useSelect)
 import qualified Orville.PostgreSQL.Expr as Expr
+import qualified Orville.PostgreSQL.Internal.Bracket as Bracket
 import Orville.PostgreSQL.Marshall (AnnotatedSqlMarshaller)
 import qualified Orville.PostgreSQL.Monad as Monad
 
@@ -88,10 +88,9 @@ withCursor ::
   (Cursor readEntity -> m a) ->
   m a
 withCursor scrollExpr holdExpr select useCursor =
-  Monad.liftBracket
-    bracket
+  Bracket.bracketWithResult
     (declareCursor scrollExpr holdExpr select)
-    closeCursor
+    (\cursor _bracketResult -> closeCursor cursor)
     useCursor
 
 {- |

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Bracket.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Internal/Bracket.hs
@@ -1,0 +1,60 @@
+{- |
+Copyright : Flipstone Technology Partners 2023
+License   : MIT
+Stability : Stable
+-}
+module Orville.PostgreSQL.Internal.Bracket
+  ( bracketWithResult
+  , BracketResult (BracketSuccess, BracketError)
+  ) where
+
+import Control.Exception (SomeException, catch, mask, throwIO)
+import Control.Monad.IO.Class (MonadIO (liftIO))
+
+import Orville.PostgreSQL.Monad.MonadOrville (MonadOrvilleControl (liftCatch, liftMask))
+
+data BracketResult
+  = BracketSuccess
+  | BracketError
+
+{- |
+  INTERNAL: A version of 'bracket' that allows us to distinguish between
+  exception and non-exception release cases. This is available in certain
+  packages as a typeclass function under the name 'generalBracket', but is
+  implemented here directly in terms of IO's 'mask' and 'catch' to guarantee
+  our exception handling semantics without forcing the Orville user's choice of
+  library for lifting and unlift IO actions (e.g. UnliftIO).
+-}
+bracketWithResult ::
+  (MonadIO m, MonadOrvilleControl m) =>
+  m a ->
+  (a -> BracketResult -> m c) ->
+  (a -> m b) ->
+  m b
+bracketWithResult acquire release action = do
+  liftMask mask $ \restore -> do
+    resource <- acquire
+
+    result <-
+      liftCatch
+        catch
+        (restore (action resource))
+        (handleAndRethrow (release resource BracketError))
+
+    _ <- release resource BracketSuccess
+
+    pure result
+
+{- |
+  INTERNAL: Catch any exception, run the given handler, and rethrow the
+  exception. This is mostly useful to force the exception being caught to be of
+  the type 'SomeException'.
+-}
+handleAndRethrow ::
+  MonadIO m =>
+  m a ->
+  SomeException ->
+  m b
+handleAndRethrow handle ex = do
+  _ <- handle
+  liftIO . throwIO $ ex


### PR DESCRIPTION
It was possible for a transaction rollback exception to get delivered to a caller listening to callbacks if an asynchronous exception occurred after the begin transaction sql was executed and the open transaction callback being delivered. In this case the `finally` clause would trigger and rollback the exception successfully and attempt to deliver an exception rollback callback. This could be confusing to the caller because they never received the begin transaction callback. In particular, the entity trace module raises an error in this scenario.

This avoids the problem be replacing the `finally` call with a call to our own version of `bracket` (the stock `bracket` is insufficient because it does not provided enough information to distinguish between releasing the transaction in success and exception scenarios).