### PR TITLE
[SC-30704] Adds support for jsonb

### DIFF
--- a/orville-postgresql-libpq/scripts/format-repo.sh
+++ b/orville-postgresql-libpq/scripts/format-repo.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
 if [ "$(command -v fourmolu)" = "" ] ; then
-    stack --resolver lts-18.28 --silent --allow-different-user install fourmolu-0.3.0.0
+    echo "Fourmolu not found, installing 0.13.1.0, with nightly-2023-07-26"
+    stack --resolver nightly-2023-07-26 --silent --allow-different-user install fourmolu-0.13.1.0
 fi
 
 find * -name '*.hs' | xargs -P0 fourmolu -i

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/DataType.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/DataType.hs
@@ -21,6 +21,7 @@ module Orville.PostgreSQL.Expr.DataType
   , serial
   , int
   , smallint
+  , jsonb
   , oid
   )
 where
@@ -124,6 +125,10 @@ int =
 smallint :: DataType
 smallint =
   DataType (RawSql.fromString "SMALLINT")
+
+jsonb :: DataType
+jsonb =
+  DataType (RawSql.fromString "JSONB")
 
 oid :: DataType
 oid =

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Marshall/FieldDefinition.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Marshall/FieldDefinition.hs
@@ -76,6 +76,7 @@ module Orville.PostgreSQL.Marshall.FieldDefinition
   , utcTimestampField
   , localTimestampField
   , uuidField
+  , jsonbField
   , fieldOfType
   , whereColumnComparison
   )
@@ -383,8 +384,6 @@ unboundedTextField = fieldOfType SqlType.unboundedText
   Builds a 'FieldDefinition' that stores Haskell 'T.Text' values as the
   PostgreSQL "VARCHAR" type. Attempting to store a value beyond the length
   specified will cause an error.
-
-  -- TODO: We should have a test for this.
 -}
 boundedTextField ::
   -- | Name of the field in the database
@@ -399,8 +398,6 @@ boundedTextField name len = fieldOfType (SqlType.boundedText len) name
   PostgreSQL "CHAR" type. Attempting to store a value beyond the length
   specified will cause an error. Storing a value that is not the full
   length of the field will result in padding by the database.
-
-  -- TODO: We should have a test for this.
 -}
 fixedTextField ::
   -- | Name of the field in the database
@@ -416,6 +413,15 @@ fixedTextField name len = fieldOfType (SqlType.fixedText len) name
 -}
 textSearchVectorField :: String -> FieldDefinition NotNull T.Text
 textSearchVectorField = fieldOfType SqlType.textSearchVector
+
+{- |
+  Builds a 'FieldDefinition' that stores Haskell 'T.Text' values as the
+  PostgreSQL "JSOBN" type.
+-}
+jsonbField ::
+  String ->
+  FieldDefinition NotNull T.Text
+jsonbField = fieldOfType SqlType.jsonb
 
 {- |
   Builds a 'FieldDefinition' that stores Haskell 'Time.Day' values as the

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Marshall/SqlType.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Marshall/SqlType.hs
@@ -31,6 +31,8 @@ module Orville.PostgreSQL.Marshall.SqlType
   , date
   , timestamp
   , timestampWithoutZone
+  -- json types
+  , jsonb
   -- postgresql types
   , oid
   -- type conversions
@@ -335,6 +337,22 @@ timestampWithoutZone =
     , sqlTypeMaximumLength = Nothing
     , sqlTypeToSql = SqlValue.fromLocalTime
     , sqlTypeFromSql = SqlValue.toLocalTime
+    , sqlTypeDontDropImplicitDefaultDuringMigrate = False
+    }
+
+{- |
+   'jsonb' represents any type that can be converted To and From JSON. This corresponds
+   to the "JSONB" type in PostgreSQL.
+-}
+jsonb :: SqlType Text
+jsonb =
+  SqlType
+    { sqlTypeExpr = Expr.jsonb
+    , sqlTypeReferenceExpr = Nothing
+    , sqlTypeOid = LibPQ.Oid 3802
+    , sqlTypeMaximumLength = Nothing
+    , sqlTypeToSql = SqlValue.fromText
+    , sqlTypeFromSql = SqlValue.toText
     , sqlTypeDontDropImplicitDefaultDuringMigrate = False
     }
 

--- a/orville-postgresql-libpq/test/Test/FieldDefinition.hs
+++ b/orville-postgresql-libpq/test/Test/FieldDefinition.hs
@@ -42,6 +42,7 @@ fieldDefinitionTests pool =
       <> dateField pool
       <> utcTimestampField pool
       <> localTimestampField pool
+      <> jsonbField pool
 
 integerField :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
 integerField pool =
@@ -158,6 +159,15 @@ localTimestampField pool =
           , InsertOnlyDefaultTest Marshall.currentLocalTimestampDefault
           ]
       , roundTripGen = PgGen.pgLocalTime
+      }
+
+jsonbField :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
+jsonbField pool =
+  testFieldProperties pool "jsonbField" $
+    FieldDefinitionTest
+      { roundTripFieldDef = Marshall.jsonbField "foo"
+      , roundTripDefaultValueTests = []
+      , roundTripGen = PgGen.pgJSON
       }
 
 testFieldProperties ::

--- a/orville-postgresql-libpq/test/Test/PgGen.hs
+++ b/orville-postgresql-libpq/test/Test/PgGen.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Test.PgGen
   ( pgText
   , pgDouble
@@ -7,6 +9,7 @@ module Test.PgGen
   , pgUTCTime
   , pgLocalTime
   , pgDay
+  , pgJSON
   )
 where
 
@@ -124,6 +127,18 @@ pgDay = do
 
 pgTimeOfDay :: HH.Gen Time.TimeOfDay
 pgTimeOfDay = fmap Time.timeToTimeOfDay pgDiffTime
+
+pgJSON :: HH.Gen T.Text
+pgJSON = do
+  let
+    alphaNumText :: HH.Range Int -> HH.Gen T.Text
+    alphaNumText range =
+      Gen.text range $ Gen.filter (/= '\NUL') Gen.alphaNum
+
+  jsonKey <- alphaNumText (Range.constant 0 1024)
+  jsonValue <- alphaNumText (Range.constant 0 1024)
+
+  pure $ "{\"" <> jsonKey <> "\": \"" <> jsonValue <> "\"}"
 
 pgDiffTime :: HH.Gen Time.DiffTime
 pgDiffTime =

--- a/orville-postgresql-libpq/test/Test/SqlType.hs
+++ b/orville-postgresql-libpq/test/Test/SqlType.hs
@@ -38,6 +38,7 @@ sqlTypeTests pool =
       <> textSearchVectorTests pool
       <> dateTests pool
       <> timestampTests pool
+      <> jsonbTests pool
 
 integerTests :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
 integerTests pool =
@@ -319,6 +320,20 @@ textSearchVectorTests pool =
           , rawSqlValue = Just $ B8.pack "'fghi'"
           , sqlType = SqlType.textSearchVector
           , expectedValue = T.pack "'fghi'"
+          }
+    )
+  ]
+
+jsonbTests :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
+jsonbTests pool =
+  [
+    ( String.fromString "Testing the decode of graph '{\"key\": \"value\"}'"
+    , runDecodingTest pool $
+        DecodingTest
+          { sqlTypeDDL = "JSONB"
+          , rawSqlValue = Just $ B8.pack "{\"key\": \"value\"}"
+          , sqlType = SqlType.jsonb
+          , expectedValue = T.pack "{\"key\": \"value\"}"
           }
     )
   ]


### PR DESCRIPTION
Adds a jsonb DataType, Field, and SqlType. No default value was given for the `jsonbField`.

Tests were added for the jsonb field and SqlType. For the jsonb field test, I chose to limit the keys and values to alpha-numeric values, despite the fact that keys and values can be any valid string.