### PR TITLE
Reworking qualification, adding qualification for column names

### DIFF
--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Raw/RawSql.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Raw/RawSql.hs
@@ -99,7 +99,9 @@ instance SqlExpression RawSql where
   toRawSql = id
   unsafeFromRawSql = id
 
-{- | A conveinence function for creating an arbitrary 'SqlExpression' from a 'String'. Great care should be exercised in use of this function as it cannot provide any sort of correctness guarantee.
+{- | A conveinence function for creating an arbitrary 'SqlExpression' from a 'String'. Great care
+   should be exercised in use of this function as it cannot provide any sort of correctness
+   guarantee.
 
 @since 0.10.0.2
 -}

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Schema/SequenceIdentifier.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Schema/SequenceIdentifier.hs
@@ -18,8 +18,8 @@ import qualified Orville.PostgreSQL.Expr as Expr
   schema.
 -}
 data SequenceIdentifier = SequenceIdentifier
-  { _sequenceIdName :: String
-  , _sequenceIdSchema :: Maybe String
+  { i_sequenceIdName :: String
+  , i_sequenceIdSchema :: Maybe String
   }
   deriving (Eq, Ord, Show)
 
@@ -30,8 +30,8 @@ data SequenceIdentifier = SequenceIdentifier
 unqualifiedNameToSequenceId :: String -> SequenceIdentifier
 unqualifiedNameToSequenceId name =
   SequenceIdentifier
-    { _sequenceIdName = name
-    , _sequenceIdSchema = Nothing
+    { i_sequenceIdName = name
+    , i_sequenceIdSchema = Nothing
     }
 
 {- |
@@ -41,7 +41,7 @@ unqualifiedNameToSequenceId name =
 setSequenceIdSchema :: String -> SequenceIdentifier -> SequenceIdentifier
 setSequenceIdSchema schema sequenceId =
   sequenceId
-    { _sequenceIdSchema = Just schema
+    { i_sequenceIdSchema = Just schema
     }
 
 {- |
@@ -50,7 +50,7 @@ setSequenceIdSchema schema sequenceId =
 -}
 sequenceIdQualifiedName :: SequenceIdentifier -> Expr.Qualified Expr.SequenceName
 sequenceIdQualifiedName sequenceId =
-  Expr.qualified
+  Expr.qualifySequence
     (sequenceIdSchemaName sequenceId)
     (sequenceIdUnqualifiedName sequenceId)
 
@@ -60,7 +60,7 @@ sequenceIdQualifiedName sequenceId =
 -}
 sequenceIdUnqualifiedName :: SequenceIdentifier -> Expr.SequenceName
 sequenceIdUnqualifiedName =
-  Expr.sequenceName . _sequenceIdName
+  Expr.sequenceName . i_sequenceIdName
 
 {- |
   Returns the 'Expr.SchemaName' (if any) that should be used to qualify
@@ -68,21 +68,21 @@ sequenceIdUnqualifiedName =
 -}
 sequenceIdSchemaName :: SequenceIdentifier -> Maybe Expr.SchemaName
 sequenceIdSchemaName =
-  fmap Expr.schemaName . _sequenceIdSchema
+  fmap Expr.schemaName . i_sequenceIdSchema
 
 {- |
   Retrieves the unqualified name of the sequence as a string.
 -}
 sequenceIdUnqualifiedNameString :: SequenceIdentifier -> String
 sequenceIdUnqualifiedNameString =
-  _sequenceIdName
+  i_sequenceIdName
 
 {- |
   Retrieves the schema name of the sequence as a string
 -}
 sequenceIdSchemaNameString :: SequenceIdentifier -> Maybe String
 sequenceIdSchemaNameString =
-  _sequenceIdSchema
+  i_sequenceIdSchema
 
 {- |
   Converts a 'SequenceIdentifier' for a string for descriptive purposes. The
@@ -93,8 +93,8 @@ sequenceIdSchemaNameString =
 -}
 sequenceIdToString :: SequenceIdentifier -> String
 sequenceIdToString sequenceId =
-  case _sequenceIdSchema sequenceId of
+  case i_sequenceIdSchema sequenceId of
     Nothing ->
-      _sequenceIdName sequenceId
+      i_sequenceIdName sequenceId
     Just schema ->
-      schema <> "." <> _sequenceIdName sequenceId
+      schema <> "." <> i_sequenceIdName sequenceId

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Schema/TableDefinition.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Schema/TableDefinition.hs
@@ -57,12 +57,12 @@ import Orville.PostgreSQL.Schema.TableIdentifier (TableIdentifier, setTableIdSch
     from the result set when entities are queried from this table.
 -}
 data TableDefinition key writeEntity readEntity = TableDefinition
-  { _tableIdentifier :: TableIdentifier
-  , _tablePrimaryKey :: TablePrimaryKey key
-  , _tableMarshaller :: AnnotatedSqlMarshaller writeEntity readEntity
-  , _tableColumnsToDrop :: Set.Set String
-  , _tableConstraints :: Map.Map ConstraintMigrationKey ConstraintDefinition
-  , _tableIndexes :: Map.Map IndexMigrationKey IndexDefinition
+  { i_tableIdentifier :: TableIdentifier
+  , i_tablePrimaryKey :: TablePrimaryKey key
+  , i_tableMarshaller :: AnnotatedSqlMarshaller writeEntity readEntity
+  , i_tableColumnsToDrop :: Set.Set String
+  , i_tableConstraints :: Map.Map ConstraintMigrationKey ConstraintDefinition
+  , i_tableIndexes :: Map.Map IndexMigrationKey IndexDefinition
   }
 
 data HasKey key
@@ -88,12 +88,12 @@ mkTableDefinition ::
   TableDefinition (HasKey key) writeEntity readEntity
 mkTableDefinition name primaryKey marshaller =
   TableDefinition
-    { _tableIdentifier = unqualifiedNameToTableId name
-    , _tablePrimaryKey = TableHasKey primaryKey
-    , _tableMarshaller = annotateSqlMarshaller (toList $ primaryKeyFieldNames primaryKey) marshaller
-    , _tableColumnsToDrop = Set.empty
-    , _tableConstraints = Map.empty
-    , _tableIndexes = Map.empty
+    { i_tableIdentifier = unqualifiedNameToTableId name
+    , i_tablePrimaryKey = TableHasKey primaryKey
+    , i_tableMarshaller = annotateSqlMarshaller (toList $ primaryKeyFieldNames primaryKey) marshaller
+    , i_tableColumnsToDrop = Set.empty
+    , i_tableConstraints = Map.empty
+    , i_tableIndexes = Map.empty
     }
 
 {- |
@@ -111,12 +111,12 @@ mkTableDefinitionWithoutKey ::
   TableDefinition NoKey writeEntity readEntity
 mkTableDefinitionWithoutKey name marshaller =
   TableDefinition
-    { _tableIdentifier = unqualifiedNameToTableId name
-    , _tablePrimaryKey = TableHasNoKey
-    , _tableMarshaller = annotateSqlMarshallerEmptyAnnotation marshaller
-    , _tableColumnsToDrop = Set.empty
-    , _tableConstraints = Map.empty
-    , _tableIndexes = Map.empty
+    { i_tableIdentifier = unqualifiedNameToTableId name
+    , i_tablePrimaryKey = TableHasNoKey
+    , i_tableMarshaller = annotateSqlMarshallerEmptyAnnotation marshaller
+    , i_tableColumnsToDrop = Set.empty
+    , i_tableConstraints = Map.empty
+    , i_tableIndexes = Map.empty
     }
 
 {- |
@@ -138,7 +138,7 @@ dropColumns ::
   TableDefinition key writeEntity readEntity
 dropColumns columns tableDef =
   tableDef
-    { _tableColumnsToDrop = _tableColumnsToDrop tableDef <> Set.fromList columns
+    { i_tableColumnsToDrop = i_tableColumnsToDrop tableDef <> Set.fromList columns
     }
 
 {- |
@@ -146,14 +146,14 @@ dropColumns columns tableDef =
 -}
 columnsToDrop :: TableDefinition key writeEntity readEntity -> Set.Set String
 columnsToDrop =
-  _tableColumnsToDrop
+  i_tableColumnsToDrop
 
 {- |
   Returns the table's 'TableIdentifier'
 -}
 tableIdentifier :: TableDefinition key writeEntity readEntity -> TableIdentifier
 tableIdentifier =
-  _tableIdentifier
+  i_tableIdentifier
 
 {- |
   Returns the table's name as an expression that can be used to build SQL
@@ -162,7 +162,7 @@ tableIdentifier =
 -}
 tableName :: TableDefinition key writeEntity readEntity -> Expr.Qualified Expr.TableName
 tableName =
-  tableIdQualifiedName . _tableIdentifier
+  tableIdQualifiedName . i_tableIdentifier
 
 {- |
   Sets the table's schema to the name in the given string, which will be
@@ -176,7 +176,7 @@ setTableSchema ::
   TableDefinition key writeEntity readEntity
 setTableSchema schemaName tableDef =
   tableDef
-    { _tableIdentifier = setTableIdSchema schemaName (_tableIdentifier tableDef)
+    { i_tableIdentifier = setTableIdSchema schemaName (i_tableIdentifier tableDef)
     }
 
 {- |
@@ -187,7 +187,7 @@ tableConstraints ::
   TableDefinition key writeEntity readEntity ->
   Map.Map ConstraintMigrationKey ConstraintDefinition
 tableConstraints =
-  _tableConstraints
+  i_tableConstraints
 
 {- |
   Adds the given table constraints to the table definition.
@@ -207,7 +207,7 @@ addTableConstraints constraintDefs tableDef =
       Map.insert (constraintMigrationKey constraint) constraint constraintMap
   in
     tableDef
-      { _tableConstraints = foldr addConstraint (_tableConstraints tableDef) constraintDefs
+      { i_tableConstraints = foldr addConstraint (i_tableConstraints tableDef) constraintDefs
       }
 
 {- |
@@ -218,7 +218,7 @@ tableIndexes ::
   TableDefinition key writeEntity readEntity ->
   Map.Map IndexMigrationKey IndexDefinition
 tableIndexes =
-  _tableIndexes
+  i_tableIndexes
 
 {- |
   Adds the given table indexes to the table definition.
@@ -237,7 +237,7 @@ addTableIndexes indexDefs tableDef =
       Map.insert (indexMigrationKey index) index indexMap
   in
     tableDef
-      { _tableIndexes = foldr addIndex (_tableIndexes tableDef) indexDefs
+      { i_tableIndexes = foldr addIndex (i_tableIndexes tableDef) indexDefs
       }
 
 {- |
@@ -245,14 +245,14 @@ addTableIndexes indexDefs tableDef =
 -}
 tablePrimaryKey :: TableDefinition (HasKey key) writeEntity readEntity -> PrimaryKey key
 tablePrimaryKey def =
-  case _tablePrimaryKey def of
+  case i_tablePrimaryKey def of
     TableHasKey primaryKey -> primaryKey
 
 {- |
   Returns the marshaller for the table, as defined at construction via 'mkTableDefinition'.
 -}
 tableMarshaller :: TableDefinition key writeEntity readEntity -> AnnotatedSqlMarshaller writeEntity readEntity
-tableMarshaller = _tableMarshaller
+tableMarshaller = i_tableMarshaller
 
 {- |
   Applies the provided function to the underlying 'SqlMarshaller' of the 'TableDefinition'
@@ -262,7 +262,7 @@ mapTableMarshaller ::
   TableDefinition key readEntityA writeEntityA ->
   TableDefinition key readEntityB writeEntityB
 mapTableMarshaller f tableDef =
-  tableDef {_tableMarshaller = mapSqlMarshaller f $ _tableMarshaller tableDef}
+  tableDef {i_tableMarshaller = mapSqlMarshaller f $ i_tableMarshaller tableDef}
 
 {- |
   Builds a 'Expr.CreateTableExpr' that will create a SQL table matching the
@@ -276,7 +276,7 @@ mkCreateTableExpr tableDef =
     (tableName tableDef)
     (mkTableColumnDefinitions tableDef)
     (mkTablePrimaryKeyExpr tableDef)
-    (map constraintSqlExpr . Map.elems . _tableConstraints $ tableDef)
+    (map constraintSqlExpr . Map.elems . i_tableConstraints $ tableDef)
 
 {- |
   Builds the 'Expr.ColumnDefinitions' for all the fields described by the
@@ -299,7 +299,7 @@ mkTablePrimaryKeyExpr ::
   TableDefinition key writeEntity readEntity ->
   Maybe Expr.PrimaryKeyExpr
 mkTablePrimaryKeyExpr tableDef =
-  case _tablePrimaryKey tableDef of
+  case i_tablePrimaryKey tableDef of
     TableHasKey primaryKey ->
       Just $ mkPrimaryKeyExpr primaryKey
     TableHasNoKey ->

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Schema/TableIdentifier.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Schema/TableIdentifier.hs
@@ -18,8 +18,8 @@ import qualified Orville.PostgreSQL.Expr as Expr
   schema.
 -}
 data TableIdentifier = TableIdentifier
-  { _tableIdName :: String
-  , _tableIdSchema :: Maybe String
+  { i_tableIdName :: String
+  , i_tableIdSchema :: Maybe String
   }
   deriving (Eq, Ord, Show)
 
@@ -30,8 +30,8 @@ data TableIdentifier = TableIdentifier
 unqualifiedNameToTableId :: String -> TableIdentifier
 unqualifiedNameToTableId name =
   TableIdentifier
-    { _tableIdName = name
-    , _tableIdSchema = Nothing
+    { i_tableIdName = name
+    , i_tableIdSchema = Nothing
     }
 
 {- |
@@ -41,7 +41,7 @@ unqualifiedNameToTableId name =
 setTableIdSchema :: String -> TableIdentifier -> TableIdentifier
 setTableIdSchema schema tableId =
   tableId
-    { _tableIdSchema = Just schema
+    { i_tableIdSchema = Just schema
     }
 
 {- |
@@ -50,7 +50,7 @@ setTableIdSchema schema tableId =
 -}
 tableIdQualifiedName :: TableIdentifier -> Expr.Qualified Expr.TableName
 tableIdQualifiedName tableId =
-  Expr.qualified
+  Expr.qualifyTable
     (tableIdSchemaName tableId)
     (tableIdUnqualifiedName tableId)
 
@@ -60,7 +60,7 @@ tableIdQualifiedName tableId =
 -}
 tableIdUnqualifiedName :: TableIdentifier -> Expr.TableName
 tableIdUnqualifiedName =
-  Expr.tableName . _tableIdName
+  Expr.tableName . i_tableIdName
 
 {- |
   Returns the 'Expr.SchemaName' (if any) that should be used to qualify
@@ -68,21 +68,21 @@ tableIdUnqualifiedName =
 -}
 tableIdSchemaName :: TableIdentifier -> Maybe Expr.SchemaName
 tableIdSchemaName =
-  fmap Expr.schemaName . _tableIdSchema
+  fmap Expr.schemaName . i_tableIdSchema
 
 {- |
   Retrieves the unqualified name of the table as a string.
 -}
 tableIdUnqualifiedNameString :: TableIdentifier -> String
 tableIdUnqualifiedNameString =
-  _tableIdName
+  i_tableIdName
 
 {- |
   Retrieves the schema name of the table as a string
 -}
 tableIdSchemaNameString :: TableIdentifier -> Maybe String
 tableIdSchemaNameString =
-  _tableIdSchema
+  i_tableIdSchema
 
 {- |
   Converts a 'TableIdentifier' for a string for descriptive purposes. The
@@ -93,8 +93,8 @@ tableIdSchemaNameString =
 -}
 tableIdToString :: TableIdentifier -> String
 tableIdToString tableId =
-  case _tableIdSchema tableId of
+  case i_tableIdSchema tableId of
     Nothing ->
-      _tableIdName tableId
+      i_tableIdName tableId
     Just schema ->
-      schema <> "." <> _tableIdName tableId
+      schema <> "." <> i_tableIdName tableId

--- a/orville-postgresql-libpq/test/Test/Expr/GroupBy.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/GroupBy.hs
@@ -105,7 +105,7 @@ groupByTest testName test =
 
 testTable :: Expr.Qualified Expr.TableName
 testTable =
-  Expr.qualified Nothing (Expr.tableName "expr_test")
+  Expr.qualifyTable Nothing (Expr.tableName "expr_test")
 
 fooColumn :: Expr.ColumnName
 fooColumn =

--- a/orville-postgresql-libpq/test/Test/Expr/GroupByOrderBy.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/GroupByOrderBy.hs
@@ -95,7 +95,7 @@ groupByOrderByTest testName test =
 
 testTable :: Expr.Qualified Expr.TableName
 testTable =
-  Expr.qualified Nothing (Expr.tableName "expr_test")
+  Expr.qualifyTable Nothing (Expr.tableName "expr_test")
 
 fooColumn :: Expr.ColumnName
 fooColumn =

--- a/orville-postgresql-libpq/test/Test/Expr/SequenceDefinition.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/SequenceDefinition.hs
@@ -59,7 +59,7 @@ prop_createWithWithOptions =
 
 exprSequenceName :: Expr.Qualified Expr.SequenceName
 exprSequenceName =
-  Expr.qualified Nothing (Expr.sequenceName sequenceNameString)
+  Expr.qualifySequence Nothing (Expr.sequenceName sequenceNameString)
 
 sequenceNameString :: String
 sequenceNameString =

--- a/orville-postgresql-libpq/test/Test/Expr/TableDefinition.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/TableDefinition.hs
@@ -70,7 +70,7 @@ prop_addMultipleColumns =
 
 exprTableName :: Expr.Qualified Expr.TableName
 exprTableName =
-  Expr.qualified Nothing (Expr.tableName tableNameString)
+  Expr.qualifyTable Nothing (Expr.tableName tableNameString)
 
 tableNameString :: String
 tableNameString =

--- a/orville-postgresql-libpq/test/Test/Expr/TestSchema.hs
+++ b/orville-postgresql-libpq/test/Test/Expr/TestSchema.hs
@@ -43,7 +43,7 @@ mkFooBar f b = FooBar (Just f) (Just b)
 
 fooBarTable :: Expr.Qualified Expr.TableName
 fooBarTable =
-  Expr.qualified Nothing (Expr.tableName "foobar")
+  Expr.qualifyTable Nothing (Expr.tableName "foobar")
 
 fooColumn :: Expr.ColumnName
 fooColumn =

--- a/orville-postgresql-libpq/test/Test/FieldDefinition.hs
+++ b/orville-postgresql-libpq/test/Test/FieldDefinition.hs
@@ -405,7 +405,7 @@ runDefaultValueInsertOnlyTest pool testCase defaultValue =
 
 testTable :: Expr.Qualified Expr.TableName
 testTable =
-  Expr.qualified Nothing (Expr.tableName "field_definition_test")
+  Expr.qualifyTable Nothing (Expr.tableName "field_definition_test")
 
 dropAndRecreateTestTable :: Marshall.FieldDefinition nullability a -> Orville.Connection -> IO ()
 dropAndRecreateTestTable fieldDef connection = do

--- a/orville-postgresql-libpq/test/Test/SqlType.hs
+++ b/orville-postgresql-libpq/test/Test/SqlType.hs
@@ -530,7 +530,7 @@ runDecodingTest pool test =
       dropAndRecreateTable connection "decoding_test" (sqlTypeDDL test)
 
       let
-        tableName = Expr.qualified Nothing (Expr.tableName "decoding_test")
+        tableName = Expr.qualifyTable Nothing (Expr.tableName "decoding_test")
 
       RawSql.executeVoid connection $
         Expr.insertExpr

--- a/orville-postgresql-libpq/test/Test/TestTable.hs
+++ b/orville-postgresql-libpq/test/Test/TestTable.hs
@@ -36,7 +36,7 @@ dropTableNameSql ::
   String ->
   RawSql.RawSql
 dropTableNameSql =
-  dropTableNameExprSql . Expr.qualified Nothing . Expr.tableName
+  dropTableNameExprSql . Expr.qualifyTable Nothing . Expr.tableName
 
 dropTableNameExprSql ::
   Expr.Qualified Expr.TableName ->


### PR DESCRIPTION
The previous qualification function is replaced by 'qualifyTable' and 'qualifySequence'. These are more constrained in type as the previous allowed for incorrect qualifications.

Further added is 'qualifyColumn' to allow columns to be correctly qualified by both schema and table.

Also any _ prefix record fields in modules associated were changed to match the i_ prefix used elsewhere.

For sequences and tables, we have a higher level "Identifier" interface, which tracks the schema separately, and is likely the interface most will want to use. Because of that the functions 'qualifySequence' and 'qualifyTable' both take 'Maybe SchemaName'. This raises a couple of direction questions though:

- Do we want a similar interface for ColumnName?

  Sequences and tables both live directly on a schema, so there is a difference at least there. And on the other end is a 'FieldDefinition', which can _feel_ a bit like providing the identification of a column. But that is not exactly the same thing, notably 'FieldDefition' do not keep a reference to the parent like the the *Identifier types do, and providing that is likely not something we want.

- Should we simply change the higher interfaces to provide something like 'Either TableName (Qualified TableName)' and deal with that complexity?

  This has lots of obvious drawbacks of additional complexity where
today we simply create a 'Qualified TableName' or 'Qualified SequenceName' that lacks the qualification if the 'SchemaName' isn't provided. It definitely seems more directly usable to not have that complexity, but then the interface of 'Qualified Type' is a bit of a lie.

Given those questions, this takes the easy path forward and simply punts on answering any of them.