### PR TITLE
Require BooleanExpr for updateFields

### DIFF
--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/EntityOperations.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Execution/EntityOperations.hs
@@ -163,11 +163,11 @@ updateFields ::
   Monad.MonadOrville m =>
   Schema.TableDefinition (Schema.HasKey key) writeEntity readEntity ->
   NonEmpty Expr.SetClause ->
-  Maybe Expr.BooleanExpr ->
+  Expr.BooleanExpr ->
   m Int
-updateFields tableDef setClauses mbWhereCondition =
+updateFields tableDef setClauses whereCondition =
   Update.executeUpdate $
-    Update.updateToTableFields tableDef setClauses mbWhereCondition
+    Update.updateToTableFields tableDef setClauses (Just whereCondition)
 
 {- |
   Like 'updateFields', but uses a @RETURNING@ clause to return the updated
@@ -179,11 +179,11 @@ updateFieldsAndReturnEntities ::
   Monad.MonadOrville m =>
   Schema.TableDefinition (Schema.HasKey key) writeEntity readEntity ->
   NonEmpty Expr.SetClause ->
-  Maybe Expr.BooleanExpr ->
+  Expr.BooleanExpr ->
   m [readEntity]
-updateFieldsAndReturnEntities tableDef setClauses mbWhereCondition =
+updateFieldsAndReturnEntities tableDef setClauses whereCondition =
   Update.executeUpdateReturnEntities $
-    Update.updateToTableFieldsReturning tableDef setClauses mbWhereCondition
+    Update.updateToTableFieldsReturning tableDef setClauses (Just whereCondition)
 
 {- |
   Deletes the row with the given key. Returns the number of rows affected

--- a/orville-postgresql-libpq/test/Test/EntityOperations.hs
+++ b/orville-postgresql-libpq/test/Test/EntityOperations.hs
@@ -399,7 +399,7 @@ prop_updateFields =
           Orville.updateFields
             Foo.table
             (Orville.setField Foo.fooNameField updatedName :| [])
-            (Just (Orville.fieldIn Foo.fooIdField fooIds))
+            (Orville.fieldIn Foo.fooIdField fooIds)
         Orville.findEntitiesBy
           Foo.table
           (Orville.where_ (Orville.fieldIn Foo.fooIdField fooIds))
@@ -423,7 +423,7 @@ prop_updateFields_NoMatch =
           Orville.updateFields
             Foo.table
             (Orville.setField Foo.fooNameField updatedName :| [])
-            (Just (Orville.fieldEquals Foo.fooIdField mismatchedId))
+            (Orville.fieldEquals Foo.fooIdField mismatchedId)
         Orville.findEntitiesBy Foo.table mempty
 
     List.sortOn Foo.fooId foosAfterUpdate === List.sortOn Foo.fooId (NEL.toList foos)
@@ -443,7 +443,7 @@ prop_updateFieldsAffectedRows =
         Orville.updateFields
           Foo.table
           (Orville.setField Foo.fooNameField updatedName :| [])
-          (Just (Orville.fieldIn Foo.fooIdField fooIds))
+          (Orville.fieldIn Foo.fooIdField fooIds)
 
     affectedRows === length foos
 
@@ -462,7 +462,7 @@ prop_updateFieldsAndReturnEntities =
         Orville.updateFieldsAndReturnEntities
           Foo.table
           (Orville.setField Foo.fooNameField updatedName :| [])
-          (Just (Orville.fieldIn Foo.fooIdField fooIds))
+          (Orville.fieldIn Foo.fooIdField fooIds)
 
     fmap Foo.fooName updatedFoos === fmap (const updatedName) (NEL.toList foos)
 
@@ -482,6 +482,6 @@ prop_updateFieldsAndReturnEntities_NoMatch =
         Orville.updateFieldsAndReturnEntities
           Foo.table
           (Orville.setField Foo.fooNameField updatedName :| [])
-          (Just (Orville.fieldEquals Foo.fooIdField mismatchedId))
+          (Orville.fieldEquals Foo.fooIdField mismatchedId)
 
     updatedFoos === []


### PR DESCRIPTION
Using `UPDATE` without a where clause is an edge case, which shouldn't hurt the usability of people executing `UPDATE` with a where clause. EntityOperations should be optimized for the common case. By requiring the BooleanExpr instead of having it be Maybe, usability is improved for users that always have where clauses, since they won't need to supply the Just constructor or define a helper to do that.

The small minority of queries that actually need to be executed without a where clause can use custom operations. If a trivially true clause isn't a problem `literalBooleanExpr` can be used.