### PR TITLE
Checks for typos and other errors in documentation

### DIFF
--- a/orville-postgresql/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL.hs
@@ -6,7 +6,7 @@ Stability : Stable
 "Orville.PostgreSQL" is the module you will most often want to import for using
 Orville. It re-exports most of the functions you need for everyday basic
 operations on table entities. If you cannot find the function you need exported here,
-you may be able to find it one of the modules that re-exports more functional
+you may be able to find it in one of the modules that re-exports more functions
 for a specific area:
 
 * "Orville.PostgreSQL.AutoMigration"

--- a/orville-postgresql/src/Orville/PostgreSQL/ErrorDetailLevel.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/ErrorDetailLevel.hs
@@ -20,7 +20,7 @@ where
 {- |
   'ErrorDetailLevel' provides a means to configure what elements of information
   are included in error messages that originate from decoding rows queried
-  from the database. This can be specified either my manually rendering the
+  from the database. This can be specified either by manually rendering the
   error message and providing the desired configuration, or by setting the
   desired detail level in the @OrvilleState@ as a default.
 
@@ -41,8 +41,8 @@ data ErrorDetailLevel = ErrorDetailLevel
     )
 
 {- |
-  A minimal 'ErrorDetailLevel' where everything all information (including
-  any situationally-specific error message!) is redacted from error messages.
+  A minimal 'ErrorDetailLevel' where all information (including any
+  situationally-specific error messages!) is redacted from error messages.
 
 @since 1.0.0.0
 -}
@@ -56,9 +56,9 @@ minimalErrorDetailLevel =
     }
 
 {- |
-  A default 'ErrorDetailLevel' that strikes balance of including all "Generic"
+  A default 'ErrorDetailLevel' that strikes a balance of including all "Generic"
   information such as the error message, schema names and row identifiers, but
-  avoids untentionally leaking non-identifier values from the database by
+  avoids unintentionally leaking non-identifier values from the database by
   redacting them.
 
 @since 1.0.0.0
@@ -75,8 +75,8 @@ defaultErrorDetailLevel =
 {- |
   A maximal 'ErrorDetailLevel' that redacts no information from the error
   messages. Error messages will include values from the database for any
-  columns are involved in a decoding failure, including some which you may
-  not have intended to expose through error message. Use with caution.
+  columns that are involved in a decoding failure, including some which you may
+  not have intended to expose through error messages. Use with caution.
 
 @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Execution/EntityOperations.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Execution/EntityOperations.hs
@@ -52,7 +52,7 @@ import qualified Orville.PostgreSQL.Monad as Monad
 import qualified Orville.PostgreSQL.Schema as Schema
 
 {- |
-  Inserts a entity into the specified table.
+  Inserts an entity into the specified table.
 
 @since 1.0.0.0
 -}
@@ -65,7 +65,7 @@ insertEntity entityTable =
   Monad.void . insertEntityAndReturnRowCount entityTable
 
 {- |
-  Inserts a entity into the specified table. Returns the number of rows
+  Inserts an entity into the specified table. Returns the number of rows
   affected by the query.
 
 @since 1.0.0.0
@@ -79,7 +79,7 @@ insertEntityAndReturnRowCount entityTable entity =
   insertEntitiesAndReturnRowCount entityTable (entity :| [])
 
 {- |
-  Inserts a entity into the specified table, returning the data inserted into
+  Inserts an entity into the specified table, returning the data inserted into
   the database.
 
   You can use this function to obtain any column values filled in by the
@@ -144,7 +144,7 @@ insertAndReturnEntities tableDef =
   Insert.executeInsertReturnEntities . Insert.insertToTableReturning tableDef
 
 {- |
-  Updates the row with the given key in with the data given by 'writeEntity'.
+  Updates the row with the given key with the data given by 'writeEntity'.
 
 @since 1.0.0.0
 -}
@@ -158,7 +158,7 @@ updateEntity tableDef key =
   Monad.void . updateEntityAndReturnRowCount tableDef key
 
 {- |
-  Updates the row with the given key in with the data given by 'writeEntity'.
+  Updates the row with the given key with the data given by 'writeEntity'.
   Returns the number of rows affected by the query.
 
 @since 1.0.0.0
@@ -177,12 +177,12 @@ updateEntityAndReturnRowCount tableDef key writeEntity =
       Update.executeUpdate update
 
 {- |
-  Updates the row with the given key in with the data given by 'writeEntity',
-  returning updated row from the database. If no row matches the given key,
+  Updates the row with the given key with the data given by 'writeEntity',
+  returning the updated row from the database. If no row matches the given key,
   'Nothing' will be returned.
 
-  You can use this function to obtain any column values computer by the database
-  during update, including columns with triggers attached to them.
+  You can use this function to obtain any column values computed by the database
+  during the update, including columns with triggers attached to them.
 
 @since 1.0.0.0
 -}
@@ -370,7 +370,7 @@ findEntitiesBy entityTable selectOptions =
     Select.selectTable entityTable selectOptions
 
 {- |
-  Like 'findEntitiesBy, but adds a 'LIMIT 1' to the query and then returns
+  Like 'findEntitiesBy', but adds a 'LIMIT 1' to the query and then returns
   the first item from the list. Usually when you use this you will want to
   provide an order by clause in the 'SelectOptions.SelectOptions' because the
   database will not guarantee ordering.

--- a/orville-postgresql/src/Orville/PostgreSQL/Execution/SelectOptions.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Execution/SelectOptions.hs
@@ -72,7 +72,7 @@ emptySelectOptions =
 
 {- |
   Combines multple select options together, unioning the options together where
-  possible. For options where this is not possible, (e.g. 'LIMIT'), the one
+  possible. For options where this is not possible (e.g. 'LIMIT'), the one
   on the left is preferred.
 
 @since 1.0.0.0
@@ -110,7 +110,7 @@ selectDistinct selectOptions =
 {- |
   Builds the 'Expr.WhereClause' that should be used to include the
   'WhereCondition's from the 'SelectOptions' on a query. This will be 'Nothing'
-  where no 'WhereCondition's have been specified.
+  when no 'WhereCondition's have been specified.
 
 @since 1.0.0.0
 -}
@@ -132,7 +132,7 @@ distinct =
 {- |
   Builds the 'Expr.OrderByClause' that should be used to include the
   'OrderByClause's from the 'SelectOptions' on a query. This will be 'Nothing'
-  where no 'OrderByClause's have been specified.
+  when no 'OrderByClause's have been specified.
 
 @since 1.0.0.0
 -}
@@ -143,7 +143,7 @@ selectOrderByClause =
 {- |
   Builds the 'Expr.GroupByClause' that should be used to include the
   'GroupByClause's from the 'SelectOptions' on a query. This will be 'Nothing'
-  where no 'GroupByClause's have been specified.
+  when no 'GroupByClause's have been specified.
 
 @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Execution/Transaction.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Execution/Transaction.hs
@@ -25,16 +25,16 @@ import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 {- |
   Performs an action in an Orville monad within a database transaction. The transaction
-  in begun before the action is called. If the action completes without raising an exception,
+  is begun before the action is called. If the action completes without raising an exception,
   the transaction will be committed. If the action raises an exception, the transaction will
   rollback.
 
-  This function in safe to call from within another transaction. When called this way the
+  This function is safe to call from within another transaction. When called this way the
   transaction will establish a new savepoint at the beginning of the nested transaction and
   either release the savepoint or rollback to it as appropriate.
 
   Note: Exceptions are handled using the implementations of 'Monad.catch' and
-  'Monad.mask'  provided by the 'MonadOrvilleControl' instance for @m@.
+  'Monad.mask' provided by the 'MonadOrvilleControl' instance for @m@.
 
 @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/WhereClause.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/WhereClause.hs
@@ -126,7 +126,7 @@ orExpr left right =
     (booleanValueExpression right)
 
 {- |
-  The SQL @OR@ operator (alias for 'orExpr')
+  The SQL @OR@ operator (alias for 'orExpr').
 
   @since 1.0.0.0
 -}
@@ -150,7 +150,7 @@ andExpr left right =
     (booleanValueExpression right)
 
 {- |
-  The SQL @AND@ operator (alias for 'andExpr')
+  The SQL @AND@ operator (alias for 'andExpr').
 
   @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Internal/FieldName.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Internal/FieldName.hs
@@ -28,7 +28,7 @@ newtype FieldName
   deriving (Eq, Ord, Show)
 
 {- |
-  Convert a field name to an 'Expr.ColumnName' for usage in SQL expressions.
+  Convert a field name to a 'Expr.ColumnName' for usage in SQL expressions.
   The field name will be properly quoted and escaped.
 
 @since 1.0.0.0
@@ -38,7 +38,7 @@ fieldNameToColumnName (FieldName name) =
   Expr.fromIdentifier (Expr.identifierFromBytes name)
 
 {- |
-  Constructs a 'FieldName' from a 'String'
+  Constructs a 'FieldName' from a 'String'.
 
 @since 1.0.0.0
 -}
@@ -47,7 +47,7 @@ stringToFieldName =
   FieldName . B8.pack
 
 {- |
-  Converts a 'FieldName' back to a 'String'
+  Converts a 'FieldName' back to a 'String'.
 
 @since 1.0.0.0
 -}
@@ -56,7 +56,7 @@ fieldNameToString =
   B8.unpack . fieldNameToByteString
 
 {- |
-  Converts a 'FieldName' back to a 'B8.ByteString'
+  Converts a 'FieldName' back to a 'B8.ByteString'.
 
 @since 1.0.0.0
 -}
@@ -65,7 +65,7 @@ fieldNameToByteString (FieldName name) =
   name
 
 {- |
-  Constructs a 'FieldName' from a 'B8.ByteString'
+  Constructs a 'FieldName' from a 'B8.ByteString'.
 
 @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Internal/IndexDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Internal/IndexDefinition.hs
@@ -34,7 +34,7 @@ import qualified Orville.PostgreSQL.Marshall.FieldDefinition as FieldDefinition
   Defines an index that can be added to a 'Orville.PostgreSQL.TableDefinition'.
   Use one of the constructor functions below (such as 'uniqueIndex') to
   construct the index definition you wish to have and then use
-  'Orville.PostgreSQL.addTableIndexes'. to add them to your table definition.
+  'Orville.PostgreSQL.addTableIndexes' to add them to your table definition.
   Orville will then add the index next time you run auto-migrations.
 
 @since 1.0.0.0
@@ -51,7 +51,7 @@ data IndexDefinition = IndexDefinition
 {- |
   Sets the 'IndexCreationStrategy' strategy to be used when creating the index
   described by the 'IndexDefinition'. By default all indexes are created using
-  the 'Transactional' strategy, but some tables are too large for for this to
+  the 'Transactional' strategy, but some tables are too large for this to
   be feasible. See the 'Asynchronous' creation strategy for how to work around
   this.
 
@@ -80,14 +80,14 @@ indexCreationStrategy =
   i_indexCreationStrategy
 
 {- |
-  Defines how an 'IndexDefinition' will be execute to add an index to a table.
-  By default all indexes a created via the 'Transactional'
+  Defines how an 'IndexDefinition' will be executed to add an index to a table.
+  By default all indexes are created using the 'Transactional' strategy.
 
 @since 1.0.0.0
 -}
 data IndexCreationStrategy
   = -- |
-    --       The default strategy. The index will be added as part of the a database
+    --       The default strategy. The index will be added as part of a database
     --       transaction along with all the other DDL being executed to migrate the
     --       database schema. If any migration should fail the index creation will be
     --       rolled back as part of the transaction. This is how schema migrations
@@ -172,7 +172,7 @@ indexCreateExpr indexDef =
 
 {- |
   Constructs an 'IndexDefinition' for a non-unique index on the given
-  columns
+  columns.
 
 @since 1.0.0.0
 -}
@@ -182,7 +182,7 @@ nonUniqueIndex =
 
 {- |
   Constructs an 'IndexDefinition' for a non-unique index with given SQL and
-  index name
+  index name.
 
 @since 1.0.0.0
 -}
@@ -212,7 +212,7 @@ uniqueNamedIndex =
 
 {- |
   Constructs an 'IndexDefinition' for an index on the given columns with the
-  given uniquness.
+  given uniqueness.
 
 @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Internal/OrvilleState.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Internal/OrvilleState.hs
@@ -50,7 +50,7 @@ import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import qualified Orville.PostgreSQL.Raw.SqlCommenter as SqlCommenter
 
 {- |
-  'OrvilleState' is used to manange opening connections to the database,
+  'OrvilleState' is used to manage opening connections to the database,
   transactions, etc. 'newOrvilleState' should be used to create an appopriate
   initial state for your monad's context.
 
@@ -132,16 +132,16 @@ orvilleSqlCommenterAttributes =
 
   The callback given will be called after the SQL statement corresponding
   to the given event has finished executing. Callbacks will be called
-  in the order the are added.
+  in the order they are added.
 
   Note: There is no specialized error handling for these callbacks. This means
   that if a callback raises an exception no further callbacks will be called
-  and the exception will propagate up until it caught elsewhere. In particular,
-  if an exception is raised by a callback upon opening the transaction it will
-  cause the transaction to be rolled-back the same as any other exception that
-  might happen during the transaction. In general, we recommend only using
-  callbacks that either raise no exceptions or can handle their own exceptions
-  cleanly.
+  and the exception will propagate up until it is caught elsewhere. In
+  particular, if an exception is raised by a callback upon opening the
+  transaction it will cause the transaction to be rolled-back the same as any
+  other exception that might happen during the transaction. In general, we
+  recommend only using callbacks that either raise no exceptions or can handle
+  their own exceptions cleanly.
 
 @since 1.0.0.0
 -}
@@ -161,7 +161,7 @@ addTransactionCallback newCallback state =
     state {_orvilleTransactionCallback = wrappedCallback}
 
 {- |
-  Creates a appropriate initial 'OrvilleState' that will use the connection
+  Creates an appropriate initial 'OrvilleState' that will use the connection
   pool given to initiate connections to the database.
 
 @since 1.0.0.0
@@ -180,7 +180,7 @@ newOrvilleState errorDetailLevel pool =
 
 {- |
   Creates a new initial 'OrvilleState' using the connection pool from the
-  provide state. You might need to use this if you are spawning one Orville
+  provided state. You might need to use this if you are spawning one Orville
   monad from another and they should not share the same connection and
   transaction state.
 
@@ -298,24 +298,24 @@ savepointNestingLevel (Savepoint n) = n
 {- |
   Describes an event in the lifecycle of a database transaction. You can use
   'addTransactionCallBack' to register a callback to respond to these events.
-  The callback will be called after the even in question has been succesfully
+  The callback will be called after the event in question has been succesfully
   executed.
 
 @since 1.0.0.0
 -}
 data TransactionEvent
-  = -- | Indicates a new transaction has been started
+  = -- | Indicates a new transaction has been started.
     BeginTransaction
-  | -- | Indicates that a new savepoint has been saved within a transaction
+  | -- | Indicates that a new savepoint has been saved within a transaction.
     NewSavepoint Savepoint
   | -- | Indicates that a previous savepoint has been released. It can no
     -- longer be rolled back to.
     ReleaseSavepoint Savepoint
-  | -- | Indicates that rollbac was performed to a prior savepoint.
+  | -- | Indicates that rollback was performed to a prior savepoint.
     --
     -- Note: It is possible to rollback to a savepoint prior to the most recent
     -- one without releasing or rolling back to intermediate savepoints. Doing
-    -- so destroys any savepoints created after given savepoint. Although
+    -- so destroys any savepoints created after the given savepoint. Although
     -- Orville currently always matches 'NewSavepoint' with either
     -- 'ReleaseSavepoint' or 'RollbackToSavepoint', it is recommended that you
     -- do not rely on this behavior.
@@ -399,15 +399,15 @@ defaultSqlExectionCallback _ _ io = io
   Adds a callback to be called when an Orville operation executes a SQL
   statement. The callback is given the IO action that will perform the
   query execution and must call that action for the query to be run.
-  In particular, you can use this to time query and log any that are slow.
+  In particular, you can use this to time queries and log any that are slow.
 
-  Calls to any previously added callbacks will also be execute as part of
+  Calls to any previously added callbacks will also be executed as part of
   the IO action passed to the new callback. Thus the newly added callback
   happens "around" the previously added callback.
 
   There is no special exception handling done for these callbacks beyond what
-  they implement themelves. Any callbacks should allow for the possibility that
-  the IO action they are given may raise an exception.
+  they implement themselves. Any callbacks should allow for the possibility
+  that the IO action they are given may raise an exception.
 
 @since 1.0.0.0
 -}
@@ -465,7 +465,8 @@ setSqlCommenterAttributes comments state =
     }
 
 {- |
-  Adds the SqlCommenterAttributes to the already existing that Orville will then add to any following statement executions.
+  Adds the SqlCommenterAttributes to the already existing attributes that
+  Orville will then add to any following statement executions.
 
 @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Marshall/DefaultValue.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Marshall/DefaultValue.hs
@@ -59,7 +59,7 @@ newtype DefaultValue a
   = DefaultValue Expr.ValueExpression
 
 {- |
-  Builds a default value for any 'Integral' type @n@ by converting it an
+  Builds a default value for any 'Integral' type @n@ by converting it to an
   'Integer'.
 
 @since 1.0.0.0
@@ -112,7 +112,7 @@ bigIntegerDefault :: Int64 -> DefaultValue Int64
 bigIntegerDefault = integralDefault
 
 {- |
-  Builds a default value from a 'Double' field with double fields.
+  Builds a default value from a 'Double' field for use with double fields.
 
 @since 1.0.0.0
 -}
@@ -190,7 +190,7 @@ currentDateDefault =
     $ "('now'::text)::date"
 
 {- |
-  Builds a default value from a 'Time.UTCTime' for use with utc timestamp fields.
+  Builds a default value from a 'Time.UTCTime' for use with UTC timestamp fields.
 
 @since 1.0.0.0
 -}
@@ -205,10 +205,10 @@ utcTimestampDefault utcTime =
         <> RawSql.fromString "::timestamp with time zone"
 
 {- |
-  Builds a default value that will default to the current utc time (i.e. the
+  Builds a default value that will default to the current UTC time (i.e. the
   time at which the database populates the default value on a given row).
 
-  For use with utc timestamp fields.
+  For use with UTC timestamp fields.
 
 @since 1.0.0.0
 -}
@@ -248,7 +248,7 @@ currentLocalTimestampDefault =
   DefaultValue $ RawSql.unsafeSqlExpression "('now'::text)::timestamp without time zone"
 
 {- |
-  Coerce's a 'DefaultValue' so that it can be used with field definitions of
+  Coerces a 'DefaultValue' so that it can be used with field definitions of
   a different Haskell type. The coercion will always succeed, and is safe as
   far as Haskell itself it concerned. As long as the 'DefaultValue' is used
   with a column whose database type is the same as the one the 'DefaultValue'
@@ -261,7 +261,7 @@ coerceDefaultValue (DefaultValue expression) =
   DefaultValue expression
 
 {- |
-  Returns database value expression for the default value
+  Returns database value expression for the default value.
 
 @since 1.0.0.0
 -}
@@ -274,15 +274,15 @@ defaultValueExpression (DefaultValue expression) =
   to construct default values for any SQL expression that Orville does not
   support directly.
 
-  Note: If you are using auto migrations, the 'Expr.ValueExpression' that you
+  Note: If you are using auto-migrations, the 'Expr.ValueExpression' that you
   pass here must match what is returned by the PostgreSQL @pg_get_expr@
   function. @pg_get_expr@ decompiles the compiled version of the default
-  experssion back to source text, sometimes in non-obvious ways. Orville's auto
-  migration compares expression given in the field definition with the
+  experssion back to source text, sometimes in non-obvious ways. Orville's
+  auto-migration compares the expression given in the field definition with the
   decompiled expression from the database to determine whether the default
-  value needs to be updated in the schema or not.  If the expression given by a
+  value needs to be updated in the schema or not. If the expression given by a
   'DefaultValue' is logically equivalent but does not match the decompiled
-  form, auto migration will continue to execute SQL statements to update the
+  form, auto-migration will continue to execute SQL statements to update the
   schema even when it does not need to.
 
 @since 1.0.0.0

--- a/orville-postgresql/src/Orville/PostgreSQL/Marshall/FieldDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Marshall/FieldDefinition.hs
@@ -147,7 +147,7 @@ fieldDescription :: FieldDefinition nullability a -> Maybe String
 fieldDescription = i_fieldDescription
 
 {- |
-  Sets the description for the field. This description not currently used
+  Sets the description for the field. This description is not currently used
   anywhere by Orville itself, but users can retrieve the description via
   'fieldDescription' for their own purposes (e.g. generating documentation).
 
@@ -161,7 +161,7 @@ setFieldDescription description fieldDef =
 
 {- |
   The 'SqlType' for the 'FieldDefinition' determines the PostgreSQL data type
-  used to define the field as well as how to mashall Haskell values to and
+  used to define the field as well as how to marshall Haskell values to and
   from the database.
 
 @since 1.0.0.0
@@ -193,8 +193,8 @@ data FieldNullability a
 {- |
  Resolves the 'nullablity' of a field to a concrete type, which is returned
  via the 'FieldNullability' type. You can pattern match on this type to then
- extract the either 'Nullable' or 'NotNull' not field for cases where you
- may require different logic based on the nullability of a field.
+ extract the either 'Nullable' or 'NotNull' field for cases where you may
+ require different logic based on the nullability of a field.
 
 @since 1.0.0.0
 -}
@@ -205,7 +205,7 @@ fieldNullability field =
     NotNullGADT -> NotNullField field
 
 {- |
-  Indicates whether a field is nullable.
+  Indicates whether a field is not nullable.
 
 @since 1.0.0.0
 -}
@@ -370,7 +370,7 @@ fieldColumnName =
   fieldNameToColumnName . fieldName
 
 {- |
-  Constructs the 'Expr.ValueExpression for a field for use in SQL expressions
+  Constructs the 'Expr.ValueExpression' for a field for use in SQL expressions
   from the 'Expr' module.
 
 @since 1.0.0.0
@@ -380,8 +380,8 @@ fieldColumnReference =
   Expr.columnReference . fieldColumnName
 
 {- |
-  Constructions the equivalant 'Expr.FieldDefinition' as a SQL expression,
-  generally for use in DDL for creating column in a table.
+  Constructs the equivalant 'Expr.FieldDefinition' as a SQL expression,
+  generally for use in DDL for creating columns in a table.
 
 @since 1.0.0.0
 -}
@@ -428,7 +428,7 @@ data NullabilityGADT nullability where
 
 {- |
 
-  'NotNull' is a values-less type used to track that a 'FieldDefinition'
+  'NotNull' is a value-less type used to track that a 'FieldDefinition'
   represents a field that is marked not-null in the database schema.  See the
   'Nullability' type for the value-level representation of field nullability.
 
@@ -437,7 +437,7 @@ data NullabilityGADT nullability where
 data NotNull
 
 {- |
-  'Nullable' is a values-less type used to track that a 'FieldDefinition'
+  'Nullable' is a value-less type used to track that a 'FieldDefinition'
   represents a field that is marked nullable in the database schema. See the
   'Nullability' type for the value-level representation of field nullability.
 
@@ -648,7 +648,7 @@ uuidField ::
 uuidField = fieldOfType SqlType.uuid
 
 {- |
-  Builds a 'FieldDefinition' for will use the given 'SqlType' to determine
+  Builds a 'FieldDefinition' that will use the given 'SqlType' to determine
   the database representation of the field. If you have created a custom
   'SqlType', you can use this function to construct a helper like the
   other functions in this module for creating 'FieldDefinition's for your
@@ -657,7 +657,7 @@ uuidField = fieldOfType SqlType.uuid
 @since 1.0.0.0
 -}
 fieldOfType ::
-  -- | 'SqlType' that represents the PostgreSQL data type for the field.
+  -- | 'SqlType' that represents the PostgreSQL data type for the field
   SqlType.SqlType a ->
   -- | Name of the field in the database
   String ->
@@ -676,7 +676,7 @@ fieldOfType sqlType name =
   Makes a 'NotNull' field 'Nullable' by wrapping the Haskell type of the field
   in 'Maybe'. The field will be marked as 'NULL' in the database schema and
   the value 'Nothing' will be used to represent 'NULL' values when converting
-  to and from sql.
+  to and from SQL.
 
 @since 1.0.0.0
 -}
@@ -706,8 +706,8 @@ nullableField field =
 {- |
   Adds a `Maybe` wrapper to a field that is already nullable. (If your field is
   'NotNull', you wanted 'nullableField' instead of this function). Note that
-  fields created using this function have asymetric encoding and decoding of
-  'NULL' values. Because the provided field is 'Nullable', 'NULL' values decode
+  fields created using this function have asymmetric encoding and decoding of
+  'NULL' values. Because the provided field is 'Nullable', 'NULL' values decoded
   from the database already have a representation in the 'a' type, so 'NULL'
   will be decoded as 'Just <value of type a for NULL>'. This means if you
   insert a 'Nothing' value using the field, it will be read back as 'Just'
@@ -738,8 +738,8 @@ asymmetricNullableField field =
 
 {- |
   Applies a 'SqlType.SqlType' conversion to a 'FieldDefinition'. You can
-  use this function the create 'FieldDefinition's for based on the primitive
-  ones provided, but with more specific Haskell types.
+  use this function to create 'FieldDefinition's based on the primitive ones
+  provided, but with more specific Haskell types.
 
   See 'SqlType.convertSqlType' and 'SqlType.tryConvertSqlType' for functions
   to create the conversion needed as the first argument to 'convertField'.
@@ -775,7 +775,7 @@ coerceField =
   Sets a default value for the field. The default value will be added as part
   of the column definition in the database. Because the default value is
   ultimately provided by the database this can be used to add a not-null column
-  to safely to an existing table as long as a reasonable default value is
+  safely to an existing table as long as a reasonable default value is
   available to use.
 
 @since 1.0.0.0
@@ -819,8 +819,8 @@ prefixField prefix fieldDef =
 
 {- |
   Constructs a 'Expr.SetClause' that will set the column named in the
-  field definition to the given value. The value is be converted to SQL
-  value using 'fieldValueToSqlValue'
+  field definition to the given value. The value is converted to a SQL
+  value using 'fieldValueToSqlValue'.
 
 @since 1.0.0.0
 -}
@@ -831,7 +831,7 @@ setField fieldDef value =
     (fieldValueToSqlValue fieldDef value)
 
 {- |
-  Operator alias for 'setField'
+  Operator alias for 'setField'.
 
 @since 1.0.0.0
 -}
@@ -848,7 +848,7 @@ fieldEquals =
   whereColumnComparison Expr.equals
 
 {- |
-  Operator alias for 'fieldEquals'
+  Operator alias for 'fieldEquals'.
 
 @since 1.0.0.0
 -}
@@ -867,7 +867,7 @@ fieldNotEquals =
   whereColumnComparison Expr.notEquals
 
 {- |
-  Operator alias for 'fieldNotEquals'
+  Operator alias for 'fieldNotEquals'.
 
 @since 1.0.0.0
 -}
@@ -886,7 +886,7 @@ fieldGreaterThan =
   whereColumnComparison Expr.greaterThan
 
 {- |
-  Operator alias for 'fieldGreaterThan'
+  Operator alias for 'fieldGreaterThan'.
 
 @since 1.0.0.0
 -}
@@ -905,7 +905,7 @@ fieldLessThan =
   whereColumnComparison Expr.lessThan
 
 {- |
-  Operator alias for 'fieldLessThan'
+  Operator alias for 'fieldLessThan'.
 
 @since 1.0.0.0
 -}
@@ -924,7 +924,7 @@ fieldGreaterThanOrEqualTo =
   whereColumnComparison Expr.greaterThanOrEqualTo
 
 {- |
-  Operator alias for 'fieldGreaterThanOrEqualTo'
+  Operator alias for 'fieldGreaterThanOrEqualTo'.
 
 @since 1.0.0.0
 -}
@@ -943,7 +943,7 @@ fieldLessThanOrEqualTo =
   whereColumnComparison Expr.lessThanOrEqualTo
 
 {- |
-  Operator alias for 'fieldLessThanOrEqualTo'
+  Operator alias for 'fieldLessThanOrEqualTo'.
 
 @since 1.0.0.0
 -}
@@ -953,7 +953,7 @@ fieldLessThanOrEqualTo =
 infixl 9 .<=
 
 {- |
-  Checks that the value in a field matches a like pattern
+  Checks that the value in a field matches a like pattern.
 
 @since 1.0.0.0
 -}
@@ -964,7 +964,7 @@ fieldLike fieldDef likePattern =
     (Expr.valueExpression (SqlValue.fromText likePattern))
 
 {- |
-  Checks that the value in a field matches a like pattern case insensitively
+  Checks that the value in a field matches a like pattern case insensitively.
 
 @since 1.0.0.0
 -}
@@ -993,7 +993,7 @@ fieldIsNotNull =
   Expr.isNotNull . fieldColumnReference
 
 {- |
-  Checks that a field matches a list of values
+  Checks that a field matches a list of values.
 
 @since 1.0.0.0
 -}
@@ -1004,7 +1004,7 @@ fieldIn fieldDef values =
     (fmap (fieldValueToExpression fieldDef) values)
 
 {- |
-  Operator alias for 'fieldIn'
+  Operator alias for 'fieldIn'.
 
 @since 1.0.0.0
 -}
@@ -1014,7 +1014,7 @@ fieldIn fieldDef values =
 infixl 9 .<-
 
 {- |
-  Checks that a field does not match a list of values
+  Checks that a field does not match a list of values.
 
 @since 1.0.0.0
 -}
@@ -1025,7 +1025,7 @@ fieldNotIn fieldDef values =
     (fmap (fieldValueToExpression fieldDef) values)
 
 {- |
-  Operator alias for 'fieldNotIn'
+  Operator alias for 'fieldNotIn'.
 
 @since 1.0.0.0
 -}
@@ -1035,7 +1035,7 @@ fieldNotIn fieldDef values =
 infixl 9 .</-
 
 {- |
-  Checks that a tuple of two fields is in the list of specified tuplies
+  Checks that a tuple of two fields is in the list of specified tuples.
 
 @since 1.0.0.0
 -}
@@ -1050,7 +1050,7 @@ fieldTupleIn fieldDefA fieldDefB values =
     (fmap (toSqlValueTuple fieldDefA fieldDefB) values)
 
 {- |
-  Checks that a tuple of two fields is not in the list of specified tuplies
+  Checks that a tuple of two fields is not in the list of specified tuples.
 
 @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Marshall/SqlMarshaller.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Marshall/SqlMarshaller.hs
@@ -69,13 +69,14 @@ import qualified Orville.PostgreSQL.Schema.ConstraintDefinition as ConstraintDef
 
 {- |
   An 'AnnotatedSqlMarshaller' is a 'SqlMarshaller' that contains extra
-  annotations cannot necessarily be determined from the data in the marshaller
-  itself. In particular, it includes the names of fields that be used to
-  identify a row in the database when an error is encoutered during decoding.
+  annotations which cannot necessarily be determined from the data in the
+  marshaller itself. In particular, it includes the names of fields that can be
+  used to identify a row in the database when an error is encoutered during
+  decoding.
 
   Normally you will not need to interact with this type directly -- the
   @TableDefinition@ type creates it for you using the information it has about
-  the primary key of table to identify rows in decoding errors. If you are
+  the primary key of the table to identify rows in decoding errors. If you are
   executing custom queries directly, you may need to annotate a raw
   'SqlMarshaller' yourself so that rows can be identified. See
   'annotateSqlMarshaller' and 'annotateSqlMarshallerEmptyAnnotation'.
@@ -129,10 +130,10 @@ mapSqlMarshaller f (AnnotatedSqlMarshaller rowIdFields marshaller) =
 
 {- |
   'SqlMarshaller' is how we group the lowest level translation of single fields
-  into a higher level marshalling of full sql records into Haskell records.
+  into a higher level marshalling of full SQL records into Haskell records.
   This is a flexible abstraction that allows us to ultimately model SQL tables
   and work with them as potentially nested Haskell records. We can then
-  "marshall" the data as we want to model it in sql and Haskell.
+  "marshall" the data as we want to model it in SQL and Haskell.
 
 @since 1.0.0.0
 -}
@@ -153,7 +154,7 @@ data SqlMarshaller a b where
   MarshallMaybeTag :: SqlMarshaller (Maybe a) (Maybe b) -> SqlMarshaller (Maybe a) (Maybe b)
   -- | Marshall a column with a possibility of error
   MarshallPartial :: SqlMarshaller a (Either String b) -> SqlMarshaller a b
-  -- | Marshall a column that is read only, like auto-incrementing ids
+  -- | Marshall a column that is read-only, like auto-incrementing ids
   MarshallReadOnly :: SqlMarshaller a b -> SqlMarshaller c b
 
 instance Functor (SqlMarshaller a) where
@@ -770,9 +771,9 @@ mkRowIdentityExtractor fields result =
 {- |
   Builds a 'SqlMarshaller' that maps a single field of a Haskell entity to
   a single column in the database. That value to store in the database will
-  be retried from the entity using provided accessor function. This function
+  be retried from the entity using a provided accessor function. This function
   is intended to be used inside of a stanza of 'Applicative' syntax that will
-  pass values read from the database a constructor function to rebuild the
+  pass values read from the database to a constructor function to rebuild the
   entity containing the field, like so:
 
   @
@@ -798,7 +799,7 @@ marshallField accessor fieldDef =
 
 {- |
   Builds a 'SqlMarshaller' that will include a SQL expression in select
-  statements to calculate a value the columns of the table being selected
+  statements to calculate a value using the columns of the table being selected
   from. The columns being used in the calculation do not themselves need
   to be selected, though they must be present in the table so they can
   be referenced.
@@ -831,8 +832,8 @@ marshallSyntheticField =
   MarshallSyntheticField
 
 {- |
-  Nests a 'SqlMarshaller' inside another, using the given accesser to retrieve
-  value to be marshalled. The resulting marshaller can then be used in the same
+  Nests a 'SqlMarshaller' inside another, using the given accessor to retrieve
+  values to be marshalled. The resulting marshaller can then be used in the same
   way as 'marshallField' within the applicative syntax of a larger marshaller.
 
   For Example:
@@ -846,8 +847,8 @@ marshallSyntheticField =
 
   data Name =
     Name
-      { firstName :: T.Text
-      , lastName :: T.Text
+      { firstName :: Text
+      , lastName :: Text
       }
 
   personMarshaller :: SqlMarshaller Person Person
@@ -944,7 +945,7 @@ prefixMarshaller prefix = go
     MarshallReadOnly m -> MarshallReadOnly $ go m
 
 {- |
-  Marks a 'SqlMarshaller' as ready only so that it will not attempt to
+  Marks a 'SqlMarshaller' as read-only so that it will not attempt to
   read any values from the @writeEntity@. You should use this if you have
   a group of fields which are populated by database rather than the application.
 
@@ -955,8 +956,8 @@ marshallReadOnly = MarshallReadOnly
 
 {- |
   A version of 'marshallField' that uses 'marshallReadOnly' to make a single
-  read only field. You will usually use this in conjuction with a
-  'FieldDefinition' like @serialField@ where the valuue is populated by the
+  read-only field. You will usually use this in conjuction with a
+  'FieldDefinition' like @serialField@ where the value is populated by the
   database.
 
 @since 1.0.0.0

--- a/orville-postgresql/src/Orville/PostgreSQL/Marshall/SqlType.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Marshall/SqlType.hs
@@ -73,32 +73,31 @@ import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 -}
 data SqlType a = SqlType
   { sqlTypeExpr :: Expr.DataType
-  -- ^ The sql data type expression to use when creating/migrating columns of
-  -- this type
+  -- ^ The SQL data type expression to use when creating/migrating columns of
+  -- this type.
   , sqlTypeReferenceExpr :: Maybe Expr.DataType
-  -- ^ The sql data type experession to use when creating/migrating columns
-  -- with foreign keys to this type. This is used foreignRefType to build a
-  -- new SqlType when making foreign key fields
+  -- ^ The SQL data type expression to use when creating/migrating columns
+  -- with foreign keys to this type. This is used by 'foreignRefType' to build a
+  -- new SqlType when making foreign key fields.
   , sqlTypeOid :: LibPQ.Oid
-  -- ^ The Oid for the type in postgresql. This will be used during
+  -- ^ The Oid for the type in PostgreSQL. This will be used during
   -- migrations to determine whether the column type needs to be altered.
   , sqlTypeMaximumLength :: Maybe Int32
-  -- ^ The maximum length for lengths that take a type parameter (such as
-  -- @char@ and @varchar@).  This will be used during migration to determine
+  -- ^ The maximum length for types that take a type parameter (such as
+  -- @char@ and @varchar@). This will be used during migration to determine
   -- whether the column type needs to be altered.
   , sqlTypeToSql :: a -> SqlValue
   -- ^ A function for converting Haskell values of this type into values to
   -- be stored in the database.
   , sqlTypeFromSql :: SqlValue -> Either String a
-  -- ^ A function for converting values of this are stored in the database
-  -- into Haskell values. This function should return 'Nothing' to indicate
+  -- ^ A function for converting values of this type stored in the database
+  -- into Haskell values. This function should return 'Left' to indicate
   -- an error if the conversion is impossible. Otherwise it should return
-  -- 'Just' the corresponding 'a' value.
+  -- a 'Right' of the corresponding 'a' value.
   , sqlTypeDontDropImplicitDefaultDuringMigrate :: Bool
   -- ^ The SERIAL and BIGSERIAL PostgreSQL types are really pesudo types that
-  -- create an implicit default value. This flag tells Orville's auto
-  -- migration logic to ignore the default value rather than drop it as it
-  -- normally would.
+  -- create an implicit default value. This flag tells Orville's auto-migration
+  -- logic to ignore the default value rather than drop it as it normally would.
   }
 
 {- |
@@ -419,11 +418,11 @@ oid =
     }
 
 {- |
-  'foreignRefType' creates a 'SqlType' suitable for columns will be foreign
-  keys referencing a column of the given 'SqlType'. For most types the
-  underlying sql type with be identical, but for special types (such as
-  autoincrementing primary keys), the type construted by 'foreignRefType' with
-  have regular underlying sql type. Each 'SqlType' definition must specify any
+  'foreignRefType' creates a 'SqlType' suitable for columns that will be
+  foreign keys referencing a column of the given 'SqlType'. For most types the
+  underlying SQL type will be identical, but for special types (such as
+  auto-incrementing primary keys), the type constructed by 'foreignRefType' will
+  have a regular underlying SQL type. Each 'SqlType' definition must specify any
   special handling required when creating foreign reference types by setting
   the 'sqlTypeReferenceExpr' field to an appropriate value.
 
@@ -440,8 +439,8 @@ foreignRefType sqlType =
   changing the column type that will be used in the database schema. The
   functions given will be used to convert the now Haskell type to and from the
   original type when reading and writing values from the database. When reading
-  an 'a' value from the database, the conversion function should produce 'Left
-  with an error message if the value cannot be successfully converted to a 'b'
+  an 'a' value from the database, the conversion function should produce 'Left'
+  with an error message if the value cannot be successfully converted to a 'b'.
 
 @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Marshall/SyntheticField.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Marshall/SyntheticField.hs
@@ -37,8 +37,8 @@ data SyntheticField a = SyntheticField
   }
 
 {- |
-  Returns the SQL expression that should be in with select statements to
-  calculated the sythetic field.
+  Returns the SQL expression that should be used in select statements to
+  calculate the sythetic field.
 
 @since 1.0.0.0
 -}
@@ -75,7 +75,7 @@ syntheticFieldValueFromSqlValue =
 syntheticField ::
   -- | The SQL expression to be selected
   Expr.ValueExpression ->
-  -- | The alias to be used to name the calculation in SQL experios
+  -- | The alias to be used to name the calculation in SQL expressions
   String ->
   -- | A function to decode the expression result from a 'SqlValue.SqlValue'
   (SqlValue.SqlValue -> Either String a) ->

--- a/orville-postgresql/src/Orville/PostgreSQL/Monad/HasOrvilleState.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Monad/HasOrvilleState.hs
@@ -22,7 +22,7 @@ import Orville.PostgreSQL.OrvilleState (OrvilleState)
   'HasOrvilleState' is the typeclass that Orville uses to access and manange
   the connection pool and state tracking when it is being executed inside an
   unknown Monad. It is a specialized version of the Reader interface so that it
-  can easily implemented by application Monads that already have a Reader
+  can be easily implemented by application Monads that already have a Reader
   context and want to simply add 'OrvilleState' as an attribute to that
   context, like so
 

--- a/orville-postgresql/src/Orville/PostgreSQL/Monad/MonadOrville.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Monad/MonadOrville.hs
@@ -59,13 +59,13 @@ class
   MonadOrville m
 
 {- |
-  'MonadOrvilleControl' presents the interface that Orville will used to
+  'MonadOrvilleControl' presents the interface that Orville will use to
   lift low-level IO operations that cannot be lifted via 'liftIO' (i.e.
-  those where the IO parameter is contravriant rather than covariant).
+  those where the IO parameter is contravariant rather than covariant).
 
   For application monads built using only 'ReaderT' and 'IO', this can be
   trivially implemented (or derived), using the 'ReaderT' instance that is
-  provided here. If you monad stack is sufficiently complicated, you may
+  provided here. If your monad stack is sufficiently complicated, you may
   need to use the 'unliftio' package as a stepping stone to implementing
   'MonadOrvilleControl'. If your monad uses features that 'unliftio' cannot
   support (e.g. the State monad or continuations), then you may need to
@@ -100,7 +100,7 @@ class MonadOrvilleControl m where
 
   -- |
   --     Orville will use this function to lift `mask` calls into the application
-  --     monad to guarantee resource cleanup is executed even when asynchrouns
+  --     monad to guarantee resource cleanup is executed even when asynchronous
   --     exceptions are thrown.
   --
   -- @since 1.0.0.0
@@ -144,10 +144,10 @@ instance (MonadOrvilleControl m, MonadIO m) => MonadOrville (ReaderT OrvilleStat
   Orville.  For the "outermost" call of 'withConnection', a connection will be
   acquired from the resource pool. Additional calls to 'withConnection' that
   happen inside the 'm a' that uses the connection will return the same
-  'Connection' the same connection. When the 'm a' finishes the connection
-  will be returned to the pool. If 'm a' throws an exception the pool's
-  exception handling will take effect, generally destroying the connection in
-  case it was the source of the error.
+  'Connection'. When the 'm a' finishes the connection will be returned to the
+  pool. If 'm a' throws an exception the pool's exception handling will take
+  effect, generally destroying the connection in case it was the source of the
+  error.
 
 @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Raw/Connection.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Raw/Connection.hs
@@ -46,8 +46,8 @@ import qualified Database.PostgreSQL.LibPQ as LibPQ
 import Orville.PostgreSQL.Raw.PgTextFormatValue (NULByteFoundError (NULByteFoundError), PgTextFormatValue, toBytesForLibPQ)
 
 {- |
-  An option for 'createConnectionPool' than indicates whether the LibPQ should
-  print notice reports for warnings to the console
+  An option for 'createConnectionPool' that indicates whether the LibPQ should
+  print notice reports for warnings to the console.
 
 @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/ConstraintDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/ConstraintDefinition.hs
@@ -97,7 +97,7 @@ tableConstraintDefinitions (TableConstraints constraints) =
   Defines a constraint that can be added to a
   'Orville.PostgreSQL.TableDefinition'. Use one of the constructor functions
   below (such as 'uniqueConstraint') to construct the constraint definition you
-  wish to have and then use 'Orville.PostgreSQL.addTableConstraints'. to add
+  wish to have and then use 'Orville.PostgreSQL.addTableConstraints' to add
   them to your table definition. Orville will then add the constraint next time
   you run auto-migrations.
 
@@ -137,7 +137,7 @@ data ConstraintKeyType
   deriving (Eq, Ord, Show)
 
 {- |
-  Gets the 'ConstraintMigrationKey' for the 'ConstraintDefinition'
+  Gets the 'ConstraintMigrationKey' for the 'ConstraintDefinition'.
 
 @since 1.0.0.0
 -}
@@ -192,7 +192,7 @@ data ForeignReference = ForeignReference
   }
 
 {- |
-  Constructs a 'ForeignReference'
+  Constructs a 'ForeignReference'.
 
 @since 1.0.0.0
 -}
@@ -217,9 +217,9 @@ foreignReference localName foreignName =
 -}
 data ForeignKeyOptions = ForeignKeyOptions
   { foreignKeyOptionsOnUpdate :: ForeignKeyAction
-  -- ^ The @ON UPDATE@ action for the foreign key
+  -- ^ The @ON UPDATE@ action for the foreign key.
   , foreignKeyOptionsOnDelete :: ForeignKeyAction
-  -- ^ The @ON DELETE@ action for the foreign key
+  -- ^ The @ON DELETE@ action for the foreign key.
   }
 
 {- |

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/PrimaryKey.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/PrimaryKey.hs
@@ -132,9 +132,9 @@ compositePrimaryKey =
 
 {- |
   'primaryKeyPart' constructs a building block for a composite primary key
-  based a 'FieldDefinition' and an accessor function to extract the value for
+  based on a 'FieldDefinition' and an accessor function to extract the value for
   that field from the Haskell 'key' type that represents the overall composite
-  key.  'PrimaryKeyPart' values built using this function are usually then
+  key. 'PrimaryKeyPart' values built using this function are usually then
   passed in a list to 'compositePrimaryKey' to build a 'PrimaryKey'.
 
 @since 1.0.0.0

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/SequenceDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/SequenceDefinition.hs
@@ -74,7 +74,7 @@ mkSequenceDefinition name =
 {- |
   Sets the sequence's schema to the name in the given string, which will be
   treated as a SQL identifier. If a sequence has a schema name set, it will be
-  included as a qualified on the sequence name for all queries involving the
+  included as a qualifier on the sequence name for all queries involving the
   sequence.
 
 @since 1.0.0.0
@@ -90,7 +90,7 @@ setSequenceSchema schemaName sequenceDef =
 
 {- |
   Retrieves the 'SequenceIdentifier' for this sequence, which is set by the
-  name provided to 'mkSequenceDefinition' and any calls make to
+  name provided to 'mkSequenceDefinition' and any calls made to
   'setSequenceSchema' thereafter.
 
 @since 1.0.0.0
@@ -157,7 +157,7 @@ setSequenceMinValue n sequenceDef =
 
 {- |
   Retrieves the max value of the sequence. If no explicit maximum has been set
-  this returns 'maxBound' for 'Int64' for ascending sequences and @-1@
+  this returns 'maxBound' for 'Int64' for ascending sequences and @-1@ for
   descending sequences.
 
 @since 1.0.0.0

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/SequenceIdentifier.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/SequenceIdentifier.hs
@@ -99,7 +99,7 @@ sequenceIdUnqualifiedNameString =
   i_sequenceIdName
 
 {- |
-  Retrieves the schema name of the sequence as a string
+  Retrieves the schema name of the sequence as a string.
 
 @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/TableDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/TableDefinition.hs
@@ -59,7 +59,7 @@ import Orville.PostgreSQL.Schema.TableIdentifier (TableIdentifier, setTableIdSch
     values to be used in this parameter.
 
   * 'writeEntity' is the Haskell type for values that Orville will write
-    to the database for you (i.e. both inserts and updates)
+    to the database for you (i.e. both inserts and updates).
 
   * 'readEntity' is the Haskell type for values that Orville will decode
     from the result set when entities are queried from this table.
@@ -78,7 +78,7 @@ data TableDefinition key writeEntity readEntity = TableDefinition
 {- |
   'HasKey' is a type with no constructors. It is used only at the type level
   as the @key@ parameter to the 'TableDefinition' type to indicate that the
-  the table has a primary key and what the Haskell type of the primary key is.
+  table has a primary key and what the Haskell type of the primary key is.
 
 @since 1.0.0.0
 -}
@@ -87,7 +87,7 @@ data HasKey key
 {- |
   'NoKey' is a type with no constructors. It is used only at the type level
   as the @key@ parameter to the 'TableDefinition' type to indicate that the
-  the table does not have a primary key.
+  table does not have a primary key.
 
 @since 1.0.0.0
 -}
@@ -133,7 +133,7 @@ mkTableDefinition name primaryKey marshaller =
 {- |
   Constructs a new 'TableDefinition' with the minimal fields required for
   operation. Note: tables created via this function will not have a primary
-  key. Certain Orville functions required a primary key. Attempting to call
+  key. Certain Orville functions require a primary key. Attempting to call
   functions requiring a primary key will fail to compile when using a table
   that has no key.
 
@@ -180,7 +180,7 @@ dropColumns columns tableDef =
     }
 
 {- |
-  Returns the set of columns that have be marked be dropped by 'dropColumns'
+  Returns the set of columns that have been marked as dropped by 'dropColumns'.
 
 @since 1.0.0.0
 -}
@@ -189,7 +189,7 @@ columnsToDrop =
   i_tableColumnsToDrop
 
 {- |
-  Returns the table's 'TableIdentifier'
+  Returns the table's 'TableIdentifier'.
 
 @since 1.0.0.0
 -}
@@ -211,7 +211,7 @@ tableName =
 {- |
   Sets the table's schema to the name in the given string, which will be
   treated as a SQL identifier. If a table has a schema name set, it will be
-  included as a qualified on the table name for all queries involving the
+  included as a qualifier on the table name for all queries involving the
   table.
 
 @since 1.0.0.0
@@ -269,7 +269,7 @@ tableConstraintsFromMarshaller =
 
 {- |
   Adds the given table constraints to the table definition. It's also possible
-  to add constraints that apply to only one column adding them to
+  to add constraints that apply to only one column, adding them to
   the 'FieldDefinition's that are included in the table's 'SqlMarshaller'.
 
   If you wish to constrain multiple columns with a single constraint (e.g. a
@@ -391,7 +391,7 @@ mkTableColumnDefinitions tableDef =
     (collectFromField IncludeReadOnlyColumns fieldColumnDefinition)
 
 {- |
-  Builds the 'Expr.PrimaryKeyExpr' for this table, or none of this table has no
+  Builds the 'Expr.PrimaryKeyExpr' for this table, or none if this table has no
   primary key.
 
 @since 1.0.0.0

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/TableIdentifier.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/TableIdentifier.hs
@@ -108,7 +108,7 @@ tableIdSchemaNameString =
   i_tableIdSchema
 
 {- |
-  Converts a 'TableIdentifier' for a string for descriptive purposes. The
+  Converts a 'TableIdentifier' to a string for descriptive purposes. The
   name will be qualified if a schema name has been set for the identifier.
 
   Note: You should not use this function for building SQL expressions. Use


### PR DESCRIPTION
This addresses some typos I found in the documentation for types and functions that are exported under `Orville.PostgreSQL`. Some of these may not be valid, so feel free to cherry-pick these suggestions as desired.