### PR TITLE
More documentation proofreading

### DIFF
--- a/orville-postgresql/src/Orville/PostgreSQL/AutoMigration.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/AutoMigration.hs
@@ -8,7 +8,7 @@ License   : MIT
 Stability : Stable
 
 Facilities for performing some database migrations automatically.
-See 'autoMigrateSchema' as a primary, high level entry point.
+See 'autoMigrateSchema' as a primary, high-level entry point.
 
 @since 1.0.0.0
 -}
@@ -90,8 +90,8 @@ data SchemaItem where
     SchemaItem
 
 {- |
-  Returns a one-line string describe the 'SchemaItem', suitable for a human to
-  identify it in a list of output.
+  Returns a one-line string describing the 'SchemaItem', suitable for a human
+  to identify it in a list of output.
 
   For example, a 'SchemaItem' constructed via 'schemaTable' gives @Table <table
   name>@.
@@ -295,7 +295,7 @@ defaultOptions =
 
 {- |
   This function compares the list of 'SchemaItem's provided against the current
-  schema found in the database to determine whether any migration are
+  schema found in the database to determine whether any migrations are
   necessary.  If any changes need to be made, this function executes. You can
   call 'generateMigrationPlan' and 'executeMigrationPlan' yourself if you want
   to have more control over the process, but must then take care to ensure that
@@ -321,12 +321,12 @@ autoMigrateSchema options schemaItems =
   in the database and returns a 'MigrationPlan' that could be executed to make
   the database schema match the items given.
 
-  You can execute the 'MigrationPlan' yourself using 'executeMigrationPlan'
+  You can execute the 'MigrationPlan' yourself using the 'executeMigrationPlan'
   convenience function, though 'autoMigrateSchema' is usually a better option
   because it uses a database lock to ensure that no other processes are also
   using 'autoMigrateSchema' to apply migrations at the same time. If you use
-  'generateMigrationPlan' and 'executeMigrationPlan' separately you are
-  responsible for ensuring that the schema has no changed between the time the
+  'generateMigrationPlan' and 'executeMigrationPlan' separately, you are
+  responsible for ensuring that the schema has not changed between the time the
   plan is generated and executed yourself.
 
 @since 1.0.0.0
@@ -357,7 +357,7 @@ generateMigrationPlanWithoutLock schemaItems =
         pure . mkMigrationPlan . concat $ migrationSteps
 
 {- |
-  Executes a 'MigrationPlan' that has be previously devised via
+  Executes a 'MigrationPlan' that has been previously devised via
   'generateMigrationPlan'. Normally all the steps in a migration plan are
   executed in a transaction so that they will all be applied together
   successfully or all rolled-back if one of them fails. Any indexes using the
@@ -366,8 +366,8 @@ generateMigrationPlanWithoutLock schemaItems =
   inside a transaction. If a 'MigrationPlan' includes any indexes whose
   creation strategy is set to 'Orville.Concurrent', Orville will create indexes
   after the rest of the migration steps have been committed successfully. This
-  function will wait for until all the migration steps that it runs to finish
-  before returning. If one of the concurrent indexes fails during creation it
+  function will wait until all of the migration steps that it runs to finish
+  before returning. If one of the concurrent indexes fails during creation, it
   will be left in an invalid state (as is the default PostgreSQL behavior). You
   should check on the status of indexes created this way manually to ensure
   they were created successfully. If they could not be, you can drop them and

--- a/orville-postgresql/src/Orville/PostgreSQL/Execution.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Execution.hs
@@ -7,14 +7,14 @@ Stability : Stable
 
 You can import "Orville.PostgreSQL.Execution" to get access to all the
 execution-related functions and types exported by the modules below. This
-includes a number of lowel-level items not exported by "Orville.PostgreSQL"
+includes a number of lower-level items not exported by "Orville.PostgreSQL"
 that give you more control (and therefore responsibility) over how the SQL is
 executed.
 
 @since 1.0.0.0
 -}
 module Orville.PostgreSQL.Execution
-  ( -- * High level modules for most common tasks
+  ( -- * High-level modules for most common tasks
       module Orville.PostgreSQL.Execution.EntityOperations
   , module Orville.PostgreSQL.Execution.SelectOptions
   , module Orville.PostgreSQL.Execution.Sequence

--- a/orville-postgresql/src/Orville/PostgreSQL/Execution/Cursor.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Execution/Cursor.hs
@@ -75,7 +75,7 @@ data Cursor readEntity where
   completes (or raises an exception).
 
   See @https://www.postgresql.org/docs/current/sql-declare.html@ for details
-  about the 'Expr.ScrollExpr' and 'Expr.HoldExpr' parameters and how cursor
+  about the 'Expr.ScrollExpr' and 'Expr.HoldExpr' parameters and how cursors
   behave in general.
 
   We recommend you use this instead of 'declareCursor' and 'closeCursor'
@@ -104,7 +104,7 @@ withCursor scrollExpr holdExpr select useCursor =
   ensure that the cursor gets closed properly.
 
   See @https://www.postgresql.org/docs/current/sql-declare.html@ for details
-  about the 'Expr.ScrollExpr' and 'Expr.HoldExpr' parameters and how cursor
+  about the 'Expr.ScrollExpr' and 'Expr.HoldExpr' parameters and how cursors
   behave in general.
 
 @since 1.0.0.0
@@ -129,8 +129,8 @@ declareCursor scrollExpr holdExpr =
 {- |
   Closes a @CURSOR@ in PostgreSQL that was previously declared.
   This should be used to close any cursors you open via 'declareCursor',
-  thought we recommend you use 'withCursor' instead to ensure that any
-  opened cursor are closed in the event of an exception.
+  though we recommend you use 'withCursor' instead to ensure that any
+  opened cursors are closed in the event of an exception.
 
 @since 1.0.0.0
 -}
@@ -147,7 +147,7 @@ closeCursor (Cursor _ cursorName) =
 {- |
   Fetch rows from a cursor according to the 'Expr.CursorDirection' given. See
   @https://www.postgresql.org/docs/current/sql-fetch.html@ for details about
-  effect of fetch and the meanings of cursor directions to PostgreSQL.
+  the effects of fetch and the meanings of cursor directions to PostgreSQL.
 
 @since 1.0.0.0
 -}
@@ -165,7 +165,7 @@ fetch direction (Cursor marshaller cursorName) =
 {- |
   Moves a cursor according to the 'Expr.CursorDirection' given. See
   @https://www.postgresql.org/docs/current/sql-fetch.html@ for details about
-  effect of move and the meanings of cursor directions to PostgreSQL.
+  the effect of move and the meanings of cursor directions to PostgreSQL.
 
 @since 1.0.0.0
 -}
@@ -181,8 +181,8 @@ move direction (Cursor _ cursorName) =
 
 {- |
   INTERNAL - Generates a unique (or very nearly guaranteed to be) cursor name.
-  Cursor names only need to be unique among the currently open cursors on the
-  current connection, so using POSIX time plus a 32 bit random tag should be
+  Cursor names only need to be unique among the currently-open cursors on the
+  current connection, so using POSIX time plus a 32-bit random tag should be
   more than sufficient to ensure conflicts are not seen in practice.
 
 @since 1.0.0.0

--- a/orville-postgresql/src/Orville/PostgreSQL/Execution/Delete.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Execution/Delete.hs
@@ -59,7 +59,7 @@ deleteFromDeleteExpr (Delete expr) = expr
 deleteFromDeleteExpr (DeleteReturning _ expr) = expr
 
 {- |
-  Excutes the database query for the 'Delete' and returns the number of
+  Executes the database query for the 'Delete' and returns the number of
   rows affected by the query.
 
 @since 1.0.0.0
@@ -71,8 +71,8 @@ executeDelete ::
 executeDelete (Delete expr) =
   Execute.executeAndReturnAffectedRows QueryType.DeleteQuery expr
 
-{- | Excutes the database query for the 'Delete' and uses its 'SqlMarshaller' to decode the rows (that
-  were just deleteed) as returned via a RETURNING clause.
+{- | Executes the database query for the 'Delete' and uses its 'SqlMarshaller' to decode the rows (that
+  were just deleted) as returned via a RETURNING clause.
 
 @since 1.0.0.0
 -}
@@ -84,7 +84,7 @@ executeDeleteReturnEntities (DeleteReturning marshaller expr) =
   Execute.executeAndDecode QueryType.DeleteQuery expr marshaller
 
 {- |
-  Builds a 'Delete' that will delete all of the writeable columns described in the
+  Builds a 'Delete' that will delete all of the writable columns described in the
   'TableDefinition' without returning the data as seen by the database.
 
 @since 1.0.0.0
@@ -97,9 +97,9 @@ deleteFromTable =
   deleteTable WithoutReturning
 
 {- |
-  Builds a 'Delete' that will delete all of the writeable columns described in the
-  'TableDefinition' and returning the data as seen by the database. This is useful for getting
-  database managed columns such as auto-incrementing identifiers and sequences.
+  Builds a 'Delete' that will delete all of the writable columns described in the
+  'TableDefinition' and return the data as seen by the database. This is useful for getting
+  database-managed columns such as auto-incrementing identifiers and sequences.
 
 @since 1.0.0.0
 -}
@@ -133,7 +133,7 @@ deleteTable returningOption tableDef whereCondition =
   can decode.
 
   This is the lowest level of escape hatch available for 'Delete'. The caller can build any query
-  that Orville supports using the expression building functions, or use @RawSql.fromRawSql@ to build
+  that Orville supports using the expression-building functions, or use @RawSql.fromRawSql@ to build
   a raw 'Expr.DeleteExpr'. It is expected that the 'ReturningOption' given matches the
   'Expr.DeleteExpr'. This level of interface does not provide an automatic enforcement of the
   expectation, however failure is likely if that is not met.

--- a/orville-postgresql/src/Orville/PostgreSQL/Execution/EntityOperations.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Execution/EntityOperations.hs
@@ -4,7 +4,7 @@ License   : MIT
 Stability : Stable
 
 Entry-level functions for executing based CRUD operations on entity tables.
-This are the functions that you will use most often for interacting with
+These are the functions that you will use most often for interacting with
 tables.
 
 @since 1.0.0.0

--- a/orville-postgresql/src/Orville/PostgreSQL/Execution/Execute.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Execution/Execute.hs
@@ -60,10 +60,10 @@ executeAndDecode queryType sql marshaller = do
   This function can only be used for the execution of a SELECT, CREATE
   TABLE AS, INSERT, UPDATE, DELETE, MOVE, FETCH, or COPY statement, or an
   EXECUTE of a prepared query that contains an INSERT, UPDATE, or DELETE
-  statement. If the query is anything else an 'AffectedRowsDecodingError'
+  statement. If the query is anything else, an 'AffectedRowsDecodingError'
   wil be raised after the query is executed when the result is read.
 
-  If the query fails an exception will be raised.
+  If the query fails, an exception will be raised.
 
 @since 1.0.0.0
 -}
@@ -137,10 +137,10 @@ executeAndDecodeIO queryType sql marshaller orvilleState conn = do
   This function can only be used for the execution of a SELECT, CREATE
   TABLE AS, INSERT, UPDATE, DELETE, MOVE, FETCH, or COPY statement, or an
   EXECUTE of a prepared query that contains an INSERT, UPDATE, or DELETE
-  statement. If the query is anything else an 'AffectedRowsDecodingError'
+  statement. If the query is anything else, an 'AffectedRowsDecodingError'
   wil be raised after the query is executed when the result is read.
 
-  If the query fails an exception will be raised.
+  If the query fails, an exception will be raised.
 
 @since 1.0.0.0
 -}
@@ -170,7 +170,7 @@ executeAndReturnAffectedRowsIO queryType sql orvilleState conn = do
   Executes a SQL query and ignores the result. Any SQL Execution callbacks
   that have been added to the 'OrvilleState' will be called.
 
-  If the query fails an exception will be raised.
+  If the query fails, an exception will be raised.
 
 @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Execution/ExecutionResult.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Execution/ExecutionResult.hs
@@ -26,7 +26,7 @@ import Orville.PostgreSQL.Raw.SqlValue (SqlValue)
 import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 {- |
-  A trivial wrapper for `Int` to help keep track of column vs row number
+  A trivial wrapper for `Int` to help keep track of column vs row number.
 
 @since 1.0.0.0
 -}
@@ -44,7 +44,7 @@ newtype Column
     )
 
 {- |
-  A trivial wrapper for `Int` to help keep track of column vs row number
+  A trivial wrapper for `Int` to help keep track of column vs row number.
 
 @since 1.0.0.0
 -}
@@ -63,7 +63,7 @@ newtype Row
 
 {- |
   'ExecutionResult' is a common interface for types that represent a result set
-  returned from the database. For real, live database interactions this the
+  returned from the database. For real, live database interactions, the
   concrete type will be a 'LibPQ.Result', but the 'FakeLibPQResult' may be
   useful as well if you are writing custom code for decoding result sets and
   want to test aspects of the decoding that don't require a real database.
@@ -77,11 +77,11 @@ class ExecutionResult result where
   getValue :: result -> Row -> Column -> IO SqlValue
 
 {- |
-  Read the rows of an 'ExecutionResult' a list of column name, 'SqlValue'
+  Reads the rows of an 'ExecutionResult' as a list of column name, 'SqlValue'
   pairs. You're almost always better off using a
   'Orville.PostgreSQL.SqlMarshaller' instead, but this function is provided for
   cases where you really want to decode the rows yourself but don't want to use
-  the 'ExecutionResult' api to read each row of each column directly.
+  the 'ExecutionResult' API to read each row of each column directly.
 
 @since 1.0.0.0
 -}
@@ -141,10 +141,10 @@ instance ExecutionResult LibPQ.Result where
       <$> LibPQ.getvalue' result (LibPQ.toRow row) (LibPQ.toColumn column)
 
 {- |
-  `FakeLibPQResult` provides a fake, in memory implementation of
+  `FakeLibPQResult` provides a fake, in-memory implementation of
   `ExecutionResult`.  This is mostly useful for writing automated tests that
-  can assume a result set has been loaded and just need to test decoding the
-  results.
+  can assume a result set has been loaded and you just need to test decoding
+  the results.
 
 @since 1.0.0.0
 -}
@@ -161,9 +161,9 @@ instance ExecutionResult FakeLibPQResult where
   getValue result column = pure . fakeLibPQGetValue result column
 
 {- |
-  Constructs a `FakeLibPQResult`. The column names given as associated with
-  the values for each row by their position in list. Any missing values (e.g.
-  because a row is shorter than the heeader list) are treated as a SQL Null
+  Constructs a `FakeLibPQResult`. The column names given are associated with
+  the values for each row by their position in-list. Any missing values (e.g.
+  because a row is shorter than the header list) are treated as a SQL Null
   value.
 
 @since 1.0.0.0

--- a/orville-postgresql/src/Orville/PostgreSQL/Execution/Insert.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Execution/Insert.hs
@@ -63,7 +63,7 @@ insertToInsertExpr (Insert _ expr) = expr
 insertToInsertExpr (InsertReturning _ expr) = expr
 
 {- |
-  Excutes the database query for the 'Insert' and returns the number of rows
+  Executes the database query for the 'Insert' and returns the number of rows
   affected by the query.
 
 @since 1.0.0.0
@@ -75,7 +75,7 @@ executeInsert ::
 executeInsert (Insert _ expr) =
   Execute.executeAndReturnAffectedRows QueryType.InsertQuery expr
 
-{- | Excutes the database query for the 'Insert' and uses its 'SqlMarshaller' to decode the rows (that
+{- | Executes the database query for the 'Insert' and uses its 'SqlMarshaller' to decode the rows (that
   were just inserted) as returned via a RETURNING clause.
 
 @since 1.0.0.0
@@ -88,7 +88,7 @@ executeInsertReturnEntities (InsertReturning marshaller expr) =
   Execute.executeAndDecode QueryType.InsertQuery expr marshaller
 
 {- |
-  Builds an 'Insert' that will insert all of the writeable columns described in the
+  Builds an 'Insert' that will insert all of the writable columns described in the
   'TableDefinition' without returning the data as seen by the database.
 
 @since 1.0.0.0
@@ -101,9 +101,9 @@ insertToTable =
   insertTable WithoutReturning
 
 {- |
-  Builds an 'Insert' that will insert all of the writeable columns described in the
-  'TableDefinition' and returning the data as seen by the database. This is useful for getting
-  database managed columns such as auto-incrementing identifiers and sequences.
+  Builds an 'Insert' that will insert all of the writable columns described in the
+  'TableDefinition' and return the data as seen by the database. This is useful for getting
+  database-managed columns such as auto-incrementing identifiers and sequences.
 
 @since 1.0.0.0
 -}
@@ -130,7 +130,7 @@ insertTable returningOption tableDef entities =
   decode.
 
   This is the lowest level of escape hatch available for 'Update'. The caller can build any query
-  that Orville supports using the expression building functions, or use @RawSql.fromRawSql@ to build
+  that Orville supports using the expression-building functions, or use @RawSql.fromRawSql@ to build
   a raw 'Expr.InsertExpr'. It is expected that the 'ReturningOption' given matches the
   'Expr.InsertExpr'. This level of interface does not provide an automatic enforcement of the
   expectation, however failure is likely if that is not met.

--- a/orville-postgresql/src/Orville/PostgreSQL/Execution/ReturningOption.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Execution/ReturningOption.hs
@@ -29,7 +29,7 @@ data NoReturningClause
 {- |
   Specifies whether or not a @RETURNING@ clause should be included when a
   query expression is built. This type is found as a parameter on a number
-  of the query building functions related to 'TableDefinition'.
+  of the query-building functions related to 'TableDefinition'.
 @since 1.0.0.0
 -}
 data ReturningOption clause where

--- a/orville-postgresql/src/Orville/PostgreSQL/Execution/Select.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Execution/Select.hs
@@ -8,8 +8,8 @@ Stability : Stable
 
 Functions for working with executable @SELECT@ statements. The 'Select' type is
 a value that can be passed around and executed later. The 'Select' is directly
-associated with how to decode the rows returned by the query . This means it
-can be safely executed via 'executeInsert' and decode the rows.. It is a
+associated with how to decode the rows returned by the query. This means it
+can be safely executed via 'executeSelect' and used to decode the rows. It is a
 lower-level API than the entity select functions in
 "Orville.PostgreSQL.Execution.EntityOperations", but not as primitive as
 "Orville.PostgreSQL.Expr.Query".
@@ -56,7 +56,7 @@ selectToQueryExpr :: Select readEntity -> Expr.QueryExpr
 selectToQueryExpr (Select _ query) = query
 
 {- |
-  Excutes the database query for the 'Select' and uses its 'SqlMarshaller' to
+  Executes the database query for the 'Select' and uses its 'SqlMarshaller' to
   decode the result set.
 
 @since 1.0.0.0
@@ -87,7 +87,7 @@ useSelect f (Select marshaller query) =
   Builds a 'Select' that will select all the columns described in the
   'TableDefinition'. This is the safest way to build a 'Select', because table
   name and columns are all read from the 'TableDefinition'. If the table is
-  being managed with Orville auto migrations, this will match the schema in the
+  being managed with Orville auto-migrations, this will match the schema in the
   database.
 
 @since 1.0.0.0
@@ -104,7 +104,7 @@ selectTable tableDef =
   from the specified table. It is up to the caller to ensure that the columns
   in the marshaller make sense for the table.
 
-  This function is useful for query a subset of table columns using a custom
+  This function is useful for querying a subset of table columns using a custom
   marshaller.
 
 @since 1.0.0.0
@@ -128,7 +128,7 @@ selectMarshalledColumns marshaller qualifiedTableName selectOptions =
   'SqlMarshaller' can decode.
 
   This is the lowest level of escape hatch available for 'Select'. The caller
-  can build any query that Orville supports using the expression building
+  can build any query that Orville supports using the expression-building
   functions, or use @RawSql.fromRawSql@ to build a raw 'Expr.QueryExpr'.
 
 @since 1.0.0.0

--- a/orville-postgresql/src/Orville/PostgreSQL/Execution/SelectOptions.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Execution/SelectOptions.hs
@@ -153,7 +153,7 @@ selectGroupByClause =
 
 {- |
   Builds a 'Expr.LimitExpr' that will limit the query results to the
-  number specified in the 'SelectOptions' (if any)
+  number specified in the 'SelectOptions' (if any).
 
 @since 1.0.0.0
 -}
@@ -162,8 +162,8 @@ selectLimitExpr =
   getFirst . i_limitExpr
 
 {- |
-  Builds a 'Expr.OffsetExpr' that will limit the query results to the
-  number specified in the 'SelectOptions' (if any)
+  Builds an 'Expr.OffsetExpr' that will limit the query results to the
+  number specified in the 'SelectOptions' (if any).
 
 @since 1.0.0.0
 -}
@@ -228,8 +228,8 @@ groupBy groupByExpr =
 
 {- |
   Builds a 'QueryExpr' that will use the specified 'Expr.SelectList' when building
-  the @SELECT@ statement to execute. It it up to the caller to make sure that
-  the 'Expr.SelectList' expression makes sens for the table being queried, and
+  the @SELECT@ statement to execute. It is up to the caller to make sure that
+  the 'Expr.SelectList' expression makes sense for the table being queried, and
   that the names of the columns in the result set match those expected by the
   given 'SqlMarshaller', which will be used to decode it.
 
@@ -237,7 +237,7 @@ groupBy groupByExpr =
   select things other than simple columns from the table, such as using
   aggregate functions. The 'Expr.SelectList' can be built however the caller
   desires. If Orville does not support building the 'Expr.SelectList' you need
-  using any of the expression building functions, you can resort to
+  using any of the expression-building functions, you can resort to
   @RawSql.fromRawSql@ as an escape hatch to build the 'Expr.SelectList' here.
 
 @since 1.0.0.0

--- a/orville-postgresql/src/Orville/PostgreSQL/Execution/Sequence.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Execution/Sequence.hs
@@ -3,8 +3,8 @@ Copyright : Flipstone Technology Partners 2023
 License   : MIT
 Stability : Stable
 
-Interactions to work with database sequence values on the Haskell side.
-Including inspection of the current and next values in the sequence as well as
+Interactions to work with database sequence values on the Haskell side,
+including inspection of the current and next values in the sequence as well as
 updating a sequence to a given value.
 
 @since 1.0.0.0

--- a/orville-postgresql/src/Orville/PostgreSQL/Execution/Transaction.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Execution/Transaction.hs
@@ -3,7 +3,7 @@ Copyright : Flipstone Technology Partners 2023
 License   : MIT
 Stability : Stable
 
-This module provides the functionality to work with SQL transactions, notably
+This module provides the functionality to work with SQL transactions - notably
 to ensure some Haskell action occurs within a database transaction.
 
 @since 1.0.0.0
@@ -29,7 +29,7 @@ import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
   the transaction will be committed. If the action raises an exception, the transaction will
   rollback.
 
-  This function is safe to call from within another transaction. When called this way the
+  This function is safe to call from within another transaction. When called this way, the
   transaction will establish a new savepoint at the beginning of the nested transaction and
   either release the savepoint or rollback to it as appropriate.
 

--- a/orville-postgresql/src/Orville/PostgreSQL/Execution/Update.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Execution/Update.hs
@@ -101,12 +101,12 @@ updateToTable =
 
 {- |
   Builds an 'Update' that will update all of the writable columns described in
-  the 'TableDefinition' and returning the data as seen by the database. This is
-  useful for getting database managed columns such as auto-incrementing
+  the 'TableDefinition' and return the data as seen by the database. This is
+  useful for getting database-managed columns such as auto-incrementing
   identifiers and sequences.
 
   This function returns 'Nothing' if the 'TableDefinition' has no columns,
-  which would otherwise generate and 'Update' with invalid SQL syntax.
+  which would otherwise generate an 'Update' with invalid SQL syntax.
 
 @since 1.0.0.0
 -}
@@ -154,7 +154,7 @@ updateToTableFieldsReturning =
   decode.
 
   This is the lowest level of escape hatch available for 'Update'. The caller can build any query
-  that Orville supports using the expression building functions, or use @RawSql.fromRawSql@ to build
+  that Orville supports using the expression-building functions, or use @RawSql.fromRawSql@ to build
   a raw 'Expr.UpdateExpr'.
 
 @since 1.0.0.0

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Count.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Count.hs
@@ -17,14 +17,14 @@ import Orville.PostgreSQL.Expr.Name (ColumnName, FunctionName, functionName)
 import Orville.PostgreSQL.Expr.ValueExpression (ValueExpression, columnReference, functionCall)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
-{- | The SQL @count@ function
+{- | The SQL @count@ function.
 
 @since 1.0.0.0
 -}
 countFunction :: FunctionName
 countFunction = functionName "count"
 
-{- | Given a 'ValueExpression', use it as the argument to the SQL @count@
+{- | Given a 'ValueExpression', use it as the argument to the SQL @count@.
 
 @since 1.0.0.0
 -}
@@ -32,7 +32,7 @@ count :: ValueExpression -> ValueExpression
 count value =
   functionCall countFunction [value]
 
-{- | The SQL @count(1)@
+{- | The SQL @count(1)@.
 
 @since 1.0.0.0
 -}
@@ -40,7 +40,7 @@ count1 :: ValueExpression
 count1 =
   count . RawSql.unsafeFromRawSql . RawSql.intDecLiteral $ 1
 
-{- | Use a given column as the argument to the SQL @count@
+{- | Use a given column as the argument to the SQL @count@.
 
 @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Cursor.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Cursor.hs
@@ -325,7 +325,8 @@ newtype CursorDirection
       RawSql.SqlExpression
     )
 
-{- | Specify a direction of the next single row. Primarily for use with 'fetch' or 'move'.
+{- | Specify the direction of the next single row. Primarily for use with
+    'fetch' or 'move'.
 
 See PostgreSQL [fetch documentation](https://www.postgresql.org/docs/current/sql-fetch.html) for
 more information.
@@ -336,7 +337,8 @@ next :: CursorDirection
 next =
   CursorDirection . RawSql.fromString $ "NEXT"
 
-{- | Specify a direction of the prior single row. Primarily for use with 'fetch' or 'move'.
+{- | Specify the direction of the prior single row. Primarily for use with
+    'fetch' or 'move'.
 
 See PostgreSQL [fetch documentation](https://www.postgresql.org/docs/current/sql-fetch.html) for
 more information.
@@ -347,7 +349,8 @@ prior :: CursorDirection
 prior =
   CursorDirection . RawSql.fromString $ "PRIOR"
 
-{- | Specify a direction of the first single row. Primarily for use with 'fetch' or 'move'.
+{- | Specify the direction of the first single row. Primarily for use with
+    'fetch' or 'move'.
 
 See PostgreSQL [fetch documentation](https://www.postgresql.org/docs/current/sql-fetch.html) for
 more information.
@@ -358,7 +361,8 @@ first :: CursorDirection
 first =
   CursorDirection . RawSql.fromString $ "FIRST"
 
-{- | Specify a direction of the last single row. Primarily for use with 'fetch' or 'move'.
+{- | Specify the direction of the last single row. Primarily for use with
+    'fetch' or 'move'.
 
 See PostgreSQL [fetch documentation](https://www.postgresql.org/docs/current/sql-fetch.html) for
 more information.
@@ -369,8 +373,8 @@ last :: CursorDirection
 last =
   CursorDirection . RawSql.fromString $ "LAST"
 
-{- | Specify a direction of the single row at an absolute position within the cursor. Primarily for
-   use with 'fetch' or 'move'.
+{- | Specify the direction of the single row at an absolute position within the
+    cursor. Primarily for use with 'fetch' or 'move'.
 
 See PostgreSQL [fetch documentation](https://www.postgresql.org/docs/current/sql-fetch.html) for
 more information.
@@ -387,8 +391,8 @@ absolute countParam =
     RawSql.fromString "ABSOLUTE "
       <> RawSql.intDecLiteral countParam
 
-{- | Specify a direction of the single row relative to the cursor's current position. Primarily for
-   use with 'fetch' or 'move'.
+{- | Specify the direction of the single row relative to the cursor's current
+    position. Primarily for use with 'fetch' or 'move'.
 
 See PostgreSQL [fetch documentation](https://www.postgresql.org/docs/current/sql-fetch.html) for
 more information.
@@ -406,7 +410,8 @@ relative countParam =
       --  LINE 1: FETCH RELATIVE $1 \"testcursor\"
       RawSql.intDecLiteral countParam
 
-{- | Specify a direction of the next n rows. Primarily for use with 'fetch' or 'move'.
+{- | Specify the direction of the next n rows. Primarily for use with 'fetch'
+    or 'move'.
 
 See PostgreSQL [fetch documentation](https://www.postgresql.org/docs/current/sql-fetch.html) for
 more information.
@@ -422,7 +427,8 @@ rowCount countParam =
   CursorDirection $
     RawSql.intDecLiteral countParam
 
-{- | Specify a direction of all the next rows. Primarily for use with 'fetch' or 'move'.
+{- | Specify the direction of all the next rows. Primarily for use with 'fetch'
+    or 'move'.
 
 See PostgreSQL [fetch documentation](https://www.postgresql.org/docs/current/sql-fetch.html) for
 more information.
@@ -433,7 +439,8 @@ fetchAll :: CursorDirection
 fetchAll =
   CursorDirection . RawSql.fromString $ "ALL"
 
-{- | Specify a direction of the next single row. Primarily for use with 'fetch' or 'move'.
+{- | Specify the direction of the next single row. Primarily for use with
+    'fetch' or 'move'.
 
 See PostgreSQL [fetch documentation](https://www.postgresql.org/docs/current/sql-fetch.html) for
 more information.
@@ -444,7 +451,8 @@ forward :: CursorDirection
 forward =
   CursorDirection . RawSql.fromString $ "FORWARD"
 
-{- | Specify a direction of the next n rows. Primarily for use with 'fetch' or 'move'.
+{- | Specify the direction of the next n rows. Primarily for use with 'fetch'
+    or 'move'.
 
 See PostgreSQL [fetch documentation](https://www.postgresql.org/docs/current/sql-fetch.html) for
 more information.
@@ -461,7 +469,8 @@ forwardCount countParam =
     RawSql.fromString "FORWARD "
       <> RawSql.intDecLiteral countParam
 
-{- | Specify a direction of all the next rows. Primarily for use with 'fetch' or 'move'.
+{- | Specify the direction of all the next rows. Primarily for use with 'fetch'
+    or 'move'.
 
 See PostgreSQL [fetch documentation](https://www.postgresql.org/docs/current/sql-fetch.html) for
 more information.
@@ -472,7 +481,8 @@ forwardAll :: CursorDirection
 forwardAll =
   CursorDirection . RawSql.fromString $ "FORWARD ALL"
 
-{- | Specify a direction of the prior single row. Primarily for use with 'fetch' or 'move'.
+{- | Specify the direction of the prior single row. Primarily for use with
+    'fetch' or 'move'.
 
 See PostgreSQL [fetch documentation](https://www.postgresql.org/docs/current/sql-fetch.html) for
 more information.
@@ -483,7 +493,8 @@ backward :: CursorDirection
 backward =
   CursorDirection . RawSql.fromString $ "BACKWARD"
 
-{- | Specify a direction of the prior n rows. Primarily for use with 'fetch' or 'move'.
+{- | Specify the direction of the prior n rows. Primarily for use with 'fetch'
+    or 'move'.
 
 See PostgreSQL [fetch documentation](https://www.postgresql.org/docs/current/sql-fetch.html) for
 more information.
@@ -500,7 +511,8 @@ backwardCount countParam =
     RawSql.fromString "BACKWARD "
       <> RawSql.intDecLiteral countParam
 
-{- | Specify a direction of all the prior rows. Primarily for use with 'fetch' or 'move'.
+{- | Specify the direction of all the prior rows. Primarily for use with
+    'fetch' or 'move'.
 
 See PostgreSQL [fetch documentation](https://www.postgresql.org/docs/current/sql-fetch.html) for
 more information.

--- a/orville-postgresql/src/Orville/PostgreSQL/Internal/MigrationLock.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Internal/MigrationLock.hs
@@ -73,7 +73,7 @@ orvilleLockScope = 17772
 {- |
   Executes an Orville action with a PostgreSQL advisory lock held that
   indicates to other Orville processes that a database migration is being done
-  an no others should be performed concurrently.
+  and no others should be performed concurrently.
 
 @since 1.0.0.0
 -}


### PR DESCRIPTION
This does another proofreading pass for the following modules:

- `Orville.PostgreSQL.AutoMigration`
- `Orville.PostgreSQL.ErrorDetailLevel`
- `Orville.PostgreSQL.Execution` and all of its submodules