### PR TITLE
Fixes stack-root volume not being used in local dev environment

### DIFF
--- a/orville-postgresql-libpq/compose.override.github.yml
+++ b/orville-postgresql-libpq/compose.override.github.yml
@@ -1,7 +1,5 @@
 version: "3"
 services:
   dev:
-    environment:
-      STACK_ROOT: /stack-root
     volumes:
       - ../stack-root:/stack-root

--- a/orville-postgresql-libpq/compose.yml
+++ b/orville-postgresql-libpq/compose.yml
@@ -11,6 +11,7 @@ services:
       - testdb-${PG_VERSION:-pg11}
     environment:
       TEST_CONN_HOST: "host=testdb-${PG_VERSION:-pg11}"
+      STACK_ROOT: /stack-root
     command:
       - ./scripts/test-loop
       - ${STACK_YAML_FILE:-stack.yml}


### PR DESCRIPTION
At some point `STACK_ROOT` stopped being set in our local dev
environment, so the `stack-root` docker volume that was mounted was not
being used.
