### PR TITLE
Allow users to concurrent index creation in a custom manner

### DIFF
--- a/orville-postgresql/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL.hs
@@ -131,7 +131,7 @@ module Orville.PostgreSQL
   , IndexDefinition.mkNamedIndexDefinition
   , IndexDefinition.IndexUniqueness (UniqueIndex, NonUniqueIndex)
   , IndexDefinition.indexCreateExpr
-  , IndexDefinition.IndexCreationStrategy (Transactional, Asynchronous)
+  , IndexDefinition.IndexCreationStrategy (Transactional, Concurrent)
   , IndexDefinition.setIndexCreationStrategy
   , IndexDefinition.indexCreationStrategy
   , PrimaryKey.PrimaryKey

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/IndexDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/IndexDefinition.hs
@@ -17,7 +17,7 @@ module Orville.PostgreSQL.Schema.IndexDefinition
   , IndexDefinition.mkNamedIndexDefinition
   , Expr.IndexUniqueness (UniqueIndex, NonUniqueIndex)
   , IndexDefinition.indexCreateExpr
-  , IndexDefinition.IndexCreationStrategy (Transactional, Asynchronous)
+  , IndexDefinition.IndexCreationStrategy (Transactional, Concurrent)
   )
 where
 


### PR DESCRIPTION
This updates the docs to reflect that PostgreSQL does NOT run concurrent
index creation the background but rather blocks waiting for it to
finish. It also adds a `MigrationOptions` argument to allow the caller
control over which block of migration steps are to be run and what
migration lock to use. This should be enough to allow callers to run the
concurrent indexes in their own user-supplied thread if they desire.
