### PR TITLE
Adds basic support for concurrent index creation

### DIFF
--- a/orville-postgresql-legacy/src/Database/Orville/PostgreSQL/Core.hs
+++ b/orville-postgresql-legacy/src/Database/Orville/PostgreSQL/Core.hs
@@ -169,7 +169,7 @@ module Database.Orville.PostgreSQL.Core
   , generateMigrationPlan -- migration guide added
   , MigrationPlan -- migration guide added
   , MigrationItem(..) -- migration guide added
-  , migrationPlanItems
+  , migrationPlanItems -- migration guide added
   , Pagination(..)
   , buildPagination
   , selectAll -- migration guide added
@@ -187,8 +187,8 @@ module Database.Orville.PostgreSQL.Core
   , sequenceNextVal
   , sequenceSetVal
   , sequenceCurrVal
-  , createIndexesConcurrently
-  , dropIndexesConcurrently
+  , createIndexesConcurrently -- migration guide added
+  , dropIndexesConcurrently -- migration guide added
   ) where
 
 import Control.Monad (void, when)

--- a/orville-postgresql-legacy/src/Database/Orville/PostgreSQL/Internal/MigrateSchema.hs
+++ b/orville-postgresql-legacy/src/Database/Orville/PostgreSQL/Internal/MigrateSchema.hs
@@ -117,8 +117,11 @@ migrateSchema schemaDef =
           nonTransactionallyExecuteMigrationPlan conn somethingToDo
 
 {-|
-   Migration Guide: @generateMigrationPlan@ has been renamed to
-   @generateMigrationSteps@
+   Migration Guide: @generateMigrationPlan@ retains the same name. It has
+   changed to always return a @MigrationPlan@. You can use check whether
+   @migrationPlanSteps@ is as empty list if you wish to determine whether any
+   migrations will be performed by the plan.
+
 
    generateMigrationPlan inspects the state of the actual database schema and
    constructs a plan describing what changes would be made to make it match the
@@ -165,6 +168,9 @@ buildMigrationPlan schemaDef schemaState = foldMap mkPlan schemaDef
           dropSequencePlan name schemaState
 
 {-|
+   Migration Plan: @createIndexesConcurrently@ has been removed. You should now
+   use @setIndexCreationStrategy Asynchronous@ instead.
+
    createIndexesConcurrently will create the given indexes, if they do not exist using the
     PostgreSQL concurrently feature. However, this does *not* mean the the function happens
     concurrently. This will wait for PostgreSQL to return, but other operations to the table will be
@@ -208,6 +214,8 @@ createIndexConcurrently conn indexDef =
 
 
 {-|
+   Migration Guide: @dropIndexesConcurrently@ has been removed.
+
    dropIndexesConcurrently will drop each of the given indexes with the CONCURRENTLY keyword,
    allowing for other table operations to continue while the index is dropped. However there are
    several caveats that come with this as noted at

--- a/orville-postgresql-legacy/src/Database/Orville/PostgreSQL/Internal/MigrationPlan.hs
+++ b/orville-postgresql-legacy/src/Database/Orville/PostgreSQL/Internal/MigrationPlan.hs
@@ -30,8 +30,7 @@ data MigrationItem = MigrationItem
   }
 
 {- |
-  Migration Guide: @MigrationPlan@ has been removed. Use @[MigrationStep]@
-  instead.
+  Migration Guide: @MigrationPlan@ retains the same name.
 -}
 data MigrationPlan =
   MigrationPlan MigrationItem
@@ -45,6 +44,10 @@ append :: MigrationPlan -> MigrationPlan -> MigrationPlan
 append (MigrationPlan itemA restA) (MigrationPlan itemB restB) =
   MigrationPlan itemA $ DList.append restA $ DList.cons itemB restB
 
+{- |
+  Migration Guide: @migrationPlanItems@ has been renamed to
+  @migrationPlanSteps@
+-}
 migrationPlanItems :: MigrationPlan -> [MigrationItem]
 migrationPlanItems (MigrationPlan item rest) =
   DList.toList $ DList.cons item rest

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL.hs
@@ -115,6 +115,9 @@ module Orville.PostgreSQL
   , IndexDefinition.AttributeBasedIndexMigrationKey (AttributeBasedIndexMigrationKey, indexKeyUniqueness, indexKeyColumns)
   , IndexDefinition.indexMigrationKey
   , IndexDefinition.indexCreateExpr
+  , IndexDefinition.IndexCreationStrategy (Transactional, Asynchronous)
+  , IndexDefinition.setIndexCreationStrategy
+  , IndexDefinition.indexCreationStrategy
   , PrimaryKey.PrimaryKey
   , PrimaryKey.primaryKey
   , PrimaryKey.compositePrimaryKey

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Index.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Index.hs
@@ -98,7 +98,10 @@ createNamedIndexExpr uniqueness mbConcurrently tableName indexName bodyExpr =
       <> RawSql.toRawSql bodyExpr
 
 {- |
-Type to represent the concurrently keyword for index creation
+Type to represent the @CONCURRENTLY@ keyword for index creation
+
+'ConcurrentlyExpr' provides a 'RawSql.SqlExpression' instance. See
+'unsafeSqlExpression' for how to construct a value with your own custom SQL.
 
 @since 0.10.0.0
 -}
@@ -122,6 +125,9 @@ concurrently =
 {- |
 Type to represent if the body of an index definition (i.e. @<body>@ in
 after @CREATE some_index ON some_table <body>@).
+
+'IndexBodyExpr' provides a 'RawSql.SqlExpression' instance. See
+'unsafeSqlExpression' for how to construct a value with your own custom SQL.
 
 @since 0.10.0.0
 -}

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Raw/RawSql.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Raw/RawSql.hs
@@ -91,6 +91,20 @@ instance Semigroup RawSql where
 instance Monoid RawSql where
   mempty = SqlSection mempty
 
+{- |
+ 'SqlExpression' provides a common interface for converting types to and from
+ 'RawSql', either via 'toRawSql' and 'unsafeFromRawSql', or the convenience
+ function 'unsafeSqlExpression'. Orville defines a large number of types that
+ represent various fragments of SQL statements as well as functions to help
+ construct the safely. These funtions can be found in the
+ 'Orville.PostgreSQL.Expr'. These types all provide 'SqlExpression' instances
+ as an escape hatch to allow you to pass any SQL you wish in place of what
+ Orville directly supports. This should be use with great care as Orville
+ cannot guarantee that the SQL you pass can be used to generate valid SQL in
+ conjuction with the rest of the 'Orville.PostgreSQL.Expr' API.
+
+@since 0.10.0.0
+-}
 class SqlExpression a where
   toRawSql :: a -> RawSql
   unsafeFromRawSql :: RawSql -> a
@@ -99,9 +113,20 @@ instance SqlExpression RawSql where
   toRawSql = id
   unsafeFromRawSql = id
 
-{- | A conveinence function for creating an arbitrary 'SqlExpression' from a 'String'. Great care
-   should be exercised in use of this function as it cannot provide any sort of correctness
-   guarantee.
+{- |
+  A conveinence function for creating an arbitrary 'SqlExpression' from a
+  'String'. Great care should be exercised in use of this function as it cannot
+  provide any sort of guarantee that the string passed is usable to generate
+  valid SQL via the rest of Orville's 'Orville.PostgreSQL.Expr' API as the
+  whatever 'SqlExpression' type is returned.
+
+  For example, if one wanted build a boolean expression not support by Orville,
+  you can do it like so
+
+   > import qualified Orville.PostgreSQL.Expr as Expr
+   >
+   > a :: Expr.BooleanExpr
+   > a RawSql.unsafeSqlExpression "foo BETWEEN 1  AND 3"
 
 @since 0.10.0.2
 -}

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Schema/IndexDefinition.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Schema/IndexDefinition.hs
@@ -1,5 +1,7 @@
 module Orville.PostgreSQL.Schema.IndexDefinition
   ( IndexDefinition
+  , indexCreationStrategy
+  , setIndexCreationStrategy
   , uniqueIndex
   , uniqueNamedIndex
   , nonUniqueIndex
@@ -12,6 +14,7 @@ module Orville.PostgreSQL.Schema.IndexDefinition
   , NamedIndexMigrationKey
   , indexMigrationKey
   , indexCreateExpr
+  , IndexCreationStrategy (Transactional, Asynchronous)
   )
 where
 
@@ -20,7 +23,6 @@ import qualified Data.List.NonEmpty as NEL
 
 import qualified Orville.PostgreSQL.Expr as Expr
 import qualified Orville.PostgreSQL.Marshall.FieldDefinition as FieldDefinition
-import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 {- |
   Defines an index that can be added to a 'Orville.PostgreSQL.TableDefinition'.
@@ -30,9 +32,69 @@ import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
   Orville will then add the index next time you run auto-migrations.
 -}
 data IndexDefinition = IndexDefinition
-  { _indexCreateExpr :: Expr.Qualified Expr.TableName -> Expr.CreateIndexExpr
-  , _indexMigrationKey :: IndexMigrationKey
+  { i_indexCreateExpr ::
+      IndexCreationStrategy ->
+      Expr.Qualified Expr.TableName ->
+      Expr.CreateIndexExpr
+  , i_indexMigrationKey :: IndexMigrationKey
+  , i_indexCreationStrategy :: IndexCreationStrategy
   }
+
+{- |
+  Sets the 'IndexCreationStrategy' strategy to be used when creating the index
+  described by the 'IndexDefinition'. By default all indexes are created using
+  the 'Transactional' strategy, but some tables are too large for for this to
+  be feasible. See the 'Asynchronous' creation strategy for how to work around
+  this.
+-}
+setIndexCreationStrategy ::
+  IndexCreationStrategy ->
+  IndexDefinition ->
+  IndexDefinition
+setIndexCreationStrategy strategy indexDef =
+  indexDef
+    { i_indexCreationStrategy = strategy
+    }
+
+{- |
+  Gets the 'IndexCreationStrategy' strategy to be used when creating the index
+  described by the 'IndexDefinition'. By default all indexes are created using
+  the 'Transactional' strategy.
+-}
+indexCreationStrategy ::
+  IndexDefinition ->
+  IndexCreationStrategy
+indexCreationStrategy =
+  i_indexCreationStrategy
+
+{- |
+  Defines how an 'IndexDefinition' will be execute to add an index to a table.
+  By default all indexes a created via the 'Transactional'
+-}
+data IndexCreationStrategy
+  = -- |
+    --       The default strategy. The index will be added as part of the a database
+    --       transaction along with all the other DDL being executed to migrate the
+    --       database schema. If any migration should fail the index creation will be
+    --       rolled back as part of the transaction. This is how schema migrations
+    --       work in general in Orville.
+    Transactional
+  | -- |
+    --       Creates the index asynchronously using the @CONCURRENTLY@ keyword in
+    --       PostgreSQL. Index creation will return immediately and the index will be
+    --       created in the background by PostgreSQL. Index creation may fail when
+    --       using the 'Asynchronous' strategy. Orville has no special provision to
+    --       detect or recover from this failure currently. You should manually check
+    --       that index creation has succeeded. If necessary, you can manually drop
+    --       the index to cause Orville to recreate it the next time migrations are
+    --       run. This is useful when you need to add an index to a very large table
+    --       because this can lock the table for a long time and cause an application
+    --       to fail health checks at startup if migrations do not finish quickly enough.
+    --       You should familiarize youself with how concurrent index creation works
+    --       in PostgreSQL before using this. See
+    --       https://www.postgresql.org/docs/current/sql-createindex.html#SQL-CREATEINDEX-CONCURRENTLY
+    Asynchronous
+  deriving (Eq, Show)
 
 data IndexMigrationKey
   = AttributeBasedIndexKey AttributeBasedIndexMigrationKey
@@ -57,14 +119,17 @@ type NamedIndexMigrationKey = String
   Gets the 'IndexMigrationKey' for the 'IndexDefinition'
 -}
 indexMigrationKey :: IndexDefinition -> IndexMigrationKey
-indexMigrationKey = _indexMigrationKey
+indexMigrationKey = i_indexMigrationKey
 
 {- |
   Gets the SQL expression that will be used to add the index to the specified
   table.
 -}
 indexCreateExpr :: IndexDefinition -> Expr.Qualified Expr.TableName -> Expr.CreateIndexExpr
-indexCreateExpr = _indexCreateExpr
+indexCreateExpr indexDef =
+  i_indexCreateExpr
+    indexDef
+    (i_indexCreationStrategy indexDef)
 
 {- |
   Constructs an 'IndexDefinition' for a non-unique index on the given
@@ -78,7 +143,7 @@ nonUniqueIndex =
   Constructs an 'IndexDefinition' for a non-unique index with given SQL and
   index name
 -}
-nonUniqueNamedIndex :: String -> RawSql.RawSql -> IndexDefinition
+nonUniqueNamedIndex :: String -> Expr.IndexBodyExpr -> IndexDefinition
 nonUniqueNamedIndex =
   mkNamedIndexDefinition Expr.NonUniqueIndex
 
@@ -94,7 +159,7 @@ uniqueIndex =
   Constructs an 'IndexDefinition' for a @UNIQUE@ index on the given
   columns.
 -}
-uniqueNamedIndex :: String -> RawSql.RawSql -> IndexDefinition
+uniqueNamedIndex :: String -> Expr.IndexBodyExpr -> IndexDefinition
 uniqueNamedIndex =
   mkNamedIndexDefinition Expr.UniqueIndex
 
@@ -108,9 +173,10 @@ mkIndexDefinition ::
   IndexDefinition
 mkIndexDefinition uniqueness fieldNames =
   let
-    expr tableName =
+    expr strategy tableName =
       Expr.createIndexExpr
         uniqueness
+        (mkMaybeConcurrently strategy)
         tableName
         (fmap FieldDefinition.fieldNameToColumnName fieldNames)
 
@@ -121,29 +187,42 @@ mkIndexDefinition uniqueness fieldNames =
         }
   in
     IndexDefinition
-      { _indexCreateExpr = expr
-      , _indexMigrationKey = AttributeBasedIndexKey migrationKey
+      { i_indexCreateExpr = expr
+      , i_indexMigrationKey = AttributeBasedIndexKey migrationKey
+      , i_indexCreationStrategy = Transactional
       }
 
 {- |
-  Constructs an 'IndexDefinition' for an index with the given uniquness, given
+  Constructs an 'IndexDefinition' for an index with the given uniqueness, given
   name, and given SQL.
 -}
 mkNamedIndexDefinition ::
   Expr.IndexUniqueness ->
   String ->
-  RawSql.RawSql ->
+  Expr.IndexBodyExpr ->
   IndexDefinition
-mkNamedIndexDefinition uniqueness indexName indexSql =
+mkNamedIndexDefinition uniqueness indexName bodyExpr =
   let
-    expr tableName =
+    expr strategy tableName =
       Expr.createNamedIndexExpr
         uniqueness
+        (mkMaybeConcurrently strategy)
         tableName
         (Expr.indexName indexName)
-        indexSql
+        bodyExpr
   in
     IndexDefinition
-      { _indexCreateExpr = expr
-      , _indexMigrationKey = NamedIndexKey indexName
+      { i_indexCreateExpr = expr
+      , i_indexMigrationKey = NamedIndexKey indexName
+      , i_indexCreationStrategy = Transactional
       }
+
+{- |
+  Internal helper to determine whether @CONCURRENTLY@ should be included in
+  the SQL to create the index.
+-}
+mkMaybeConcurrently :: IndexCreationStrategy -> Maybe Expr.ConcurrentlyExpr
+mkMaybeConcurrently strategy =
+  case strategy of
+    Transactional -> Nothing
+    Asynchronous -> Just Expr.concurrently

--- a/orville-postgresql-libpq/test/Main.hs
+++ b/orville-postgresql-libpq/test/Main.hs
@@ -89,7 +89,8 @@ main = do
 createTestConnectionPool :: IO (Orville.Pool Orville.Connection)
 createTestConnectionPool = do
   connStr <- lookupConnStr
-  Orville.createConnectionPool Orville.DisableNoticeReporting 1 10 1 connStr
+  -- Some tests use more than one connection, so the pool size must be greater
+  Orville.createConnectionPool Orville.DisableNoticeReporting 1 10 2 connStr
 
 recheckDBProperty :: HH.Size -> HH.Seed -> Property.NamedDBProperty -> IO ()
 recheckDBProperty size seed namedProperty = do


### PR DESCRIPTION
This adds the option for a user to specify an `IndexDefinition` should
be created asynchronously during migrations.

To do this the migration lock needed to be changed to be acquired at the
session level rather than the transaction level, which means we need to
manually release the lock. I added tests to ensure that this lock
release happens as expected. I also exported the `withTransactionLock`
function both to test it, and to make it available to users in case they
want to use `generateMigrationPlan` and `executeMigrationPlan`
separately.
