### PR TITLE
Adds `ConnectionOptions` for `createConnectionPool` parameters

### DIFF
--- a/orville-postgresql/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL.hs
@@ -53,10 +53,19 @@ module Orville.PostgreSQL
   , Orville.runOrvilleWithState
 
     -- * Creating a connection pool
+  , Connection.ConnectionOptions
+    ( ConnectionOptions
+    , connectionString
+    , connectionNoticeReporting
+    , connectionPoolStripes
+    , connectionPoolLingerTime
+    , connectionPoolMaxConnectionsPerStripe
+    )
   , Connection.createConnectionPool
-  , Connection.Connection
-  , Connection.Pool
   , Connection.NoticeReporting (EnableNoticeReporting, DisableNoticeReporting)
+  , Connection.StripeOption (OneStripePerCapability, StripeCount)
+  , Connection.Connection
+  , Connection.ConnectionPool
 
     -- * Opening transactions and savepoints
   , Transaction.withTransaction

--- a/orville-postgresql/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL.hs
@@ -59,10 +59,11 @@ module Orville.PostgreSQL
     , connectionNoticeReporting
     , connectionPoolStripes
     , connectionPoolLingerTime
-    , connectionPoolMaxConnectionsPerStripe
+    , connectionPoolMaxConnections
     )
   , Connection.createConnectionPool
   , Connection.NoticeReporting (EnableNoticeReporting, DisableNoticeReporting)
+  , Connection.MaxConnections (MaxConnectionsTotal, MaxConnectionsPerStripe)
   , Connection.StripeOption (OneStripePerCapability, StripeCount)
   , Connection.Connection
   , Connection.ConnectionPool

--- a/orville-postgresql/src/Orville/PostgreSQL/Internal/OrvilleState.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Internal/OrvilleState.hs
@@ -40,12 +40,11 @@ module Orville.PostgreSQL.Internal.OrvilleState
 where
 
 import qualified Data.Map.Strict as Map
-import Data.Pool (Pool)
 
 import Orville.PostgreSQL.ErrorDetailLevel (ErrorDetailLevel)
 import Orville.PostgreSQL.Execution.QueryType (QueryType)
 import qualified Orville.PostgreSQL.Expr as Expr
-import Orville.PostgreSQL.Raw.Connection (Connection)
+import Orville.PostgreSQL.Raw.Connection (Connection, ConnectionPool)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import qualified Orville.PostgreSQL.Raw.SqlCommenter as SqlCommenter
 
@@ -57,7 +56,7 @@ import qualified Orville.PostgreSQL.Raw.SqlCommenter as SqlCommenter
 @since 1.0.0.0
 -}
 data OrvilleState = OrvilleState
-  { _orvilleConnectionPool :: Pool Connection
+  { _orvilleConnectionPool :: ConnectionPool
   , _orvilleConnectionState :: ConnectionState
   , _orvilleErrorDetailLevel :: ErrorDetailLevel
   , _orvilleTransactionCallback :: TransactionEvent -> IO ()
@@ -71,7 +70,7 @@ data OrvilleState = OrvilleState
 
 @since 1.0.0.0
 -}
-orvilleConnectionPool :: OrvilleState -> Pool Connection
+orvilleConnectionPool :: OrvilleState -> ConnectionPool
 orvilleConnectionPool =
   _orvilleConnectionPool
 
@@ -166,7 +165,7 @@ addTransactionCallback newCallback state =
 
 @since 1.0.0.0
 -}
-newOrvilleState :: ErrorDetailLevel -> Pool Connection -> OrvilleState
+newOrvilleState :: ErrorDetailLevel -> ConnectionPool -> OrvilleState
 newOrvilleState errorDetailLevel pool =
   OrvilleState
     { _orvilleConnectionPool = pool

--- a/orville-postgresql/src/Orville/PostgreSQL/Monad/MonadOrville.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Monad/MonadOrville.hs
@@ -20,7 +20,6 @@ where
 import Control.Exception (Exception)
 import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Trans.Reader (ReaderT (ReaderT), mapReaderT, runReaderT)
-import Data.Pool (withResource)
 
 import Orville.PostgreSQL.Internal.OrvilleState
   ( ConnectedState (ConnectedState, connectedConnection, connectedTransaction)
@@ -31,7 +30,7 @@ import Orville.PostgreSQL.Internal.OrvilleState
   , orvilleConnectionState
   )
 import Orville.PostgreSQL.Monad.HasOrvilleState (HasOrvilleState (askOrvilleState, localOrvilleState))
-import Orville.PostgreSQL.Raw.Connection (Connection)
+import Orville.PostgreSQL.Raw.Connection (Connection, withPoolConnection)
 
 {- |
   'MonadOrville' is the typeclass that most Orville operations require to
@@ -188,7 +187,7 @@ withConnectedState connectedAction = do
       let
         pool = orvilleConnectionPool state
       in
-        liftWithConnection (withResource pool) $ \conn ->
+        liftWithConnection (withPoolConnection pool) $ \conn ->
           let
             connectedState =
               ConnectedState

--- a/orville-postgresql/src/Orville/PostgreSQL/Monad/Orville.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Monad/Orville.hs
@@ -17,13 +17,12 @@ where
 import qualified Control.Exception.Safe as ExSafe
 import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Trans.Reader (ReaderT, runReaderT)
-import Data.Pool (Pool)
 
 import qualified Orville.PostgreSQL.ErrorDetailLevel as ErrorDetailLevel
 import qualified Orville.PostgreSQL.Monad.HasOrvilleState as HasOrvilleState
 import qualified Orville.PostgreSQL.Monad.MonadOrville as MonadOrville
 import qualified Orville.PostgreSQL.OrvilleState as OrvilleState
-import Orville.PostgreSQL.Raw.Connection (Connection)
+import Orville.PostgreSQL.Raw.Connection (ConnectionPool)
 
 {- |
   The 'Orville' Monad provides a easy starter implementation of
@@ -61,7 +60,7 @@ newtype Orville a = Orville
 
 @since 1.0.0.0
 -}
-runOrville :: Pool Connection -> Orville a -> IO a
+runOrville :: ConnectionPool -> Orville a -> IO a
 runOrville =
   runOrvilleWithState
     . OrvilleState.newOrvilleState ErrorDetailLevel.defaultErrorDetailLevel

--- a/orville-postgresql/test/Main.hs
+++ b/orville-postgresql/test/Main.hs
@@ -96,7 +96,7 @@ createTestConnectionPool = do
       , Orville.connectionNoticeReporting = Orville.DisableNoticeReporting
       , Orville.connectionPoolStripes = Orville.OneStripePerCapability
       , Orville.connectionPoolLingerTime = 10
-      , Orville.connectionPoolMaxConnectionsPerStripe = 2
+      , Orville.connectionPoolMaxConnections = Orville.MaxConnectionsPerStripe 2
       }
 
 recheckDBProperty :: HH.Size -> HH.Seed -> Property.NamedDBProperty -> IO ()

--- a/orville-postgresql/test/Test/AutoMigration.hs
+++ b/orville-postgresql/test/Test/AutoMigration.hs
@@ -36,7 +36,7 @@ import qualified Test.PgGen as PgGen
 import qualified Test.Property as Property
 import qualified Test.TestTable as TestTable
 
-autoMigrationTests :: Orville.Pool Orville.Connection -> Property.Group
+autoMigrationTests :: Orville.ConnectionPool -> Property.Group
 autoMigrationTests pool =
   Property.group
     "AutoMigration"
@@ -416,7 +416,7 @@ prop_respectsImplicitDefaultOnSerialFields =
     migrationPlanStepStrings secondTimePlan === []
 
 assertDefaultValuesMigrateProperly ::
-  Orville.Pool Orville.Connection ->
+  Orville.ConnectionPool ->
   HH.Gen SomeField ->
   HH.PropertyT IO ()
 assertDefaultValuesMigrateProperly pool genSomeField = do
@@ -835,7 +835,7 @@ prop_altersModifiedSequences =
 
 assertSequenceExistsMatching ::
   (HH.MonadTest m, MIO.MonadIO m) =>
-  Orville.Pool Orville.Connection ->
+  Orville.ConnectionPool ->
   Orville.SequenceDefinition ->
   m ()
 assertSequenceExistsMatching pool sequenceDef = do
@@ -886,7 +886,7 @@ prop_arbitrarySchemaInitialMigration =
 
 assertTableStructure ::
   (HH.MonadTest m, MIO.MonadIO m) =>
-  Orville.Pool Orville.Connection ->
+  Orville.ConnectionPool ->
   TestTable ->
   m ()
 assertTableStructure pool testTable = do

--- a/orville-postgresql/test/Test/Cursor.hs
+++ b/orville-postgresql/test/Test/Cursor.hs
@@ -17,7 +17,7 @@ import qualified Orville.PostgreSQL.Execution as Exec
 import qualified Test.Entities.Foo as Foo
 import qualified Test.Property as Property
 
-cursorTests :: Orville.Pool Orville.Connection -> Property.Group
+cursorTests :: Orville.ConnectionPool -> Property.Group
 cursorTests pool =
   Property.group "Cursor" $
     [ prop_withCursorFetch pool

--- a/orville-postgresql/test/Test/Entities/Bar.hs
+++ b/orville-postgresql/test/Test/Entities/Bar.hs
@@ -10,13 +10,13 @@ where
 
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import Data.Int (Int32)
-import Data.Pool (Pool, withResource)
 import qualified Data.Text as T
 import qualified Hedgehog as HH
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 import qualified Orville.PostgreSQL as Orville
+import qualified Orville.PostgreSQL.Raw.Connection as Conn
 
 import qualified Test.PgGen as PgGen
 import qualified Test.TestTable as TestTable
@@ -60,9 +60,9 @@ generateList :: HH.Range Int -> HH.Gen [BarWrite]
 generateList range =
   (Gen.list range generate)
 
-withTable :: MonadIO m => Pool Orville.Connection -> Orville.Orville a -> m a
+withTable :: MonadIO m => Orville.ConnectionPool -> Orville.Orville a -> m a
 withTable pool operation =
   liftIO $ do
-    withResource pool $ \connection ->
+    Conn.withPoolConnection pool $ \connection ->
       TestTable.dropAndRecreateTableDef connection table
     Orville.runOrville pool operation

--- a/orville-postgresql/test/Test/Entities/CompositeKeyEntity.hs
+++ b/orville-postgresql/test/Test/Entities/CompositeKeyEntity.hs
@@ -19,13 +19,13 @@ import Control.Monad.IO.Class (MonadIO (liftIO))
 import Data.Function (on)
 import Data.Int (Int32)
 import qualified Data.List.NonEmpty as NEL
-import Data.Pool (Pool, withResource)
 import qualified Data.Text as T
 import qualified Hedgehog as HH
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 import qualified Orville.PostgreSQL as Orville
+import qualified Orville.PostgreSQL.Raw.Connection as Conn
 
 import qualified Test.PgGen as PgGen
 import qualified Test.TestTable as TestTable
@@ -113,9 +113,9 @@ generateNonEmpty range =
     (NEL.nubBy ((==) `on` compositeKey))
     (Gen.nonEmpty range generate)
 
-withTable :: MonadIO m => Pool Orville.Connection -> Orville.Orville a -> m a
+withTable :: MonadIO m => Orville.ConnectionPool -> Orville.Orville a -> m a
 withTable pool operation =
   liftIO $ do
-    withResource pool $ \connection ->
+    Conn.withPoolConnection pool $ \connection ->
       TestTable.dropAndRecreateTableDef connection table
     Orville.runOrville pool operation

--- a/orville-postgresql/test/Test/Entities/Foo.hs
+++ b/orville-postgresql/test/Test/Entities/Foo.hs
@@ -25,13 +25,13 @@ import Data.Function (on)
 import Data.Int (Int32)
 import qualified Data.List as List
 import qualified Data.List.NonEmpty as NEL
-import Data.Pool (Pool, withResource)
 import qualified Data.Text as T
 import qualified Hedgehog as HH
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 import qualified Orville.PostgreSQL as Orville
+import qualified Orville.PostgreSQL.Raw.Connection as Conn
 
 import qualified Test.PgGen as PgGen
 import qualified Test.TestTable as TestTable
@@ -132,9 +132,9 @@ generateNonEmpty range =
     (NEL.nubBy ((==) `on` fooId))
     (Gen.nonEmpty range generate)
 
-withTable :: MonadIO m => Pool Orville.Connection -> Orville.Orville a -> m a
+withTable :: MonadIO m => Orville.ConnectionPool -> Orville.Orville a -> m a
 withTable pool operation =
   liftIO $ do
-    withResource pool $ \connection ->
+    Conn.withPoolConnection pool $ \connection ->
       TestTable.dropAndRecreateTableDef connection table
     Orville.runOrville pool operation

--- a/orville-postgresql/test/Test/Entities/FooChild.hs
+++ b/orville-postgresql/test/Test/Entities/FooChild.hs
@@ -14,11 +14,11 @@ import Control.Monad.IO.Class (MonadIO (liftIO))
 import Data.Function (on)
 import Data.Int (Int32)
 import qualified Data.List as List
-import Data.Pool (withResource)
 import qualified Hedgehog as HH
 import qualified Hedgehog.Gen as Gen
 
 import qualified Orville.PostgreSQL as Orville
+import qualified Orville.PostgreSQL.Raw.Connection as Conn
 
 import qualified Test.Entities.Foo as Foo
 import qualified Test.PgGen as PgGen
@@ -66,10 +66,10 @@ generateList range foos =
     (List.nubBy ((==) `on` fooChildId))
     (Gen.list range $ generate foos)
 
-withTables :: MonadIO m => Orville.Pool Orville.Connection -> Orville.Orville a -> m a
+withTables :: MonadIO m => Orville.ConnectionPool -> Orville.Orville a -> m a
 withTables pool operation =
   liftIO $ do
-    withResource pool $ \connection -> do
+    Conn.withPoolConnection pool $ \connection -> do
       TestTable.dropAndRecreateTableDef connection Foo.table
       TestTable.dropAndRecreateTableDef connection table
     Orville.runOrville pool operation

--- a/orville-postgresql/test/Test/EntityOperations.hs
+++ b/orville-postgresql/test/Test/EntityOperations.hs
@@ -20,7 +20,7 @@ import qualified Test.Entities.CompositeKeyEntity as CompositeKeyEntity
 import qualified Test.Entities.Foo as Foo
 import qualified Test.Property as Property
 
-entityOperationsTests :: Orville.Pool Orville.Connection -> Property.Group
+entityOperationsTests :: Orville.ConnectionPool -> Property.Group
 entityOperationsTests pool =
   Property.group "EntityOperations" $
     [ prop_insertEntitiesFindEntitiesByRoundTrip pool

--- a/orville-postgresql/test/Test/Execution.hs
+++ b/orville-postgresql/test/Test/Execution.hs
@@ -12,7 +12,7 @@ import qualified Orville.PostgreSQL as Orville
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import qualified Test.Property as Property
 
-executionTests :: Orville.Pool Orville.Connection -> Property.Group
+executionTests :: Orville.ConnectionPool -> Property.Group
 executionTests pool =
   Property.group
     "Execution"

--- a/orville-postgresql/test/Test/Expr/Count.hs
+++ b/orville-postgresql/test/Test/Expr/Count.hs
@@ -16,7 +16,7 @@ import qualified Orville.PostgreSQL.Expr as Expr
 import qualified Test.Entities.Foo as Foo
 import qualified Test.Property as Property
 
-countTests :: Orville.Pool Orville.Connection -> Property.Group
+countTests :: Orville.ConnectionPool -> Property.Group
 countTests pool =
   Property.group
     "Expr - Count"

--- a/orville-postgresql/test/Test/Expr/Cursor.hs
+++ b/orville-postgresql/test/Test/Expr/Cursor.hs
@@ -7,7 +7,6 @@ import qualified Control.Exception.Safe as ExSafe
 import qualified Control.Monad.IO.Class as MIO
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Int as Int
-import qualified Data.Pool as Pool
 import Hedgehog ((===))
 import qualified Hedgehog as HH
 
@@ -21,7 +20,7 @@ import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 import Test.Expr.TestSchema (FooBar, assertEqualFooBarRows, findAllFooBars, mkFooBar, withFooBarData)
 import qualified Test.Property as Property
 
-cursorTests :: Orville.Pool Orville.Connection -> Property.Group
+cursorTests :: Orville.ConnectionPool -> Property.Group
 cursorTests pool =
   Property.group
     "Expr - Cursor"
@@ -70,7 +69,7 @@ prop_cursorOutsideTransactionWithHold =
 prop_cursorCloseAll :: Property.NamedDBProperty
 prop_cursorCloseAll =
   Property.singletonNamedDBProperty "Close all cursors" $ \pool -> do
-    MIO.liftIO . Pool.withResource pool $ \connection -> do
+    MIO.liftIO . Conn.withPoolConnection pool $ \connection -> do
       let
         cursorName :: Expr.CursorName
         cursorName = Expr.fromIdentifier $ Expr.identifier "testcursor"
@@ -277,7 +276,7 @@ row :: Int.Int32 -> FooBar
 row n = mkFooBar n ("row " <> show n)
 
 runFetchDirectionsOnData ::
-  Orville.Pool Orville.Connection ->
+  Orville.ConnectionPool ->
   Maybe Expr.ScrollExpr ->
   [FooBar] ->
   [Expr.CursorDirection] ->

--- a/orville-postgresql/test/Test/Expr/GroupBy.hs
+++ b/orville-postgresql/test/Test/Expr/GroupBy.hs
@@ -7,12 +7,12 @@ import qualified Control.Monad.IO.Class as MIO
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Int as Int
 import qualified Data.List.NonEmpty as NE
-import qualified Data.Pool as Pool
 import qualified Data.Text as T
 
 import qualified Orville.PostgreSQL as Orville
 import qualified Orville.PostgreSQL.Execution as Execution
 import qualified Orville.PostgreSQL.Expr as Expr
+import qualified Orville.PostgreSQL.Raw.Connection as Conn
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
@@ -24,7 +24,7 @@ data FooBar = FooBar
   , bar :: String
   }
 
-groupByTests :: Orville.Pool Orville.Connection -> Property.Group
+groupByTests :: Orville.ConnectionPool -> Property.Group
 groupByTests pool =
   Property.group
     "Expr - GroupBy"
@@ -86,7 +86,7 @@ mkGroupByTestExpectedRows test =
 groupByTest :: String -> GroupByTest -> Property.NamedDBProperty
 groupByTest testName test =
   Property.singletonNamedDBProperty testName $ \pool -> do
-    rows <- MIO.liftIO . Pool.withResource pool $ \connection -> do
+    rows <- MIO.liftIO . Conn.withPoolConnection pool $ \connection -> do
       dropAndRecreateTestTable connection
 
       RawSql.executeVoid connection $

--- a/orville-postgresql/test/Test/Expr/GroupByOrderBy.hs
+++ b/orville-postgresql/test/Test/Expr/GroupByOrderBy.hs
@@ -6,12 +6,12 @@ where
 import qualified Control.Monad.IO.Class as MIO
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Int as Int
-import qualified Data.Pool as Pool
 import qualified Data.Text as T
 
 import qualified Orville.PostgreSQL as Orville
 import qualified Orville.PostgreSQL.Execution as Execution
 import qualified Orville.PostgreSQL.Expr as Expr
+import qualified Orville.PostgreSQL.Raw.Connection as Conn
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
@@ -23,7 +23,7 @@ data FooBar = FooBar
   , bar :: String
   }
 
-groupByOrderByTests :: Orville.Pool Orville.Connection -> Property.Group
+groupByOrderByTests :: Orville.ConnectionPool -> Property.Group
 groupByOrderByTests pool =
   Property.group
     "Expr - GroupBy and OrderBy"
@@ -76,7 +76,7 @@ mkGroupByOrderByTestExpectedRows test =
 groupByOrderByTest :: String -> GroupByOrderByTest -> Property.NamedDBProperty
 groupByOrderByTest testName test =
   Property.singletonNamedDBProperty testName $ \pool -> do
-    rows <- MIO.liftIO . Pool.withResource pool $ \connection -> do
+    rows <- MIO.liftIO . Conn.withPoolConnection pool $ \connection -> do
       dropAndRecreateTestTable connection
 
       RawSql.executeVoid connection $

--- a/orville-postgresql/test/Test/Expr/InsertUpdateDelete.hs
+++ b/orville-postgresql/test/Test/Expr/InsertUpdateDelete.hs
@@ -5,19 +5,19 @@ where
 
 import qualified Control.Monad.IO.Class as MIO
 import Data.List.NonEmpty (NonEmpty ((:|)))
-import qualified Data.Pool as Pool
 import qualified Data.Text as T
 
 import qualified Orville.PostgreSQL as Orville
 import qualified Orville.PostgreSQL.Execution as Execution
 import qualified Orville.PostgreSQL.Expr as Expr
+import qualified Orville.PostgreSQL.Raw.Connection as Conn
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 import Test.Expr.TestSchema (assertEqualFooBarRows, barColumn, barColumnRef, dropAndRecreateTestTable, findAllFooBars, fooBarTable, fooColumn, insertFooBarSource, mkFooBar)
 import qualified Test.Property as Property
 
-insertUpdateDeleteTests :: Orville.Pool Orville.Connection -> Property.Group
+insertUpdateDeleteTests :: Orville.ConnectionPool -> Property.Group
 insertUpdateDeleteTests pool =
   Property.group
     "Expr - Insert/Update/Delete"
@@ -39,7 +39,7 @@ prop_insertExpr =
 
     rows <-
       MIO.liftIO $
-        Pool.withResource pool $ \connection -> do
+        Conn.withPoolConnection pool $ \connection -> do
           dropAndRecreateTestTable connection
 
           RawSql.executeVoid connection $
@@ -59,7 +59,7 @@ prop_insertExprWithReturning =
 
     rows <-
       MIO.liftIO $
-        Pool.withResource pool $ \connection -> do
+        Conn.withPoolConnection pool $ \connection -> do
           dropAndRecreateTestTable connection
 
           result <-
@@ -90,7 +90,7 @@ prop_updateExpr =
 
     rows <-
       MIO.liftIO $
-        Pool.withResource pool $ \connection -> do
+        Conn.withPoolConnection pool $ \connection -> do
           dropAndRecreateTestTable connection
 
           RawSql.executeVoid connection $
@@ -120,7 +120,7 @@ prop_updateExprWithWhere =
 
     rows <-
       MIO.liftIO $
-        Pool.withResource pool $ \connection -> do
+        Conn.withPoolConnection pool $ \connection -> do
           dropAndRecreateTestTable connection
 
           RawSql.executeVoid connection $
@@ -150,7 +150,7 @@ prop_updateExprWithReturning =
 
     rows <-
       MIO.liftIO $
-        Pool.withResource pool $ \connection -> do
+        Conn.withPoolConnection pool $ \connection -> do
           dropAndRecreateTestTable connection
 
           RawSql.executeVoid connection $
@@ -176,7 +176,7 @@ prop_deleteExpr =
 
     rows <-
       MIO.liftIO $
-        Pool.withResource pool $ \connection -> do
+        Conn.withPoolConnection pool $ \connection -> do
           dropAndRecreateTestTable connection
 
           RawSql.executeVoid connection $
@@ -205,7 +205,7 @@ prop_deleteExprWithWhere =
 
     rows <-
       MIO.liftIO $
-        Pool.withResource pool $ \connection -> do
+        Conn.withPoolConnection pool $ \connection -> do
           dropAndRecreateTestTable connection
 
           RawSql.executeVoid connection $
@@ -233,7 +233,7 @@ prop_deleteExprWithReturning =
 
     rows <-
       MIO.liftIO $
-        Pool.withResource pool $ \connection -> do
+        Conn.withPoolConnection pool $ \connection -> do
           dropAndRecreateTestTable connection
 
           RawSql.executeVoid connection $

--- a/orville-postgresql/test/Test/Expr/Math.hs
+++ b/orville-postgresql/test/Test/Expr/Math.hs
@@ -18,7 +18,7 @@ import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 import qualified Test.Property as Property
 
-mathTests :: Orville.Pool Orville.Connection -> Property.Group
+mathTests :: Orville.ConnectionPool -> Property.Group
 mathTests pool =
   Property.group
     "Expr - Math"
@@ -183,7 +183,7 @@ intExpression n =
   Expr.cast (Expr.valueExpression (SqlValue.fromInt n)) Expr.int
 
 evaluateIntegerExpression ::
-  Orville.Pool Orville.Connection ->
+  Orville.ConnectionPool ->
   Expr.ValueExpression ->
   HH.PropertyT IO Int32
 evaluateIntegerExpression pool expression = do

--- a/orville-postgresql/test/Test/Expr/OrderBy.hs
+++ b/orville-postgresql/test/Test/Expr/OrderBy.hs
@@ -5,17 +5,17 @@ where
 
 import qualified Control.Monad.IO.Class as MIO
 import qualified Data.List.NonEmpty as NE
-import qualified Data.Pool as Pool
 
 import qualified Orville.PostgreSQL as Orville
 import qualified Orville.PostgreSQL.Execution as Execution
 import qualified Orville.PostgreSQL.Expr as Expr
+import qualified Orville.PostgreSQL.Raw.Connection as Conn
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 import Test.Expr.TestSchema (FooBar (..), assertEqualFooBarRows, barColumn, dropAndRecreateTestTable, fooBarTable, fooColumn, insertFooBarSource, mkFooBar)
 import qualified Test.Property as Property
 
-orderByTests :: Orville.Pool Orville.Connection -> Property.Group
+orderByTests :: Orville.ConnectionPool -> Property.Group
 orderByTests pool =
   Property.group
     "Expr - OrderBy"
@@ -120,7 +120,7 @@ orderByTest testName test =
   Property.singletonNamedDBProperty testName $ \pool -> do
     rows <-
       MIO.liftIO $ do
-        Pool.withResource pool $ \connection -> do
+        Conn.withPoolConnection pool $ \connection -> do
           dropAndRecreateTestTable connection
 
           RawSql.executeVoid connection $

--- a/orville-postgresql/test/Test/Expr/SequenceDefinition.hs
+++ b/orville-postgresql/test/Test/Expr/SequenceDefinition.hs
@@ -13,7 +13,7 @@ import qualified Orville.PostgreSQL.PgCatalog as PgCatalog
 import qualified Test.PgAssert as PgAssert
 import qualified Test.Property as Property
 
-sequenceDefinitionTests :: Orville.Pool Orville.Connection -> Property.Group
+sequenceDefinitionTests :: Orville.ConnectionPool -> Property.Group
 sequenceDefinitionTests pool =
   Property.group
     "Expr - SequenceDefinition"

--- a/orville-postgresql/test/Test/Expr/TableDefinition.hs
+++ b/orville-postgresql/test/Test/Expr/TableDefinition.hs
@@ -12,7 +12,7 @@ import qualified Orville.PostgreSQL.Expr as Expr
 import qualified Test.PgAssert as PgAssert
 import qualified Test.Property as Property
 
-tableDefinitionTests :: Orville.Pool Orville.Connection -> Property.Group
+tableDefinitionTests :: Orville.ConnectionPool -> Property.Group
 tableDefinitionTests pool =
   Property.group
     "Expr - TableDefinition"

--- a/orville-postgresql/test/Test/Expr/TestSchema.hs
+++ b/orville-postgresql/test/Test/Expr/TestSchema.hs
@@ -21,7 +21,6 @@ where
 import qualified Control.Monad.IO.Class as MIO
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Int as Int
-import qualified Data.Pool as Pool
 import qualified Data.Text as T
 import GHC.Stack (HasCallStack, withFrozenCallStack)
 import Hedgehog ((===))
@@ -29,6 +28,7 @@ import qualified Hedgehog as HH
 
 import qualified Orville.PostgreSQL as Orville
 import qualified Orville.PostgreSQL.Expr as Expr
+import qualified Orville.PostgreSQL.Raw.Connection as Conn
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
@@ -95,13 +95,13 @@ nullOr :: (a -> SqlValue.SqlValue) -> Maybe a -> SqlValue.SqlValue
 nullOr = maybe SqlValue.sqlNull
 
 withFooBarData ::
-  Pool.Pool Orville.Connection ->
+  Orville.ConnectionPool ->
   [FooBar] ->
   (Orville.Connection -> IO a) ->
   HH.PropertyT IO a
 withFooBarData pool fooBars action =
   MIO.liftIO $
-    Pool.withResource pool $ \connection -> do
+    Conn.withPoolConnection pool $ \connection -> do
       dropAndRecreateTestTable connection
 
       RawSql.executeVoid connection $

--- a/orville-postgresql/test/Test/Expr/Time.hs
+++ b/orville-postgresql/test/Test/Expr/Time.hs
@@ -21,7 +21,7 @@ import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 import qualified Test.Property as Property
 
-timeTests :: Orville.Pool Orville.Connection -> Property.Group
+timeTests :: Orville.ConnectionPool -> Property.Group
 timeTests pool =
   Property.group
     "Expr - Time"

--- a/orville-postgresql/test/Test/Expr/Where.hs
+++ b/orville-postgresql/test/Test/Expr/Where.hs
@@ -6,19 +6,19 @@ where
 import qualified Control.Monad.IO.Class as MIO
 import Data.Int (Int32)
 import Data.List.NonEmpty (NonEmpty ((:|)))
-import qualified Data.Pool as Pool
 import qualified Data.Text as T
 
 import qualified Orville.PostgreSQL as Orville
 import qualified Orville.PostgreSQL.Execution as Execution
 import qualified Orville.PostgreSQL.Expr as Expr
+import qualified Orville.PostgreSQL.Raw.Connection as Conn
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 import Test.Expr.TestSchema (FooBar (..), assertEqualFooBarRows, barColumn, barColumnRef, dropAndRecreateTestTable, fooBarTable, fooColumn, fooColumnRef, insertFooBarSource, mkFooBar)
 import qualified Test.Property as Property
 
-whereTests :: Orville.Pool Orville.Connection -> Property.Group
+whereTests :: Orville.ConnectionPool -> Property.Group
 whereTests pool =
   Property.group "Expr - WhereClause" $
     [ prop_noWhereClauseSpecified pool
@@ -200,7 +200,7 @@ whereConditionTest testName test =
   Property.singletonNamedDBProperty testName $ \pool -> do
     rows <-
       MIO.liftIO $
-        Pool.withResource pool $ \connection -> do
+        Conn.withPoolConnection pool $ \connection -> do
           dropAndRecreateTestTable connection
 
           RawSql.executeVoid connection $

--- a/orville-postgresql/test/Test/FieldDefinition.hs
+++ b/orville-postgresql/test/Test/FieldDefinition.hs
@@ -6,7 +6,6 @@ where
 import qualified Control.Exception as E
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Maybe as Maybe
-import qualified Data.Pool as Pool
 import qualified Data.String as String
 import qualified Data.Text as T
 import qualified Data.UUID as UUID
@@ -27,7 +26,7 @@ import Test.Expr.TestSchema (sqlRowsToText)
 import qualified Test.PgGen as PgGen
 import qualified Test.Property as Property
 
-fieldDefinitionTests :: Orville.Pool Orville.Connection -> Property.Group
+fieldDefinitionTests :: Orville.ConnectionPool -> Property.Group
 fieldDefinitionTests pool =
   Property.group "FieldDefinition" $
     integerField pool
@@ -44,7 +43,7 @@ fieldDefinitionTests pool =
       <> localTimestampField pool
       <> jsonbField pool
 
-integerField :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
+integerField :: Orville.ConnectionPool -> [(HH.PropertyName, HH.Property)]
 integerField pool =
   testFieldProperties pool "integerField" $
     FieldDefinitionTest
@@ -53,7 +52,7 @@ integerField pool =
       , roundTripGen = PgGen.pgInt32
       }
 
-bigIntegerField :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
+bigIntegerField :: Orville.ConnectionPool -> [(HH.PropertyName, HH.Property)]
 bigIntegerField pool =
   testFieldProperties pool "bigIntegerField" $
     FieldDefinitionTest
@@ -62,7 +61,7 @@ bigIntegerField pool =
       , roundTripGen = Gen.integral (Range.linearFrom 0 minBound maxBound)
       }
 
-doubleField :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
+doubleField :: Orville.ConnectionPool -> [(HH.PropertyName, HH.Property)]
 doubleField pool =
   testFieldProperties pool "doubleField" $
     FieldDefinitionTest
@@ -71,7 +70,7 @@ doubleField pool =
       , roundTripGen = PgGen.pgDouble
       }
 
-booleanField :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
+booleanField :: Orville.ConnectionPool -> [(HH.PropertyName, HH.Property)]
 booleanField pool =
   testFieldProperties pool "booleanField" $
     FieldDefinitionTest
@@ -80,7 +79,7 @@ booleanField pool =
       , roundTripGen = Gen.bool
       }
 
-unboundedTextField :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
+unboundedTextField :: Orville.ConnectionPool -> [(HH.PropertyName, HH.Property)]
 unboundedTextField pool =
   testFieldProperties pool "unboundedTextField" $
     FieldDefinitionTest
@@ -89,7 +88,7 @@ unboundedTextField pool =
       , roundTripGen = PgGen.pgText (Range.constant 0 1024)
       }
 
-boundedTextField :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
+boundedTextField :: Orville.ConnectionPool -> [(HH.PropertyName, HH.Property)]
 boundedTextField pool =
   testFieldProperties pool "boundedTextField" $
     FieldDefinitionTest
@@ -98,7 +97,7 @@ boundedTextField pool =
       , roundTripGen = PgGen.pgText (Range.constant 0 4)
       }
 
-fixedTextField :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
+fixedTextField :: Orville.ConnectionPool -> [(HH.PropertyName, HH.Property)]
 fixedTextField pool =
   testFieldProperties pool "fixedTextField" $
     FieldDefinitionTest
@@ -107,7 +106,7 @@ fixedTextField pool =
       , roundTripGen = PgGen.pgText (Range.constant 4 4)
       }
 
-textSearchVectorField :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
+textSearchVectorField :: Orville.ConnectionPool -> [(HH.PropertyName, HH.Property)]
 textSearchVectorField pool =
   testFieldProperties pool "textSearchVectorField" $
     FieldDefinitionTest
@@ -116,7 +115,7 @@ textSearchVectorField pool =
       , roundTripGen = tsVectorGen
       }
 
-uuidField :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
+uuidField :: Orville.ConnectionPool -> [(HH.PropertyName, HH.Property)]
 uuidField pool =
   testFieldProperties pool "uuidField" $
     FieldDefinitionTest
@@ -125,7 +124,7 @@ uuidField pool =
       , roundTripGen = uuidGen
       }
 
-dateField :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
+dateField :: Orville.ConnectionPool -> [(HH.PropertyName, HH.Property)]
 dateField pool =
   testFieldProperties pool "dateField" $
     FieldDefinitionTest
@@ -137,7 +136,7 @@ dateField pool =
       , roundTripGen = PgGen.pgDay
       }
 
-utcTimestampField :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
+utcTimestampField :: Orville.ConnectionPool -> [(HH.PropertyName, HH.Property)]
 utcTimestampField pool =
   testFieldProperties pool "utcTimestampField" $
     FieldDefinitionTest
@@ -149,7 +148,7 @@ utcTimestampField pool =
       , roundTripGen = PgGen.pgUTCTime
       }
 
-localTimestampField :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
+localTimestampField :: Orville.ConnectionPool -> [(HH.PropertyName, HH.Property)]
 localTimestampField pool =
   testFieldProperties pool "localTimestampField" $
     FieldDefinitionTest
@@ -161,7 +160,7 @@ localTimestampField pool =
       , roundTripGen = PgGen.pgLocalTime
       }
 
-jsonbField :: Orville.Pool Orville.Connection -> [(HH.PropertyName, HH.Property)]
+jsonbField :: Orville.ConnectionPool -> [(HH.PropertyName, HH.Property)]
 jsonbField pool =
   testFieldProperties pool "jsonbField" $
     FieldDefinitionTest
@@ -172,7 +171,7 @@ jsonbField pool =
 
 testFieldProperties ::
   (Show a, Eq a) =>
-  Orville.Pool Orville.Connection ->
+  Orville.ConnectionPool ->
   String ->
   FieldDefinitionTest a ->
   [(HH.PropertyName, HH.Property)]
@@ -191,7 +190,7 @@ testFieldProperties pool fieldDefName roundTripTest =
 
 testDefaultValueProperties ::
   (Show a, Eq a) =>
-  Orville.Pool Orville.Connection ->
+  Orville.ConnectionPool ->
   String ->
   FieldDefinitionTest a ->
   DefaultValueTest a ->
@@ -236,13 +235,13 @@ data DefaultValueTest a
   = RoundTripDefaultTest (a -> Marshall.DefaultValue a)
   | InsertOnlyDefaultTest (Marshall.DefaultValue a)
 
-runRoundTripTest :: (Show a, Eq a) => Orville.Pool Orville.Connection -> FieldDefinitionTest a -> HH.PropertyT IO ()
+runRoundTripTest :: (Show a, Eq a) => Orville.ConnectionPool -> FieldDefinitionTest a -> HH.PropertyT IO ()
 runRoundTripTest pool testCase = do
   let
     fieldDef = roundTripFieldDef testCase
 
   value <- HH.forAll (roundTripGen testCase)
-  rows <- HH.evalIO . Pool.withResource pool $ \connection -> do
+  rows <- HH.evalIO . Conn.withPoolConnection pool $ \connection -> do
     dropAndRecreateTestTable fieldDef connection
 
     RawSql.executeVoid connection $
@@ -271,7 +270,7 @@ runRoundTripTest pool testCase = do
 
   roundTripResult === Right value
 
-runNullableRoundTripTest :: (Show a, Eq a) => Orville.Pool Orville.Connection -> FieldDefinitionTest a -> HH.PropertyT IO ()
+runNullableRoundTripTest :: (Show a, Eq a) => Orville.ConnectionPool -> FieldDefinitionTest a -> HH.PropertyT IO ()
 runNullableRoundTripTest pool testCase = do
   let
     fieldDef = Marshall.nullableField (roundTripFieldDef testCase)
@@ -286,7 +285,7 @@ runNullableRoundTripTest pool testCase = do
   HH.cover 1 (String.fromString "Nothing") (Maybe.isNothing value)
   HH.cover 20 (String.fromString "Just") (Maybe.isJust value)
 
-  rows <- HH.evalIO . Pool.withResource pool $ \connection -> do
+  rows <- HH.evalIO . Conn.withPoolConnection pool $ \connection -> do
     dropAndRecreateTestTable fieldDef connection
 
     RawSql.executeVoid connection $
@@ -315,9 +314,9 @@ runNullableRoundTripTest pool testCase = do
 
   roundTripResult === Right value
 
-runNullCounterExampleTest :: Orville.Pool Orville.Connection -> FieldDefinitionTest a -> HH.PropertyT IO ()
+runNullCounterExampleTest :: Orville.ConnectionPool -> FieldDefinitionTest a -> HH.PropertyT IO ()
 runNullCounterExampleTest pool testCase = do
-  result <- HH.evalIO . Pool.withResource pool $ \connection -> do
+  result <- HH.evalIO . Conn.withPoolConnection pool $ \connection -> do
     let
       fieldDef = roundTripFieldDef testCase
 
@@ -340,7 +339,7 @@ runNullCounterExampleTest pool testCase = do
 
 runDefaultValueFieldDefinitionTest ::
   (Show a, Eq a) =>
-  Orville.Pool Orville.Connection ->
+  Orville.ConnectionPool ->
   FieldDefinitionTest a ->
   (a -> Marshall.DefaultValue a) ->
   HH.PropertyT IO ()
@@ -354,7 +353,7 @@ runDefaultValueFieldDefinitionTest pool testCase mkDefaultValue = do
     fieldDef =
       Marshall.setDefaultValue defaultValue $ roundTripFieldDef testCase
 
-  rows <- HH.evalIO . Pool.withResource pool $ \connection -> do
+  rows <- HH.evalIO . Conn.withPoolConnection pool $ \connection -> do
     dropAndRecreateTestTable fieldDef connection
 
     RawSql.executeVoid connection $
@@ -384,12 +383,12 @@ runDefaultValueFieldDefinitionTest pool testCase mkDefaultValue = do
   roundTripResult === Right value
 
 runDefaultValueInsertOnlyTest ::
-  Orville.Pool Orville.Connection ->
+  Orville.ConnectionPool ->
   FieldDefinitionTest a ->
   Marshall.DefaultValue a ->
   HH.PropertyT IO ()
 runDefaultValueInsertOnlyTest pool testCase defaultValue =
-  HH.evalIO . Pool.withResource pool $ \connection -> do
+  HH.evalIO . Conn.withPoolConnection pool $ \connection -> do
     let
       fieldDef =
         Marshall.setDefaultValue defaultValue $ roundTripFieldDef testCase

--- a/orville-postgresql/test/Test/MarshallError.hs
+++ b/orville-postgresql/test/Test/MarshallError.hs
@@ -19,7 +19,7 @@ import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 import qualified Test.Property as Property
 
-marshallErrorTests :: Orville.Pool Orville.Connection -> Property.Group
+marshallErrorTests :: Orville.ConnectionPool -> Property.Group
 marshallErrorTests pool =
   Property.group
     "MarshallError"

--- a/orville-postgresql/test/Test/PgAssert.hs
+++ b/orville-postgresql/test/Test/PgAssert.hs
@@ -36,7 +36,7 @@ import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 assertTableExists ::
   (HH.MonadTest m, MIO.MonadIO m, HasCallStack) =>
-  Orville.Pool Orville.Connection ->
+  Orville.ConnectionPool ->
   String ->
   m PgCatalog.RelationDescription
 assertTableExists pool =
@@ -44,7 +44,7 @@ assertTableExists pool =
 
 assertTableDoesNotExist ::
   (HH.MonadTest m, MIO.MonadIO m, HasCallStack) =>
-  Orville.Pool Orville.Connection ->
+  Orville.ConnectionPool ->
   String ->
   m ()
 assertTableDoesNotExist pool =
@@ -52,7 +52,7 @@ assertTableDoesNotExist pool =
 
 assertTableExistsInSchema ::
   (HH.MonadTest m, MIO.MonadIO m, HasCallStack) =>
-  Orville.Pool Orville.Connection ->
+  Orville.ConnectionPool ->
   String ->
   String ->
   m PgCatalog.RelationDescription
@@ -61,7 +61,7 @@ assertTableExistsInSchema pool schemaName tableName =
 
 assertTableDoesNotExistInSchema ::
   (HH.MonadTest m, MIO.MonadIO m, HasCallStack) =>
-  Orville.Pool Orville.Connection ->
+  Orville.ConnectionPool ->
   String ->
   String ->
   m ()
@@ -70,7 +70,7 @@ assertTableDoesNotExistInSchema pool schemaName tableName =
 
 assertSequenceExists ::
   (HH.MonadTest m, MIO.MonadIO m, HasCallStack) =>
-  Orville.Pool Orville.Connection ->
+  Orville.ConnectionPool ->
   String ->
   m PgCatalog.RelationDescription
 assertSequenceExists pool =
@@ -78,7 +78,7 @@ assertSequenceExists pool =
 
 assertSequenceDoesNotExist ::
   (HH.MonadTest m, MIO.MonadIO m, HasCallStack) =>
-  Orville.Pool Orville.Connection ->
+  Orville.ConnectionPool ->
   String ->
   m ()
 assertSequenceDoesNotExist pool =
@@ -86,7 +86,7 @@ assertSequenceDoesNotExist pool =
 
 assertSequenceExistsInSchema ::
   (HH.MonadTest m, MIO.MonadIO m, HasCallStack) =>
-  Orville.Pool Orville.Connection ->
+  Orville.ConnectionPool ->
   String ->
   String ->
   m PgCatalog.RelationDescription
@@ -95,7 +95,7 @@ assertSequenceExistsInSchema pool schemaName sequenceName =
 
 assertSequenceDoesNotExistInSchema ::
   (HH.MonadTest m, MIO.MonadIO m, HasCallStack) =>
-  Orville.Pool Orville.Connection ->
+  Orville.ConnectionPool ->
   String ->
   String ->
   m ()
@@ -117,7 +117,7 @@ assertRelationHasPgSequence relationDesc =
 
 assertRelationExistsInSchema ::
   (HH.MonadTest m, MIO.MonadIO m, HasCallStack) =>
-  Orville.Pool Orville.Connection ->
+  Orville.ConnectionPool ->
   String ->
   String ->
   PgCatalog.RelationKind ->
@@ -140,7 +140,7 @@ assertRelationExistsInSchema pool schemaName relationName relationKind = do
 
 assertRelationDoesNotExistInSchema ::
   (HH.MonadTest m, MIO.MonadIO m, HasCallStack) =>
-  Orville.Pool Orville.Connection ->
+  Orville.ConnectionPool ->
   String ->
   String ->
   PgCatalog.RelationKind ->

--- a/orville-postgresql/test/Test/PgCatalog.hs
+++ b/orville-postgresql/test/Test/PgCatalog.hs
@@ -18,7 +18,7 @@ import qualified Test.Entities.Foo as Foo
 import qualified Test.Property as Property
 import qualified Test.TestTable as TestTable
 
-pgCatalogTests :: Orville.Pool Orville.Connection -> Property.Group
+pgCatalogTests :: Orville.ConnectionPool -> Property.Group
 pgCatalogTests pool =
   Property.group
     "PgCatalog"

--- a/orville-postgresql/test/Test/PgTime.hs
+++ b/orville-postgresql/test/Test/PgTime.hs
@@ -13,7 +13,7 @@ import qualified Orville.PostgreSQL.Raw.PgTime as PgTime
 
 import qualified Test.Property as Property
 
-pgTimeTests :: Orville.Pool Orville.Connection -> Property.Group
+pgTimeTests :: Orville.ConnectionPool -> Property.Group
 pgTimeTests _pool =
   Property.group "PgTime" $
     [

--- a/orville-postgresql/test/Test/Plan.hs
+++ b/orville-postgresql/test/Test/Plan.hs
@@ -38,7 +38,7 @@ import qualified Test.Property as Property
 
 {- ORMOLU_DISABLE -}
 {- disable formatting so fourmolu doesn't go haywire with the cpp within the list -}
-planTests :: Orville.Pool Orville.Connection -> Property.Group
+planTests :: Orville.ConnectionPool -> Property.Group
 planTests pool =
   Property.group "Plan" $
     [ prop_askParam pool

--- a/orville-postgresql/test/Test/PostgreSQLAxioms.hs
+++ b/orville-postgresql/test/Test/PostgreSQLAxioms.hs
@@ -15,7 +15,7 @@ import qualified Orville.PostgreSQL.Raw.Connection as Conn
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import qualified Test.Property as Property
 
-postgreSQLAxiomTests :: Orville.Pool Orville.Connection -> Property.Group
+postgreSQLAxiomTests :: Orville.ConnectionPool -> Property.Group
 postgreSQLAxiomTests pool =
   Property.group
     "PostgreSQL Axioms"
@@ -44,7 +44,7 @@ prop_bigIntegerBounds =
 
 assertPostgreSQLMinValueMatchesHaskell ::
   (Eq a, Show a, Bounded a, HH.MonadTest m, MIO.MonadIO m, ExSafe.MonadCatch m) =>
-  Orville.Pool Orville.Connection ->
+  Orville.ConnectionPool ->
   SqlType.SqlType a ->
   m ()
 assertPostgreSQLMinValueMatchesHaskell pool sqlType = do
@@ -59,7 +59,7 @@ assertPostgreSQLMinValueMatchesHaskell pool sqlType = do
 
 assertPostgreSQLMaxValueMatchesHaskell ::
   (Eq a, Show a, Bounded a, HH.MonadTest m, MIO.MonadIO m, ExSafe.MonadCatch m) =>
-  Orville.Pool Orville.Connection ->
+  Orville.ConnectionPool ->
   SqlType.SqlType a ->
   m ()
 assertPostgreSQLMaxValueMatchesHaskell pool sqlType = do
@@ -83,7 +83,7 @@ evalEitherMLeft =
 
 selectValue ::
   (HH.MonadTest m, MIO.MonadIO m) =>
-  Orville.Pool Orville.Connection ->
+  Orville.ConnectionPool ->
   a ->
   SqlType.SqlType a ->
   m (Either Conn.SqlExecutionError a)
@@ -92,7 +92,7 @@ selectValue pool inputValue sqlType =
 
 selectValueWithModifier ::
   (HH.MonadTest m, MIO.MonadIO m) =>
-  Orville.Pool Orville.Connection ->
+  Orville.ConnectionPool ->
   a ->
   RawSql.RawSql ->
   SqlType.SqlType a ->

--- a/orville-postgresql/test/Test/Property.hs
+++ b/orville-postgresql/test/Test/Property.hs
@@ -27,7 +27,7 @@ import qualified Hedgehog.Internal.Seed as Seed
 import qualified Orville.PostgreSQL as Orville
 
 type NamedProperty = (HH.PropertyName, HH.Property)
-type NamedDBProperty = Orville.Pool Orville.Connection -> NamedProperty
+type NamedDBProperty = Orville.ConnectionPool -> NamedProperty
 
 namedProperty :: String -> HH.PropertyT IO () -> NamedProperty
 namedProperty nameString propertyT =
@@ -42,14 +42,14 @@ singletonNamedProperty nameString property =
 
 namedDBProperty ::
   String ->
-  (Orville.Pool Orville.Connection -> HH.PropertyT IO ()) ->
+  (Orville.ConnectionPool -> HH.PropertyT IO ()) ->
   NamedDBProperty
 namedDBProperty nameString dbProperty pool =
   namedProperty nameString (dbProperty pool)
 
 singletonNamedDBProperty ::
   String ->
-  (Orville.Pool Orville.Connection -> HH.PropertyT IO ()) ->
+  (Orville.ConnectionPool -> HH.PropertyT IO ()) ->
   NamedDBProperty
 singletonNamedDBProperty nameString dbProperty pool =
   HH.withTests 1 <$> namedProperty nameString (dbProperty pool)

--- a/orville-postgresql/test/Test/RawSql.hs
+++ b/orville-postgresql/test/Test/RawSql.hs
@@ -5,19 +5,19 @@ where
 
 import qualified Data.ByteString.Char8 as B8
 import Data.Functor.Identity (runIdentity)
-import qualified Data.Pool as Pool
 import qualified Data.Text as T
 import Hedgehog ((===))
 import qualified Hedgehog as HH
 
 import qualified Orville.PostgreSQL as Orville
+import qualified Orville.PostgreSQL.Raw.Connection as Conn
 import qualified Orville.PostgreSQL.Raw.PgTextFormatValue as PgTextFormatValue
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 import qualified Test.Property as Property
 
-rawSqlTests :: Orville.Pool Orville.Connection -> Property.Group
+rawSqlTests :: Orville.ConnectionPool -> Property.Group
 rawSqlTests pool =
   Property.group
     "RawSql"
@@ -127,7 +127,7 @@ prop_escapesStringLiteralsForConnections =
 
     (actualBytes, _) <-
       HH.evalIO $
-        Pool.withResource pool $ \conn ->
+        Conn.withPoolConnection pool $ \conn ->
           RawSql.toBytesAndParams (RawSql.connectionQuoting conn) rawSql
 
     actualBytes === expectedBytes
@@ -144,7 +144,7 @@ prop_escapesIdentifiersForConnections =
 
     (actualBytes, _) <-
       HH.evalIO $
-        Pool.withResource pool $ \conn ->
+        Conn.withPoolConnection pool $ \conn ->
           RawSql.toBytesAndParams (RawSql.connectionQuoting conn) rawSql
 
     actualBytes === expectedBytes

--- a/orville-postgresql/test/Test/ReservedWords.hs
+++ b/orville-postgresql/test/Test/ReservedWords.hs
@@ -4,17 +4,17 @@ module Test.ReservedWords
 where
 
 import qualified Control.Monad.IO.Class as MIO
-import qualified Data.Pool as Pool
 import qualified Data.String as String
 import qualified Hedgehog as HH
 
 import qualified Orville.PostgreSQL as Orville
+import qualified Orville.PostgreSQL.Raw.Connection as Conn
 
 import qualified Test.Entities.User as User
 import qualified Test.Property as Property
 import qualified Test.TestTable as TestTable
 
-reservedWordsTests :: Orville.Pool Orville.Connection -> Property.Group
+reservedWordsTests :: Orville.ConnectionPool -> Property.Group
 reservedWordsTests pool =
   Property.group "ReservedWords" $
     [
@@ -24,7 +24,7 @@ reservedWordsTests pool =
 
           usersFromDB <-
             MIO.liftIO $ do
-              Pool.withResource pool $ \connection ->
+              Conn.withPoolConnection pool $ \connection ->
                 TestTable.dropAndRecreateTableDef connection User.table
 
               Orville.runOrville pool $ do

--- a/orville-postgresql/test/Test/Sequence.hs
+++ b/orville-postgresql/test/Test/Sequence.hs
@@ -11,7 +11,7 @@ import qualified Orville.PostgreSQL.Expr as Expr
 
 import qualified Test.Property as Property
 
-sequenceTests :: Orville.Pool Orville.Connection -> Property.Group
+sequenceTests :: Orville.ConnectionPool -> Property.Group
 sequenceTests pool =
   Property.group
     "Sequence"

--- a/orville-postgresql/test/Test/SqlCommenter.hs
+++ b/orville-postgresql/test/Test/SqlCommenter.hs
@@ -7,7 +7,6 @@ import qualified Control.Monad.IO.Class as MIO
 import qualified Data.ByteString.Char8 as B8
 import Data.Functor.Identity (runIdentity)
 import qualified Data.Map.Strict as Map
-import qualified Data.Pool as Pool
 import qualified Data.Text as T
 import Hedgehog ((===))
 import qualified Hedgehog as HH
@@ -15,6 +14,7 @@ import qualified Hedgehog as HH
 import qualified Orville.PostgreSQL as Orville
 import qualified Orville.PostgreSQL.Execution as Execution
 import qualified Orville.PostgreSQL.Expr as Expr
+import qualified Orville.PostgreSQL.Raw.Connection as Conn
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import qualified Orville.PostgreSQL.Raw.SqlCommenter as SqlCommenter
 
@@ -28,7 +28,7 @@ import Test.Expr.TestSchema
   )
 import qualified Test.Property as Property
 
-sqlCommenterTests :: Orville.Pool Orville.Connection -> Property.Group
+sqlCommenterTests :: Orville.ConnectionPool -> Property.Group
 sqlCommenterTests pool =
   Property.group
     "SqlCommenterAttributes"
@@ -66,7 +66,7 @@ prop_sqlCommenterInsertExpr =
 
     rows <-
       MIO.liftIO $
-        Pool.withResource pool $ \connection -> do
+        Conn.withPoolConnection pool $ \connection -> do
           dropAndRecreateTestTable connection
 
           let

--- a/orville-postgresql/test/Test/TableDefinition.hs
+++ b/orville-postgresql/test/Test/TableDefinition.hs
@@ -7,7 +7,6 @@ import qualified Control.Exception as E
 import qualified Control.Monad.IO.Class as MIO
 import qualified Data.ByteString.Char8 as B8
 import Data.List.NonEmpty (NonEmpty ((:|)))
-import qualified Data.Pool as Pool
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import Hedgehog ((===))
@@ -26,7 +25,7 @@ import qualified Test.Entities.Foo as Foo
 import qualified Test.Property as Property
 import qualified Test.TestTable as TestTable
 
-tableDefinitionTests :: Pool.Pool Orville.Connection -> Property.Group
+tableDefinitionTests :: Orville.ConnectionPool -> Property.Group
 tableDefinitionTests pool =
   Property.group
     "TableDefinition"
@@ -97,7 +96,7 @@ prop_primaryKey =
           Foo.table
           (originalFoo :| [conflictingFoo])
 
-    result <- MIO.liftIO . E.try . Pool.withResource pool $ \connection -> do
+    result <- MIO.liftIO . E.try . Conn.withPoolConnection pool $ \connection -> do
       TestTable.dropAndRecreateTableDef connection Foo.table
       RawSql.executeVoid connection insertFoos
 
@@ -128,7 +127,7 @@ prop_uniqueConstraint =
           Foo.table
           (originalFoo :| [conflictingFoo])
 
-    result <- MIO.liftIO . E.try . Pool.withResource pool $ \connection -> do
+    result <- MIO.liftIO . E.try . Conn.withPoolConnection pool $ \connection -> do
       TestTable.dropAndRecreateTableDef connection fooTableWithUniqueNameConstraint
       RawSql.executeVoid connection insertFoos
 


### PR DESCRIPTION
Providing a `ConnectionOptions` record should be a better experience for
anyone trying to read the docs or look at example code. This also adds a
`StripeOption` type that allows users to easily get one stripe allocated
per thread capability, which is what is recommended by `resource-pool`.
