### PR TITLE
Short EntityOperations functions always produce ()

### DIFF
--- a/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
@@ -6,16 +6,22 @@ Stability : Stable
 module Orville.PostgreSQL
   ( -- * Basic operations on entities in tables
     EntityOperations.insertEntity
+  , EntityOperations.insertEntityAndReturnRowCount
   , EntityOperations.insertAndReturnEntity
   , EntityOperations.insertEntities
+  , EntityOperations.insertEntitiesAndReturnRowCount
   , EntityOperations.insertAndReturnEntities
   , EntityOperations.updateEntity
+  , EntityOperations.updateEntityAndReturnRowCount
   , EntityOperations.updateAndReturnEntity
   , EntityOperations.updateFields
   , EntityOperations.updateFieldsAndReturnEntities
+  , EntityOperations.updateFieldsAndReturnRowCount
   , EntityOperations.deleteEntity
+  , EntityOperations.deleteEntityAndReturnRowCount
   , EntityOperations.deleteAndReturnEntity
   , EntityOperations.deleteEntities
+  , EntityOperations.deleteEntitiesAndReturnRowCount
   , EntityOperations.deleteAndReturnEntities
   , EntityOperations.findEntitiesBy
   , EntityOperations.findFirstEntityBy


### PR DESCRIPTION
It's very common to not need the row count returned by these functions, since one assumes that the database operation failed if not all the given rows were inserted. Having these operations return unit avoids having to do `_ <-` or using `Monad.void`.