### PR TITLE
Adds Haddocks to the rest of the Expr module

### DIFF
--- a/orville-postgresql-libpq/scripts/gen-local-docs.sh
+++ b/orville-postgresql-libpq/scripts/gen-local-docs.sh
@@ -4,5 +4,5 @@ set -e
 
 docker-compose run \
   --no-deps --rm dev \
-  stack --stack-yaml stack-lts-17.0.yml \
+  stack --stack-yaml stack-lts-18.28-ghc-8.10.7.yml \
   haddock --force-dirty --no-haddock-deps --haddock-arguments --odir=local-docs

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/BinaryOperator.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/BinaryOperator.hs
@@ -41,17 +41,14 @@ where
 import Orville.PostgreSQL.Expr.ValueExpression (ValueExpression)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
-{- | Type to represent any SQL operator of two arguments.
+{- |
+Type to represent any SQL operator of two arguments. E.G.
 
-There is an low level escape hatch included here, by means of the instance of
-'RawSql.SqlExpression'. This is intended to be used when some functionality is required but not
-already included. The extension mechanism provided does require care in use as no guarantees are
-provided for correctness in usage.
+> AND
 
-For example, if one wanted to have a binary operator corresponding to the fictional SQL operator
-MY_OPERATOR, that could be done as
-
- > RawSql.unsafeSqlExpression "MY_OPERATOR"
+'BinaryOperator' provides' a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/ColumnDefinition.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/ColumnDefinition.hs
@@ -25,16 +25,14 @@ import Orville.PostgreSQL.Expr.Name (ColumnName)
 import Orville.PostgreSQL.Expr.ValueExpression (ValueExpression)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
-{- | Represent a complete definition of a column.
+{- |
+Represent a complete definition of a column. E.G.
 
-There is an low level escape hatch included here, by means of the instance of
-'RawSql.SqlExpression'. This is intended to be used when some functionality is required but not
-already included. The extension mechanism provided does require care in use as no guarantees are
-provided for correctness in usage.
+> foo INTEGER
 
-For example, if one wanted to have a column named FOO of type INT, that could be done as
-
- > RawSql.unsafeSqlExpression "FOO INT"
+'ColumnDefinition' provides' a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}
@@ -69,16 +67,14 @@ columnDefinition columnName dataType maybeColumnConstraint maybeColumnDefault =
       , fmap RawSql.toRawSql maybeColumnDefault
       ]
 
-{- | Represent constraints, such as nullability, on a column.
+{- |
+Represent constraints, such as nullability, on a column. E.G.
 
-There is an low level escape hatch included here, by means of the instance of
-'RawSql.SqlExpression'. This is intended to be used when some functionality is required but not
-already included. The extension mechanism provided does require care in use as no guarantees are
-provided for correctness in usage.
+> NOT NULL
 
-For example, if one wanted to have a constraint of NOT NULL, that could be done as
-
- > RawSql.unsafeSqlExpression "NOT NULL"
+'ColumnConstraint' provides' a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}
@@ -105,16 +101,14 @@ nullConstraint :: ColumnConstraint
 nullConstraint =
   ColumnConstraint (RawSql.fromString "NULL")
 
-{- | Represent the default value of a column.
+{- |
+Represents the default value of a column. E.G.
 
-There is an low level escape hatch included here, by means of the instance of
-'RawSql.SqlExpression'. This is intended to be used when some functionality is required but not
-already included. The extension mechanism provided does require care in use as no guarantees are
-provided for correctness in usage.
+> now()
 
-For example, if one wanted to have a default of FOO, that could be done as
-
- > RawSql.unsafeSqlExpression "FOO"
+'ColumnDefault' provides' a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Cursor.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Cursor.hs
@@ -49,20 +49,19 @@ import Orville.PostgreSQL.Expr.Name (CursorName)
 import Orville.PostgreSQL.Expr.Query (QueryExpr)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
-{- | 'DeclareExpr' corresponds to the SQL DECLARE statement, for declaring and opening cursors.
+{- |
+'DeclareExpr' corresponds to the SQL DECLARE statement, for declaring and
+opening cursors. E.G.
+
+> DECLARE FOO CURSOR FOR SELECT * FROM BAR
 
 See PostgreSQL [cursor declare
-documentation](https://www.postgresql.org/docs/current/sql-declare.html) for more information.
+documentation](https://www.postgresql.org/docs/current/sql-declare.html) for
+more information.
 
-There is an low level escape hatch included here, by means of the instance of
-'RawSql.SqlExpression'. This is intended to be used when some functionality is required but not
-already included. The extension mechanism provided does require care in use as no guarantees are
-provided for correctness in usage.
-
-For example, if one wanted to have a cusor named FOO, with a query of select * from BAR, that could
-be done as
-
- > RawSql.unsafeSqlExpression "DECLARE FOO CURSOR FOR SELECT * FROM BAR"
+'DeclareExpr' provides' a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}
@@ -97,24 +96,22 @@ declare cursorName maybeScrollExpr maybeHoldExpr queryExpr =
         , Just $ RawSql.toRawSql queryExpr
         ]
 
-{- | 'ScrollExpr' is used to determine if a cursor should be able to fetch nonsequentially.
+{- |
+'ScrollExpr' is used to determine if a cursor should be able to fetch
+nonsequentially. E.G.
 
-Note that the default in at least PostgreSQL versions 11-15 is to allow nonsequential fetches under
-some, but not all, circumstances.
+> NO SCROLL
+
+Note that the default in at least PostgreSQL versions 11-15 is to allow
+nonsequential fetches under some, but not all, circumstances.
 
 See PostgreSQL [cursor declare
 documentation](https://www.postgresql.org/docs/current/sql-declare.html) for more information.
 
-There is an low level escape hatch included here, by means of the instance of
-'RawSql.SqlExpression'. This is intended to be used when some functionality is required but not
-already included. The extension mechanism provided does require care in use as no guarantees are
-provided for correctness in usage.
+'ScrollExpr' provides' a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
-For example, if one wanted to allow only sequential fetches, that could be done as
-
- > RawSql.unsafeSqlExpression "NO SCROLL"
-
-The above is provided as a built-in, 'noScroll'.
 @since 0.10.0.0
 -}
 newtype ScrollExpr
@@ -140,23 +137,18 @@ noScroll :: ScrollExpr
 noScroll =
   ScrollExpr . RawSql.fromString $ "NO SCROLL"
 
-{- | 'HoldExpr' is used to determine if a cursor should be available for use after the transaction
-   that created it has been comitted.
+{- |
+'HoldExpr' is used to determine if a cursor should be available for use after
+the transaction that created it has been comitted. E.G.
+
+> WITH HOLD
 
 See PostgreSQL [cursor documentation](https://www.postgresql.org/docs/current/sql-declare.html) for
 more information.
 
-There is an low level escape hatch included here, by means of the instance of
-'RawSql.SqlExpression'. This is intended to be used when some functionality is required but not
-already included. The extension mechanism provided does require care in use as no guarantees are
-provided for correctness in usage.
-
-For example, if one wanted to have a cursor available after the transaction creating it commits,
-that could be done as
-
- > RawSql.unsafeSqlExpression "WITH HOLD"
-
-The above is provided as a built-in, 'withHold'.
+'HoldExpr' provides' a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}
@@ -183,23 +175,17 @@ withoutHold :: HoldExpr
 withoutHold =
   HoldExpr . RawSql.fromString $ "WITHOUT HOLD"
 
-{- | 'CloseExpr' corresponds to the SQL CLOSE statement.
+{- |
+'CloseExpr' corresponds to the SQL CLOSE statement. E.G.
+
+> CLOSE ALL
 
 See PostgreSQL [close documentation](https://www.postgresql.org/docs/current/sql-close.html) for
 more information.
 
-There is an low level escape hatch included here, by means of the instance of
-'RawSql.SqlExpression'. This is intended to be used when some functionality is required but not
-already included. The extension mechanism provided does require care in use as no guarantees are
-provided for correctness in usage.
-
-For example, if one wanted to close all cursors, that could be done as
-
-> RawSql.unsafeSqlExpression "CLOSE ALL"
-
-The above is available via built-ins as,
-
-> close (Left allCursors)
+'HoldExpr' provides' a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}
@@ -221,21 +207,14 @@ close allOrCursorName =
     RawSql.fromString "CLOSE "
       <> either RawSql.toRawSql RawSql.toRawSql allOrCursorName
 
-{- | 'AllCursors' corresponds to the ALL keyword in a CLOSE statement.
+{- |
+'AllCursors' corresponds to the ALL keyword in a CLOSE statement. E.G.
 
-See PostgreSQL [close documentation](https://www.postgresql.org/docs/current/sql-close.html) for
-more information.
+> ALL
 
-There is an low level escape hatch included here, by means of the instance of
-'RawSql.SqlExpression'. This is intended to be used when some functionality is required but not
-already included. The extension mechanism provided does require care in use as no guarantees are
-provided for correctness in usage.
-
-For example, this could be done as
-
-> RawSql.unsafeSqlExpression "ALL"
-
-The above is available as a built-in, 'allCursors'
+'AllCursors' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}
@@ -254,26 +233,19 @@ allCursors :: AllCursors
 allCursors =
   AllCursors . RawSql.fromString $ "ALL"
 
-{- | 'FetchExpr' corresponds to the SQL FETCH statement, for retrieving rows from a previously created
-   cursor.
+{- |
+'FetchExpr' corresponds to the SQL FETCH statement, for retrieving rows from a
+previously created cursor. E.G.
 
-See PostgreSQL [fetch documentation](https://www.postgresql.org/docs/current/sql-fetch.html) for
-more information.
+> FETCH NEXT FOO
 
-There is an low level escape hatch included here, by means of the instance of
-'RawSql.SqlExpression'. This is intended to be used when some functionality is required but not
-already included. The extension mechanism provided does require care in use as no guarantees are
-provided for correctness in usage.
+See PostgreSQL [fetch
+documentation](https://www.postgresql.org/docs/current/sql-fetch.html) for more
+information.
 
-For example, if one wanted to use a cusor named FOO, to get the next row, that could
-be done as
-
- > RawSql.unsafeSqlExpression "FETCH NEXT FOO"
-
-The above is available via built-ins, given you have previously created the cursor and named it foo
-as,
-
-> fetch (Just next) foo
+'FetchExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}
@@ -298,26 +270,15 @@ fetch maybeDirection cursorName =
         , Just $ RawSql.toRawSql cursorName
         ]
 
-{- | 'MoveExpr' corresponds to the SQL MOVE statement, for positioning a previously created cursor,
-   /without/ retrieving any rows.
+{- |
+'MoveExpr' corresponds to the SQL MOVE statement, for positioning a previously
+created cursor, /without/ retrieving any rows. E.G.
 
-See PostgreSQL [move
-documentation](https://www.postgresql.org/docs/current/sql-move.html) for more information.
+> MOVE NEXT FOO
 
-There is an low level escape hatch included here, by means of the instance of
-'RawSql.SqlExpression'. This is intended to be used when some functionality is required but not
-already included. The extension mechanism provided does require care in use as no guarantees are
-provided for correctness in usage.
-
-For example, if one wanted to use a cusor named FOO, and position on next row, that could
-be done as
-
- > RawSql.unsafeSqlExpression "MOVE NEXT FOO"
-
-The above is available via built-ins, given you have previously created the cursor and named it foo
-as,
-
-> move (Just next) foo
+'MoveExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}
@@ -342,22 +303,18 @@ move maybeDirection cursorName =
       , Just $ RawSql.toRawSql cursorName
       ]
 
-{- | 'CursorDirection' corresponds to the direction argument to the SQL FETCH and MOVE statements.
+{- |
+'CursorDirection' corresponds to the direction argument to the SQL FETCH and
+MOVE statements. E.G.
+
+> BACKWARD
 
 See PostgreSQL [fetch documentation](https://www.postgresql.org/docs/current/sql-fetch.html) for
 more information.
 
-There is an low level escape hatch included here, by means of the instance of
-'RawSql.SqlExpression'. This is intended to be used when some functionality is required but not
-already included. The extension mechanism provided does require care in use as no guarantees are
-provided for correctness in usage.
-
-For example, if one wanted to specify a backwards direction for use in a 'FetchExpr' or 'MoveExpr',
-this could be done as
-
-> RawSql.unsafeSqlExpression "BACKWARD"
-
-The above is available as a built-in, 'backward'
+'CursorDirection' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/DataType.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/DataType.hs
@@ -33,17 +33,13 @@ import Data.Int (Int32)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 {- |
-Type to represent any SQL data type expression.
+Type to represent any SQL data type expression. E.G.
 
-There is a low level escape hatch included here, by means of the instance of
-'RawSql.SqlExpression'. This is intended to be used when some functionality is
-required but not already included. The extension mechanism provided does require
-care in use as no guarantees are provided for correctness in usage.
+> INTEGER
 
-For example, if one wanted to have a data type corresponding to the fictional
-SQL operator MY_DATA_TYPE, that could be done as
-
- > RawSql.unsafeSqlExpression "MY_DATA_TYPE"
+'DataType' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Delete.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Delete.hs
@@ -23,17 +23,13 @@ import Orville.PostgreSQL.Expr.WhereClause (WhereClause)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 {- |
-Type to represent a SQL delete statement.
+Type to represent a SQL delete statement. E.G.
 
-There is an low level escape hatch included here, by means of the instance of
-'RawSql.SqlExpression'. This is intended to be used when some functionality is
-required but not already included. The extension mechanism provided does require
-care in use as no guarantees are provided for correctness in usage.
+> DELETE FROM foo WHERE id < 10
 
-For example, if one wanted to write a delete statement by hand and use it in a
-place that expected a 'DeleteExpr', that could be done as
-
- > RawSql.unsafeSqlExpression "DELETE FROM <my things to delete>"
+'DeleteExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/GroupBy.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/GroupBy.hs
@@ -23,17 +23,13 @@ import Orville.PostgreSQL.Expr.Name (ColumnName)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 {- |
-Type to represent a SQL group by clause.
+Type to represent a SQL group by clause. E.G.
 
-There is an low level escape hatch included here, by means of the instance of
-'RawSql.SqlExpression'. This is intended to be used when some functionality is
-required but not already included. The extension mechanism provided does require
-care in use as no guarantees are provided for correctness in usage.
+> GROUP BY team_name
 
-For example, if one wanted to write a group by clause by hand and use it in a
-place that expected a 'GroupByClause', that could be done as
-
- > RawSql.unsafeSqlExpression "GROUP BY <my unusual group by>"
+'GroupByClause' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}
@@ -53,17 +49,13 @@ groupByClause expr = GroupByClause (RawSql.fromString "GROUP BY " <> RawSql.toRa
 
 {- |
 Type to represent a SQL group by expression (the part that follows the @GROUP
-BY@ in sql).
+BY@ in sql). E.G.
 
-There is an low level escape hatch included here, by means of the instance of
-'RawSql.SqlExpression'. This is intended to be used when some functionality is
-required but not already included. The extension mechanism provided does require
-care in use as no guarantees are provided for correctness in usage.
+> team_name
 
-For example, if one wanted to write a group by expression by hand and use it in a
-place that expected a 'GroupByExpr', that could be done as
-
- > RawSql.unsafeSqlExpression "<my unusual group by>"
+'GroupByExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/IfExists.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/IfExists.hs
@@ -16,17 +16,13 @@ where
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 {- |
-Type to represent a SQL "IF EXISTS" expression
+Type to represent a SQL "IF EXISTS" expression. E.G.
 
-There is an low level escape hatch included here, by means of the instance of
-'RawSql.SqlExpression'. This is intended to be used when some functionality is
-required but not already included. The extension mechanism provided does require
-care in use as no guarantees are provided for correctness in usage.
+> IF EXISTS
 
-For example, if one wanted to write a some other sql and use it in a place that
-expected an 'IfExists', that could be done as
-
- > RawSql.unsafeSqlExpression "<some other than IF EXISTS>"
+'IfExists' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Index.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Index.hs
@@ -27,17 +27,13 @@ import Orville.PostgreSQL.Expr.Name (ColumnName, IndexName, Qualified, TableName
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 {- |
-Type to represent a SQL "CREATE INDEX" statement
+Type to represent a SQL "CREATE INDEX" statement. E.G.
 
-There is an low level escape hatch included here, by means of the instance of
-'RawSql.SqlExpression'. This is intended to be used when some functionality is
-required but not already included. The extension mechanism provided does require
-care in use as no guarantees are provided for correctness in usage.
+> CREATE INDEX ON table (foo, bar, baz)
 
-For example, if one wanted to write a create index by hand and use it in a place that
-expected a 'CreateIndexExpr', that could be done as
-
- > RawSql.unsafeSqlExpression "CREATE INDEX <some unusual index creation>"
+'CreateIndexExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}
@@ -98,10 +94,13 @@ createNamedIndexExpr uniqueness mbConcurrently tableName indexName bodyExpr =
       <> RawSql.toRawSql bodyExpr
 
 {- |
-Type to represent the @CONCURRENTLY@ keyword for index creation
+Type to represent the @CONCURRENTLY@ keyword for index creation. E.G.
+
+> CONCURRENTLY
 
 'ConcurrentlyExpr' provides a 'RawSql.SqlExpression' instance. See
-'unsafeSqlExpression' for how to construct a value with your own custom SQL.
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}
@@ -123,11 +122,17 @@ concurrently =
   RawSql.unsafeSqlExpression "CONCURRENTLY"
 
 {- |
-Type to represent if the body of an index definition (i.e. @<body>@ in
-after @CREATE some_index ON some_table <body>@).
+Type to represent if the body of an index definition E.G.
+
+> (foo, bar)
+
+in
+
+> CREATE some_index ON some_table (foo, bar)
 
 'IndexBodyExpr' provides a 'RawSql.SqlExpression' instance. See
-'unsafeSqlExpression' for how to construct a value with your own custom SQL.
+'Rawsql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}
@@ -178,17 +183,13 @@ uniquenessToSql uniqueness =
     NonUniqueIndex -> mempty
 
 {- |
-Type to represent a SQL "DROP INDEX" statement
+Type to represent a SQL "DROP INDEX" statement. E.G.
 
-There is an low level escape hatch included here, by means of the instance of
-'RawSql.SqlExpression'. This is intended to be used when some functionality is
-required but not already included. The extension mechanism provided does require
-care in use as no guarantees are provided for correctness in usage.
+> DROP INDEX foo
 
-For example, if one wanted to write a drop index by hand and use it in a place that
-expected a 'DropIndexExpr', that could be done as
-
- > RawSql.unsafeSqlExpression "DROP INDEX <some unusual index drop>"
+'DropIndexExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Insert.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Insert.hs
@@ -27,17 +27,13 @@ import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import Orville.PostgreSQL.Raw.SqlValue (SqlValue)
 
 {- |
-Type to represent a SQL "INSERT" statement
+Type to represent a SQL "INSERT" statement. E.G.
 
-There is an low level escape hatch included here, by means of the instance of
-'RawSql.SqlExpression'. This is intended to be used when some functionality is
-required but not already included. The extension mechanism provided does require
-care in use as no guarantees are provided for correctness in usage.
+> INSERT INTO foo (id) VALUES (1),(3),(3)
 
-For example, if one wanted to write an insert by hand and use it in a place that
-expected a 'InsertExpr', that could be done as
-
- > RawSql.unsafeSqlExpression "INSERT <some unusual insert>"
+'InsertExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}
@@ -73,17 +69,13 @@ insertExpr target maybeInsertColumns source maybeReturning =
       ]
 
 {- |
-Type to represent the SQL columns list for an insert statement
+Type to represent the SQL columns list for an insert statement. E.G.
 
-There is an low level escape hatch included here, by means of the instance of
-'RawSql.SqlExpression'. This is intended to be used when some functionality is
-required but not already included. The extension mechanism provided does require
-care in use as no guarantees are provided for correctness in usage.
+> (foo,bar,baz)
 
-For example, if one wanted to write insert columns by hand and use them in a
-place that expected a 'InsertExpr', that could be done as
-
- > RawSql.unsafeSqlExpression "(my,raw,column,list)"
+'InsertColumnList' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}
@@ -107,18 +99,13 @@ insertColumnList columnNames =
       <> RawSql.rightParen
 
 {- |
-Type to represent the SQL for the source of data for an insert statement (e.g.
-a @VALUES@ clause).
+Type to represent the SQL for the source of data for an insert statement E.G.
 
-There is an low level escape hatch included here, by means of the instance of
-'RawSql.SqlExpression'. This is intended to be used when some functionality is
-required but not already included. The extension mechanism provided does require
-care in use as no guarantees are provided for correctness in usage.
+> VALUES ('Bob',32),('Cindy',33)
 
-For example, if one wanted to write an insert source by hand and use
-it in a place that expected a 'InsertSource', that could be done as
-
- > RawSql.unsafeSqlExpression "VALUES ('my','raw','insert','values')"
+'InsertSource' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}
@@ -150,18 +137,14 @@ insertSqlValues =
   insertRowValues . fmap rowValues
 
 {- |
-Type to represent a SQL row literal (e.g. for use as a row to insert
-inside a @VALUES@ clause).
+Type to represent a SQL row literal. For example, a single row to insert
+in a @VALUES@ clause. E.G.
 
-There is an low level escape hatch included here, by means of the instance of
-'RawSql.SqlExpression'. This is intended to be used when some functionality is
-required but not already included. The extension mechanism provided does require
-care in use as no guarantees are provided for correctness in usage.
+> ('Cindy',33)
 
-For example, if one wanted to write a row by hand and use it in a place that
-expected a 'RowValues', that could be done as
-
- > RawSql.unsafeSqlExpression "('my','raw','insert','values')"
+'RowValues' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/ColumnName.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/ColumnName.hs
@@ -18,17 +18,13 @@ import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 {- |
 Type to represent a SQL column name. 'ColumnName' values constructed via the
-'columnName' function will be properly escaped as part of the generated SQL.
+'columnName' function will be properly escaped as part of the generated SQL. E.G.
 
-There is an low level escape hatch included here, by means of the instance of
-'RawSql.SqlExpression'. This is intended to be used when some functionality is
-required but not already included. The extension mechanism provided does require
-care in use as no guarantees are provided for correctness in usage.
+> "some_column_name"
 
-For example, if one wanted to write a raw (unescaped) column name by hand and
-use it in a place that expected a 'ColumnName', that could be done as
-
- > RawSql.unsafeSqlExpression "my_column_name"
+'ColumnName' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/ConstraintName.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/ConstraintName.hs
@@ -19,17 +19,13 @@ import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 {- |
 Type to represent a SQL constraint name. 'ConstraintName' values constructed
 via the 'constraintName' function will be properly escaped as part of the
-generated SQL.
+generated SQL. E.G.
 
-There is an low level escape hatch included here, by means of the instance of
-'RawSql.SqlExpression'. This is intended to be used when some functionality is
-required but not already included. The extension mechanism provided does require
-care in use as no guarantees are provided for correctness in usage.
+> "some_constraint_name"
 
-For example, if one wanted to write a raw (unescaped) constraint name by hand and
-use it in a place that expected a 'ConstraintName', that could be done as
-
- > RawSql.unsafeSqlExpression "my_constraint_name"
+'ConstraintName' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/CursorName.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/CursorName.hs
@@ -19,17 +19,13 @@ import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 {- |
 Type to represent a SQL cursor name. 'CursorName' values constructed
 via the 'cursorName' function will be properly escaped as part of the
-generated SQL.
+generated SQL. E.G.
 
-There is an low level escape hatch included here, by means of the instance of
-'RawSql.SqlExpression'. This is intended to be used when some functionality is
-required but not already included. The extension mechanism provided does require
-care in use as no guarantees are provided for correctness in usage.
+> "some_cursor_name"
 
-For example, if one wanted to write a raw (unescaped) cursor name by hand and
-use it in a place that expected a 'CursorName', that could be done as
-
- > RawSql.unsafeSqlExpression "my_cursor_name"
+'CursorName' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/FunctionName.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/FunctionName.hs
@@ -19,17 +19,13 @@ import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 {- |
 Type to represent a SQL function name. 'FunctionName' values constructed
 via the 'functionName' function will be properly escaped as part of the
-generated SQL.
+generated SQL. E.G.
 
-There is an low level escape hatch included here, by means of the instance of
-'RawSql.SqlExpression'. This is intended to be used when some functionality is
-required but not already included. The extension mechanism provided does require
-care in use as no guarantees are provided for correctness in usage.
+> "some_function_name"
 
-For example, if one wanted to write a raw (unescaped) function name by hand and
-use it in a place that expected a 'FunctionName', that could be done as
-
- > RawSql.unsafeSqlExpression "my_function_name"
+'FunctionName' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/Identifier.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/Identifier.hs
@@ -21,16 +21,13 @@ import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 {- |
 Type to represent a SQL identifier. 'Identifier' values constructed via the
 'identifier' function will be properly escaped as part of the generated SQL.
+E.G.
 
-There is an low level escape hatch included here, by means of the instance of
-'RawSql.SqlExpression'. This is intended to be used when some functionality is
-required but not already included. The extension mechanism provided does require
-care in use as no guarantees are provided for correctness in usage.
+> "some_identifier"
 
-For example, if one wanted to write a raw (unescaped) identifier by hand and
-use it in a place that expected an 'Identifer', that could be done as
-
- > RawSql.unsafeSqlExpression "my_identifier"
+'Identifer' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/IndexName.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/IndexName.hs
@@ -16,17 +16,13 @@ import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 {- |
 Type to represent a SQL index name. 'IndexName' values constructed via the
-'indexName' function will be properly escaped as part of the generated SQL.
+'indexName' function will be properly escaped as part of the generated SQL. E.G.
 
-There is an low level escape hatch included here, by means of the instance of
-'RawSql.SqlExpression'. This is intended to be used when some functionality is
-required but not already included. The extension mechanism provided does require
-care in use as no guarantees are provided for correctness in usage.
+> "some_index_name"
 
-For example, if one wanted to write a raw (unescaped) index name by hand and
-use it in a place that expected an 'IndexName', that could be done as
-
- > RawSql.unsafeSqlExpression "my_index_name"
+'IndexName' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/Qualified.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/Qualified.hs
@@ -23,17 +23,13 @@ import Orville.PostgreSQL.Expr.Internal.Name.TableName (TableName)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 {- |
-Type to represent a qualified SQL name.
+Type to represent a qualified SQL name. E.G.
 
-There is an low level escape hatch included here, by means of the instance of
-'RawSql.SqlExpression'. This is intended to be used when some functionality is
-required but not already included. The extension mechanism provided does require
-care in use as no guarantees are provided for correctness in usage.
+> "some_schema_name"."some_table_name"
 
-For example, if one wanted to write a raw (unescaped) qualified name by hand
-and use it in a place that expected a 'Qualified a', that could be done as
-
- > RawSql.unsafeSqlExpression "my.qualified_name"
+'Qualified' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/SavepointName.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/SavepointName.hs
@@ -17,18 +17,15 @@ import Orville.PostgreSQL.Expr.Internal.Name.Identifier (Identifier, IdentifierE
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 {- |
-Type to represent a SQL savepoint name. 'SavepointName' values constructed via the
-'savepointName' function will be properly escaped as part of the generated SQL.
+Type to represent a SQL savepoint name. 'SavepointName' values constructed via
+the 'savepointName' function will be properly escaped as part of the generated
+SQL. E.G.
 
-There is an low level escape hatch included here, by means of the instance of
-'RawSql.SqlExpression'. This is intended to be used when some functionality is
-required but not already included. The extension mechanism provided does require
-care in use as no guarantees are provided for correctness in usage.
+> "some_savepoint_name"
 
-For example, if one wanted to write a raw (unescaped) savepoint name by hand and
-use it in a place that expected a 'SavepointName', that could be done as
-
- > RawSql.unsafeSqlExpression "my_savepoint_name"
+'SavepointName' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/SchemaName.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/SchemaName.hs
@@ -19,16 +19,13 @@ import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 {- |
 Type to represent a SQL schema name. 'SchemaName' values constructed via the
 'schemaName' function will be properly escaped as part of the generated SQL.
+E.G.
 
-There is an low level escape hatch included here, by means of the instance of
-'RawSql.SqlExpression'. This is intended to be used when some functionality is
-required but not already included. The extension mechanism provided does require
-care in use as no guarantees are provided for correctness in usage.
+> "some_schema_name"
 
-For example, if one wanted to write a raw (unescaped) schema name by hand and
-use it in a place that expected a 'SchemaName', that could be done as
-
- > RawSql.unsafeSqlExpression "my_schema_name"
+'SchemaName' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/SequenceName.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/SequenceName.hs
@@ -17,18 +17,15 @@ import Orville.PostgreSQL.Expr.Internal.Name.Identifier (Identifier, IdentifierE
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 {- |
-Type to represent a SQL sequence name. 'SequenceName' values constructed via the
-'sequenceName' function will be properly escaped as part of the generated SQL.
+Type to represent a SQL sequence name. 'SequenceName' values constructed via
+the 'sequenceName' function will be properly escaped as part of the generated
+SQL. E.G.
 
-There is an low level escape hatch included here, by means of the instance of
-'RawSql.SqlExpression'. This is intended to be used when some functionality is
-required but not already included. The extension mechanism provided does require
-care in use as no guarantees are provided for correctness in usage.
+> "some_sequence_name"
 
-For example, if one wanted to write a raw (unescaped) sequence name by hand and
-use it in a place that expected a 'SequenceName', that could be done as
-
- > RawSql.unsafeSqlExpression "my_sequence_name"
+'SequenceName' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/TableName.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Internal/Name/TableName.hs
@@ -19,16 +19,13 @@ import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 {- |
 Type to represent a SQL table name. 'TableName' values constructed via the
 'tableName' function will be properly escaped as part of the generated SQL.
+E.G.
 
-There is an low level escape hatch included here, by means of the instance of
-'RawSql.SqlExpression'. This is intended to be used when some functionality is
-required but not already included. The extension mechanism provided does require
-care in use as no guarantees are provided for correctness in usage.
+> "some_table_name"
 
-For example, if one wanted to write a raw (unescaped) table name by hand and
-use it in a place that expected a 'TableName', that could be done as
-
- > RawSql.unsafeSqlExpression "my_table_name"
+'TableName' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/LimitExpr.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/LimitExpr.hs
@@ -17,17 +17,13 @@ import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 {- |
-Type to represent a SQL limit expression (e.g. @LIMIT ...@)
+Type to represent a SQL limit expression. E.G.
 
-There is an low level escape hatch included here, by means of the instance of
-'RawSql.SqlExpression'. This is intended to be used when some functionality is
-required but not already included. The extension mechanism provided does require
-care in use as no guarantees are provided for correctness in usage.
+> LIMIT 10
 
-For example, if one wanted to write a limit expression by hand and
-use it in a place that expected a 'LimitExpr', that could be done as
-
- > RawSql.unsafeSqlExpression "LIMIT some expression"
+'LimitExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/OffsetExpr.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/OffsetExpr.hs
@@ -17,17 +17,13 @@ import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 {- |
-Type to represent a SQL offset expression (e.g. @OFFSET ...@)
+Type to represent a SQL offset expression. E.G.
 
-There is an low level escape hatch included here, by means of the instance of
-'RawSql.SqlExpression'. This is intended to be used when some functionality is
-required but not already included. The extension mechanism provided does require
-care in use as no guarantees are provided for correctness in usage.
+> OFFSET 10
 
-For example, if one wanted to write a offset expression by hand and
-use it in a place that expected a 'OffsetExpr', that could be done as
-
- > RawSql.unsafeSqlExpression "OFFSET some expression"
+'OffsetExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/OrderBy.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/OrderBy.hs
@@ -30,17 +30,13 @@ import Orville.PostgreSQL.Expr.Name (ColumnName)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 {- |
-Type to represent a SQL order by clause.
+Type to represent a SQL order by clause. E.G.
 
-There is an low level escape hatch included here, by means of the instance of
-'RawSql.SqlExpression'. This is intended to be used when some functionality is
-required but not already included. The extension mechanism provided does require
-care in use as no guarantees are provided for correctness in usage.
+> ORDER BY foo, bar
 
-For example, if one wanted to write a order by clause by hand and use it in a
-place that expected a 'OrderByClause', that could be done as
-
- > RawSql.unsafeSqlExpression "ORDER BY <my unusual order by>"
+'OrderByClause' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}
@@ -53,17 +49,13 @@ orderByClause expr = OrderByClause (RawSql.fromString "ORDER BY " <> RawSql.toRa
 
 {- |
 Type to represent a SQL order by expression (the part that follows the @ORDER
-BY@ in sql).
+BY@ in sql). E.G.
 
-There is an low level escape hatch included here, by means of the instance of
-'RawSql.SqlExpression'. This is intended to be used when some functionality is
-required but not already included. The extension mechanism provided does require
-care in use as no guarantees are provided for correctness in usage.
+> foo, bar
 
-For example, if one wanted to write a order by expression by hand and use it in a
-place that expected a 'OrderByExpr, that could be done as
-
- > RawSql.unsafeSqlExpression "<my unusual order by>"
+'OrderByExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}
@@ -119,17 +111,13 @@ orderByColumnName =
   orderByExpr . RawSql.toRawSql
 
 {- |
-Type to represent a SQL order by direction expression.
+Type to represent a SQL order by direction expression. E.G.
 
-There is an low level escape hatch included here, by means of the instance of
-'RawSql.SqlExpression'. This is intended to be used when some functionality is
-required but not already included. The extension mechanism provided does require
-care in use as no guarantees are provided for correctness in usage.
+> ASC
 
-For example, if one wanted to write a order by direction by hand and use it in a
-place that expected a 'OrderByDirection', that could be done as
-
- > RawSql.unsafeSqlExpression "<my unusual order by direction>"
+'OrderByDirection' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
 
 @since 0.10.0.0
 -}

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Query.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Query.hs
@@ -33,10 +33,28 @@ import Orville.PostgreSQL.Expr.WhereClause (WhereClause)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 -- This is a rough model of "query specification" see https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#_7_16_query_specification for more detail than you probably want
+
+{- |
+Type to represent a SQL query, E.G.
+
+> SELECT id FROM some_table
+
+'QueryExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype QueryExpr
   = QueryExpr RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  Builds a 'QueryExpr' from the given 'SelectClause', 'SelectList' and
+  'TableExpr'. The resulting 'QueryExpr' is suitable execution via the SQL
+  execution functions in "Orville.PostgreSQL.Execution" and
+  "Orville.PostgreSQL.Raw.RawSql".
+-}
 queryExpr :: SelectClause -> SelectList -> Maybe TableExpr -> QueryExpr
 queryExpr querySelectClause selectList maybeTableExpr =
   let
@@ -51,28 +69,88 @@ queryExpr querySelectClause selectList maybeTableExpr =
         , fromMaybe (RawSql.fromString "") maybeFromClause
         ]
 
+{- |
+Type to represent the list of items to be selected in a @SELECT@ clause.
+E.G. the
+
+> foo, bar, baz
+
+in
+
+> SELECT foo, bar, baz FROM some_table
+
+'SelectList' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype SelectList = SelectList RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  Constructs a 'SelectList' that will select all colums (i.e. the @*@ in
+  @SELECT *@").
+
+  @since 0.10.0.0
+-}
 selectStar :: SelectList
 selectStar =
   SelectList (RawSql.fromString "*")
 
+{- |
+  Constructs a 'SelectList' that will select the specified column names. This
+  is a special case of 'selectDerivedColumns' where all the items to be
+  selected are simple column references.
+
+  @since 0.10.0.0
+-}
 selectColumns :: [ColumnName] -> SelectList
 selectColumns =
   selectDerivedColumns . map (deriveColumn . columnReference)
 
+{- |
+Type to represent an individual item in a list of selected items. E.G.
+
+> now() as current_time
+
+'DerivedColumn' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype DerivedColumn = DerivedColumn RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  Constructs a 'SelectList' that will select the specified items, which may be
+  column references or other expressions as allowed by 'DerivedColumn'. See
+  also 'selectColumns' the simpler case of selecting a list of column names.
+
+@since 0.10.0.0
+-}
 selectDerivedColumns :: [DerivedColumn] -> SelectList
 selectDerivedColumns =
   SelectList . RawSql.intercalate RawSql.comma
 
+{- |
+  Constructs a 'DerivedColumn' that will select the given value. No name will
+  be given to the value in the result set. See 'deriveColumnAs' to give the
+  value a name in the result set.
+
+@since 0.10.0.0
+-}
 deriveColumn :: ValueExpression -> DerivedColumn
 deriveColumn =
   DerivedColumn . RawSql.toRawSql
 
+{- |
+  Constructs a 'DerivedColumn' that will select the given value and give it
+  the specified column name in the result set.
+
+@since 0.10.0.0
+-}
 deriveColumnAs :: ValueExpression -> ColumnName -> DerivedColumn
 deriveColumnAs valueExpr asColumn =
   DerivedColumn
@@ -81,16 +159,43 @@ deriveColumnAs valueExpr asColumn =
         <> RawSql.toRawSql asColumn
     )
 
+{- |
+Type to represent a table expression (including its associated options) in a
+@SELECT@. This is the part that would appear *after* the word @FROM@. E.G.
+
+> foo
+> WHERE id > 100
+> ORDER BY id
+> LIMIT 1
+> OFFSET 2
+
+'TableExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype TableExpr
   = TableExpr RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  Constructs a 'TableExpr' with the given options.
+
+@since 0.10.0.0
+-}
 tableExpr ::
+  -- | The list of tables to query from
   TableReferenceList ->
+  -- | An optional @WHERE@ clause to limit the results returned
   Maybe WhereClause ->
+  -- | An optional @GROUP BY@ clause to group the result set rows
   Maybe GroupByClause ->
+  -- | An optional @ORDER BY@ clause to order the result set rows
   Maybe OrderByClause ->
+  -- | An optional @LIMIT@ to apply to the result set
   Maybe LimitExpr ->
+  -- | An optional @OFFSET@ to apply to the result set
   Maybe OffsetExpr ->
   TableExpr
 tableExpr

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/ReturningExpr.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/ReturningExpr.hs
@@ -9,10 +9,25 @@ where
 import Orville.PostgreSQL.Expr.Query (SelectList)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
+{- |
+Type to represent a @RETURNING@ clause in a SQL @SELECT@ statement. E.G.
+
+> RETURNING (id)
+
+'ReturningExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype ReturningExpr
   = ReturningExpr RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  Constructs a 'ReturningExpr' that returns the items given in the
+  'SelectList'. Essentialy this retults @RETURNING <SelectList items>@
+-}
 returningExpr :: SelectList -> ReturningExpr
 returningExpr selectList =
   ReturningExpr $

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Select.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Select.hs
@@ -15,18 +15,60 @@ where
 
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
+{- |
+Type to represent the @SELECT@ part of SQL query E.G.
+
+> SELECT
+
+or
+
+> SELECT DISTINCT
+
+'SelectClause' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom SQL.
+
+@since 0.10.0.0
+-}
 newtype SelectClause
   = SelectClause RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  Constructs a 'SelectClause' using the given 'SelectExpr', which may indicate
+  that this is a @DISTINCT@ select.
+
+@since 0.10.0.0
+-}
 selectClause :: SelectExpr -> SelectClause
 selectClause expr = SelectClause (RawSql.fromString "SELECT " <> RawSql.toRawSql expr)
 
+{- |
+Type to represent the any expression modifying the @SELECT@ part of a SQL. E.G.
+
+> DISTINCT
+
+'SelectExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom SQL.
+
+@since 0.10.0.0
+-}
 newtype SelectExpr = SelectExpr RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  A simple value type used to indicate that a @SELECT@ should be distinct when
+  constructing a 'SelectExpr'
+
+@since 0.10.0.0
+-}
 data Distinct = Distinct
 
+{- |
+  Constructs a 'SelectExpr' that may or may not make the @SELECT@ distinct,
+  dependending on whether 'Just Distinct' is passed or not.
+
+@since 0.10.0.0
+-}
 selectExpr :: Maybe Distinct -> SelectExpr
 selectExpr mbDistinct =
   SelectExpr . RawSql.fromString $

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/SequenceDefinition.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/SequenceDefinition.hs
@@ -57,17 +57,40 @@ import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
    @@
 -}
 
+{- |
+Type to represent a @CREATE SEQUENCE@ statement. E.G.
+
+> CREATE SEQUENCE foo INCREMENT 2
+
+'CreateSequenceExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype CreateSequenceExpr
   = CreateSequenceExpr RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  Constructs a 'CreateSequenceExpr' with the given sequence options.
+
+  @since 0.10.0.0
+-}
 createSequenceExpr ::
+  -- | The name to be used for the sequence
   Qualified SequenceName ->
+  -- | An optional @INCREMENT@ expression
   Maybe IncrementByExpr ->
+  -- | An optional @MINVALUE@ expression
   Maybe MinValueExpr ->
+  -- | An optional @MAXVALUE@ expression
   Maybe MaxValueExpr ->
+  -- | An optional @START WITH@ expression
   Maybe StartWithExpr ->
+  -- | An optional @CACHE@ expression
   Maybe CacheExpr ->
+  -- | An optional @CYCLE@ expression
   Maybe CycleExpr ->
   CreateSequenceExpr
 createSequenceExpr sequenceName mbIncrementBy mbMinValue mbMaxValue mbStartWith mbCache mbCycle =
@@ -103,17 +126,40 @@ createSequenceExpr sequenceName mbIncrementBy mbMinValue mbMaxValue mbStartWith 
   @@
 -}
 
+{- |
+Type to represent a @CREATE SEQUENCE@ statement. E.G.
+
+> ALTER SEQUENCE foo START WITH 0
+
+'AlterSequenceExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype AlterSequenceExpr
   = AlterSequenceExpr RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  Constructs an 'AlterSequenceExpr' with the given sequence options.
+
+  @since 0.10.0.0
+-}
 alterSequenceExpr ::
+  -- | The name of the sequence to alter
   Qualified SequenceName ->
+  -- | An optional @INCREMENT@ expression
   Maybe IncrementByExpr ->
+  -- | An optional @MINVALUE@ expression
   Maybe MinValueExpr ->
+  -- | An optional @MAXVALUE@ expression
   Maybe MaxValueExpr ->
+  -- | An optional @START WITH@ expression
   Maybe StartWithExpr ->
+  -- | An optional @CACHE@ expression
   Maybe CacheExpr ->
+  -- | An optional @CYCLE@ expression
   Maybe CycleExpr ->
   AlterSequenceExpr
 alterSequenceExpr sequenceName mbIncrementBy mbMinValue mbMaxValue mbStartWith mbCache mbCycle =
@@ -130,84 +176,230 @@ alterSequenceExpr sequenceName mbIncrementBy mbMinValue mbMaxValue mbStartWith m
       , fmap RawSql.toRawSql mbCycle
       ]
 
+{- |
+Type to represent a @INCREMENT BY@ expression for sequences. E.G.
+
+> INCREMENT BY 0
+
+'IncrementByExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype IncrementByExpr
   = IncrementByExpr RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  Constructs an 'IncrementByExpr' that will make the sequence increment by
+  the given value
+
+  @since 0.10.0.0
+-}
 incrementBy :: Int64 -> IncrementByExpr
 incrementBy n =
   IncrementByExpr $
     RawSql.fromString "INCREMENT BY "
       <> RawSql.int64DecLiteral n
 
+{- |
+Type to represent a @MINVALUE@ expression for sequences. E.G.
+
+> MINVALUE 0
+
+'MinValueExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype MinValueExpr
   = MinValueExpr RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  Constructs an 'MinValueExpr' which gives the sequence the specified minimum
+  value
+
+  @since 0.10.0.0
+-}
 minValue :: Int64 -> MinValueExpr
 minValue n =
   MinValueExpr $
     RawSql.fromString "MINVALUE "
       <> RawSql.int64DecLiteral n
 
+{- |
+  Constructs an 'MinValueExpr' which gives the sequence no minimum value (i.e.
+  @NO MINVALUE@)
+
+  @since 0.10.0.0
+-}
 noMinValue :: MinValueExpr
 noMinValue =
   MinValueExpr . RawSql.fromString $ "NO MINVALUE"
 
+{- |
+Type to represent a @MAXVALUE@ expression for sequences. E.G.
+
+> MAXVALUE 1000000
+
+'MaxValueExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype MaxValueExpr
   = MaxValueExpr RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  Constructs an 'maxValueExpr' which gives the sequence the specified maximum
+  value
+
+  @since 0.10.0.0
+-}
 maxValue :: Int64 -> MaxValueExpr
 maxValue n =
   MaxValueExpr $
     RawSql.fromString "MAXVALUE "
       <> RawSql.int64DecLiteral n
 
+{- |
+  Constructs an 'MinValueExpr' which gives the sequence no maximum value (i.e.
+  @NO MAXVALUE@)
+
+  @since 0.10.0.0
+-}
 noMaxValue :: MaxValueExpr
 noMaxValue =
   MaxValueExpr . RawSql.fromString $ "NO MAXVALUE"
 
+{- |
+Type to represent a @START WITH@ expression for sequences. E.G.
+
+> START WITH 1
+
+'StartWithExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype StartWithExpr
   = StartWithExpr RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  Constructs a 'StartWithExpr' which gives the sequence the specified start
+  value
+
+  @since 0.10.0.0
+-}
 startWith :: Int64 -> StartWithExpr
 startWith n =
   StartWithExpr $
     RawSql.fromString "START WITH "
       <> RawSql.int64DecLiteral n
 
+{- |
+Type to represent a @CACHE @ expression for sequences. E.G.
+
+> CACHE 16
+
+'CacheExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype CacheExpr
   = CacheExpr RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  Constructs a 'CacheExpr' that will make the sequence pre-allocate the
+  specified number of sequence values.
+
+  @since 0.10.0.0
+-}
 cache :: Int64 -> CacheExpr
 cache n =
   CacheExpr $
     RawSql.fromString "CACHE "
       <> RawSql.int64DecLiteral n
 
+{- |
+Type to represent a @CYCLE@ expression for sequences. E.G.
+
+> CYCLE
+
+or
+
+> NO CYCLE
+
+'CycleExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype CycleExpr
   = CycleExpr RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  Constructs a 'CycleExpr' that indicate that the sequence should cycle.
+
+  @since 0.10.0.0
+-}
 cycle :: CycleExpr
 cycle = CycleExpr $ RawSql.fromString "CYCLE"
 
+{- |
+  Constructs a 'CycleExpr' that indicate that the sequence should not cycle.
+
+  @since 0.10.0.0
+-}
 noCycle :: CycleExpr
 noCycle = CycleExpr $ RawSql.fromString "NO CYCLE"
 
+{- |
+  Constructs a 'CycleExpr' will cause the sequence to cycle if the flag passed
+  is 'True'.
+
+  @since 0.10.0.0
+-}
 cycleIfTrue :: Bool -> CycleExpr
 cycleIfTrue cycleFlag =
   if cycleFlag
     then cycle
     else noCycle
 
+{- |
+Type to represent a @DROP SEQUENCE@ statement. E.G.
+
+> DROP SEQUENCE foo
+
+'DropSequenceExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype DropSequenceExpr
   = DropSequenceExpr RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  Constructs a 'DropSequenceExpr' that will drop sequence with the given name.
+  You maybe specific an 'IfExists' argument if you want to include an @IF
+  EXISTS@ condition in the statement.
+
+  @since 0.10.0.0
+-}
 dropSequenceExpr :: Maybe IfExists -> Qualified SequenceName -> DropSequenceExpr
 dropSequenceExpr maybeIfExists sequenceName =
   DropSequenceExpr $
@@ -220,26 +412,63 @@ dropSequenceExpr maybeIfExists sequenceName =
           ]
       )
 
+{- |
+  Constructs a 'ValueExpression' that will use the @nextval@ PostgreSQL
+  function to get the next value from the given sequence. If you're trying to
+  construct your own @SELECT@ to get the value of the sequnce, you can use the
+  constructed 'ValueExpression' with 'Orville.PostgreSQL.Expr.deriveColumnAs'
+  to build the item to select.
+
+  @since 0.10.0.0
+-}
 nextVal :: Qualified SequenceName -> ValueExpression
 nextVal sequenceName =
   functionCall
     nextValFunction
     [valueExpression . SqlValue.fromRawBytes . RawSql.toExampleBytes $ sequenceName]
 
+{- |
+  The @nextval@ PostgreSQL function.
+
+  @since 0.10.0.0
+-}
 nextValFunction :: FunctionName
 nextValFunction =
   functionName "nextval"
 
+{- |
+  Constructs a 'ValueExpression' that will use the @currval@ PostgreSQL
+  function to get the current value from the given sequence. If you're trying to
+  construct your own @SELECT@ to get the value of the sequnce, you can use the
+  constructed 'ValueExpression' with 'Orville.PostgreSQL.Expr.deriveColumnAs'
+  to build the item to select.
+
+  @since 0.10.0.0
+-}
 currVal :: Qualified SequenceName -> ValueExpression
 currVal sequenceName =
   functionCall
     currValFunction
     [valueExpression . SqlValue.fromRawBytes . RawSql.toExampleBytes $ sequenceName]
 
+{- |
+  The @currval@ PostgreSQL function.
+
+  @since 0.10.0.0
+-}
 currValFunction :: FunctionName
 currValFunction =
   functionName "currval"
 
+{- |
+  Constructs a 'ValueExpression' that will use the @setval@ PostgreSQL function
+  to set the value from the given sequence. If you're trying to construct your
+  own @SELECT@ to set the value of the sequnce, you can use the constructed
+  'ValueExpression' with 'Orville.PostgreSQL.Expr.deriveColumnAs' to build the
+  item to select.
+
+  @since 0.10.0.0
+-}
 setVal :: Qualified SequenceName -> Int64 -> ValueExpression
 setVal sequenceName newValue =
   functionCall
@@ -248,6 +477,11 @@ setVal sequenceName newValue =
     , valueExpression . SqlValue.fromInt64 $ newValue
     ]
 
+{- |
+  The @setval@ PostgreSQL function.
+
+  @since 0.10.0.0
+-}
 setValFunction :: FunctionName
 setValFunction =
   functionName "setval"

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/TableConstraint.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/TableConstraint.hs
@@ -21,10 +21,32 @@ import Data.List.NonEmpty (NonEmpty)
 import Orville.PostgreSQL.Expr.Name (ColumnName, Qualified, TableName)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
+{- |
+Type to represent a table constraint that would be part of a @CREATE TABLE@ or
+@ALTER TABLE@ statement. For instances, the @UNIQUE@ constraint in
+
+> CREATE TABLE FOO
+>  ( id integer
+>  , UNIQUE id
+>  )
+>
+
+'TableConstraint' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype TableConstraint
   = TableConstraint RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  Constructs a 'TableConstraint' will create a @UNIQUE@ constraint on the
+  given columns.
+
+  @since 0.10.0.0
+-}
 uniqueConstraint :: NonEmpty ColumnName -> TableConstraint
 uniqueConstraint columnNames =
   TableConstraint $
@@ -33,26 +55,76 @@ uniqueConstraint columnNames =
       <> RawSql.intercalate RawSql.comma columnNames
       <> RawSql.rightParen
 
+{- |
+Type to represent a foreign key action on a @FOREIGN KEY@ constraint. E.G.
+the @CASCADE@ in
+
+> FOREIGN KEY (foo_id) REFERENCES foo (id) ON DELETE CASCADE
+
+'ForeignKeyActionExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype ForeignKeyActionExpr
   = ForeignKeyActionExpr RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  The foreign key action @RESTRICT@.
+
+  @since 0.10.0.0
+-}
 restrictExpr :: ForeignKeyActionExpr
 restrictExpr = ForeignKeyActionExpr $ RawSql.fromString "RESTRICT"
 
+{- |
+  The foreign key action @CASCADE@.
+
+  @since 0.10.0.0
+-}
 cascadeExpr :: ForeignKeyActionExpr
 cascadeExpr = ForeignKeyActionExpr $ RawSql.fromString "CASCADE"
 
+{- |
+  The foreign key action @SET NULL@.
+
+  @since 0.10.0.0
+-}
 setNullExpr :: ForeignKeyActionExpr
 setNullExpr = ForeignKeyActionExpr $ RawSql.fromString "SET NULL"
 
+{- |
+  The foreign key action @SET DEFAULT@.
+
+  @since 0.10.0.0
+-}
 setDefaultExpr :: ForeignKeyActionExpr
 setDefaultExpr = ForeignKeyActionExpr $ RawSql.fromString "SET DEFAULT"
 
+{- |
+Type to represent an foreign key update action on a @FOREIGN KEY@ constraint. E.G.
+the @ON UPDATE RESTRICT@ in
+
+> FOREIGN KEY (foo_id) REFERENCES foo (id) ON UPDATE RESTRICT
+
+'ForeignKeyUpdateActionExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype ForeignKeyUpdateActionExpr
   = ForeignKeyUpdateActionExpr RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  Constructs a 'ForeignKeyActionExpr' that use the given 'ForeignKeyActionExpr'
+  in an @ON UPDATE@ clause for a foreign key.
+
+  @since 0.10.0.0
+-}
 foreignKeyUpdateActionExpr :: ForeignKeyActionExpr -> ForeignKeyUpdateActionExpr
 foreignKeyUpdateActionExpr action =
   ForeignKeyUpdateActionExpr $
@@ -60,10 +132,28 @@ foreignKeyUpdateActionExpr action =
       <> RawSql.space
       <> RawSql.toRawSql action
 
+{- |
+Type to represent an foreign key update action on a @FOREIGN KEY@ constraint. E.G.
+the @ON DELETE RESTRICT@ in
+
+> FOREIGN KEY (foo_id) REFERENCES foo (id) ON DELETE RESTRICT
+
+'ForeignKeyDeleteActionExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype ForeignKeyDeleteActionExpr
   = ForeignKeyDeleteActionExpr RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  Constructs a 'ForeignKeyActionExpr' that use the given 'ForeignKeyActionExpr'
+  in an @ON UPDATE@ clause for a foreign key.
+
+  @since 0.10.0.0
+-}
 foreignKeyDeleteActionExpr :: ForeignKeyActionExpr -> ForeignKeyDeleteActionExpr
 foreignKeyDeleteActionExpr action =
   ForeignKeyDeleteActionExpr $
@@ -71,11 +161,21 @@ foreignKeyDeleteActionExpr action =
       <> RawSql.space
       <> RawSql.toRawSql action
 
+{- |
+  Constructs a 'TableConstraint' that represent a @FOREIGN KEY@ constraint
+
+  @since 0.10.0.0
+-}
 foreignKeyConstraint ::
+  -- | The names of the columns in the source table that form the foreign key
   NonEmpty ColumnName ->
+  -- | The table of the table that the foreign key references
   Qualified TableName ->
+  -- | The names of the columns in the foreign table that the foreign key references
   NonEmpty ColumnName ->
+  -- | An optional @ON UPDATE@ foreign key action to perform
   Maybe ForeignKeyUpdateActionExpr ->
+  -- | An optional @ON DELETE@ foreign key action to perform
   Maybe ForeignKeyDeleteActionExpr ->
   TableConstraint
 foreignKeyConstraint columnNames foreignTableName foreignColumnNames mbUpdateAction mbDeleteAction =

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/TableDefinition.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/TableDefinition.hs
@@ -36,14 +36,34 @@ import Orville.PostgreSQL.Expr.Name (ColumnName, ConstraintName, Qualified, Tabl
 import Orville.PostgreSQL.Expr.TableConstraint (TableConstraint)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
+{- |
+Type to represent a @CREATE TABLE@ statement. E.G.
+
+> CREATE TABLE foo (id integer)
+
+'CreateTableExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype CreateTableExpr
   = CreateTableExpr RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  Constructs a 'CreateTableExpr' with the given options.
+
+  @since 0.10.0.0
+-}
 createTableExpr ::
+  -- | The name to be use for the table
   Qualified TableName ->
+  -- | The columns to include in the table
   [ColumnDefinition] ->
+  -- | A primary key expression for the table
   Maybe PrimaryKeyExpr ->
+  -- | Any table constraints to include with the table
   [TableConstraint] ->
   CreateTableExpr
 createTableExpr tableName columnDefs mbPrimaryKey constraints =
@@ -71,10 +91,26 @@ createTableExpr tableName columnDefs mbPrimaryKey constraints =
         , RawSql.rightParen
         ]
 
+{- |
+Type to represent a the primary key of a table. E.G.
+
+> PRIMARY KEY (id)
+
+'PrimaryKeyExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype PrimaryKeyExpr
   = PrimaryKeyExpr RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  Constructs a 'PrimaryKeyExpr' with the given columns
+
+  @since 0.10.0.0
+-}
 primaryKeyExpr :: NonEmpty ColumnName -> PrimaryKeyExpr
 primaryKeyExpr columnNames =
   PrimaryKeyExpr $
@@ -85,10 +121,26 @@ primaryKeyExpr columnNames =
       , RawSql.rightParen
       ]
 
+{- |
+Type to represent a @ALTER TABLE@ statement. E.G.
+
+> ALTER TABLE foo ADD COLUMN bar integer
+
+'AlterTableExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype AlterTableExpr
   = AlterTableExpr RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  Constructs an 'AlterTableExpr' with the given alter table actions.
+
+  @since 0.10.0.0
+-}
 alterTableExpr :: Qualified TableName -> NonEmpty AlterTableAction -> AlterTableExpr
 alterTableExpr tableName actions =
   AlterTableExpr $
@@ -97,33 +149,78 @@ alterTableExpr tableName actions =
       <> RawSql.space
       <> RawSql.intercalate RawSql.commaSpace actions
 
+{- |
+Type to represent an action as part of an @ALTER TABLE@ statement. E.G.
+
+> ADD COLUMN bar integer
+
+'AlterTableAction' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype AlterTableAction
   = AlterTableAction RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  Constructs an 'AlterTableAction' that will add the specified column to the
+  table.
+
+  @since 0.10.0.0
+-}
 addColumn :: ColumnDefinition -> AlterTableAction
 addColumn columnDef =
   AlterTableAction $
     RawSql.fromString "ADD COLUMN " <> RawSql.toRawSql columnDef
 
+{- |
+  Constructs an 'AlterTableAction' that will drop the specified column from the
+  table.
+
+  @since 0.10.0.0
+-}
 dropColumn :: ColumnName -> AlterTableAction
 dropColumn columnName =
   AlterTableAction $
     RawSql.fromString "DROP COLUMN " <> RawSql.toRawSql columnName
 
+{- |
+  Constructs an 'AlterTableAction' that will add the specified constraint to the
+  table.
+
+  @since 0.10.0.0
+-}
 addConstraint :: TableConstraint -> AlterTableAction
 addConstraint constraint =
   AlterTableAction $
     RawSql.fromString "ADD " <> RawSql.toRawSql constraint
 
+{- |
+  Constructs an 'AlterTableAction' that will drop the specified constraint from the
+  table.
+
+  @since 0.10.0.0
+-}
 dropConstraint :: ConstraintName -> AlterTableAction
 dropConstraint constraintName =
   AlterTableAction $
     RawSql.fromString "DROP CONSTRAINT " <> RawSql.toRawSql constraintName
 
+{- |
+  Constructs an 'AlterTableAction' that will alter the type of the specified
+  column.
+
+  @since 0.10.0.0
+-}
 alterColumnType ::
+  -- | The name of the column whose type willbe altered
   ColumnName ->
+  -- | The new type to use for the column
   DataType ->
+  -- | An optional 'UsingClause' to indicate to the database how data from the
+  -- old type should be converted to the new type.
   Maybe UsingClause ->
   AlterTableAction
 alterColumnType columnName dataType maybeUsingClause =
@@ -137,10 +234,27 @@ alterColumnType columnName dataType maybeUsingClause =
           : maybeToList (fmap RawSql.toRawSql maybeUsingClause)
       )
 
+{- |
+Type to represent a @USING@ clause as part of an @ALTER COLUMN@ when changing
+the type of a column. E.G.
+
+> USING id :: integer
+
+'UsingClause' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype UsingClause
   = UsingClause RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  Constructs a 'UsingClause' that will cast the column to the specified type.
+
+  @since 0.10.0.0
+-}
 usingCast :: ColumnName -> DataType -> UsingClause
 usingCast columnName dataType =
   UsingClause $
@@ -149,6 +263,12 @@ usingCast columnName dataType =
       <> RawSql.doubleColon
       <> RawSql.toRawSql dataType
 
+{- |
+  Constructs an 'AlterTableAction' that will alter the nullability of the
+  column.
+
+  @since 0.10.0.0
+-}
 alterColumnNullability :: ColumnName -> AlterNotNull -> AlterTableAction
 alterColumnNullability columnName alterNotNull =
   AlterTableAction $
@@ -159,18 +279,45 @@ alterColumnNullability columnName alterNotNull =
       , RawSql.toRawSql alterNotNull
       ]
 
+{- |
+Type to represent an action to alter the nullability of a column. E.G.
+
+> SET NOT NULL
+
+'AlterNotNull' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype AlterNotNull
   = AlterNotNull RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  Sets the column to not null via @SET NOT NULL@
+
+  @since 0.10.0.0
+-}
 setNotNull :: AlterNotNull
 setNotNull =
   AlterNotNull $ RawSql.fromString "SET NOT NULL"
 
+{- |
+  Sets the column to allow null via @DROP NOT NULL@
+
+  @since 0.10.0.0
+-}
 dropNotNull :: AlterNotNull
 dropNotNull =
   AlterNotNull $ RawSql.fromString "DROP NOT NULL"
 
+{- |
+  Constructs an 'AlterTableAction' that will use @DROP DEFAULT@ to drop the
+  default value of the specified column.
+
+  @since 0.10.0.0
+-}
 alterColumnDropDefault :: ColumnName -> AlterTableAction
 alterColumnDropDefault columnName =
   AlterTableAction $
@@ -181,6 +328,12 @@ alterColumnDropDefault columnName =
       , RawSql.fromString "DROP DEFAULT"
       ]
 
+{- |
+  Constructs an 'AlterTableAction' that will use @SET DEFAULT@ to set the
+  default value of the specified column.
+
+  @since 0.10.0.0
+-}
 alterColumnSetDefault ::
   RawSql.SqlExpression valueExpression =>
   ColumnName ->
@@ -196,10 +349,26 @@ alterColumnSetDefault columnName defaultValue =
       , RawSql.toRawSql defaultValue
       ]
 
+{- |
+Type to represent a @DROP TABLE@ statement. E.G.
+
+> DROP TABLE FOO
+
+'DropTableExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype DropTableExpr
   = DropTableExpr RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  Constructs an 'DropTableExpr' that will drop the specified table.
+
+  @since 0.10.0.0
+-}
 dropTableExpr :: Maybe IfExists -> Qualified TableName -> DropTableExpr
 dropTableExpr maybeIfExists tableName =
   DropTableExpr $

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/TableReferenceList.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/TableReferenceList.hs
@@ -9,10 +9,32 @@ where
 import Orville.PostgreSQL.Expr.Name (Qualified, TableName)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
+{- |
+Type to represent the tables references in the @FROM@ clause of a @SELECT
+statement. E.G. just the
+
+> foo
+
+in
+
+> FROM foo
+
+'TableReferenceList' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype TableReferenceList
   = TableReferenceList RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  Constructs a 'TableReferenceList' consisting of just the specified table
+  name.
+
+  @since 0.10.0.0
+-}
 referencesTable :: Qualified TableName -> TableReferenceList
 referencesTable qualifiedTableName =
   TableReferenceList $

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Time.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Time.hs
@@ -18,40 +18,105 @@ import Orville.PostgreSQL.Expr.Name (functionName)
 import Orville.PostgreSQL.Expr.ValueExpression (ParameterName, ValueExpression, functionCall, functionCallNamedParams)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
+{- |
+  The value of the current time as returned by the PostgreSQL function @now()@.
+
+  @since 0.10.0.0
+-}
 now :: ValueExpression
 now = functionCall (functionName "now") []
 
+{- |
+  Constructs a 'ValueExpression' whose value in PostgreSQL is the result of
+  calling @make_interval@ with the specified time intervals passed as named
+  arguments.
+
+  @since 0.10.0.0
+-}
 makeInterval :: [(IntervalArgument, ValueExpression)] -> ValueExpression
 makeInterval args =
   functionCallNamedParams
     (functionName "make_interval")
     (fmap (\(IntervalArgument paramName, value) -> (paramName, value)) args)
 
+{- |
+Type to represent the name of a time interval argument to the PostgreSQL
+@make_interval@ function. E.G.
+
+> years
+
+'IntervalArgument' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype IntervalArgument
   = IntervalArgument ParameterName
   deriving (RawSql.SqlExpression)
 
+{- |
+  Constructs an arbitrary 'IntervalArgument' with whatever name you specify. It
+  is up to you to ensure that name a valid argument name for @make_interval@.
+
+  @since 0.10.0.0
+-}
 unsafeIntervalArg :: String -> IntervalArgument
 unsafeIntervalArg =
   IntervalArgument . RawSql.unsafeSqlExpression
 
+{- |
+  The @years@ argument to @make_interval@.
+
+  @since 0.10.0.0
+-}
 years :: IntervalArgument
 years = unsafeIntervalArg "years"
 
+{- |
+  The @months@ argument to @make_interval@.
+
+  @since 0.10.0.0
+-}
 months :: IntervalArgument
 months = unsafeIntervalArg "months"
 
+{- |
+  The @weeks@ argument to @make_interval@.
+
+  @since 0.10.0.0
+-}
 weeks :: IntervalArgument
 weeks = unsafeIntervalArg "weeks"
 
+{- |
+  The @days@ argument to @make_interval@.
+
+  @since 0.10.0.0
+-}
 days :: IntervalArgument
 days = unsafeIntervalArg "days"
 
+{- |
+  The @hours@ argument to @make_interval@.
+
+  @since 0.10.0.0
+-}
 hours :: IntervalArgument
 hours = unsafeIntervalArg "hours"
 
+{- |
+  The @mins@ argument to @make_interval@.
+
+  @since 0.10.0.0
+-}
 minutes :: IntervalArgument
 minutes = unsafeIntervalArg "mins"
 
+{- |
+  The @secs@ argument to @make_interval@.
+
+  @since 0.10.0.0
+-}
 seconds :: IntervalArgument
 seconds = unsafeIntervalArg "secs"

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Transaction.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Transaction.hs
@@ -31,10 +31,27 @@ import Data.Maybe (maybeToList)
 import qualified Orville.PostgreSQL.Expr.Name as Name
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
+{- |
+Type to represent the name of a begin transaction statement. E.G.
+
+> BEGIN TRANSACTION
+
+'BeginTransactionExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype BeginTransactionExpr
   = BeginTransactionExpr RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  Constructs a 'BeginTransactionExpr' that will begin a transaction using
+  the specified mode, if any.
+
+  @since 0.10.0.0
+-}
 beginTransaction :: Maybe TransactionMode -> BeginTransactionExpr
 beginTransaction maybeTransactionMode =
   BeginTransactionExpr $
@@ -43,85 +60,222 @@ beginTransaction maybeTransactionMode =
           : maybeToList (RawSql.toRawSql <$> maybeTransactionMode)
       )
 
+{- |
+Type to represent the a transaction mode. E.G.
+
+> ISOLATION LEVEL SERIALIZABLE
+
+'TransactionMode' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype TransactionMode
   = TransactionMode RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  The @READ WRITE@ transaction mode.
+
+  @since 0.10.0.0
+-}
 readWrite :: TransactionMode
 readWrite =
   TransactionMode (RawSql.fromString "READ WRITE")
 
+{- |
+  The @READ ONLY@ transaction mode.
+
+  @since 0.10.0.0
+-}
 readOnly :: TransactionMode
 readOnly =
   TransactionMode (RawSql.fromString "READ ONLY")
 
+{- |
+  The @DEFERRABLE@ transaction mode.
+
+  @since 0.10.0.0
+-}
 deferrable :: TransactionMode
 deferrable =
   TransactionMode (RawSql.fromString "DEFERRABLE")
 
+{- |
+  The @NOT DEFERRABLE@ transaction mode.
+
+  @since 0.10.0.0
+-}
 notDeferrable :: TransactionMode
 notDeferrable =
   TransactionMode (RawSql.fromString "NOT DEFERRABLE")
 
+{- |
+  An @ISOLATION LEVEL@ transaction mode with the given 'IsolationLevel'.
+
+  @since 0.10.0.0
+-}
 isolationLevel :: IsolationLevel -> TransactionMode
 isolationLevel level =
   TransactionMode $
     (RawSql.fromString "ISOLATION LEVEL " <> RawSql.toRawSql level)
 
+{- |
+Type to represent the a transaction isolation level. E.G.
+
+> SERIALIZABLE
+
+'IsolationLevel' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype IsolationLevel
   = IsolationLevel RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  The @SERIALIZABLE@ isolation level.
+
+  @since 0.10.0.0
+-}
 serializable :: IsolationLevel
 serializable =
   IsolationLevel (RawSql.fromString "SERIALIZABLE")
 
+{- |
+  The @REPEATABLE READ@ isolation level.
+
+  @since 0.10.0.0
+-}
 repeatableRead :: IsolationLevel
 repeatableRead =
   IsolationLevel (RawSql.fromString "REPEATABLE READ")
 
+{- |
+  The @READ COMMITTED@ isolation level.
+
+  @since 0.10.0.0
+-}
 readCommitted :: IsolationLevel
 readCommitted =
   IsolationLevel (RawSql.fromString "READ COMMITTED")
 
+{- |
+  The @READ UNCOMMITTED@ isolation level.
+
+  @since 0.10.0.0
+-}
 readUncommitted :: IsolationLevel
 readUncommitted =
   IsolationLevel (RawSql.fromString "READ UNCOMMITTED")
 
+{- |
+Type to represent the transaction commit statement. E.G.
+
+> COMMIT
+
+'CommitExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype CommitExpr
   = CommitExpr RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  A @COMMIT@ transaction statement
+
+  @since 0.10.0.0
+-}
 commit :: CommitExpr
 commit =
   CommitExpr (RawSql.fromString "COMMIT")
 
+{- |
+Type to represent the transaction rollback statement. E.G.
+
+> ROLLBACK
+
+'RollbackExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype RollbackExpr
   = RollbackExpr RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  A @ROLLBACK@ transaction statement
+
+  @since 0.10.0.0
+-}
 rollback :: RollbackExpr
 rollback =
   RollbackExpr (RawSql.fromString "ROLLBACK")
 
+{- |
+  A @ROLLBACK TO@ transaction statement that will rollback to the specified
+  savepoint.
+
+  @since 0.10.0.0
+-}
 rollbackTo :: Name.SavepointName -> RollbackExpr
 rollbackTo savepointName =
   RollbackExpr $
     RawSql.fromString "ROLLBACK TO SAVEPOINT " <> RawSql.toRawSql savepointName
 
+{- |
+Type to represent the transaction savepoint statement. E.G.
+
+> SAVEPOINT foo
+
+'SavepointExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype SavepointExpr
   = SavepointExpr RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  A @SAVEPOINT@ statement that will create a savepoint with the given name.
+
+  @since 0.10.0.0
+-}
 savepoint :: Name.SavepointName -> SavepointExpr
 savepoint savepointName =
   SavepointExpr $
     RawSql.fromString "SAVEPOINT " <> RawSql.toRawSql savepointName
 
+{- |
+Type to represent the transaction release savepoint statement. E.G.
+
+> RELEASE SAVEPOINT foo
+
+'ReleaseSavepointExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype ReleaseSavepointExpr
   = ReleaseSavepontExpr RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  A @RELEASE SAVEPOINT@ statement that will release the specified savepoint.
+
+  @since 0.10.0.0
+-}
 releaseSavepoint :: Name.SavepointName -> ReleaseSavepointExpr
 releaseSavepoint savepointName =
   ReleaseSavepontExpr $

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Update.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/Update.hs
@@ -24,14 +24,36 @@ import Orville.PostgreSQL.Expr.WhereClause (WhereClause)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
+{- |
+Type to represent the transaction a SQL @UPDATE@ statement. E.G.
+
+> UPDATE foo
+> SET id = 1
+> WHERE id <> 1
+
+'UpdateExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype UpdateExpr
   = UpdateExpr RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  Constructs an 'UpdateExpr' with the given options.
+
+  @since 0.10.0.0
+-}
 updateExpr ::
+  -- | The name of the table to be updated
   Qualified TableName ->
+  -- | The updates to be made to the table
   SetClauseList ->
+  -- | An optional where clause to limit the rows updated
   Maybe WhereClause ->
+  -- | An optional returning clause to return data from the updated rows
   Maybe ReturningExpr ->
   UpdateExpr
 updateExpr tableName setClause maybeWhereClause maybeReturningExpr =
@@ -46,18 +68,52 @@ updateExpr tableName setClause maybeWhereClause maybeReturningExpr =
         , fmap RawSql.toRawSql maybeReturningExpr
         ]
 
+{- |
+Type to represent the list of updates to be made in a @UPDATE@ statament. E.G.
+
+> foo = 1,
+> bar = 2
+
+'SetClauseList' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype SetClauseList
   = SetClauseList RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  Constructs a 'SetClauseList' with the specified set clauses
+
+  @since 0.10.0.0
+-}
 setClauseList :: NonEmpty SetClause -> SetClauseList
 setClauseList =
   SetClauseList . RawSql.intercalate RawSql.comma
 
+{- |
+Type to represent a single updates to be made in a @UPDATE@ statament. E.G.
+
+> foo = 1
+
+'SetClause' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype SetClause
   = SetClause RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  Constructs a 'SetClause' that will set the specified column to the specified
+  value.
+
+  @since 0.10.0.0
+-}
 setColumn :: ColumnName -> SqlValue.SqlValue -> SetClause
 setColumn columnName value =
   SetClause $

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/ValueExpression.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/ValueExpression.hs
@@ -23,9 +23,30 @@ import Orville.PostgreSQL.Expr.Name (ColumnName, FunctionName)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import Orville.PostgreSQL.Raw.SqlValue (SqlValue)
 
+{- |
+Type to represent an arbitrary value in a SQL expression. This could be a
+constant value, a column reference or any arbitrary calculated expression.
+E.G.
+
+> (foo + bar) > 20
+
+'ValueExpression' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype ValueExpression = ValueExpression RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+Performs a SQL type cast to the specified type on the given 'ValueExpression'.
+E.G.
+
+> foo :: integer
+
+@since 0.10.0.0
+-}
 cast :: ValueExpression -> DataType -> ValueExpression
 cast value dataType =
   ValueExpression $
@@ -33,12 +54,37 @@ cast value dataType =
       <> RawSql.fromString "::"
       <> RawSql.toRawSql dataType
 
+{- |
+Uses a 'ColumnName' to reference a column as a 'ValueExpression'. This
+is the equivalent of simply writing the column name as the expression. E.G.
+
+> foo
+
+@since 0.10.0.0
+-}
 columnReference :: ColumnName -> ValueExpression
 columnReference = ValueExpression . RawSql.toRawSql
 
+{- |
+  Uses the given 'SqlValue' as a constant expression. The value will be passed
+  as a statement parameter, not as a literal expression, so there is not need
+  to worry about escaping. However, there are a few places (usually in DDL)
+  where PostgreSQL does not support values passed as paremeters where this
+  cannot be used.
+
+  @since 0.10.0.0
+-}
 valueExpression :: SqlValue -> ValueExpression
 valueExpression = ValueExpression . RawSql.parameter
 
+{- |
+Constructs a PostgreSQL row value expression from the given list of
+expressions. E.G.
+
+> (foo, bar, now())
+
+@since 0.10.0.0
+-}
 rowValueConstructor :: NE.NonEmpty ValueExpression -> ValueExpression
 rowValueConstructor elements =
   ValueExpression $
@@ -46,6 +92,14 @@ rowValueConstructor elements =
       <> RawSql.intercalate RawSql.comma elements
       <> RawSql.rightParen
 
+{- |
+Constructs a 'ValueExpression' that will call the specified PostgreSQL
+function with the given arguments passed as position parameters. E.G.
+
+> nextval(sequence_name)
+
+@since 0.10.0.0
+-}
 functionCall :: FunctionName -> [ValueExpression] -> ValueExpression
 functionCall functionName parameters =
   ValueExpression $
@@ -54,9 +108,33 @@ functionCall functionName parameters =
       <> RawSql.intercalate RawSql.comma parameters
       <> RawSql.rightParen
 
+{- |
+Type to represent the name of a name parameter in PostgreSQL function call.
+E.G.
+
+> foo
+
+in
+
+> some_func(foo => 1)
+
+'ParameterName' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype ParameterName = ParameterName RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+Constructs a 'ValueExpression' that will call the specified PostgreSQL
+function with the given arguments passed as named parameters. E.G.
+
+> make_interval(years => 1)
+
+@since 0.10.0.0
+-}
 functionCallNamedParams :: FunctionName -> [(ParameterName, ValueExpression)] -> ValueExpression
 functionCallNamedParams functionName parameters =
   ValueExpression $
@@ -65,6 +143,12 @@ functionCallNamedParams functionName parameters =
       <> RawSql.intercalate RawSql.comma (fmap (uncurry namedParameterArgument) parameters)
       <> RawSql.rightParen
 
+{- |
+  Constructs a sql fragment that will pass the given named argument with the
+  specified value.
+
+  @since 0.10.0.0
+-}
 namedParameterArgument :: ParameterName -> ValueExpression -> RawSql.RawSql
 namedParameterArgument name value =
   RawSql.toRawSql name

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/WhereClause.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Expr/WhereClause.hs
@@ -41,19 +41,56 @@ import Orville.PostgreSQL.Expr.BinaryOperator (andOp, binaryOpExpression, equals
 import Orville.PostgreSQL.Expr.ValueExpression (ValueExpression, rowValueConstructor)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
+{- |
+Type to represent a @WHERE@ clause restriction an a @SELECT@, @UPDATE@ or
+@DELETE@ statement. E.G.
+
+> WHERE (foo > 10)
+
+'WhereClause' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype WhereClause
   = WhereClause RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+Constructs a 'WHERE' clause from the given 'BooleanExpr'. E.G.
+
+> WHERE <boolean expr>
+
+@since 0.10.0.0
+-}
 whereClause :: BooleanExpr -> WhereClause
 whereClause booleanExpr =
   WhereClause $
     RawSql.fromString "WHERE " <> RawSql.toRawSql booleanExpr
 
+{- |
+Type to represent a SQL value expression that evaluates to a boolean and thereforce
+can used with boolean logic functions. E.G.
+
+> foo > 10
+
+'BooleanExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype BooleanExpr
   = BooleanExpr RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  Constructs a 'BooleanExpr' whose value the SQL literal @TRUE@ or @FALSE@
+  depending on the argument given.
+
+  @since 0.10.0.0
+-}
 literalBooleanExpr :: Bool -> BooleanExpr
 literalBooleanExpr bool =
   BooleanExpr . RawSql.fromString $
@@ -61,10 +98,23 @@ literalBooleanExpr bool =
       False -> "FALSE"
       True -> "TRUE"
 
+{- |
+  Converts a 'BooleanExpr' to a 'ValueExpression' so that it can be used
+  anywhere 'ValueExpression' is allowed.
+
+  @since 0.10.0.0
+-}
 booleanValueExpression :: BooleanExpr -> ValueExpression
 booleanValueExpression (BooleanExpr rawSql) =
   RawSql.unsafeFromRawSql rawSql
 
+{- |
+  The SQL @OR@ operator. The arguments will be surrounded with parentheses
+  to ensure that the associativity of expression in the resulting SQL matches
+  the associtivity implied by this Haskell function.
+
+  @since 0.10.0.0
+-}
 orExpr :: BooleanExpr -> BooleanExpr -> BooleanExpr
 orExpr left right =
   binaryOpExpression
@@ -73,13 +123,22 @@ orExpr left right =
     (booleanValueExpression right)
 
 {- |
-  Operator alias for 'orExpr'
+  The SQL @OR@ operator (alias for 'orExpr')
+
+  @since 0.10.0.0
 -}
 (.||) :: BooleanExpr -> BooleanExpr -> BooleanExpr
 (.||) = orExpr
 
 infixr 8 .||
 
+{- |
+  The SQL @AND@ operator. The arguments will be surrounded with parentheses
+  to ensure that the associativity of expression in the resulting SQL matches
+  the associtivity implied by this Haskell function.
+
+  @since 0.10.0.0
+-}
 andExpr :: BooleanExpr -> BooleanExpr -> BooleanExpr
 andExpr left right =
   binaryOpExpression
@@ -88,25 +147,41 @@ andExpr left right =
     (booleanValueExpression right)
 
 {- |
-  Operator alias for 'andExpr'
+  The SQL @AND@ operator (alias for 'andExpr')
+
+  @since 0.10.0.0
 -}
 (.&&) :: BooleanExpr -> BooleanExpr -> BooleanExpr
 (.&&) = andExpr
 
 infixr 8 .&&
 
+{- |
+  The SQL @IN@ operator. The result will be @TRUE@ if the given value
+  appears in the list of values given.
+
+  @since 0.10.0.0
+-}
 valueIn :: ValueExpression -> NE.NonEmpty ValueExpression -> BooleanExpr
 valueIn needle haystack =
   inPredicate needle (inValueList haystack)
 
+{- |
+  The SQL @IN@ operator. The result will be @TRUE@ if the given value
+  does not appear in the list of values given.
+
+  @since 0.10.0.0
+-}
 valueNotIn :: ValueExpression -> NE.NonEmpty ValueExpression -> BooleanExpr
 valueNotIn needle haystack =
   notInPredicate needle (inValueList haystack)
 
 {- |
-  Checks that the tuple constructed from the given values in one of the tuples
-  specified in the input list. It is up to the caller to ensure that all the
-  tuples given have the same arity.
+  The SQL @IN@ operator, like 'valueIn', but for when you want to construct a
+  tuple in SQL and check if it is in a list of tuples. It is up to the caller
+  to ensure that all the tuples given have the same arity.
+
+  @since 0.10.0.0
 -}
 tupleIn :: NE.NonEmpty ValueExpression -> NE.NonEmpty (NE.NonEmpty ValueExpression) -> BooleanExpr
 tupleIn needle haystack =
@@ -115,9 +190,11 @@ tupleIn needle haystack =
     (inValueList (fmap rowValueConstructor haystack))
 
 {- |
-  Checks that the tuple constructed from the given values is NOT one of the
-  tuples specified in the input list. It is up to the caller to ensure that all
-  the tuples given have the same arity.
+  The SQL @NOT IN@ operator, like 'valueNotIn', but for when you want to
+  construct a tuple in SQL and check if it is not in a list of tuples. It is up
+  to the caller to ensure that all the tuples given have the same arity.
+
+  @since 0.10.0.0
 -}
 tupleNotIn :: NE.NonEmpty ValueExpression -> NE.NonEmpty (NE.NonEmpty ValueExpression) -> BooleanExpr
 tupleNotIn needle haystack =
@@ -125,6 +202,13 @@ tupleNotIn needle haystack =
     (rowValueConstructor needle)
     (inValueList (fmap rowValueConstructor haystack))
 
+{- |
+  Lowel lever access to the the SQL @IN@ operator. This takes any
+  'ValueExpression' and 'InValuePredicate'. It is up to the caller to ensure
+  the expressions given makes sense together.
+
+  @since 0.10.0.0
+-}
 inPredicate :: ValueExpression -> InValuePredicate -> BooleanExpr
 inPredicate predicand predicate =
   BooleanExpr $
@@ -132,6 +216,13 @@ inPredicate predicand predicate =
       <> RawSql.fromString " IN "
       <> RawSql.toRawSql predicate
 
+{- |
+  Lowel lever access to the the SQL @NOT IN@ operator. This takes any
+  'ValueExpression' and 'InValuePredicate'. It is up to the caller to ensure
+  the expressions given makes sense together.
+
+  @since 0.10.0.0
+-}
 notInPredicate :: ValueExpression -> InValuePredicate -> BooleanExpr
 notInPredicate predicand predicate =
   BooleanExpr $
@@ -139,10 +230,27 @@ notInPredicate predicand predicate =
       <> RawSql.fromString " NOT IN "
       <> RawSql.toRawSql predicate
 
+{- |
+Type to represent the right hand side of an @IN@ or @NOT IN@ expression.
+E.G.
+
+> (10,12,13)
+
+'InValuePredicate' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 0.10.0.0
+-}
 newtype InValuePredicate
   = InValuePredicate RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+{- |
+  Constructs an 'InValuePredicate' from the given list of 'ValueExpression'
+
+  @since 0.10.0.0
+-}
 inValueList :: NE.NonEmpty ValueExpression -> InValuePredicate
 inValueList values =
   InValuePredicate $
@@ -150,43 +258,93 @@ inValueList values =
       <> RawSql.intercalate RawSql.commaSpace values
       <> RawSql.rightParen
 
+{- |
+  Surrounds the given 'BooleanExpr' with parentheses.
+
+  @since 0.10.0.0
+-}
 parenthesized :: BooleanExpr -> BooleanExpr
 parenthesized expr =
   BooleanExpr $
     RawSql.leftParen <> RawSql.toRawSql expr <> RawSql.rightParen
 
+{- |
+  The SQL @=@ operator.
+
+  @since 0.10.0.0
+-}
 equals :: ValueExpression -> ValueExpression -> BooleanExpr
 equals =
   binaryOpExpression equalsOp
 
+{- |
+  The SQL @<>@ operator.
+
+  @since 0.10.0.0
+-}
 notEquals :: ValueExpression -> ValueExpression -> BooleanExpr
 notEquals =
   binaryOpExpression notEqualsOp
 
+{- |
+  The SQL @>@ operator.
+
+  @since 0.10.0.0
+-}
 greaterThan :: ValueExpression -> ValueExpression -> BooleanExpr
 greaterThan =
   binaryOpExpression greaterThanOp
 
+{- |
+  The SQL @<@ operator.
+
+  @since 0.10.0.0
+-}
 lessThan :: ValueExpression -> ValueExpression -> BooleanExpr
 lessThan =
   binaryOpExpression lessThanOp
 
+{- |
+  The SQL @>=@ operator.
+
+  @since 0.10.0.0
+-}
 greaterThanOrEqualTo :: ValueExpression -> ValueExpression -> BooleanExpr
 greaterThanOrEqualTo =
   binaryOpExpression greaterThanOrEqualsOp
 
+{- |
+  The SQL @<=@ operator.
+
+  @since 0.10.0.0
+-}
 lessThanOrEqualTo :: ValueExpression -> ValueExpression -> BooleanExpr
 lessThanOrEqualTo =
   binaryOpExpression lessThanOrEqualsOp
 
+{- |
+  The SQL @LIKE@ operator.
+
+  @since 0.10.0.0
+-}
 like :: ValueExpression -> ValueExpression -> BooleanExpr
 like =
   binaryOpExpression likeOp
 
+{- |
+  The SQL @ILIKE@ operator.
+
+  @since 0.10.0.0
+-}
 likeInsensitive :: ValueExpression -> ValueExpression -> BooleanExpr
 likeInsensitive =
   binaryOpExpression iLikeOp
 
+{- |
+  The SQL @IS NULL@ condition.
+
+  @since 0.10.0.0
+-}
 isNull :: ValueExpression -> BooleanExpr
 isNull value =
   BooleanExpr $
@@ -194,6 +352,11 @@ isNull value =
       <> RawSql.space
       <> RawSql.fromString "IS NULL"
 
+{- |
+  The SQL @IS NOT NULL@ condition.
+
+  @since 0.10.0.0
+-}
 isNotNull :: ValueExpression -> BooleanExpr
 isNotNull value =
   BooleanExpr $

--- a/orville-postgresql-libpq/src/Orville/PostgreSQL/Raw/RawSql.hs
+++ b/orville-postgresql-libpq/src/Orville/PostgreSQL/Raw/RawSql.hs
@@ -114,19 +114,19 @@ instance SqlExpression RawSql where
   unsafeFromRawSql = id
 
 {- |
-  A conveinence function for creating an arbitrary 'SqlExpression' from a
-  'String'. Great care should be exercised in use of this function as it cannot
-  provide any sort of guarantee that the string passed is usable to generate
-  valid SQL via the rest of Orville's 'Orville.PostgreSQL.Expr' API as the
-  whatever 'SqlExpression' type is returned.
+A conveinence function for creating an arbitrary 'SqlExpression' from a
+'String'. Great care should be exercised in use of this function as it cannot
+provide any sort of guarantee that the string passed is usable to generate
+valid SQL via the rest of Orville's 'Orville.PostgreSQL.Expr' API as the
+whatever 'SqlExpression' type is returned.
 
-  For example, if one wanted build a boolean expression not support by Orville,
-  you can do it like so
+For example, if one wanted build a boolean expression not support by Orville,
+you can do it like so
 
-   > import qualified Orville.PostgreSQL.Expr as Expr
-   >
-   > a :: Expr.BooleanExpr
-   > a RawSql.unsafeSqlExpression "foo BETWEEN 1  AND 3"
+> import qualified Orville.PostgreSQL.Expr as Expr
+>
+> a :: Expr.BooleanExpr
+> a RawSql.unsafeSqlExpression "foo BETWEEN 1  AND 3"
 
 @since 0.10.0.2
 -}


### PR DESCRIPTION
This standardizes that callout to the `SqlExpression` escape hatch and
the examples given is such places across all the places I could find
that were using the old way as well.
