### PR TITLE
Fix 'cabal check' warnings 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,3 +88,38 @@ jobs:
             sh -c ./scripts/format-repo.sh
 
           sh -c scripts/format-check-ci.sh
+
+  cabal-check:
+    name: Cabal Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Cache
+        uses: actions/cache@v3
+        env:
+          cache-version: format-v1
+        with:
+          key: ${{ env.cache-version }}-${{ hashFiles('orville-postgresql-libpq/stack*.yml') }}-${{ hashFiles('orville-postgresql-libpq/package.yaml') }}
+          restore-keys: |
+            ${{ env.cache-version }}-
+          path: |
+            ./stack-root
+
+      - name: Build dev environment
+        run: |
+          set -e
+          cd orville-postgresql-libpq
+          docker-compose build -q
+
+      - name: Format and Check for Diff
+        run: |
+          set -e
+
+          cd orville-postgresql-libpq
+          cp compose.override.github.yml compose.override.yml
+          docker-compose run \
+            --rm \
+            dev \
+            cabal check

--- a/orville-postgresql-libpq/LICENSE
+++ b/orville-postgresql-libpq/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2016-2023 Flipstone Technology Partners
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/orville-postgresql-libpq/orville-postgresql-libpq.cabal
+++ b/orville-postgresql-libpq/orville-postgresql-libpq.cabal
@@ -12,6 +12,7 @@ category:       Database
 author:         Flipstone Technology Partners
 maintainer:     development@flipstone.com
 license:        MIT
+license-file:   LICENSE
 build-type:     Simple
 tested-with:
     GHC == 8.10.7, GHC == 9.0.2, GHC == 9.2.8, GHC == 9.4.5, GHC == 9.6.2
@@ -137,21 +138,21 @@ library
   hs-source-dirs:
       src
   build-depends:
-      attoparsec >=0.10
+      attoparsec >=0.10 && <0.15
     , base >=4.8 && <5
-    , bytestring
+    , bytestring >=0.10 && <0.13
     , containers ==0.6.*
     , dlist >=0.8 && <1.1
     , network-uri ==2.6.*
     , postgresql-libpq >=0.9.4.2 && <0.10
     , random >=1.0 && <2
-    , resource-pool <0.3 || >=0.4
-    , safe-exceptions >=0.1.7
-    , text
-    , time >=1.9.1
+    , resource-pool <0.3 || >=0.4 && <0.5
+    , safe-exceptions >=0.1.7 && <0.2
+    , text >=1.2 && <1.3 || >=2.0 && <2.1
+    , time >=1.9.1 && <1.13
     , transformers >=0.5 && <0.7
     , unliftio-core >=0.1 && <0.3
-    , uuid
+    , uuid >=1.3.15 && <1.4
   default-language: Haskell2010
   if flag(ci)
     ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-patterns -Wincomplete-record-updates -Wmissing-local-signatures -Wmissing-export-lists -Wmissing-import-lists -Wnoncanonical-monad-instances -Wredundant-constraints -Wpartial-fields -Wmissed-specialisations -Wno-implicit-prelude -Wno-safe -Wno-unsafe
@@ -208,18 +209,21 @@ test-suite spec
       Paths_orville_postgresql_libpq
   hs-source-dirs:
       test
-  ghc-options: -j -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wmissing-local-signatures -Wmissing-export-lists -Wno-implicit-prelude -Wno-safe -Wno-unsafe -Wnoncanonical-monad-instances -Wredundant-constraints -Wpartial-fields -Wmissed-specialisations -Woverflowed-literals
   build-depends:
-      attoparsec
-    , base
-    , bytestring
-    , containers
-    , hedgehog
+      attoparsec >=0.10 && <0.15
+    , base >=4.8 && <5
+    , bytestring >=0.10 && <0.13
+    , containers ==0.6.*
+    , hedgehog >=1.0.5 && <1.4
     , orville-postgresql-libpq
-    , postgresql-libpq
-    , resource-pool
-    , safe-exceptions
-    , text
-    , time
-    , uuid
+    , postgresql-libpq >=0.9.4.2 && <0.10
+    , resource-pool <0.3 || >=0.4 && <0.5
+    , safe-exceptions >=0.1.7 && <0.2
+    , text >=1.2 && <1.3 || >=2.0 && <2.1
+    , time >=1.9.1 && <1.13
+    , uuid >=1.3.15 && <1.4
   default-language: Haskell2010
+  if flag(ci)
+    ghc-options: -j -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wmissing-local-signatures -Wmissing-export-lists -Wno-implicit-prelude -Wno-safe -Wno-unsafe -Wnoncanonical-monad-instances -Wredundant-constraints -Wpartial-fields -Wmissed-specialisations -Woverflowed-literals
+  else
+    ghc-options: -Wall -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wmissing-local-signatures -Wmissing-export-lists -Wno-implicit-prelude -Wno-safe -Wno-unsafe -Wnoncanonical-monad-instances -Wredundant-constraints -Wpartial-fields -Wmissed-specialisations -Woverflowed-literals

--- a/orville-postgresql-libpq/package.yaml
+++ b/orville-postgresql-libpq/package.yaml
@@ -7,6 +7,7 @@ category: Database
 author: Flipstone Technology Partners
 maintainer: development@flipstone.com
 license: MIT
+license-file: LICENSE
 git: git@github.com:flipstone/orville.git
 tested-with: GHC == 8.10.7, GHC == 9.0.2, GHC == 9.2.8, GHC == 9.4.5, GHC == 9.6.2
 extra-source-files:
@@ -128,53 +129,73 @@ library:
           - -fwarn-incomplete-record-updates
   dependencies:
     - base >=4.8 && <5
-    - attoparsec >=0.10
-    - bytestring
+    - attoparsec >=0.10 && <0.15
+    - bytestring >=0.10 && <0.13
     - dlist >= 0.8 && < 1.1
     - postgresql-libpq >= 0.9.4.2 && <0.10
     - containers >= 0.6 && < 0.7
     - network-uri >= 2.6 && < 2.7
     - random >= 1.0 && <2
-    - resource-pool <0.3 || >= 0.4
-    - safe-exceptions >=0.1.7
-    - text
-    - time >=1.9.1
+    - resource-pool <0.3 || (>= 0.4  && <0.5)
+    - safe-exceptions >=0.1.7 && < 0.2
+    - text (>= 1.2 && < 1.3) || (>=2.0 && <2.1)
+    - time >=1.9.1 && < 1.13
     - transformers >= 0.5 && < 0.7
     - unliftio-core >= 0.1 && < 0.3
-    - uuid
+    - uuid >= 1.3.15 && <1.4
 
 tests:
   spec:
     source-dirs: test
     main: Main.hs
     dependencies:
-      - attoparsec
-      - base
-      - bytestring
-      - containers
-      - hedgehog
-      - postgresql-libpq
+      - attoparsec >=0.10 && <0.15
+      - base >=4.8 && <5
+      - bytestring >=0.10 && <0.13
+      - containers >= 0.6 && < 0.7
+      - hedgehog >= 1.0.5 && <1.4
+      - postgresql-libpq >= 0.9.4.2 && <0.10
       - orville-postgresql-libpq
-      - resource-pool
-      - safe-exceptions
-      - text
-      - time
-      - uuid
-    ghc-options:
-      - -j
-      - -Wall
-      - -Werror
-      - -Wcompat
-      - -Widentities
-      - -Wincomplete-uni-patterns
-      - -Wincomplete-record-updates
-      - -Wmissing-local-signatures
-      - -Wmissing-export-lists
-      - -Wno-implicit-prelude
-      - -Wno-safe
-      - -Wno-unsafe
-      - -Wnoncanonical-monad-instances
-      - -Wredundant-constraints
-      - -Wpartial-fields
-      - -Wmissed-specialisations
-      - -Woverflowed-literals
+      - resource-pool <0.3 || (>= 0.4  && <0.5)
+      - safe-exceptions >=0.1.7 && < 0.2
+      - text (>= 1.2 && < 1.3) || (>=2.0 && <2.1)
+      - time >=1.9.1 && < 1.13
+      - uuid >= 1.3.15 && <1.4
+    when:
+      - condition: flag(ci)
+        then:
+          ghc-options:
+            - -j
+            - -Wall
+            - -Werror
+            - -Wcompat
+            - -Widentities
+            - -Wincomplete-uni-patterns
+            - -Wincomplete-record-updates
+            - -Wmissing-local-signatures
+            - -Wmissing-export-lists
+            - -Wno-implicit-prelude
+            - -Wno-safe
+            - -Wno-unsafe
+            - -Wnoncanonical-monad-instances
+            - -Wredundant-constraints
+            - -Wpartial-fields
+            - -Wmissed-specialisations
+            - -Woverflowed-literals
+        else:
+          ghc-options:
+            - -Wall
+            - -Wcompat
+            - -Widentities
+            - -Wincomplete-uni-patterns
+            - -Wincomplete-record-updates
+            - -Wmissing-local-signatures
+            - -Wmissing-export-lists
+            - -Wno-implicit-prelude
+            - -Wno-safe
+            - -Wno-unsafe
+            - -Wnoncanonical-monad-instances
+            - -Wredundant-constraints
+            - -Wpartial-fields
+            - -Wmissed-specialisations
+            - -Woverflowed-literals


### PR DESCRIPTION
 This adds a CI job that will let us know of future failures here as
well.

The constraints added are informed by what is on stackage for versions
we test against and 'cabal gen-bounds'.

The LICENSE file is copied, with updated copyright year, from the legacy side.

Fixes #282