### PR TITLE
Updates the postgresql versions tested against.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pg-version: ["pg11", "pg12", "pg13", "pg14", "pg15"]
+        pg-version: ["pg12", "pg13", "pg14", "pg15", "pg16"]
         stack-yaml: ["stack-lts-18.28-ghc-8.10.7.yml","stack-lts-19.33-ghc-9.0.2.yml","stack-lts-20.26-ghc-9.2.8.yml","stack-nightly-2023-07-09-ghc-9.6.2.yml","stack.yml"]
     permissions:
       packages: write

--- a/orville-postgresql-libpq/compose.yml
+++ b/orville-postgresql-libpq/compose.yml
@@ -8,9 +8,9 @@ services:
       - stack-root:/stack-root
     working_dir: /orville-postgresql
     depends_on:
-      - testdb-${PG_VERSION:-pg11}
+      - testdb-${PG_VERSION:-pg12}
     environment:
-      TEST_CONN_HOST: "host=testdb-${PG_VERSION:-pg11}"
+      TEST_CONN_HOST: "host=testdb-${PG_VERSION:-pg12}"
       STACK_ROOT: /stack-root
     command:
       - ./scripts/test-loop
@@ -19,12 +19,6 @@ services:
     # stack test. stdin_open would be sufficient, but
     # allocating a tty provides colorful test output :)
     tty: true
-
-  testdb-pg11:
-    image: postgres:11.17-alpine
-    environment:
-      POSTGRES_USER: orville_test
-      POSTGRES_PASSWORD: orville
 
   testdb-pg12:
     image: postgres:12.12-alpine
@@ -45,7 +39,13 @@ services:
       POSTGRES_PASSWORD: orville
 
   testdb-pg15:
-    image: postgres:15.0-alpine
+    image: postgres:15.4-alpine
+    environment:
+      POSTGRES_USER: orville_test
+      POSTGRES_PASSWORD: orville
+
+  testdb-pg16:
+    image: postgres:16.0-alpine
     environment:
       POSTGRES_USER: orville_test
       POSTGRES_PASSWORD: orville

--- a/orville-postgresql-libpq/scripts/psql.sh
+++ b/orville-postgresql-libpq/scripts/psql.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-docker-compose exec testdb-pg11 psql -U orville_test
+docker-compose exec testdb-pg12 psql -U orville_test


### PR DESCRIPTION
Version 11 is no longer supported so the default for local is now 12. Additionally version 16 has been released so be sure to test against that in CI.