### PR TITLE
Final documentation proofreading

### DIFF
--- a/orville-postgresql/src/Orville/PostgreSQL/Execution/Cursor.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Execution/Cursor.hs
@@ -5,7 +5,7 @@ Copyright : Flipstone Technology Partners 2023
 License   : MIT
 Stability : Stable
 
-Funtions and types for working with PostgreSQL cursors. You can use cursors to
+Functions and types for working with PostgreSQL cursors. You can use cursors to
 execute a query and consume rows from the result set incrementally. Rows that
 you do not consume will never be sent from the database to the client.
 

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/BinaryOperator.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/BinaryOperator.hs
@@ -5,7 +5,7 @@ Copyright : Flipstone Technology Partners 2023
 License   : MIT
 Stability : Stable
 
-Provides a type representing sql operators with exactly two arguments, as well
+Provides a type representing SQL operators with exactly two arguments, as well
 as values of that type for many common operators.
 
 @since 1.0.0.0
@@ -46,7 +46,7 @@ Type to represent any SQL operator of two arguments. E.G.
 
 > AND
 
-'BinaryOperator' provides' a 'RawSql.SqlExpression' instance. See
+'BinaryOperator' provides a 'RawSql.SqlExpression' instance. See
 'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
 SQL.
 
@@ -59,8 +59,8 @@ newtype BinaryOperator
       RawSql.SqlExpression
     )
 
-{- | Construct a binary operator, note that this does not include any check to determine if the
-operator is valid either by being a native SQL operator, or a custom defined operator in the
+{- | Construct a binary operator. Note that this does not include any check to determine if the
+operator is valid, either by being a native SQL operator, or a custom-defined operator in the
 database.
 
 @since 1.0.0.0

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/ColumnDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/ColumnDefinition.hs
@@ -30,7 +30,7 @@ Represent a complete definition of a column. E.G.
 
 > foo INTEGER
 
-'ColumnDefinition' provides' a 'RawSql.SqlExpression' instance. See
+'ColumnDefinition' provides a 'RawSql.SqlExpression' instance. See
 'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
 SQL.
 
@@ -43,18 +43,18 @@ newtype ColumnDefinition
       RawSql.SqlExpression
     )
 
-{- | Smart constructor for ensuring a 'ColumnDefinition' is setup correctly.
+{- | Smart constructor for ensuring a 'ColumnDefinition' is set up correctly.
 
 @since 1.0.0.0
 -}
 columnDefinition ::
   -- | The name the resulting column should have.
   ColumnName ->
-  -- | The SQL type of the column
+  -- | The SQL type of the column.
   DataType ->
-  -- | The constraint on the column if any
+  -- | The constraint on the column, if any.
   Maybe ColumnConstraint ->
-  -- | The default value for the column if any
+  -- | The default value for the column, if any.
   Maybe ColumnDefault ->
   ColumnDefinition
 columnDefinition columnName dataType maybeColumnConstraint maybeColumnDefault =
@@ -72,7 +72,7 @@ Represent constraints, such as nullability, on a column. E.G.
 
 > NOT NULL
 
-'ColumnConstraint' provides' a 'RawSql.SqlExpression' instance. See
+'ColumnConstraint' provides a 'RawSql.SqlExpression' instance. See
 'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
 SQL.
 
@@ -119,7 +119,7 @@ newtype ColumnDefault
       RawSql.SqlExpression
     )
 
-{- | Given a 'ValueExpression' use that as a 'ColumnDefault'. This is the preferred path to creating a
+{- | Given a 'ValueExpression', use that as a 'ColumnDefault'. This is the preferred path to creating a
    column default. Note that it is up to the caller to ensure the 'ValueExpression' makes sense for
    the resulting 'ColumnDefinition' this will be a part of.
 

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Cursor.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Cursor.hs
@@ -59,7 +59,7 @@ See PostgreSQL [cursor declare
 documentation](https://www.postgresql.org/docs/current/sql-declare.html) for
 more information.
 
-'DeclareExpr' provides' a 'RawSql.SqlExpression' instance. See
+'DeclareExpr' provides a 'RawSql.SqlExpression' instance. See
 'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
 SQL.
 
@@ -72,8 +72,8 @@ newtype DeclareExpr
       RawSql.SqlExpression
     )
 
-{- | A smart constructor for setting up a 'DeclareExpr'. This, along with other functions provided
-   allow to more safely declare a cursor.
+{- | A smart constructor for setting up a 'DeclareExpr'. This, along with other functions provided,
+   allows users to more safely declare a cursor.
 
 @since 1.0.0.0
 -}
@@ -108,7 +108,7 @@ nonsequential fetches under some, but not all, circumstances.
 See PostgreSQL [cursor declare
 documentation](https://www.postgresql.org/docs/current/sql-declare.html) for more information.
 
-'ScrollExpr' provides' a 'RawSql.SqlExpression' instance. See
+'ScrollExpr' provides a 'RawSql.SqlExpression' instance. See
 'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
 SQL.
 
@@ -139,14 +139,14 @@ noScroll =
 
 {- |
 'HoldExpr' is used to determine if a cursor should be available for use after
-the transaction that created it has been comitted. E.G.
+the transaction that created it has been committed. E.G.
 
 > WITH HOLD
 
 See PostgreSQL [cursor documentation](https://www.postgresql.org/docs/current/sql-declare.html) for
 more information.
 
-'HoldExpr' provides' a 'RawSql.SqlExpression' instance. See
+'HoldExpr' provides a 'RawSql.SqlExpression' instance. See
 'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
 SQL.
 
@@ -183,7 +183,7 @@ withoutHold =
 See PostgreSQL [close documentation](https://www.postgresql.org/docs/current/sql-close.html) for
 more information.
 
-'HoldExpr' provides' a 'RawSql.SqlExpression' instance. See
+'HoldExpr' provides a 'RawSql.SqlExpression' instance. See
 'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
 SQL.
 
@@ -196,7 +196,7 @@ newtype CloseExpr
       RawSql.SqlExpression
     )
 
-{- | A smart constructor for setting up a 'CloseExpr' either closing all cursors or the given named
+{- | A smart constructor for setting up a 'CloseExpr', either closing all cursors or the given named
    cursor.
 
 @since 1.0.0.0
@@ -225,7 +225,7 @@ newtype AllCursors
       RawSql.SqlExpression
     )
 
-{- | Specify closing all open cursors, for use with a 'CloseExpr'
+{- | Specify closing all open cursors, for use with a 'CloseExpr'.
 
 @since 1.0.0.0
 -}
@@ -235,7 +235,7 @@ allCursors =
 
 {- |
 'FetchExpr' corresponds to the SQL FETCH statement, for retrieving rows from a
-previously created cursor. E.G.
+previously-created cursor. E.G.
 
 > FETCH NEXT FOO
 

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/GroupBy.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/GroupBy.hs
@@ -40,7 +40,7 @@ newtype GroupByClause
       RawSql.SqlExpression
     )
 
-{- | Create a full sql GROUP BY clause with the given expression.
+{- | Create a full SQL GROUP BY clause with the given expression.
 
 @since 1.0.0.0
 -}
@@ -48,8 +48,8 @@ groupByClause :: GroupByExpr -> GroupByClause
 groupByClause expr = GroupByClause (RawSql.fromString "GROUP BY " <> RawSql.toRawSql expr)
 
 {- |
-Type to represent a SQL group by expression (the part that follows the @GROUP
-BY@ in sql). E.G.
+Type to represent a SQL group by expression (the part that follows the
+@GROUP BY@ in SQL). E.G.
 
 > team_name
 

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/IfExists.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/IfExists.hs
@@ -34,7 +34,7 @@ newtype IfExists
     )
 
 {- |
-A value of the SQL "IF EXISTS"
+A value of the SQL "IF EXISTS".
 
 @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Index.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Index.hs
@@ -69,7 +69,7 @@ createIndexExpr uniqueness mbConcurrently tableName columns =
 
 {- |
 Construct a SQL CREATE INDEX from an indicator of if the index should be
-unique, a table, a name for the index, and some sql representing the rest of
+unique, a table, a name for the index, and some SQL representing the rest of
 the index creation.
 
 @since 1.0.0.0
@@ -113,7 +113,7 @@ newtype ConcurrentlyExpr
 
 {- |
 The @CONCURRENTLY@ keyword indicates to PostgreSQL that an index should be
-create concurrently.
+created concurrently.
 
 @since 1.0.0.0
 -}
@@ -122,7 +122,7 @@ concurrently =
   RawSql.unsafeSqlExpression "CONCURRENTLY"
 
 {- |
-Type to represent if the body of an index definition E.G.
+Type to represent the body of an index definition E.G.
 
 > (foo, bar)
 
@@ -131,7 +131,7 @@ in
 > CREATE some_index ON some_table (foo, bar)
 
 'IndexBodyExpr' provides a 'RawSql.SqlExpression' instance. See
-'Rawsql.unsafeSqlExpression' for how to construct a value with your own custom
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
 SQL.
 
 @since 1.0.0.0

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Insert.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Insert.hs
@@ -99,7 +99,7 @@ insertColumnList columnNames =
       <> RawSql.rightParen
 
 {- |
-Type to represent the SQL for the source of data for an insert statement E.G.
+Type to represent the SQL for the source of data for an insert statement. E.G.
 
 > VALUES ('Bob',32),('Cindy',33)
 
@@ -117,7 +117,7 @@ newtype InsertSource
     )
 
 {- | Create an 'InsertSource' for the given 'RowValues'. This ensures that all input values are used
-as parameters and comma separated in the generated SQL.
+as parameters and comma-separated in the generated SQL.
 
 @since 1.0.0.0
 -}
@@ -128,7 +128,7 @@ insertRowValues rows =
       <> RawSql.intercalate RawSql.comma (fmap RawSql.toRawSql rows)
 
 {- | Create an 'InsertSource' for the given 'SqlValue's. This ensures that all input values are used
-as parameters and comma separated in the generated SQL.
+as parameters and comma-separated in the generated SQL.
 
 @since 1.0.0.0
 -}
@@ -156,7 +156,7 @@ newtype RowValues
     )
 
 {- | Create a 'RowValues' for the given 'SqlValue's. This ensures that all input values are used as
-parameters and comma separated in the generated SQL.
+parameters and comma-separated in the generated SQL.
 
 @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Internal/Name/Identifier.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Internal/Name/Identifier.hs
@@ -56,7 +56,7 @@ identifierFromBytes :: B8.ByteString -> Identifier
 identifierFromBytes =
   Identifier . RawSql.identifier
 
-{- | This class aids in giving additional polymorphism and so that many different identifiers can be
+{- | This class aids in giving additional polymorphism so that many different identifiers can be
 created without being forced to only use the `Identifier` type.
 
 @since 1.0.0.0

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Internal/Name/IndexName.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Internal/Name/IndexName.hs
@@ -38,7 +38,7 @@ newtype IndexName
     )
 
 {- |
-Construct a 'IndexName' from a 'String' with proper escaping as part of the generated SQL.
+Construct an 'IndexName' from a 'String' with proper escaping as part of the generated SQL.
 
 @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/LimitExpr.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/LimitExpr.hs
@@ -35,7 +35,7 @@ newtype LimitExpr
     )
 
 {- | Create a 'LimitExpr' for the given 'Int'. This ensures that the input value is used
-as parameters in the generated SQL.
+as a parameter in the generated SQL.
 
 @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/OffsetExpr.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/OffsetExpr.hs
@@ -35,7 +35,7 @@ newtype OffsetExpr
     )
 
 {- | Create an 'OffsetExpr' for the given 'Int'. This ensures that the input value is used
-as parameters in the generated SQL.
+as a parameter in the generated SQL.
 
 @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/OrderBy.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/OrderBy.hs
@@ -49,7 +49,7 @@ orderByClause expr = OrderByClause (RawSql.fromString "ORDER BY " <> RawSql.toRa
 
 {- |
 Type to represent a SQL order by expression (the part that follows the @ORDER
-BY@ in sql). E.G.
+BY@ in SQL). E.G.
 
 > foo, bar
 
@@ -80,9 +80,9 @@ appendOrderByExpr (OrderByExpr a) (OrderByExpr b) =
   OrderByExpr (a <> RawSql.commaSpace <> b)
 
 {- |
-Create a 'OrderByExpr' from some 'RawSql.RawSql' and a 'OrderByDirection'. Note
+Create an 'OrderByExpr' from some 'RawSql.RawSql' and a 'OrderByDirection'. Note
 that it is up to the caller to ensure that the given value can actually be used
-for a 'OrderByExpr'
+for an 'OrderByExpr'
 
 @since 1.0.0.0
 -}
@@ -90,7 +90,7 @@ orderByExpr :: RawSql.RawSql -> OrderByDirection -> OrderByExpr
 orderByExpr sql orderSql =
   OrderByExpr $ sql <> RawSql.space <> RawSql.toRawSql orderSql
 
-{- | Create a 'OrderByExpr' for 'ColumnName' and 'OrderByDirection' pairs, ensuring commas as
+{- | Create an 'OrderByExpr' for 'ColumnName' and 'OrderByDirection' pairs, ensuring commas as
   needed.
 
 @since 1.0.0.0

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Query.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Query.hs
@@ -54,7 +54,7 @@ newtype QueryExpr
 
 {- |
   Builds a 'QueryExpr' from the given 'SelectClause', 'SelectList' and
-  'TableExpr'. The resulting 'QueryExpr' is suitable execution via the SQL
+  'TableExpr'. The resulting 'QueryExpr' is suitable for execution via the SQL
   execution functions in "Orville.PostgreSQL.Execution" and
   "Orville.PostgreSQL.Raw.RawSql".
 
@@ -190,17 +190,17 @@ newtype TableExpr
 @since 1.0.0.0
 -}
 tableExpr ::
-  -- | The list of tables to query from
+  -- | The list of tables to query from.
   TableReferenceList ->
-  -- | An optional @WHERE@ clause to limit the results returned
+  -- | An optional @WHERE@ clause to limit the results returned.
   Maybe WhereClause ->
-  -- | An optional @GROUP BY@ clause to group the result set rows
+  -- | An optional @GROUP BY@ clause to group the result set rows.
   Maybe GroupByClause ->
-  -- | An optional @ORDER BY@ clause to order the result set rows
+  -- | An optional @ORDER BY@ clause to order the result set rows.
   Maybe OrderByClause ->
-  -- | An optional @LIMIT@ to apply to the result set
+  -- | An optional @LIMIT@ to apply to the result set.
   Maybe LimitExpr ->
-  -- | An optional @OFFSET@ to apply to the result set
+  -- | An optional @OFFSET@ to apply to the result set.
   Maybe OffsetExpr ->
   TableExpr
 tableExpr

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/ReturningExpr.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/ReturningExpr.hs
@@ -33,7 +33,7 @@ newtype ReturningExpr
 
 {- |
   Constructs a 'ReturningExpr' that returns the items given in the
-  'SelectList'. Essentialy this retults @RETURNING <SelectList items>@
+  'SelectList'. Essentialy this retults @RETURNING <SelectList items>@.
 
 @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Select.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Select.hs
@@ -19,7 +19,7 @@ where
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 {- |
-Type to represent the @SELECT@ part of SQL query E.G.
+Type to represent the @SELECT@ part of a SQL query. E.G.
 
 > SELECT
 
@@ -46,7 +46,7 @@ selectClause :: SelectExpr -> SelectClause
 selectClause expr = SelectClause (RawSql.fromString "SELECT " <> RawSql.toRawSql expr)
 
 {- |
-Type to represent the any expression modifying the @SELECT@ part of a SQL. E.G.
+Type to represent any expression modifying the @SELECT@ part of a SQL. E.G.
 
 > DISTINCT
 
@@ -60,7 +60,7 @@ newtype SelectExpr = SelectExpr RawSql.RawSql
 
 {- |
   A simple value type used to indicate that a @SELECT@ should be distinct when
-  constructing a 'SelectExpr'
+  constructing a 'SelectExpr'.
 
 @since 1.0.0.0
 -}
@@ -68,7 +68,7 @@ data Distinct = Distinct
 
 {- |
   Constructs a 'SelectExpr' that may or may not make the @SELECT@ distinct,
-  dependending on whether 'Just Distinct' is passed or not.
+  depending on whether 'Just Distinct' is passed or not.
 
 @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/SequenceDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/SequenceDefinition.hs
@@ -85,19 +85,19 @@ newtype CreateSequenceExpr
   @since 1.0.0.0
 -}
 createSequenceExpr ::
-  -- | The name to be used for the sequence
+  -- | The name to be used for the sequence.
   Qualified SequenceName ->
-  -- | An optional @INCREMENT@ expression
+  -- | An optional @INCREMENT@ expression.
   Maybe IncrementByExpr ->
-  -- | An optional @MINVALUE@ expression
+  -- | An optional @MINVALUE@ expression.
   Maybe MinValueExpr ->
-  -- | An optional @MAXVALUE@ expression
+  -- | An optional @MAXVALUE@ expression.
   Maybe MaxValueExpr ->
-  -- | An optional @START WITH@ expression
+  -- | An optional @START WITH@ expression.
   Maybe StartWithExpr ->
-  -- | An optional @CACHE@ expression
+  -- | An optional @CACHE@ expression.
   Maybe CacheExpr ->
-  -- | An optional @CYCLE@ expression
+  -- | An optional @CYCLE@ expression.
   Maybe CycleExpr ->
   CreateSequenceExpr
 createSequenceExpr sequenceName mbIncrementBy mbMinValue mbMaxValue mbStartWith mbCache mbCycle =
@@ -184,7 +184,7 @@ alterSequenceExpr sequenceName mbIncrementBy mbMinValue mbMaxValue mbStartWith m
       ]
 
 {- |
-Type to represent a @INCREMENT BY@ expression for sequences. E.G.
+Type to represent an @INCREMENT BY@ expression for sequences. E.G.
 
 > INCREMENT BY 0
 
@@ -200,7 +200,7 @@ newtype IncrementByExpr
 
 {- |
   Constructs an 'IncrementByExpr' that will make the sequence increment by
-  the given value
+  the given value.
 
   @since 1.0.0.0
 -}
@@ -226,8 +226,8 @@ newtype MinValueExpr
   deriving (RawSql.SqlExpression)
 
 {- |
-  Constructs an 'MinValueExpr' which gives the sequence the specified minimum
-  value
+  Constructs a 'MinValueExpr' which gives the sequence the specified minimum
+  value.
 
   @since 1.0.0.0
 -}
@@ -238,8 +238,8 @@ minValue n =
       <> RawSql.int64DecLiteral n
 
 {- |
-  Constructs an 'MinValueExpr' which gives the sequence no minimum value (i.e.
-  @NO MINVALUE@)
+  Constructs a 'MinValueExpr' which gives the sequence no minimum value (i.e.
+  @NO MINVALUE@).
 
   @since 1.0.0.0
 -}
@@ -263,8 +263,8 @@ newtype MaxValueExpr
   deriving (RawSql.SqlExpression)
 
 {- |
-  Constructs an 'MaxValueExpr' which gives the sequence the specified maximum
-  value
+  Constructs a 'MaxValueExpr' which gives the sequence the specified maximum
+  value.
 
   @since 1.0.0.0
 -}
@@ -275,8 +275,8 @@ maxValue n =
       <> RawSql.int64DecLiteral n
 
 {- |
-  Constructs an 'MinValueExpr' which gives the sequence no maximum value (i.e.
-  @NO MAXVALUE@)
+  Constructs a 'MaxValueExpr' which gives the sequence no maximum value (i.e.
+  @NO MAXVALUE@).
 
   @since 1.0.0.0
 -}
@@ -301,7 +301,7 @@ newtype StartWithExpr
 
 {- |
   Constructs a 'StartWithExpr' which gives the sequence the specified start
-  value
+  value.
 
   @since 1.0.0.0
 -}
@@ -312,7 +312,7 @@ startWith n =
       <> RawSql.int64DecLiteral n
 
 {- |
-Type to represent a @CACHE @ expression for sequences. E.G.
+Type to represent a @CACHE@ expression for sequences. E.G.
 
 > CACHE 16
 
@@ -358,7 +358,7 @@ newtype CycleExpr
   deriving (RawSql.SqlExpression)
 
 {- |
-  Constructs a 'CycleExpr' that indicate that the sequence should cycle.
+  Constructs a 'CycleExpr' that indicates that the sequence should cycle.
 
   @since 1.0.0.0
 -}
@@ -366,7 +366,7 @@ cycle :: CycleExpr
 cycle = CycleExpr $ RawSql.fromString "CYCLE"
 
 {- |
-  Constructs a 'CycleExpr' that indicate that the sequence should not cycle.
+  Constructs a 'CycleExpr' that indicates that the sequence should not cycle.
 
   @since 1.0.0.0
 -}
@@ -374,8 +374,8 @@ noCycle :: CycleExpr
 noCycle = CycleExpr $ RawSql.fromString "NO CYCLE"
 
 {- |
-  Constructs a 'CycleExpr' will cause the sequence to cycle if the flag passed
-  is @True@.
+  Constructs a 'CycleExpr' that will cause the sequence to cycle if the flag
+  passed is @True@.
 
   @since 1.0.0.0
 -}
@@ -402,8 +402,8 @@ newtype DropSequenceExpr
 
 {- |
   Constructs a 'DropSequenceExpr' that will drop sequence with the given name.
-  You maybe specific an 'IfExists' argument if you want to include an @IF
-  EXISTS@ condition in the statement.
+  You may specify an 'IfExists' argument if you want to include an @IF EXISTS@
+  condition in the statement.
 
   @since 1.0.0.0
 -}
@@ -422,7 +422,7 @@ dropSequenceExpr maybeIfExists sequenceName =
 {- |
   Constructs a 'ValueExpression' that will use the @nextval@ PostgreSQL
   function to get the next value from the given sequence. If you're trying to
-  construct your own @SELECT@ to get the value of the sequnce, you can use the
+  construct your own @SELECT@ to get the value of the sequence, you can use the
   constructed 'ValueExpression' with 'Orville.PostgreSQL.Expr.deriveColumnAs'
   to build the item to select.
 
@@ -446,7 +446,7 @@ nextValFunction =
 {- |
   Constructs a 'ValueExpression' that will use the @currval@ PostgreSQL
   function to get the current value from the given sequence. If you're trying to
-  construct your own @SELECT@ to get the value of the sequnce, you can use the
+  construct your own @SELECT@ to get the value of the sequence, you can use the
   constructed 'ValueExpression' with 'Orville.PostgreSQL.Expr.deriveColumnAs'
   to build the item to select.
 
@@ -470,7 +470,7 @@ currValFunction =
 {- |
   Constructs a 'ValueExpression' that will use the @setval@ PostgreSQL function
   to set the value from the given sequence. If you're trying to construct your
-  own @SELECT@ to set the value of the sequnce, you can use the constructed
+  own @SELECT@ to set the value of the sequence, you can use the constructed
   'ValueExpression' with 'Orville.PostgreSQL.Expr.deriveColumnAs' to build the
   item to select.
 

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/TableConstraint.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/TableConstraint.hs
@@ -30,7 +30,7 @@ import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 {- |
 Type to represent a table constraint that would be part of a @CREATE TABLE@ or
-@ALTER TABLE@ statement. For instances, the @UNIQUE@ constraint in
+@ALTER TABLE@ statement. For instance, the @UNIQUE@ constraint in
 
 > CREATE TABLE FOO
 >  ( id integer
@@ -111,7 +111,7 @@ setDefaultExpr :: ForeignKeyActionExpr
 setDefaultExpr = ForeignKeyActionExpr $ RawSql.fromString "SET DEFAULT"
 
 {- |
-Type to represent an foreign key update action on a @FOREIGN KEY@ constraint. E.G.
+Type to represent a foreign key update action on a @FOREIGN KEY@ constraint. E.G.
 the @ON UPDATE RESTRICT@ in
 
 > FOREIGN KEY (foo_id) REFERENCES foo (id) ON UPDATE RESTRICT
@@ -127,7 +127,7 @@ newtype ForeignKeyUpdateActionExpr
   deriving (RawSql.SqlExpression)
 
 {- |
-  Constructs a 'ForeignKeyActionExpr' that use the given 'ForeignKeyActionExpr'
+  Constructs a 'ForeignKeyActionExpr' that uses the given 'ForeignKeyActionExpr'
   in an @ON UPDATE@ clause for a foreign key.
 
   @since 1.0.0.0
@@ -140,7 +140,7 @@ foreignKeyUpdateActionExpr action =
       <> RawSql.toRawSql action
 
 {- |
-Type to represent an foreign key update action on a @FOREIGN KEY@ constraint. E.G.
+Type to represent a foreign key update action on a @FOREIGN KEY@ constraint. E.G.
 the @ON DELETE RESTRICT@ in
 
 > FOREIGN KEY (foo_id) REFERENCES foo (id) ON DELETE RESTRICT
@@ -156,7 +156,7 @@ newtype ForeignKeyDeleteActionExpr
   deriving (RawSql.SqlExpression)
 
 {- |
-  Constructs a 'ForeignKeyActionExpr' that use the given 'ForeignKeyActionExpr'
+  Constructs a 'ForeignKeyActionExpr' that uses the given 'ForeignKeyActionExpr'
   in an @ON UPDATE@ clause for a foreign key.
 
   @since 1.0.0.0
@@ -174,15 +174,15 @@ foreignKeyDeleteActionExpr action =
   @since 1.0.0.0
 -}
 foreignKeyConstraint ::
-  -- | The names of the columns in the source table that form the foreign key
+  -- | The names of the columns in the source table that form the foreign key.
   NonEmpty ColumnName ->
-  -- | The table of the table that the foreign key references
+  -- | The name of the table that the foreign key references.
   Qualified TableName ->
-  -- | The names of the columns in the foreign table that the foreign key references
+  -- | The names of the columns in the foreign table that the foreign key references.
   NonEmpty ColumnName ->
-  -- | An optional @ON UPDATE@ foreign key action to perform
+  -- | An optional @ON UPDATE@ foreign key action to perform.
   Maybe ForeignKeyUpdateActionExpr ->
-  -- | An optional @ON DELETE@ foreign key action to perform
+  -- | An optional @ON DELETE@ foreign key action to perform.
   Maybe ForeignKeyDeleteActionExpr ->
   TableConstraint
 foreignKeyConstraint columnNames foreignTableName foreignColumnNames mbUpdateAction mbDeleteAction =

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/TableDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/TableDefinition.hs
@@ -64,13 +64,13 @@ newtype CreateTableExpr
   @since 1.0.0.0
 -}
 createTableExpr ::
-  -- | The name to be use for the table
+  -- | The name to be used for the table.
   Qualified TableName ->
-  -- | The columns to include in the table
+  -- | The columns to include in the table.
   [ColumnDefinition] ->
-  -- | A primary key expression for the table
+  -- | A primary key expression for the table.
   Maybe PrimaryKeyExpr ->
-  -- | Any table constraints to include with the table
+  -- | Any table constraints to include with the table.
   [TableConstraint] ->
   CreateTableExpr
 createTableExpr tableName columnDefs mbPrimaryKey constraints =
@@ -99,7 +99,7 @@ createTableExpr tableName columnDefs mbPrimaryKey constraints =
         ]
 
 {- |
-Type to represent a the primary key of a table. E.G.
+Type to represent the primary key of a table. E.G.
 
 > PRIMARY KEY (id)
 
@@ -114,7 +114,7 @@ newtype PrimaryKeyExpr
   deriving (RawSql.SqlExpression)
 
 {- |
-  Constructs a 'PrimaryKeyExpr' with the given columns
+  Constructs a 'PrimaryKeyExpr' with the given columns.
 
   @since 1.0.0.0
 -}
@@ -129,7 +129,7 @@ primaryKeyExpr columnNames =
       ]
 
 {- |
-Type to represent a @ALTER TABLE@ statement. E.G.
+Type to represent an @ALTER TABLE@ statement. E.G.
 
 > ALTER TABLE foo ADD COLUMN bar integer
 
@@ -222,9 +222,9 @@ dropConstraint constraintName =
   @since 1.0.0.0
 -}
 alterColumnType ::
-  -- | The name of the column whose type willbe altered
+  -- | The name of the column whose type will be altered.
   ColumnName ->
-  -- | The new type to use for the column
+  -- | The new type to use for the column.
   DataType ->
   -- | An optional 'UsingClause' to indicate to the database how data from the
   -- old type should be converted to the new type.
@@ -302,7 +302,7 @@ newtype AlterNotNull
   deriving (RawSql.SqlExpression)
 
 {- |
-  Sets the column to not null via @SET NOT NULL@
+  Sets the column to not null via @SET NOT NULL@.
 
   @since 1.0.0.0
 -}
@@ -311,7 +311,7 @@ setNotNull =
   AlterNotNull $ RawSql.fromString "SET NOT NULL"
 
 {- |
-  Sets the column to allow null via @DROP NOT NULL@
+  Sets the column to allow null via @DROP NOT NULL@.
 
   @since 1.0.0.0
 -}
@@ -372,7 +372,7 @@ newtype DropTableExpr
   deriving (RawSql.SqlExpression)
 
 {- |
-  Constructs an 'DropTableExpr' that will drop the specified table.
+  Constructs a 'DropTableExpr' that will drop the specified table.
 
   @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/TableReferenceList.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/TableReferenceList.hs
@@ -17,7 +17,7 @@ import Orville.PostgreSQL.Expr.Name (Qualified, TableName)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 {- |
-Type to represent the tables references in the @FROM@ clause of a @SELECT
+Type to represent the table's references in the @FROM@ clause of a @SELECT
 statement. E.G. just the
 
 > foo

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Transaction.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Transaction.hs
@@ -68,7 +68,7 @@ beginTransaction maybeTransactionMode =
       )
 
 {- |
-Type to represent the a transaction mode. E.G.
+Type to represent the transaction mode. E.G.
 
 > ISOLATION LEVEL SERIALIZABLE
 
@@ -129,7 +129,7 @@ isolationLevel level =
     (RawSql.fromString "ISOLATION LEVEL " <> RawSql.toRawSql level)
 
 {- |
-Type to represent the a transaction isolation level. E.G.
+Type to represent the transaction isolation level. E.G.
 
 > SERIALIZABLE
 
@@ -195,7 +195,7 @@ newtype CommitExpr
   deriving (RawSql.SqlExpression)
 
 {- |
-  A @COMMIT@ transaction statement
+  A @COMMIT@ transaction statement.
 
   @since 1.0.0.0
 -}
@@ -219,7 +219,7 @@ newtype RollbackExpr
   deriving (RawSql.SqlExpression)
 
 {- |
-  A @ROLLBACK@ transaction statement
+  A @ROLLBACK@ transaction statement.
 
   @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Update.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Update.hs
@@ -27,7 +27,7 @@ import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 {- |
-Type to represent the transaction a SQL @UPDATE@ statement. E.G.
+Type to represent a SQL @UPDATE@ statement. E.G.
 
 > UPDATE foo
 > SET id = 1
@@ -49,13 +49,13 @@ newtype UpdateExpr
   @since 1.0.0.0
 -}
 updateExpr ::
-  -- | The name of the table to be updated
+  -- | The name of the table to be updated.
   Qualified TableName ->
-  -- | The updates to be made to the table
+  -- | The updates to be made to the table.
   SetClauseList ->
-  -- | An optional where clause to limit the rows updated
+  -- | An optional where clause to limit the rows updated.
   Maybe WhereClause ->
-  -- | An optional returning clause to return data from the updated rows
+  -- | An optional returning clause to return data from the updated rows.
   Maybe ReturningExpr ->
   UpdateExpr
 updateExpr tableName setClause maybeWhereClause maybeReturningExpr =
@@ -71,7 +71,7 @@ updateExpr tableName setClause maybeWhereClause maybeReturningExpr =
         ]
 
 {- |
-Type to represent the list of updates to be made in a @UPDATE@ statament. E.G.
+Type to represent the list of updates to be made in an @UPDATE@ statement. E.G.
 
 > foo = 1,
 > bar = 2
@@ -87,7 +87,7 @@ newtype SetClauseList
   deriving (RawSql.SqlExpression)
 
 {- |
-  Constructs a 'SetClauseList' with the specified set clauses
+  Constructs a 'SetClauseList' with the specified set clauses.
 
   @since 1.0.0.0
 -}
@@ -96,7 +96,7 @@ setClauseList =
   SetClauseList . RawSql.intercalate RawSql.comma
 
 {- |
-Type to represent a single updates to be made in a @UPDATE@ statament. E.G.
+Type to represent a single update to be made in an @UPDATE@ statement. E.G.
 
 > foo = 1
 

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/ValueExpression.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/ValueExpression.hs
@@ -72,7 +72,7 @@ columnReference = ValueExpression . RawSql.toRawSql
   Uses the given 'SqlValue' as a constant expression. The value will be passed
   as a statement parameter, not as a literal expression, so there is not need
   to worry about escaping. However, there are a few places (usually in DDL)
-  where PostgreSQL does not support values passed as paremeters where this
+  where PostgreSQL does not support values passed as parameters where this
   cannot be used.
 
   @since 1.0.0.0
@@ -112,7 +112,7 @@ functionCall functionName parameters =
       <> RawSql.rightParen
 
 {- |
-Type to represent the name of a name parameter in PostgreSQL function call.
+Type to represent the name of a name parameter in a PostgreSQL function call.
 E.G.
 
 > foo

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/WhereClause.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/WhereClause.hs
@@ -45,7 +45,7 @@ import Orville.PostgreSQL.Expr.ValueExpression (ValueExpression, rowValueConstru
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 {- |
-Type to represent a @WHERE@ clause restriction an a @SELECT@, @UPDATE@ or
+Type to represent a @WHERE@ clause restriction on a @SELECT@, @UPDATE@ or
 @DELETE@ statement. E.G.
 
 > WHERE (foo > 10)
@@ -73,7 +73,7 @@ whereClause booleanExpr =
     RawSql.fromString "WHERE " <> RawSql.toRawSql booleanExpr
 
 {- |
-Type to represent a SQL value expression that evaluates to a boolean and thereforce
+Type to represent a SQL value expression that evaluates to a boolean and therefore
 can used with boolean logic functions. E.G.
 
 > foo > 10
@@ -89,7 +89,7 @@ newtype BooleanExpr
   deriving (RawSql.SqlExpression)
 
 {- |
-  Constructs a 'BooleanExpr' whose value the SQL literal @TRUE@ or @FALSE@
+  Constructs a 'BooleanExpr' whose value is the SQL literal @TRUE@ or @FALSE@
   depending on the argument given.
 
   @since 1.0.0.0
@@ -114,7 +114,7 @@ booleanValueExpression (BooleanExpr rawSql) =
 {- |
   The SQL @OR@ operator. The arguments will be surrounded with parentheses
   to ensure that the associativity of expression in the resulting SQL matches
-  the associtivity implied by this Haskell function.
+  the associativity implied by this Haskell function.
 
   @since 1.0.0.0
 -}
@@ -138,7 +138,7 @@ infixr 8 .||
 {- |
   The SQL @AND@ operator. The arguments will be surrounded with parentheses
   to ensure that the associativity of expression in the resulting SQL matches
-  the associtivity implied by this Haskell function.
+  the associativity implied by this Haskell function.
 
   @since 1.0.0.0
 -}
@@ -170,7 +170,7 @@ valueIn needle haystack =
   inPredicate needle (inValueList haystack)
 
 {- |
-  The SQL @IN@ operator. The result will be @TRUE@ if the given value
+  The SQL @NOT IN@ operator. The result will be @TRUE@ if the given value
   does not appear in the list of values given.
 
   @since 1.0.0.0
@@ -206,9 +206,9 @@ tupleNotIn needle haystack =
     (inValueList (fmap rowValueConstructor haystack))
 
 {- |
-  Lowel lever access to the the SQL @IN@ operator. This takes any
-  'ValueExpression' and 'InValuePredicate'. It is up to the caller to ensure
-  the expressions given makes sense together.
+  Lower-level access to the SQL @IN@ operator. This takes any 'ValueExpression'
+  and 'InValuePredicate'. It is up to the caller to ensure the expressions
+  given make sense together.
 
   @since 1.0.0.0
 -}
@@ -220,9 +220,9 @@ inPredicate predicand predicate =
       <> RawSql.toRawSql predicate
 
 {- |
-  Lowel lever access to the the SQL @NOT IN@ operator. This takes any
+  Lower-level access to the SQL @NOT IN@ operator. This takes any
   'ValueExpression' and 'InValuePredicate'. It is up to the caller to ensure
-  the expressions given makes sense together.
+  the expressions given make sense together.
 
   @since 1.0.0.0
 -}
@@ -250,7 +250,7 @@ newtype InValuePredicate
   deriving (RawSql.SqlExpression)
 
 {- |
-  Constructs an 'InValuePredicate' from the given list of 'ValueExpression'
+  Constructs an 'InValuePredicate' from the given list of 'ValueExpression'.
 
   @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Internal/IndexDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Internal/IndexDefinition.hs
@@ -49,11 +49,10 @@ data IndexDefinition = IndexDefinition
   }
 
 {- |
-  Sets the 'IndexCreationStrategy' strategy to be used when creating the index
-  described by the 'IndexDefinition'. By default all indexes are created using
-  the 'Transactional' strategy, but some tables are too large for this to
-  be feasible. See the 'Concurrent' creation strategy for how to work around
-  this.
+  Sets the 'IndexCreationStrategy' to be used when creating the index described
+  by the 'IndexDefinition'. By default, all indexes are created using the
+  'Transactional' strategy, but some tables are too large for this to be
+  feasible. See the 'Concurrent' creation strategy for how to work around this.
 
 @since 1.0.0.0
 -}
@@ -67,9 +66,9 @@ setIndexCreationStrategy strategy indexDef =
     }
 
 {- |
-  Gets the 'IndexCreationStrategy' strategy to be used when creating the index
-  described by the 'IndexDefinition'. By default all indexes are created using
-  the 'Transactional' strategy.
+  Gets the 'IndexCreationStrategy' to be used when creating the index described
+  by the 'IndexDefinition'. By default, all indexes are created using the
+  'Transactional' strategy.
 
 @since 1.0.0.0
 -}
@@ -81,22 +80,22 @@ indexCreationStrategy =
 
 {- |
   Defines how an 'IndexDefinition' will be executed to add an index to a table.
-  By default all indexes are created using the 'Transactional' strategy.
+  By default, all indexes are created using the 'Transactional' strategy.
 
 @since 1.0.0.0
 -}
 data IndexCreationStrategy
   = -- |
-    --       The default strategy. The index will be added as part of a database
-    --       transaction along with all the other DDL being executed to migrate the
-    --       database schema. If any migration should fail the index creation will be
-    --       rolled back as part of the transaction. This is how schema migrations
-    --       work in general in Orville.
+    --       The default strategy. The index will be added as part of a
+    --       database transaction along with all the other DDL being executed
+    --       to migrate the database schema. If any migration should fail, the
+    --       index creation will be rolled back as part of the transaction.
+    --       This is how schema migrations work in general in Orville.
     Transactional
   | -- |
     --       Creates the index using the @CONCURRENTLY@ keyword in PostgreSQL.
     --       Index creation will not lock the table during creation, allowing
-    --       the application access the table normally while the index is
+    --       the application to access the table normally while the index is
     --       created. Concurrent index creation cannot be done in a
     --       transaction, so indexes created using @CONCURRENTLY@ are created
     --       outside the normal schema transaction. Index creation may fail
@@ -111,7 +110,7 @@ data IndexCreationStrategy
     --       details about how to work around this if it is a problem for you.
     --       Also, it a good idea to read the PostgreSQL docs about creating
     --       indexes concurrently before you use this strategy. See
-    --       https://www.postgresql.org/docs/current/sql-createindex.html#SQL-CREATEINDEX-CONCURRENTLY
+    --       https://www.postgresql.org/docs/current/sql-createindex.html#SQL-CREATEINDEX-CONCURRENTLY.
     Concurrent
   deriving (Eq, Show)
 
@@ -176,8 +175,7 @@ indexCreateExpr indexDef =
     (i_indexCreationStrategy indexDef)
 
 {- |
-  Constructs an 'IndexDefinition' for a non-unique index on the given
-  columns.
+  Constructs an 'IndexDefinition' for a non-unique index on the given columns.
 
 @since 1.0.0.0
 -}
@@ -196,8 +194,7 @@ nonUniqueNamedIndex =
   mkNamedIndexDefinition Expr.NonUniqueIndex
 
 {- |
-  Constructs an 'IndexDefinition' for a @UNIQUE@ index on the given
-  columns.
+  Constructs an 'IndexDefinition' for a @UNIQUE@ index on the given columns.
 
 @since 1.0.0.0
 -}
@@ -206,8 +203,8 @@ uniqueIndex =
   mkIndexDefinition Expr.UniqueIndex
 
 {- |
-  Constructs an 'IndexDefinition' for a @UNIQUE@ index on the given
-  columns.
+  Constructs an 'IndexDefinition' for a @UNIQUE@ index with given SQL and index
+  name.
 
 @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Internal/OrvilleState.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Internal/OrvilleState.hs
@@ -66,7 +66,7 @@ data OrvilleState = OrvilleState
   }
 
 {- |
-  Get the connection pool being used for the 'OrvilleState'
+  Get the connection pool being used for the 'OrvilleState'.
 
 @since 1.0.0.0
 -}
@@ -75,8 +75,8 @@ orvilleConnectionPool =
   _orvilleConnectionPool
 
 {- |
-  INTERNAL: The 'ConnectionState' indicates whether Orville currently has a connection
-  open, and contains the connection if it does.
+  INTERNAL: The 'ConnectionState' indicates whether Orville currently has a
+  connection open, and contains the connection if it does.
 
 @since 1.0.0.0
 -}
@@ -86,7 +86,8 @@ orvilleConnectionState =
 
 {- |
   The 'ErrorDetailLevel' controls how much information Orville includes in
-  error messages it generates when data cannot be decoded rows in the database.
+  error messages it generates when data cannot be decoded from rows in the
+  database.
 
 @since 1.0.0.0
 -}
@@ -96,7 +97,7 @@ orvilleErrorDetailLevel =
 
 {- |
   Orville will call the transaction callback any time a transaction event
-  occurrs. You can register a callback with 'addTransactionCallback'.
+  occurs. You can register a callback with 'addTransactionCallback'.
 
 @since 1.0.0.0
 -}
@@ -106,7 +107,7 @@ orvilleTransactionCallback =
 
 {- |
   The SQL expression that Orville will use to begin a transaction. You can set
-  this via 'setBeginTransactionExpr' to have fine grained control over the
+  this via 'setBeginTransactionExpr' to have fine-grained control over the
   transaction parameters, such as isolation level.
 
 @since 1.0.0.0
@@ -134,10 +135,10 @@ orvilleSqlCommenterAttributes =
   in the order they are added.
 
   Note: There is no specialized error handling for these callbacks. This means
-  that if a callback raises an exception no further callbacks will be called
+  that if a callback raises an exception, no further callbacks will be called
   and the exception will propagate up until it is caught elsewhere. In
   particular, if an exception is raised by a callback upon opening the
-  transaction it will cause the transaction to be rolled-back the same as any
+  transaction, it will cause the transaction to be rolled-back the same as any
   other exception that might happen during the transaction. In general, we
   recommend only using callbacks that either raise no exceptions or can handle
   their own exceptions cleanly.
@@ -276,8 +277,8 @@ initialSavepoint =
   Savepoint 1
 
 {- |
-  Determines identifier for the next savepoint in a transaction after the
-  given saveponit>
+  Determines the identifier for the next savepoint in a transaction after the
+  given savepoint.
 
 @since 1.0.0.0
 -}
@@ -297,7 +298,7 @@ savepointNestingLevel (Savepoint n) = n
 {- |
   Describes an event in the lifecycle of a database transaction. You can use
   'addTransactionCallback' to register a callback to respond to these events.
-  The callback will be called after the event in question has been succesfully
+  The callback will be called after the event in question has been successfully
   executed.
 
 @since 1.0.0.0
@@ -450,7 +451,8 @@ setBeginTransactionExpr expr state =
     }
 
 {- |
-  Sets the SqlCommenterAttributes that Orville will then add to any following statement executions.
+  Sets the SqlCommenterAttributes that Orville will then add to any following
+  statement executions.
 
 @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Marshall.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Marshall.hs
@@ -7,7 +7,7 @@ Stability : Stable
 
 You can import "Orville.PostgreSQL.Marshall" to get access to all the functions
 related to marshalling Haskell values to and from their SQL representations.
-This includes a number of lowel-level items not exported by
+This includes a number of lower-level items not exported by
 "Orville.PostgreSQL" that give you more control (and therefore responsibility)
 over how the marshalling is performed.
 

--- a/orville-postgresql/src/Orville/PostgreSQL/Marshall/DefaultValue.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Marshall/DefaultValue.hs
@@ -250,7 +250,7 @@ currentLocalTimestampDefault =
 {- |
   Coerces a 'DefaultValue' so that it can be used with field definitions of
   a different Haskell type. The coercion will always succeed, and is safe as
-  far as Haskell itself it concerned. As long as the 'DefaultValue' is used
+  far as Haskell itself is concerned. As long as the 'DefaultValue' is used
   with a column whose database type is the same as the one the 'DefaultValue'
   was originally intended for, everything will work as expected.
 
@@ -261,7 +261,7 @@ coerceDefaultValue (DefaultValue expression) =
   DefaultValue expression
 
 {- |
-  Returns database value expression for the default value.
+  Returns a database value expression for the default value.
 
 @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Marshall/FieldDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Marshall/FieldDefinition.hs
@@ -114,7 +114,7 @@ import qualified Orville.PostgreSQL.Schema.ConstraintDefinition as ConstraintDef
 import qualified Orville.PostgreSQL.Schema.TableIdentifier as TableIdentifier
 
 {- |
-  'FieldDefinition' determines the SQL constsruction of a column in the
+  'FieldDefinition' determines the SQL construction of a column in the
   database, comprising the name, SQL type and whether the field is nullable.
   A 'FieldDefinition' is matched to a particular Haskell type, which it knows
   how to marshall to and from the database representation of SQL type for
@@ -228,7 +228,7 @@ fieldIsNotNullable field =
     NotNullGADT -> True
 
 {- |
-  A list a table constraints that will be included on any table that uses this
+  A list of table constraints that will be included on any table that uses this
   field definition.
 
 @since 1.0.0.0
@@ -252,7 +252,7 @@ fieldTableConstraints fieldDef =
 {- |
   Adds the given table constraints to the field definition. These constraints
   will then be included on any table where the field is used. The constraints
-  are passed a functions that will take the name of the field definition an
+  are passed a function that will take the name of the field definition and
   construct the constraints. This allows the
   'ConstraintDefinition.ConstraintDefinition's to use the correct name of the
   field in the case where 'setFieldName' is used after constraints are added.
@@ -282,9 +282,9 @@ addFieldTableConstraints constraintDefs fieldDef =
 @since 1.0.0.0
 -}
 addForeignKeyConstraint ::
-  -- | Identifier of the table referenced by the foreign key
+  -- | Identifier of the table referenced by the foreign key.
   TableIdentifier.TableIdentifier ->
-  -- | The field name that this field definition references in the foreign table
+  -- | The field name that this field definition references in the foreign table.
   FieldName ->
   FieldDefinition nullability a ->
   FieldDefinition nullability a
@@ -301,9 +301,9 @@ addForeignKeyConstraint foreignTableId foreignFieldName =
 @since 1.0.0.0
 -}
 addForeignKeyConstraintWithOptions ::
-  -- | Identifier of the table referenced by the foreign key
+  -- | Identifier of the table referenced by the foreign key.
   TableIdentifier.TableIdentifier ->
-  -- | The field name that this field definition references in the foreign table
+  -- | The field name that this field definition references in the foreign table.
   FieldName ->
   ConstraintDefinition.ForeignKeyOptions ->
   FieldDefinition nullability a ->
@@ -341,8 +341,8 @@ addUniqueConstraint fieldDef =
     addFieldTableConstraints [constraintToAdd] fieldDef
 
 {- |
-  Mashalls a Haskell value to be stored in the field to its 'SqlValue.SqlValue'
-  representation and packages the resul as a 'Expr.ValueExression' so that
+  Marshalls a Haskell value to be stored in the field to its 'SqlValue.SqlValue'
+  representation and packages the result as a 'Expr.ValueExpression' so that
   it can be easily used with other @Expr@ functions.
 
 @since 1.0.0.0
@@ -352,7 +352,7 @@ fieldValueToExpression field =
   Expr.valueExpression . fieldValueToSqlValue field
 
 {- |
-  Mashalls a Haskell value to be stored in the field to its 'SqlValue.SqlValue'
+  Marshalls a Haskell value to be stored in the field to its 'SqlValue.SqlValue'
   representation.
 
 @since 1.0.0.0
@@ -392,7 +392,7 @@ fieldColumnReference =
   Expr.columnReference . fieldColumnName
 
 {- |
-  Constructs the equivalant 'Expr.FieldDefinition' as a SQL expression,
+  Constructs the equivalent 'Expr.FieldDefinition' as a SQL expression,
   generally for use in DDL for creating columns in a table.
 
 @since 1.0.0.0
@@ -440,7 +440,7 @@ data NullabilityGADT nullability where
 
 {- |
 
-  'NotNull' is a value-less type used to track that a 'FieldDefinition'
+  'NotNull' is a valueless type used to track that a 'FieldDefinition'
   represents a field that is marked not-null in the database schema. See the
   'FieldNullability' type for the value-level representation of field nullability.
 
@@ -449,7 +449,7 @@ data NullabilityGADT nullability where
 data NotNull
 
 {- |
-  'Nullable' is a value-less type used to track that a 'FieldDefinition'
+  'Nullable' is a valueless type used to track that a 'FieldDefinition'
   represents a field that is marked nullable in the database schema. See the
   'FieldNullability' type for the value-level representation of field nullability.
 
@@ -464,7 +464,7 @@ data Nullable
 @since 1.0.0.0
 -}
 integerField ::
-  -- | Name of the field in the database
+  -- | Name of the field in the database.
   String ->
   FieldDefinition NotNull Int32
 integerField = fieldOfType SqlType.integer
@@ -476,7 +476,7 @@ integerField = fieldOfType SqlType.integer
 @since 1.0.0.0
 -}
 smallIntegerField ::
-  -- | Name of the field in the database
+  -- | Name of the field in the database.
   String ->
   FieldDefinition NotNull Int16
 smallIntegerField = fieldOfType SqlType.smallInteger
@@ -488,7 +488,7 @@ smallIntegerField = fieldOfType SqlType.smallInteger
 @since 1.0.0.0
 -}
 serialField ::
-  -- | Name of the field in the database
+  -- | Name of the field in the database.
   String ->
   FieldDefinition NotNull Int32
 serialField = fieldOfType SqlType.serial
@@ -500,7 +500,7 @@ serialField = fieldOfType SqlType.serial
 @since 1.0.0.0
 -}
 bigIntegerField ::
-  -- | Name of the field in the database
+  -- | Name of the field in the database.
   String ->
   FieldDefinition NotNull Int64
 bigIntegerField = fieldOfType SqlType.bigInteger
@@ -512,7 +512,7 @@ bigIntegerField = fieldOfType SqlType.bigInteger
 @since 1.0.0.0
 -}
 bigSerialField ::
-  -- | Name of the field in the database
+  -- | Name of the field in the database.
   String ->
   FieldDefinition NotNull Int64
 bigSerialField = fieldOfType SqlType.bigSerial
@@ -526,7 +526,7 @@ bigSerialField = fieldOfType SqlType.bigSerial
 @since 1.0.0.0
 -}
 doubleField ::
-  -- | Name of the field in the database
+  -- | Name of the field in the database.
   String ->
   FieldDefinition NotNull Double
 doubleField = fieldOfType SqlType.double
@@ -538,7 +538,7 @@ doubleField = fieldOfType SqlType.double
 @since 1.0.0.0
 -}
 booleanField ::
-  -- | Name of the field in the database
+  -- | Name of the field in the database.
   String ->
   FieldDefinition NotNull Bool
 booleanField = fieldOfType SqlType.boolean
@@ -551,7 +551,7 @@ booleanField = fieldOfType SqlType.boolean
 @since 1.0.0.0
 -}
 unboundedTextField ::
-  -- | Name of the field in the database
+  -- | Name of the field in the database.
   String ->
   FieldDefinition NotNull T.Text
 unboundedTextField = fieldOfType SqlType.unboundedText
@@ -564,9 +564,9 @@ unboundedTextField = fieldOfType SqlType.unboundedText
 @since 1.0.0.0
 -}
 boundedTextField ::
-  -- | Name of the field in the database
+  -- | Name of the field in the database.
   String ->
-  -- | Maximum length of text in the field
+  -- | Maximum length of text in the field.
   Int32 ->
   FieldDefinition NotNull T.Text
 boundedTextField name len = fieldOfType (SqlType.boundedText len) name
@@ -580,9 +580,9 @@ boundedTextField name len = fieldOfType (SqlType.boundedText len) name
 @since 1.0.0.0
 -}
 fixedTextField ::
-  -- | Name of the field in the database
+  -- | Name of the field in the database.
   String ->
-  -- | Maximum length of text in the field
+  -- | Maximum length of text in the field.
   Int32 ->
   FieldDefinition NotNull T.Text
 fixedTextField name len = fieldOfType (SqlType.fixedText len) name
@@ -618,7 +618,7 @@ jsonbField = fieldOfType SqlType.jsonb
 @since 1.0.0.0
 -}
 dateField ::
-  -- | Name of the field in the database
+  -- | Name of the field in the database.
   String ->
   FieldDefinition NotNull Time.Day
 dateField = fieldOfType SqlType.date
@@ -630,7 +630,7 @@ dateField = fieldOfType SqlType.date
 @since 1.0.0.0
 -}
 utcTimestampField ::
-  -- | Name of the field in the database
+  -- | Name of the field in the database.
   String ->
   FieldDefinition NotNull Time.UTCTime
 utcTimestampField = fieldOfType SqlType.timestamp
@@ -642,7 +642,7 @@ utcTimestampField = fieldOfType SqlType.timestamp
 @since 1.0.0.0
 -}
 localTimestampField ::
-  -- | Name of the field in the database
+  -- | Name of the field in the database.
   String ->
   FieldDefinition NotNull Time.LocalTime
 localTimestampField = fieldOfType SqlType.timestampWithoutZone
@@ -654,7 +654,7 @@ localTimestampField = fieldOfType SqlType.timestampWithoutZone
 @since 1.0.0.0
 -}
 uuidField ::
-  -- | Name of the field in the database
+  -- | Name of the field in the database.
   String ->
   FieldDefinition NotNull UUID.UUID
 uuidField = fieldOfType SqlType.uuid
@@ -669,9 +669,9 @@ uuidField = fieldOfType SqlType.uuid
 @since 1.0.0.0
 -}
 fieldOfType ::
-  -- | 'SqlType.SqlType' that represents the PostgreSQL data type for the field
+  -- | 'SqlType.SqlType' that represents the PostgreSQL data type for the field.
   SqlType.SqlType a ->
-  -- | Name of the field in the database
+  -- | Name of the field in the database.
   String ->
   FieldDefinition NotNull a
 fieldOfType sqlType name =
@@ -771,7 +771,7 @@ convertField conversion fieldDef =
 
 {- |
   A specialization of 'convertField' that can be used with types that implement
-  'Coere.Coercible'. This is particularly useful for newtype wrappers around
+  'Coerce.Coercible'. This is particularly useful for newtype wrappers around
   primitive types.
 
 @since 1.0.0.0
@@ -787,7 +787,7 @@ coerceField =
 {- |
   Sets a default value for the field. The default value will be added as part
   of the column definition in the database. Because the default value is
-  ultimately provided by the database this can be used to add a not-null column
+  ultimately provided by the database, this can be used to add a not-null column
   safely to an existing table as long as a reasonable default value is
   available to use.
 
@@ -1078,7 +1078,7 @@ fieldTupleNotIn fieldDefA fieldDefB values =
     (fmap (toSqlValueTuple fieldDefA fieldDefB) values)
 
 {- |
-  Constructs a SqlValue "tuple" (i.e. NonEmpty list) for two fields
+  Constructs a SqlValue "tuple" (i.e. NonEmpty list) for two fields.
 
 @since 1.0.0.0
 -}
@@ -1093,7 +1093,7 @@ toSqlValueTuple fieldDefA fieldDefB (a, b) =
 
 {- |
   Constructs a field-based 'Expr.BooleanExpr' using a function that
-  builds a 'Expr.BooleanExpr'
+  builds a 'Expr.BooleanExpr'.
 
 @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Marshall/MarshallError.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Marshall/MarshallError.hs
@@ -36,15 +36,15 @@ import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 -}
 data MarshallError = MarshallError
   { marshallErrorDetailLevel :: ErrorDetailLevel
-  -- ^ The level of details that will be used to render this error as a
-  -- message if 'show' is called
+  -- ^ The level of detail that will be used to render this error as a
+  -- message if 'show' is called.
   , marshallErrorRowIdentifier :: [(B8.ByteString, SqlValue.SqlValue)]
   -- ^ The identifier of the row that caused the error. This is a list
   -- of pairs of column name and value in their raw form from the database
-  -- to avoid further possible decoding errors when reading the values
+  -- to avoid further possible decoding errors when reading the values.
   , marshallErrorDetails :: MarshallErrorDetails
   -- ^ The detailed information about the error that occurred during
-  -- decoding
+  -- decoding.
   }
 
 instance Show MarshallError where
@@ -58,14 +58,14 @@ instance Exception MarshallError
 {- |
   Renders a 'MarshallError' to a string using the specified 'ErrorDetailLevel'.
 
-  This ingores any 'ErrorDetailLevel' that was captured by default from
+  This ignores any 'ErrorDetailLevel' that was captured by default from
   the Orville context and uses the specified level of detail instead.
 
-  You may want to use this function to render certain with a higher level of
-  detail that you consider safe for (for example) you application logs while
-  using a lower default error detail level to be used with the 'Show' instance
+  You may want to use this function to render certain errors with a higher
+  level of detail than you consider safe for (for example) your application
+  logs while using a lower default error detail level with the 'Show' instance
   of 'MarshallError' in case an exception is handled in a more visible section
-  of code that return information more publicly (e.g. a request handler for a
+  of code that returns information more publicly (e.g. a request handler for a
   public endpoint).
 
 @since 1.0.0.0
@@ -121,10 +121,10 @@ presentSqlColumnValue detailLevel redacter (columnName, sqlValue) =
 @since 1.0.0.0
 -}
 data MarshallErrorDetails
-  = -- | Indicates that a one ore more values in a columns could not be decoded,
-    -- either individually or as a group
+  = -- | Indicates that one or more values in a column could not be decoded,
+    -- either individually or as a group.
     DecodingError DecodingErrorDetails
-  | -- | Indicates that an expected column was not found in the result set
+  | -- | Indicates that an expected column was not found in the result set.
     MissingColumnError MissingColumnErrorDetails
 
 {- |
@@ -140,7 +140,7 @@ renderMarshallErrorDetails detailLevel err =
     MissingColumnError details -> renderMissingColumnErrorDetails detailLevel details
 
 {- |
-  Details about an error that occurred while decoding values found a SQL
+  Details about an error that occurred while decoding values found in a SQL
   result set.
 
 @since 1.0.0.0
@@ -151,7 +151,7 @@ data DecodingErrorDetails = DecodingErrorDetails
   }
 
 {- |
-  Renders a 'DecodingErrorDetails to a 'String' with a specified
+  Renders a 'DecodingErrorDetails' to a 'String' with a specified
   'ErrorDetailLevel'.
 
 @since 1.0.0.0
@@ -173,7 +173,7 @@ renderDecodingErrorDetails detailLevel details =
       ]
 
 {- |
-  Details about an column that was found to be missing in a SQL result set
+  Details about a column that was found to be missing in a SQL result set
   during decoding.
 
 @since 1.0.0.0

--- a/orville-postgresql/src/Orville/PostgreSQL/Marshall/SqlMarshaller.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Marshall/SqlMarshaller.hs
@@ -9,9 +9,9 @@ Stability : Stable
 This module provides functions for constructing a mapping between Haskell data
 types and SQL column schemas. The 'SqlMarshaller' that represents this mapping
 can be used to serialize Haskell values both to and from SQL column sets. In
-most cases you construct a 'SqlMarshaller' as part of building you
+most cases, you construct a 'SqlMarshaller' as part of building your
 'Orville.PostgreSQL.Schema.TableDefinition' and Orville handles the rest. In
-other cases you might use a 'SqlMarshaller' with a lower-level Orville
+other cases, you might use a 'SqlMarshaller' with a lower-level Orville
 function. For instance, to decode the result set of a custom SQL query.
 
 @since 1.0.0.0
@@ -71,7 +71,7 @@ import qualified Orville.PostgreSQL.Schema.ConstraintDefinition as ConstraintDef
   An 'AnnotatedSqlMarshaller' is a 'SqlMarshaller' that contains extra
   annotations which cannot necessarily be determined from the data in the
   marshaller itself. In particular, it includes the names of fields that can be
-  used to identify a row in the database when an error is encoutered during
+  used to identify a row in the database when an error is encountered during
   decoding.
 
   Normally you will not need to interact with this type directly -- the
@@ -129,8 +129,8 @@ mapSqlMarshaller f (AnnotatedSqlMarshaller rowIdFields marshaller) =
   AnnotatedSqlMarshaller rowIdFields (f marshaller)
 
 {- |
-  'SqlMarshaller' is how we group the lowest level translation of single fields
-  into a higher level marshalling of full SQL records into Haskell records.
+  'SqlMarshaller' is how we group the lowest-level translation of single fields
+  into a higher-level marshalling of full SQL records into Haskell records.
   This is a flexible abstraction that allows us to ultimately model SQL tables
   and work with them as potentially nested Haskell records. We can then
   "marshall" the data as we want to model it in SQL and Haskell.
@@ -138,23 +138,23 @@ mapSqlMarshaller f (AnnotatedSqlMarshaller rowIdFields marshaller) =
 @since 1.0.0.0
 -}
 data SqlMarshaller a b where
-  -- | Our representation of 'pure' in the 'Applicative' sense
+  -- | Our representation of 'pure' in the 'Applicative' sense.
   MarshallPure :: b -> SqlMarshaller a b
-  -- | Representation of application like '<*>' from 'Applicative'
+  -- | Representation of application like '<*>' from 'Applicative'.
   MarshallApply :: SqlMarshaller a (b -> c) -> SqlMarshaller a b -> SqlMarshaller a c
-  -- | Nest an arbitrary function, this is used when modeling a SQL table as nested Haskell records
+  -- | Nest an arbitrary function; this is used when modeling a SQL table as nested Haskell records.
   MarshallNest :: (a -> b) -> SqlMarshaller b c -> SqlMarshaller a c
-  -- | Marshall a SQL column using the given 'FieldDefinition'
+  -- | Marshall a SQL column using the given 'FieldDefinition'.
   MarshallField :: FieldDefinition nullability a -> SqlMarshaller a a
   -- | Marshall a SQL expression on selecting using the given 'SyntheticField'
   -- to generate selects. SyntheticFields are implicitly read-only, as they
-  -- do not represent a column that can be inserted in to.
+  -- do not represent a column that can be inserted into.
   MarshallSyntheticField :: SyntheticField a -> SqlMarshaller b a
-  -- | Tag a maybe-mapped marshaller so we don't map it twice
+  -- | Tag a maybe-mapped marshaller so we don't map it twice.
   MarshallMaybeTag :: SqlMarshaller (Maybe a) (Maybe b) -> SqlMarshaller (Maybe a) (Maybe b)
-  -- | Marshall a column with a possibility of error
+  -- | Marshall a column with a possibility of error.
   MarshallPartial :: SqlMarshaller a (Either String b) -> SqlMarshaller a b
-  -- | Marshall a column that is read-only, like auto-incrementing ids
+  -- | Marshall a column that is read-only, like auto-incrementing ids.
   MarshallReadOnly :: SqlMarshaller a b -> SqlMarshaller c b
 
 instance Functor (SqlMarshaller a) where
@@ -220,8 +220,8 @@ marshallerTableConstraints marshaller =
 
 {- |
   Represents a primitive entry in a 'SqlMarshaller'. This type is used with
-  'foldMarshallerFields' to provided the entry from the mashaller to the
-  folding function to be incorporate in the result of the fold.
+  'foldMarshallerFields' to provided the entry from the marshaller to the
+  folding function to be incorporated in the result of the fold.
 
 @since 1.0.0.0
 -}
@@ -258,9 +258,9 @@ collectFromField readOnlyColumnOption fromField entry results =
       results
 
 {- |
-  Uses the field defintions in the marshaller to construct SQL expressions
-  that will set columns of the field defintions to their corresponding value
-  found in the Haskell @writeEntity@  value.
+  Uses the field definitions in the marshaller to construct SQL expressions
+  that will set columns of the field definitions to their corresponding values
+  found in the Haskell @writeEntity@ value.
 
 @since 1.0.0.0
 -}
@@ -295,7 +295,7 @@ collectSetClauses entity entry clauses =
       clauses
 
 {- |
-  Specifies whether read-only fields should be included when the function
+  Specifies whether read-only fields should be included when using functions
   such as 'collectFromField'.
 
 @since 1.0.0.0
@@ -358,11 +358,11 @@ foldMarshallerFieldsPart marshaller getPart currentResult addToResult =
       foldMarshallerFieldsPart m Nothing currentResult addToResult
 
 {- |
-  Decodes all the rows found in a execution result at once. The first row that
+  Decodes all the rows found in an execution result at once. The first row that
   fails to decode will return the 'MarshallError.MarshallErrorDetails' that
   results, otherwise all decoded rows will be returned.
 
-  Note that this function loads are decoded rows into memory at once, so it
+  Note that this function loads all decoded rows into memory at once, so it
   should only be used with result sets that you know will fit into memory.
 
 @since 1.0.0.0
@@ -387,7 +387,7 @@ marshallResultFromSql errorDetailLevel marshallerWithMeta result =
   while decoding a row, the 'RowIdentityExtractor' will be used to extract
   values to identify the row in the error details.
 
-  Note that this function loads are decoded rows into memory at once, so it
+  Note that this function loads all decoded rows into memory at once, so it
   should only be used with result sets that you know will fit into memory.
 
 @since 1.0.0.0
@@ -462,7 +462,7 @@ decodeRow errorDetailLevel (RowSource source) (RowIdentityExtractor getRowId) ro
 {- |
   A 'RowSource' can fetch and decode rows from a database result set. Using
   a 'RowSource' gives random access to the rows in the result set, only
-  attempting to decode them when they are requested by the use via 'decodeRow'.
+  attempting to decode them when they are requested by the user via 'decodeRow'.
 
   Note that even though the rows are not decoded into Haskell until 'decodeRow'
   is called, all the rows returned from the query are held in memory on the
@@ -504,7 +504,7 @@ constRowSource =
 
 {- |
   Applies a function that will be decoded from the result set to another
-  value decode from the result set.
+  value decoded from the result set.
 
 @since 1.0.0.0
 -}
@@ -731,8 +731,8 @@ newtype RowIdentityExtractor
 
 {- |
   Constructs a 'RowIdentityExtractor' that will extract values for the given
-  fields from the result set to indentify rows in decoding errors. Any of the
-  named fields that are missing from the result set not be included in the
+  fields from the result set to identify rows in decoding errors. Any of the
+  named fields that are missing from the result set will not be included in the
   extracted row identity.
 
 @since 1.0.0.0
@@ -770,8 +770,8 @@ mkRowIdentityExtractor fields result =
 
 {- |
   Builds a 'SqlMarshaller' that maps a single field of a Haskell entity to
-  a single column in the database. That value to store in the database will
-  be retried from the entity using a provided accessor function. This function
+  a single column in the database. That value to store in the database will be
+  retrieved from the entity using a provided accessor function. This function
   is intended to be used inside of a stanza of 'Applicative' syntax that will
   pass values read from the database to a constructor function to rebuild the
   entity containing the field, like so:
@@ -783,8 +783,8 @@ mkRowIdentityExtractor fields result =
   fooMarshaller :: SqlMarshaller Foo Foo
   fooMarshaller =
     Foo
-      <$> marshallField bar (integerField "bar")
-      <*> marshallField baz (unboundedTextField "baz")
+      \<$\> marshallField bar (integerField "bar")
+      \<*\> marshallField baz (unboundedTextField "baz")
 
   @
 
@@ -812,7 +812,7 @@ marshallField accessor fieldDef =
   fooMarshaller :: SqlMarshaller Void AgeCheck
   fooMarshaller =
     AgeCheck
-      <*> Orville.marshallSyntheticField atLeast21Field
+      \<*\> Orville.marshallSyntheticField atLeast21Field
 
   atLeast21Field :: SyntheticField Bool
   atLeast21Field =
@@ -854,14 +854,14 @@ marshallSyntheticField =
   personMarshaller :: SqlMarshaller Person Person
   personMarshaller =
     Person
-      <$> marshallField personId personIdField
-      <*> marshallNested personName nameMarshaller
+      \<$\> marshallField personId personIdField
+      \<*\> marshallNested personName nameMarshaller
 
   nameMarshaller :: SqlMarshaller Name Name
   nameMarshaller =
     Name
-      <$> marshallField firstName firstNameField
-      <*> marshallField lastName lastNameField
+      \<$\> marshallField firstName firstNameField
+      \<*\> marshallField lastName lastNameField
   @
 
 @since 1.0.0.0
@@ -956,7 +956,7 @@ marshallReadOnly = MarshallReadOnly
 
 {- |
   A version of 'marshallField' that uses 'marshallReadOnly' to make a single
-  read-only field. You will usually use this in conjuction with a
+  read-only field. You will usually use this in conjunction with a
   'FieldDefinition' like @serialField@ where the value is populated by the
   database.
 

--- a/orville-postgresql/src/Orville/PostgreSQL/Marshall/SqlType.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Marshall/SqlType.hs
@@ -95,7 +95,7 @@ data SqlType a = SqlType
   -- an error if the conversion is impossible. Otherwise it should return
   -- a 'Right' of the corresponding @a@ value.
   , sqlTypeDontDropImplicitDefaultDuringMigrate :: Bool
-  -- ^ The SERIAL and BIGSERIAL PostgreSQL types are really pesudo types that
+  -- ^ The SERIAL and BIGSERIAL PostgreSQL types are really pseudo-types that
   -- create an implicit default value. This flag tells Orville's auto-migration
   -- logic to ignore the default value rather than drop it as it normally would.
   }
@@ -189,8 +189,8 @@ smallInteger =
     }
 
 {- |
-  'double' defines a floating point numeric type. This corresponds to the "DOUBLE
-  PRECISION" type in SQL.
+  'double' defines a floating point numeric type. This corresponds to the
+  "DOUBLE PRECISION" type in SQL.
 
 @since 1.0.0.0
 -}
@@ -225,7 +225,7 @@ boolean =
     }
 
 {- |
-  'unboundedText' defines a unbounded length text field type. This corresponds to a
+  'unboundedText' defines an unbounded length text field type. This corresponds to a
   "TEXT" type in PostgreSQL.
 
 @since 1.0.0.0
@@ -401,7 +401,7 @@ jsonb =
 
 {- |
   'oid' corresponds to the type used in PostgreSQL for identifying system
-  objects
+  objects.
 
 @since 1.0.0.0
 -}
@@ -419,7 +419,7 @@ oid =
 
 {- |
   'foreignRefType' creates a 'SqlType' suitable for columns that will be
-  foreign keys referencing a column of the given 'SqlType'. For most types the
+  foreign keys referencing a column of the given 'SqlType'. For most types, the
   underlying SQL type will be identical, but for special types (such as
   auto-incrementing primary keys), the type constructed by 'foreignRefType' will
   have a regular underlying SQL type. Each 'SqlType' definition must specify any
@@ -436,7 +436,7 @@ foreignRefType sqlType =
 
 {- |
   'tryConvertSqlType' changes the Haskell type used by a 'SqlType' which
-  changing the column type that will be used in the database schema. The
+  changes the column type that will be used in the database schema. The
   functions given will be used to convert the now Haskell type to and from the
   original type when reading and writing values from the database. When reading
   an @a@ value from the database, the conversion function should produce 'Left'

--- a/orville-postgresql/src/Orville/PostgreSQL/Marshall/SyntheticField.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Marshall/SyntheticField.hs
@@ -38,7 +38,7 @@ data SyntheticField a = SyntheticField
 
 {- |
   Returns the SQL expression that should be used in select statements to
-  calculate the sythetic field.
+  calculate the synthetic field.
 
 @since 1.0.0.0
 -}
@@ -48,7 +48,7 @@ syntheticFieldExpression =
 
 {- |
   Returns the alias that should be used in select statements to name the
-  the synthetic field.
+  synthetic field.
 
 @since 1.0.0.0
 -}
@@ -73,11 +73,11 @@ syntheticFieldValueFromSqlValue =
 @since 1.0.0.0
 -}
 syntheticField ::
-  -- | The SQL expression to be selected
+  -- | The SQL expression to be selected.
   Expr.ValueExpression ->
-  -- | The alias to be used to name the calculation in SQL expressions
+  -- | The alias to be used to name the calculation in SQL expressions.
   String ->
-  -- | A function to decode the expression result from a 'SqlValue.SqlValue'
+  -- | A function to decode the expression result from a 'SqlValue.SqlValue'.
   (SqlValue.SqlValue -> Either String a) ->
   SyntheticField a
 syntheticField expression alias fromSqlValue =

--- a/orville-postgresql/src/Orville/PostgreSQL/Monad.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Monad.hs
@@ -7,7 +7,7 @@ Stability : Stable
 
 You can import "Orville.PostgreSQL.Monad" to get access to all the functions
 related to managing Orville context within an application Monad. This includes
-a number of lowel-level items not exported by "Orville.PostgreSQL" that give
+a number of lower-level items not exported by "Orville.PostgreSQL" that give
 you more control (and therefore responsibility) over the Monad context.
 
 @since 1.0.0.0

--- a/orville-postgresql/src/Orville/PostgreSQL/Monad/HasOrvilleState.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Monad/HasOrvilleState.hs
@@ -43,7 +43,7 @@ import Orville.PostgreSQL.OrvilleState (OrvilleState)
       localOrvilleState f (MyApplicationMonad reader) =
         MyApplicationMonad $
           local
-            (\state -> state { appOrvilleState = f (appOrvilleState state))
+            (\\state -> state { appOrvilleState = f (appOrvilleState state))
             reader
   @
 
@@ -55,7 +55,7 @@ import Orville.PostgreSQL.OrvilleState (OrvilleState)
 class HasOrvilleState m where
   -- |
   --     Fetches the current 'OrvilleState' from the host Monad context. The
-  --     equivalent of 'ask' for 'ReaderT OrvilleState'
+  --     equivalent of 'ask' for 'ReaderT OrvilleState'.
   --
   -- @since 1.0.0.0
   askOrvilleState :: m OrvilleState
@@ -64,14 +64,14 @@ class HasOrvilleState m where
   --     Applies a modification to the 'OrvilleState' that is local to the given
   --     monad operation. Calls to 'askOrvilleState' made within the 'm a' provided
   --     must return the modified state. The modified state must only apply to
-  --     the given 'm a' and not persisted beyond it. The equivalent of 'local'
-  --     for 'ReaderT OrvilleState'
+  --     the given 'm a' and not be persisted beyond it. The equivalent of 'local'
+  --     for 'ReaderT OrvilleState'.
   --
   -- @since 1.0.0.0
   localOrvilleState ::
-    -- | The function to modify the 'OrvilleState'
+    -- | The function to modify the 'OrvilleState'.
     (OrvilleState -> OrvilleState) ->
-    -- | The monad operation to execute with the modified state
+    -- | The monad operation to execute with the modified state.
     m a ->
     m a
 

--- a/orville-postgresql/src/Orville/PostgreSQL/Monad/MonadOrville.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Monad/MonadOrville.hs
@@ -35,7 +35,7 @@ import Orville.PostgreSQL.Raw.Connection (Connection, withPoolConnection)
 {- |
   'MonadOrville' is the typeclass that most Orville operations require to
   do anything that connects to the database. 'MonadOrville' itself is empty,
-  but it lists all the required typeclasses as superclass contraints so that
+  but it lists all the required typeclasses as superclass constraints so that
   it can be used instead of listing all the constraints on every function.
 
   If you want to be able to run Orville operations directly in your own
@@ -144,8 +144,8 @@ instance (MonadOrvilleControl m, MonadIO m) => MonadOrville (ReaderT OrvilleStat
   Orville.  For the "outermost" call of 'withConnection', a connection will be
   acquired from the resource pool. Additional calls to 'withConnection' that
   happen inside the 'm a' that uses the connection will return the same
-  'Connection'. When the 'm a' finishes the connection will be returned to the
-  pool. If 'm a' throws an exception the pool's exception handling will take
+  'Connection'. When the 'm a' finishes, the connection will be returned to the
+  pool. If 'm a' throws an exception, the pool's exception handling will take
   effect, generally destroying the connection in case it was the source of the
   error.
 
@@ -161,8 +161,8 @@ withConnection connectedAction = do
   even without using the handle because it ensures that all the Orville
   operations performed by the action passed to it occur on the same connection.
   Orville uses connection pooling, so unless you use either 'withConnection' or
-  'Orville.PostgreSQL.withTransaction' each database operation may be performed
-  on a different connection.
+  'Orville.PostgreSQL.withTransaction', each database operation may be
+  performed on a different connection.
 
 @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Monad/Orville.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Monad/Orville.hs
@@ -25,11 +25,11 @@ import qualified Orville.PostgreSQL.OrvilleState as OrvilleState
 import Orville.PostgreSQL.Raw.Connection (ConnectionPool)
 
 {- |
-  The 'Orville' Monad provides a easy starter implementation of
+  The 'Orville' Monad provides an easy starter implementation of
   'MonadOrville.MonadOrville' when you don't have a monad specific to your
   application that you need to use.
 
-  If you want add Orville capabilities to your own monad, take a look at
+  If you want to add Orville capabilities to your own monad, take a look at
   'MonadOrville.MonadOrville' to learn what needs to be done.
 
 @since 1.0.0.0
@@ -54,9 +54,10 @@ newtype Orville a = Orville
   pool.
 
   This will run the 'Orville' operation with the
-  'ErrorDetailLevel.ErrorDetailLevel' set to the default. If want to run with a
-  different detail level, you can use 'OrvilleState.newOrvilleState' to create
-  a state with the desired detail level and then use 'runOrvilleWithState'.
+  'ErrorDetailLevel.ErrorDetailLevel' set to the default. If you want to run
+  with a different detail level, you can use 'OrvilleState.newOrvilleState' to
+  create a state with the desired detail level and then use
+  'runOrvilleWithState'.
 
 @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/DatabaseDescription.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/DatabaseDescription.hs
@@ -101,7 +101,7 @@ data RelationDescription = RelationDescription
   }
 
 {- |
-  Find an attribute by name from the 'RelationDescription'
+  Find an attribute by name from the 'RelationDescription'.
 
 @since 1.0.0.0
 -}
@@ -113,7 +113,7 @@ lookupAttribute key =
   Map.lookup key . relationAttributes
 
 {- |
-  Find an attribute default from the 'RelationDescription'
+  Find an attribute default from the 'RelationDescription'.
 
 @since 1.0.0.0
 -}
@@ -162,7 +162,7 @@ data IndexDescription = IndexDescription
   }
 
 {- |
-  A description of an index member in the PostgreSQL database. If they member
+  A description of an index member in the PostgreSQL database. If the member
   is a simple attribute, the 'PgAttribute' for that is provided. If it is an
   index over an expression, no further description is currently provided.
 

--- a/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/OidField.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/OidField.hs
@@ -17,7 +17,7 @@ import qualified Orville.PostgreSQL as Orville
 import qualified Orville.PostgreSQL.Marshall.SqlType as SqlType
 
 {- |
-  The @oid@ field found on many (but not all!) @pg_catalog@ tables
+  The @oid@ field found on many (but not all!) @pg_catalog@ tables.
 
 @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/PgAttribute.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/PgAttribute.hs
@@ -41,7 +41,7 @@ import Orville.PostgreSQL.PgCatalog.OidField (oidTypeField)
 
 {- |
   The Haskell representation of data read from the @pg_catalog.pg_attribute@
-  table. Rows in this table correspond to table columns, but also for attributes
+  table. Rows in this table correspond to table columns, but also to attributes
   of other items from the @pg_class@ table.
 
   See also 'Orville.PostgreSQL.PgCatalog.PgClass'.
@@ -51,34 +51,36 @@ import Orville.PostgreSQL.PgCatalog.OidField (oidTypeField)
 data PgAttribute = PgAttribute
   { pgAttributeRelationOid :: LibPQ.Oid
   -- ^ The PostgreSQL @oid@ for the relation that this
-  -- attribute belongs to. References @pg_class.oid@
+  -- attribute belongs to. References @pg_class.oid@.
   , pgAttributeName :: AttributeName
-  -- ^ The name of attribute
+  -- ^ The name of the attribute.
   , pgAttributeNumber :: AttributeNumber
-  -- ^ The PostgreSQL number of attribute
+  -- ^ The PostgreSQL number of the attribute.
   , pgAttributeTypeOid :: LibPQ.Oid
   -- ^ The PostgreSQL @oid@ for the type of this attribute. References
-  -- @pg_type.oid@
+  -- @pg_type.oid@.
   , pgAttributeLength :: Int16
-  -- ^ The length of this attributes type (a copy of @pg_type.typlen@). Note
+  -- ^ The length of this attribute\'s type (a copy of @pg_type.typlen@). Note
   -- that this is _NOT_ the maximum length of a @varchar@ column!
   , pgAttributeTypeModifier :: Int32
-  -- ^ Type-specific data supplied at creation time, such as the maximum length of a @varchar@ column
+  -- ^ Type-specific data supplied at creation time, such as the maximum length
+  -- of a @varchar@ column.
   , pgAttributeIsDropped :: Bool
-  -- ^ Indicates whether the column has been dropped and is not longer valid
+  -- ^ Indicates whether the column has been dropped and is not longer valid.
   , pgAttributeIsNotNull :: Bool
-  -- ^ Indicates whether the column has a not-null constraint
+  -- ^ Indicates whether the column has a not-null constraint.
   }
 
 {- |
   Returns the maximum length for an attribute with a variable length type,
-  or 'Nothing' if the length if the type is not variable.
+  or 'Nothing' if the length of the type is not variable.
 
 @since 1.0.0.0
 -}
 pgAttributeMaxLength :: PgAttribute -> Maybe Int32
 pgAttributeMaxLength attr =
-  -- This function is a port of the follow function from _pg_char_max_length function postgresql:
+  -- This function is a port of the following function from _pg_char_max_length
+  -- function postgresql:
   --
   -- Note that it does not handle DOMAIN (user created) types correctly at the
   -- moment. Handling domain types would require loading the pg_type record and
@@ -118,7 +120,7 @@ isOrdinaryColumn attr =
   pgAttributeNumber attr > AttributeNumber 0
 
 {- |
-  A Haskell type for the name of the attribute represented by a 'PgAttribute'
+  A Haskell type for the name of the attribute represented by a 'PgAttribute'.
 
 @since 1.0.0.0
 -}
@@ -127,7 +129,7 @@ newtype AttributeName
   deriving (Show, Eq, Ord, String.IsString)
 
 {- |
-  Converts an 'AttributeName' to a plain old string
+  Converts an 'AttributeName' to a plain 'String'.
 
 @since 1.0.0.0
 -}
@@ -136,7 +138,7 @@ attributeNameToString (AttributeName txt) =
   T.unpack txt
 
 {- |
-  A Haskell type for the number of the attribute represented by a 'PgAttribute'
+  A Haskell type for the number of the attribute represented by a 'PgAttribute'.
 
 @since 1.0.0.0
 -}
@@ -145,19 +147,19 @@ newtype AttributeNumber
   deriving (Show, Eq, Ord, Enum, Num, Integral, Real)
 
 {- |
-  Converts an 'AttributeNumber' to an integer
+  Converts an 'AttributeNumber' to an integer.
 -}
 attributeNumberToInt16 :: AttributeNumber -> Int16
 attributeNumberToInt16 (AttributeNumber int) = int
 
 {- |
-  Converts an integer to an 'AttributeNumber'
+  Converts an integer to an 'AttributeNumber'.
 -}
 attributeNumberFromInt16 :: Int16 -> AttributeNumber
 attributeNumberFromInt16 = AttributeNumber
 
 {- |
-  Attoparsec parser for 'AttributeNumber'
+  Attoparsec parser for 'AttributeNumber'.
 
 @since 1.0.0.0
 -}
@@ -166,7 +168,7 @@ attributeNumberParser =
   AttoText.signed AttoText.decimal
 
 {- |
-  Encodes an 'AttributeNumber' to lazy text as a builder
+  Encodes an 'AttributeNumber' to lazy text as a builder.
 
 @since 1.0.0.0
 -}
@@ -176,7 +178,7 @@ attributeNumberTextBuilder =
 
 {- |
   An Orville 'Orville.TableDefinition' for querying the
-  @pg_catalog.pg_attribute@ table
+  @pg_catalog.pg_attribute@ table.
 
 @since 1.0.0.0
 -}
@@ -200,7 +202,7 @@ pgAttributeMarshaller =
     <*> Orville.marshallField pgAttributeIsNotNull attributeIsNotNullField
 
 {- |
-  The @attrelid@ column of the @pg_catalog.pg_attribute@ table
+  The @attrelid@ column of the @pg_catalog.pg_attribute@ table.
 
 @since 1.0.0.0
 -}
@@ -209,7 +211,7 @@ attributeRelationOidField =
   oidTypeField "attrelid"
 
 {- |
-  The @attname@ column of the @pg_catalog.pg_attribute@ table
+  The @attname@ column of the @pg_catalog.pg_attribute@ table.
 
 @since 1.0.0.0
 -}
@@ -219,7 +221,7 @@ attributeNameField =
     Orville.unboundedTextField "attname"
 
 {- |
-  The @attnum@ column of the @pg_catalog.pg_attribute@ table
+  The @attnum@ column of the @pg_catalog.pg_attribute@ table.
 
 @since 1.0.0.0
 -}
@@ -228,7 +230,7 @@ attributeNumberField =
   attributeNumberTypeField "attnum"
 
 {- |
-  Builds a 'Orville.FieldDefinition' for a field with type 'AttributeNumber'
+  Builds a 'Orville.FieldDefinition' for a field with type 'AttributeNumber'.
 
 @since 1.0.0.0
 -}
@@ -237,7 +239,7 @@ attributeNumberTypeField =
   Orville.coerceField . Orville.smallIntegerField
 
 {- |
-  The @atttypid@ column of the @pg_catalog.pg_attribute@ table
+  The @atttypid@ column of the @pg_catalog.pg_attribute@ table.
 
 @since 1.0.0.0
 -}
@@ -246,7 +248,7 @@ attributeTypeOidField =
   oidTypeField "atttypid"
 
 {- |
-  The @attlen@ column of the @pg_catalog.pg_attribute@ table
+  The @attlen@ column of the @pg_catalog.pg_attribute@ table.
 
 @since 1.0.0.0
 -}
@@ -255,7 +257,7 @@ attributeLengthField =
   Orville.smallIntegerField "attlen"
 
 {- |
-  The @atttypmod@ column of the @pg_catalog.pg_attribute@ table
+  The @atttypmod@ column of the @pg_catalog.pg_attribute@ table.
 
 @since 1.0.0.0
 -}
@@ -264,7 +266,7 @@ attributeTypeModifierField =
   Orville.integerField "atttypmod"
 
 {- |
-  The @attisdropped@ column of the @pg_catalog.pg_attribute@ table
+  The @attisdropped@ column of the @pg_catalog.pg_attribute@ table.
 
 @since 1.0.0.0
 -}
@@ -273,7 +275,7 @@ attributeIsDroppedField =
   Orville.booleanField "attisdropped"
 
 {- |
-  The @attnotnull@ column of the @pg_catalog.pg_attribute@ table
+  The @attnotnull@ column of the @pg_catalog.pg_attribute@ table.
 
 @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/PgAttributeDefault.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/PgAttributeDefault.hs
@@ -29,10 +29,10 @@ import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 -}
 data PgAttributeDefault = PgAttributeDefault
   { pgAttributeDefaultOid :: LibPQ.Oid
-  -- ^ The PostgreSQL @oid@ for the default value
+  -- ^ The PostgreSQL @oid@ for the default value.
   , pgAttributeDefaultRelationOid :: LibPQ.Oid
   -- ^ The PostgreSQL @oid@ for the relation that this
-  -- attribute belongs to. References @pg_class.oid@
+  -- attribute belongs to. References @pg_class.oid@.
   , pgAttributeDefaultAttributeNumber :: AttributeNumber
   -- ^ The PostgreSQL attribute number for the column that this
   -- default belongs to. References @pg_attribute.attnum@.
@@ -43,7 +43,7 @@ data PgAttributeDefault = PgAttributeDefault
 
 {- |
   An Orville 'Orville.TableDefinition' for querying the
-  @pg_catalog.pg_attrdef@ table
+  @pg_catalog.pg_attrdef@ table.
 
 @since 1.0.0.0
 -}
@@ -63,7 +63,7 @@ pgAttributeDefaultMarshaller =
     <*> Orville.marshallSyntheticField attributeDefaultExpressionField
 
 {- |
-  The @adrelid@ column of the @pg_catalog.pg_attrdef@ table
+  The @adrelid@ column of the @pg_catalog.pg_attrdef@ table.
 
 @since 1.0.0.0
 -}
@@ -72,7 +72,7 @@ attributeDefaultRelationOidField =
   oidTypeField "adrelid"
 
 {- |
-  The @adnum@ column of the @pg_catalog.pg_attrdef@ table
+  The @adnum@ column of the @pg_catalog.pg_attrdef@ table.
 
 @since 1.0.0.0
 -}
@@ -81,7 +81,7 @@ attributeDefaultAttributeNumberField =
   attributeNumberTypeField "adnum"
 
 {- |
-  A syntheticField for selecting the default expression by decompling the
+  A syntheticField for selecting the default expression by decompiling the
   @adbin@ column of the @pg_catalog.pg_attrdef@ table. The @pg_node_tree@ found
   in the column is decompiled by selecting the expression
   @pg_get_expr(adbin,adrelid)@.

--- a/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/PgClass.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/PgClass.hs
@@ -35,18 +35,18 @@ import Orville.PostgreSQL.PgCatalog.OidField (oidField, oidTypeField)
 -}
 data PgClass = PgClass
   { pgClassOid :: LibPQ.Oid
-  -- ^ The PostgreSQL @oid@ for the relation
+  -- ^ The PostgreSQL @oid@ for the relation.
   , pgClassNamespaceOid :: LibPQ.Oid
   -- ^ The PostgreSQL @oid@ of the namespace that the relation belongs to.
   -- References @pg_namespace.oid@.
   , pgClassRelationName :: RelationName
-  -- ^ The name of relation
+  -- ^ The name of the relation.
   , pgClassRelationKind :: RelationKind
-  -- ^ The kind of relation (table, view, etc)
+  -- ^ The kind of relation (table, view, etc).
   }
 
 {- |
-  A Haskell type for the name of the relation represented by a 'PgClass'
+  A Haskell type for the name of the relation represented by a 'PgClass'.
 
 @since 1.0.0.0
 -}
@@ -55,7 +55,7 @@ newtype RelationName
   deriving (Show, Eq, Ord, String.IsString)
 
 {- |
-  Convert a 'RelationName' to a plain 'String'
+  Convert a 'RelationName' to a plain 'String'.
 
 @since 1.0.0.0
 -}
@@ -84,7 +84,7 @@ data RelationKind
 
 {- |
   An Orville 'Orville.TableDefinition' for querying the
-  @pg_catalog.pg_class@ table
+  @pg_catalog.pg_class@ table.
 
 @since 1.0.0.0
 -}
@@ -105,7 +105,7 @@ pgClassMarshaller =
     <*> Orville.marshallField pgClassRelationKind relationKindField
 
 {- |
-  The @relnamespace@ column of the @pg_catalog.pg_class@ table
+  The @relnamespace@ column of the @pg_catalog.pg_class@ table.
 
 @since 1.0.0.0
 -}
@@ -114,7 +114,7 @@ namespaceOidField =
   oidTypeField "relnamespace"
 
 {- |
-  The @relname@ column of the @pg_catalog.pg_class@ table
+  The @relname@ column of the @pg_catalog.pg_class@ table.
 
 @since 1.0.0.0
 -}
@@ -124,7 +124,7 @@ relationNameField =
     Orville.unboundedTextField "relname"
 
 {- |
-  The @relkind@ column of the @pg_catalog.pg_class@ table
+  The @relkind@ column of the @pg_catalog.pg_class@ table.
 
 @since 1.0.0.0
 -}
@@ -159,7 +159,7 @@ relationKindToPgText kind =
 
 {- |
   Attempts to parse a PostgreSQL single character textual value as a
-  'RelationKind'
+  'RelationKind'.
 
   See also 'relationKindToPgText'
 

--- a/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/PgConstraint.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/PgConstraint.hs
@@ -31,46 +31,47 @@ import Orville.PostgreSQL.PgCatalog.PgAttribute (AttributeNumber, attributeNumbe
 
 {- |
   The Haskell representation of data read from the @pg_catalog.pg_constraint@
-  tale. Rows in this table correspond to check, primary key, unique, foreign
+  table. Rows in this table correspond to check, primary key, unique, foreign
   key and exclusion constraints on tables.
 
 @since 1.0.0.0
 -}
 data PgConstraint = PgConstraint
   { pgConstraintOid :: LibPQ.Oid
-  -- ^ The PostgreSQL @oid@ for the constraint
+  -- ^ The PostgreSQL @oid@ for the constraint.
   , pgConstraintName :: ConstraintName
-  -- ^ The constraint name (which may not be unique)
+  -- ^ The constraint name (which may not be unique).
   , pgConstraintNamespaceOid :: LibPQ.Oid
-  -- ^ The oid of the namespace that contains the constraint
+  -- ^ The oid of the namespace that contains the constraint.
   , pgConstraintType :: ConstraintType
-  -- ^ The type of constraint
+  -- ^ The type of constraint.
   , pgConstraintRelationOid :: LibPQ.Oid
   -- ^ The PostgreSQL @oid@ of the table that the constraint is on
-  -- (or @0@ if not a table constraint)
+  -- (or @0@ if not a table constraint).
   , pgConstraintIndexOid :: LibPQ.Oid
   -- ^ The PostgreSQL @oid@ ef the index supporting this constraint, if it's a
   -- unique, primary key, foreign key or exclusion constraint. Otherwise @0@.
   , pgConstraintKey :: Maybe [AttributeNumber]
   -- ^ For table constraints, the attribute numbers of the constrained columns.
-  -- These correspond to them 'Orville.PostgreSQL.PGCatalog.pgAttributeNumber'
+  -- These correspond to the 'Orville.PostgreSQL.PGCatalog.pgAttributeNumber'
   -- field of 'Orville.PostgreSQL.PGCatalog.PgAttribute'.
   , pgConstraintForeignRelationOid :: LibPQ.Oid
   -- ^ For foreign key constraints, the PostgreSQL @oid@ of the table the
-  -- foreign key references
+  -- foreign key references.
   , pgConstraintForeignKey :: Maybe [AttributeNumber]
-  -- ^ For foreignkey constraints, the attribute numbers of the referenced
+  -- ^ For foreign key constraints, the attribute numbers of the referenced
   -- columns. These correspond to the
   -- 'Orville.PostgreSQL.PGCatalog.pgAttributeNumber' field of
   -- 'Orville.PostgreSQL.PGCatalog.PgAttribute'.
   , pgConstraintForeignKeyOnUpdateType :: Maybe Orville.ForeignKeyAction
-  -- ^ For foreignkey constraints, the on update action type
+  -- ^ For foreign key constraints, the on update action type.
   , pgConstraintForeignKeyOnDeleteType :: Maybe Orville.ForeignKeyAction
-  -- ^ For foreignkey constraints, the on delete action type
+  -- ^ For foreign key constraints, the on delete action type.
   }
 
 {- |
-  A Haskell type for the name of the constraint represented by a 'PgConstraint'
+  A Haskell type for the name of the constraint represented by a
+  'PgConstraint'.
 
 @since 1.0.0.0
 -}
@@ -79,7 +80,7 @@ newtype ConstraintName
   deriving (Show, Eq, Ord, String.IsString)
 
 {- |
-  Converts an 'ConstraintName' to a plain old string
+  Converts a 'ConstraintName' to a plain 'String'.
 
 @since 1.0.0.0
 -}
@@ -89,7 +90,7 @@ constraintNameToString (ConstraintName txt) =
 
 {- |
   The type of constraint that a 'PgConstraint' represents, as described at
-  https://www.postgresql.org/docs/13/catalog-pg-constraint.html
+  https://www.postgresql.org/docs/13/catalog-pg-constraint.html.
 
 @since 1.0.0.0
 -}
@@ -180,7 +181,7 @@ pgTextToForeignKeyAction text =
 
 {- |
   An Orville 'Orville.TableDefinition' for querying the
-  @pg_catalog.pg_constraint@ table
+  @pg_catalog.pg_constraint@ table.
 
 @since 1.0.0.0
 -}
@@ -208,7 +209,7 @@ pgConstraintMarshaller =
     <*> Orville.marshallField pgConstraintForeignKeyOnDeleteType constraintForeignKeyOnDeleteTypeField
 
 {- |
-  The @conname@ column of the @pg_constraint@ table
+  The @conname@ column of the @pg_constraint@ table.
 
 @since 1.0.0.0
 -}
@@ -218,7 +219,7 @@ constraintNameField =
     Orville.unboundedTextField "conname"
 
 {- |
-  The @connamespace@ column of the @pg_constraint@ table
+  The @connamespace@ column of the @pg_constraint@ table.
 
 @since 1.0.0.0
 -}
@@ -227,7 +228,7 @@ constraintNamespaceOidField =
   oidTypeField "connamespace"
 
 {- |
-  The @contype@ column of the @pg_constraint@ table
+  The @contype@ column of the @pg_constraint@ table.
 
 @since 1.0.0.0
 -}
@@ -238,7 +239,7 @@ constraintTypeField =
     (Orville.unboundedTextField "contype")
 
 {- |
-  The @conrelid@ column of the @pg_constraint@ table
+  The @conrelid@ column of the @pg_constraint@ table.
 
 @since 1.0.0.0
 -}
@@ -247,7 +248,7 @@ constraintRelationOidField =
   oidTypeField "conrelid"
 
 {- |
-  The @conindid@ column of the @pg_constraint@ table
+  The @conindid@ column of the @pg_constraint@ table.
 
 @since 1.0.0.0
 -}
@@ -256,7 +257,7 @@ constraintIndexOidField =
   oidTypeField "conindid"
 
 {- |
-  The @conkey@ column of the @pg_constraint@ table
+  The @conkey@ column of the @pg_constraint@ table.
 
 @since 1.0.0.0
 -}
@@ -268,7 +269,7 @@ constraintKeyField =
       (Orville.unboundedTextField "conkey")
 
 {- |
-  The @confrelid@ column of the @pg_constraint@ table
+  The @confrelid@ column of the @pg_constraint@ table.
 
 @since 1.0.0.0
 -}
@@ -277,7 +278,7 @@ constraintForeignRelationOidField =
   oidTypeField "confrelid"
 
 {- |
-  The @confkey@ column of the @pg_constraint@ table
+  The @confkey@ column of the @pg_constraint@ table.
 
 @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/PgIndex.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/PgIndex.hs
@@ -25,7 +25,7 @@ import Orville.PostgreSQL.PgCatalog.OidField (oidTypeField)
 import Orville.PostgreSQL.PgCatalog.PgAttribute (AttributeNumber, attributeNumberParser, attributeNumberTextBuilder)
 
 {- |
-  The Haskell representation of data read from the @pg_catalog.pg_index@ tale.
+  The Haskell representation of data read from the @pg_catalog.pg_index@ table.
   Rows in this table contain extended information about indices. Information
   about indices is also contained in the @pg_catalog.pg_class@ table as well.
 
@@ -38,25 +38,25 @@ data PgIndex = PgIndex
   -- ^ The PostgreSQL @oid@ of the @pg_class@ entry for the table that this
   -- index is for.
   , pgIndexAttributeNumbers :: [AttributeNumber]
-  -- ^ An array of attribute numbers references the columns the table that
-  -- are included in the index. An attribute number of @0@ indicates an
+  -- ^ An array of attribute number references for the columns of the table
+  -- that are included in the index. An attribute number of @0@ indicates an
   -- expression over the table's columns rather than just a reference to a
   -- column.
   --
-  -- In PostgreSQL 11+ this includes both key columns and non-key
-  -- included columns. Orville is currently not aware of this distinction,
-  -- however.
+  -- In PostgreSQL 11+ this includes both key columns and non-key-included
+  -- columns. Orville is currently not aware of this distinction, however.
   , pgIndexIsUnique :: Bool
-  -- ^ Indicates whether this is a unique index
+  -- ^ Indicates whether this is a unique index.
   , pgIndexIsPrimary :: Bool
-  -- ^ Indicates whether this is the primary key index for the table
+  -- ^ Indicates whether this is the primary key index for the table.
   , pgIndexIsLive :: Bool
-  -- ^ When @False@, indicates that this index is in the process of being dropped and should be ignored
+  -- ^ When @False@, indicates that this index is in the process of being
+  -- dropped and should be ignored.
   }
 
 {- |
   An Orville 'Orville.TableDefinition' for querying the
-  @pg_catalog.pg_index@ table
+  @pg_catalog.pg_index@ table.
 
 @since 1.0.0.0
 -}
@@ -78,7 +78,7 @@ pgIndexMarshaller =
     <*> Orville.marshallField pgIndexIsLive indexIsLiveField
 
 {- |
-  The @indexrelid@ column of the @pg_index@ table
+  The @indexrelid@ column of the @pg_index@ table.
 
 @since 1.0.0.0
 -}
@@ -87,7 +87,7 @@ indexPgClassOidField =
   oidTypeField "indexrelid"
 
 {- |
-  The @indrelid@ column of the @pg_index@ table
+  The @indrelid@ column of the @pg_index@ table.
 
 @since 1.0.0.0
 -}
@@ -96,7 +96,7 @@ indexRelationOidField =
   oidTypeField "indrelid"
 
 {- |
-  The @indkey@ column of the @pg_index@ table
+  The @indkey@ column of the @pg_index@ table.
 
 @since 1.0.0.0
 -}
@@ -107,7 +107,7 @@ indexAttributeNumbersField =
     (Orville.unboundedTextField "indkey")
 
 {- |
-  The @indisunique@ column of the @pg_index@ table
+  The @indisunique@ column of the @pg_index@ table.
 
 @since 1.0.0.0
 -}
@@ -116,7 +116,7 @@ indexIsUniqueField =
   Orville.booleanField "indisunique"
 
 {- |
-  The @indisprimary@ column of the @pg_index@ table
+  The @indisprimary@ column of the @pg_index@ table.
 
 @since 1.0.0.0
 -}
@@ -125,7 +125,7 @@ indexIsPrimaryField =
   Orville.booleanField "indisprimary"
 
 {- |
-  The @indislive@ column of the @pg_index@ table
+  The @indislive@ column of the @pg_index@ table.
 
 @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/PgNamespace.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/PgNamespace.hs
@@ -39,7 +39,7 @@ data PgNamespace = PgNamespace
   }
 
 {- |
-  A Haskell type for the name of a namespace
+  A Haskell type for the name of a namespace.
 
 @since 1.0.0.0
 -}
@@ -48,7 +48,7 @@ newtype NamespaceName
   deriving (Show, Eq, Ord, String.IsString)
 
 {- |
-  Convert a 'NamespaceName to a plain 'String'
+  Convert a 'NamespaceName' to a plain 'String'.
 
 @since 1.0.0.0
 -}
@@ -58,7 +58,7 @@ namespaceNameToString (NamespaceName text) =
 
 {- |
   An Orville 'Orville.TableDefinition' for querying the
-  @pg_catalog.pg_namespace@ table
+  @pg_catalog.pg_namespace@ table.
 
 @since 1.0.0.0
 -}
@@ -77,7 +77,7 @@ pgNamespaceMarshaller =
     <*> Orville.marshallField pgNamespaceName namespaceNameField
 
 {- |
-  The @nspname@ column of the @pg_catalog.pg_namespace@ table
+  The @nspname@ column of the @pg_catalog.pg_namespace@ table.
 
 @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/PgSequence.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/PgSequence.hs
@@ -22,33 +22,33 @@ import Orville.PostgreSQL.PgCatalog.OidField (oidField, oidTypeField)
 
 {- |
   The Haskell representation of data read from the @pg_catalog.pg_sequence@
-  table. Rows in this table sequences in PostgreSQL.
+  table. Rows in this table are sequences in PostgreSQL.
 
 @since 1.0.0.0
 -}
 data PgSequence = PgSequence
   { pgSequenceClassOid :: LibPQ.Oid
-  -- ^ The PostgreSQL @oid@ of the @pg_class@ for this sequence
+  -- ^ The PostgreSQL @oid@ of the @pg_class@ for this sequence.
   , pgSequenceTypeOid :: LibPQ.Oid
-  -- ^ The PostgreSQL @oid@ of the data type  of the sequence. References
-  -- @pg_type.oid@
+  -- ^ The PostgreSQL @oid@ of the data type of the sequence. References
+  -- @pg_type.oid@.
   , pgSequenceStart :: Int64
-  -- ^ The start value of the sequence
+  -- ^ The start value of the sequence.
   , pgSequenceIncrement :: Int64
-  -- ^ The increment value of the sequence
+  -- ^ The increment value of the sequence.
   , pgSequenceMax :: Int64
-  -- ^ The max value of the sequence
+  -- ^ The max value of the sequence.
   , pgSequenceMin :: Int64
-  -- ^ The max value of the sequence
+  -- ^ The min value of the sequence.
   , pgSequenceCache :: Int64
-  -- ^ The cache size of the sequence
+  -- ^ The cache size of the sequence.
   , pgSequenceCycle :: Bool
-  -- ^ Wether the sequence cycles
+  -- ^ Whether the sequence cycles.
   }
 
 {- |
   An Orville 'Orville.TableDefinition' for querying the
-  @pg_catalog.pg_sequence@ table
+  @pg_catalog.pg_sequence@ table.
 
 @since 1.0.0.0
 -}
@@ -73,7 +73,7 @@ pgSequenceMarshaller =
     <*> Orville.marshallField pgSequenceCycle sequenceCycleField
 
 {- |
-  The @seqrelid@ column of the @pg_cataglog.pg_sequence@ table
+  The @seqrelid@ column of the @pg_cataglog.pg_sequence@ table.
 
 @since 1.0.0.0
 -}
@@ -82,7 +82,7 @@ sequencePgClassOidField =
   oidTypeField "seqrelid"
 
 {- |
-  The @seqtypid@ column of the @pg_catalog.pg_sequence@ table
+  The @seqtypid@ column of the @pg_catalog.pg_sequence@ table.
 
 @since 1.0.0.0
 -}
@@ -91,7 +91,7 @@ sequenceTypeOidField =
   oidTypeField "seqtypid"
 
 {- |
-  The @seqstart@ column of the @pg_catalog.pg_sequence@ table
+  The @seqstart@ column of the @pg_catalog.pg_sequence@ table.
 
 @since 1.0.0.0
 -}
@@ -100,7 +100,7 @@ sequenceStartField =
   Orville.bigIntegerField "seqstart"
 
 {- |
-  The @seqincrement@ column of the @pg_catalog.pg_sequence@ table
+  The @seqincrement@ column of the @pg_catalog.pg_sequence@ table.
 
 @since 1.0.0.0
 -}
@@ -109,7 +109,7 @@ sequenceIncrementField =
   Orville.bigIntegerField "seqincrement"
 
 {- |
-  The @seqmax@ column of the @pg_catalog.pg_sequence@ table
+  The @seqmax@ column of the @pg_catalog.pg_sequence@ table.
 
 @since 1.0.0.0
 -}
@@ -118,7 +118,7 @@ sequenceMaxField =
   Orville.bigIntegerField "seqmax"
 
 {- |
-  The @seqmin@ column of the @pg_catalog.pg_sequence@ table
+  The @seqmin@ column of the @pg_catalog.pg_sequence@ table.
 
 @since 1.0.0.0
 -}
@@ -127,7 +127,7 @@ sequenceMinField =
   Orville.bigIntegerField "seqmin"
 
 {- |
-  The @seqcache@ column of the @pg_catalog.pg_sequence@ table
+  The @seqcache@ column of the @pg_catalog.pg_sequence@ table.
 
 @since 1.0.0.0
 -}
@@ -136,7 +136,7 @@ sequenceCacheField =
   Orville.bigIntegerField "seqcache"
 
 {- |
-  The @seqcycle@ column of the @pg_catalog.pg_sequence@ table
+  The @seqcycle@ column of the @pg_catalog.pg_sequence@ table.
 
 @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Plan.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Plan.hs
@@ -77,11 +77,11 @@ import qualified Orville.PostgreSQL.Schema as Schema
   different queries based on other query results. Allowing this would prevent
   the 'Plan' structure from eliminating N+1 query loops.
 
-  Note that during execution queries are never combined across tables to form
+  Note that during execution, queries are never combined across tables to form
   joins or subqueries. Queries are still executed in the same sequence as
   specified in the plan, just on all the inputs at once rather than in a loop.
-  If you need to do a join with a plan, you can always construction your
-  own custom 'Op.Operation' and use 'planOperation' to incorporate into a plan.
+  If you need to do a join with a plan, you can always construct your own
+  custom 'Op.Operation' and use 'planOperation' to incorporate it into a plan.
 
   The @param@ type variable indicates what type of value is expected as input
   when the plan is executed.
@@ -89,11 +89,11 @@ import qualified Orville.PostgreSQL.Schema as Schema
   The @result@ type for a plan indicates what Haskell type is produced
   when the plan is executed.
 
-  The @scope@ type is used internally by Orville to track the plan is currently
-  executed against a single input or multiple inputs. This type parameter
-  should never specified as a concrete type in user code, but must be exposed
-  as a variable to ensure that execute scope is tracked correctly through
-  usages of 'bind'.
+  The @scope@ type is used internally by Orville to track how the plan is
+  currently executed against a single input or multiple inputs. This type
+  parameter should never be specified as a concrete type in user code, but must
+  be exposed as a variable to ensure that execute scope is tracked correctly
+  through usages of 'bind'.
 
 @since 1.0.0.0
 -}
@@ -129,8 +129,8 @@ instance Applicative (Plan scope param) where
   (<*>) = Apply
 
 {- |
-  'Execute' is a tag type used by as the @scope@ variable for
-  'Plan' values when executing them via the 'execute' function.
+  'Execute' is a tag type used as the @scope@ variable for 'Plan' values when
+  executing them via the 'execute' function.
 
 @since 1.0.0.0
 -}
@@ -146,8 +146,8 @@ data Execute
 data ExecuteMany
 
 {- |
-  A 'Planned' value is a wrapper around the results of previous run queries
-  when using the 'bind' function. At the time that you are writing a plan you
+  A 'Planned' value is a wrapper around the results of previously-run queries
+  when using the 'bind' function. At the time that you are writing a plan, you
   do not know whether the 'Plan' will be run with a single input or multiple
   inputs. A 'Planned' value may end up being either an individual item or a
   list of items. Due to this, your ability to interact with the value is
@@ -156,8 +156,8 @@ data ExecuteMany
   make a 'Plan' that produces the extracted value.
 
   Note that while 'Planned' could provide an 'Applicative' instance as well, it
-  does not to avoid confusion with 'Applicative' instance for 'Plan' itself.
-  If you need to build a value from several 'Planned' values using
+  does not to avoid confusion with the 'Applicative' instance for 'Plan'
+  itself. If you need to build a value from several 'Planned' values using
   'Applicative', you should call 'use' on each of the values and use the
   'Applicative' instance for 'Plan'.
 
@@ -222,7 +222,7 @@ planOperation =
 {- |
   'planSelect' allows any Orville 'Select' query to be incorporated into a
   plan. Note that the 'Select' cannot depend on the plan's input parameters in
-  this case. If the plan is executed with multiple inputs the same set of all
+  this case. If the plan is executed with multiple inputs, the same set of all
   the results will be used as the results for each of the input parameters.
 
 @since 1.0.0.0
@@ -274,11 +274,11 @@ findMaybeOneWhere tableDef fieldDef cond =
   planOperation (Op.findOneWhere tableDef (Op.byField fieldDef) cond)
 
 {- |
-  'findOneShowVia' is similar to 'findMaybeOne, but it expects that there will always
-  be a row found matching the plan's input value. If no row is found an
+  'findOneShowVia' is similar to 'findMaybeOne', but it expects that there will
+  always be a row found matching the plan's input value. If no row is found, an
   'Op.AssertionFailed' exception will be thrown. This is a useful convenience
-  when looking up foreign-key associations that are expected to be enforced
-  by the database itself.
+  when looking up foreign-key associations that are expected to be enforced by
+  the database itself.
 
 @since 1.0.0.0
 -}
@@ -295,8 +295,8 @@ findOneShowVia showParam tableDef fieldDef =
 
 {- |
   'findOne' is an alias to 'findOneShowVia' that uses the 'Show' instance of
-  @fieldValue@ when producing a failure message in the result the entity cannot
-  be found.
+  @fieldValue@ when producing a failure message in the event that the entity
+  cannot be found.
 
 @since 1.0.0.0
 -}
@@ -308,8 +308,9 @@ findOne ::
 findOne = findOneShowVia show
 
 {- |
-  'findOneWhereShowVia' is similar to 'findOneShowVia', but allows a 'Expr.BooleanExpr' to be
-  specified to restrict which rows are matched by the database query.
+  'findOneWhereShowVia' is similar to 'findOneShowVia', but allows a
+  'Expr.BooleanExpr' to be specified to restrict which rows are matched by the
+  database query.
 
 @since 1.0.0.0
 -}
@@ -326,9 +327,9 @@ findOneWhereShowVia showParam tableDef fieldDef cond =
     (findMaybeOneWhere tableDef fieldDef cond)
 
 {- |
-  'findOneWhere' is an alias to 'findOneWhereShowVia' that uses the 'Show' instance of
-  @fieldValue@ when producing a failure message in the result the entity cannot
-  be found.
+  'findOneWhere' is an alias to 'findOneWhereShowVia' that uses the 'Show'
+  instance of @fieldValue@ when producing a failure message in the event that
+  the entity cannot be found.
 
 @since 1.0.0.0
 -}
@@ -370,7 +371,7 @@ assertFound showParam tableDef fieldDef param maybeRecord =
 
 {- |
   'findAll' constructs a 'Plan' that will find all the rows from the given
-  table there the plan's input value matches the given database field.
+  table where the plan's input value matches the given database field.
 
 @since 1.0.0.0
 -}
@@ -399,7 +400,7 @@ findAllWhere tableDef fieldDef cond =
 
 {- |
   'planMany' adapts a plan that takes a single input parameter to work on
-  multiple input parameters. When the new plan is executed each query will
+  multiple input parameters. When the new plan is executed, each query will
   execute in the same basic order, but with adjusted conditions to find all the
   rows for all inputs at once rather than running the planned queries once for
   each input.
@@ -422,7 +423,7 @@ planMany =
   input parameters. This may be counter-intuitive in the trivial case where a
   plan that queries a single table is passed to 'planList' but cannot be
   avoided due to more complicated situations where the original plan executes
-  queries against multiple tables. When a plan that queries multiple table is
+  queries against multiple tables. When a plan that queries multiple tables is
   passed, the query results must be correlated based on the input parameters to
   build each @result@ value.
 
@@ -435,11 +436,11 @@ planList plan =
   Many.elems <$> planMany plan
 
 {- |
-  'focusParam' builds a plan from a function and an existing plan taking the
-  result of that function as input. This is especially useful when there is some
-  structure, and a plan that only needs a part of that structure as input. The
-  function argument can access part of the structure for the plan argument to use,
-  so the final returned plan can take the entire structure as input.
+  'focusParam' builds a plan from a function and an existing plan, taking the
+  result of that function as input. This is especially useful when there is
+  some structure, and a plan that only needs a part of that structure as input.
+  The function argument can access part of the structure for the plan argument
+  to use, so the final returned plan can take the entire structure as input.
 
 @since 1.0.0.0
 -}
@@ -453,7 +454,7 @@ focusParam focuser plan =
 {- |
   'planEither' lets you construct a plan that branches by executing a different
   plan for the 'Left' and 'Right' sides of an 'Either' value. When used with a
-  single input parameter only one of the two plans will be used, based on the
+  single input parameter, only one of the two plans will be used, based on the
   input parameter. When used on multiple input parameters, each of the two
   plans will be executed only once with all the 'Left' and 'Right' values
   provided as input parameters respectively.
@@ -484,11 +485,11 @@ planMaybe plan =
   plans. The plan result is given the input parameter to the provided function,
   which must produce the remaining 'Plan' to be executed. The value will be
   wrapped in the 'Planned' type, which may represent either a result or
-  multiple results, depending on whether one plan is currently be executed with
-  one and multiple input parameters. This ensures that the caller produces only
-  a single remaining 'Plan' to be used for all inputs when there are multiple
-  to eliminate the need to possibly run different queries for different inputs
-  (which would an introduce N+1 query execution).
+  multiple results, depending on whether one plan is currently being executed
+  with one and multiple input parameters. This ensures that the caller produces
+  only a single remaining 'Plan' to be used for all inputs when there are
+  multiple to eliminate the need to possibly run different queries for
+  different inputs (which would an introduce N+1 query execution).
 
   The 'Planned' value (or values) provided by 'bind' have actually been
   retrieved from the database, so the value can be used multiple times when
@@ -579,8 +580,8 @@ chainMaybe a b =
     Chain a (optionalInput b)
 
 {- |
-  'assert' allows you to make an assertion about a plans result that will throw
-  an 'Op.AssertionFailed' failed exception during execution if it proves to be
+  'assert' allows you to make an assertion about a plan's result that will
+  throw an 'Op.AssertionFailed' exception during execution if it proves to be
   false. The first parameter is the assertion function, which should return
   either an error message to be given in the exception or the value to be used
   as the plan's result.
@@ -735,8 +736,8 @@ executeMany plan params =
       pure $ Many.compose cs bs
 
 {- |
-  'Explain' is an tag type used as the @scope@ variable when explaining a
-  'Plan' via the 'explain' function.
+  'Explain' is a tag type used as the @scope@ variable when explaining a 'Plan'
+  via the 'explain' function.
 
 @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Plan/Many.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Plan/Many.hs
@@ -124,7 +124,7 @@ keys (Many ks _) =
   ks
 
 {- |
-  'elems' returns all the values that correspond the keys of the 'Many'. The
+  'elems' returns all the values that correspond to the keys of the 'Many'. The
   values will be returned in the same order that the keys were present at the
   time of creation, though if you truly care about this it's probably better to
   use 'lookup' to make that correspondence explicit.

--- a/orville-postgresql/src/Orville/PostgreSQL/Plan/Operation.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Plan/Operation.hs
@@ -54,7 +54,7 @@ import qualified Orville.PostgreSQL.Schema as Schema
   You only need to care about this type if you want to create new custom
   operations to include in a 'Database.Orville.PostgreSQL.Plan.Plan' beyond
   those already provided in the 'Database.Orville.PostgreSQL.Plan.Plan'
-  api.
+  API.
 
   You can build your own custom 'Operation' values either directly, or using
   the function and types in this module, such as 'WherePlanner' (via 'findAll',
@@ -68,14 +68,14 @@ data Operation param result = Operation
       Monad.MonadOrville m =>
       param ->
       m (Either AssertionFailed result)
-  -- ^ 'executeOperationOne' will be called when an plan is
-  -- executed with a single input parameter
+  -- ^ 'executeOperationOne' will be called when a plan is
+  -- executed with a single input parameter.
   , executeOperationMany ::
       forall m.
       Monad.MonadOrville m =>
       NonEmpty param ->
       m (Either AssertionFailed (Many param result))
-  -- ^ 'executeOperationMany' will be called when an plan is executed with
+  -- ^ 'executeOperationMany' will be called when a plan is executed with
   -- multiple input parameters (via 'Orville.PostgreSQL.Plan.planMany').
   , explainOperationOne :: Exp.Explanation
   -- ^ 'explainOperationOne' will be called when producing an explanation
@@ -94,7 +94,7 @@ data Operation param result = Operation
   'Operation' to indicate that some expected invariant has failed. For example,
   following a foreign key that is enforced by the database only to find that no
   record exists. When an 'Operation' returns an 'AssertionFailed' value during
-  plan execution the error is thrown as an exception using the
+  plan execution, the error is thrown as an exception using the
   'Control.Monad.Catch.MonadThrow' instance for whatever monad the plan is
   executing in.
 
@@ -116,7 +116,7 @@ mkAssertionFailed =
 instance Exception AssertionFailed
 
 {- |
-  'askParam' simply returns the paremeter given from the plan.
+  'askParam' simply returns the parameter given from the plan.
 
 @since 1.0.0.0
 -}
@@ -132,7 +132,7 @@ askParam =
 {- |
   'assertRight' returns the value on the 'Right' side of an 'Either'. If
   the 'Either' is a 'Left', it raises 'AssertionFailed' with the message
-  from the left side of the either.
+  from the 'Left' side of the 'Either'.
 
 @since 1.0.0.0
 -}
@@ -172,15 +172,15 @@ assertRight =
 {- |
   The functions below ('findOne', 'findAll', etc) accept a 'WherePlanner'
   to determine how to build the where conditions for executing a 'Exec.Select'
-  statement as part of a the plan operation.
+  statement as part of a plan operation.
 
-  For simple queries you can use the functions such as 'byField' that are
+  For simple queries, you can use the functions such as 'byField' that are
   provided here to build a 'WherePlanner', but you may also build your own
   custom 'WherePlanner' for more advanced use cases.
 
-  If you need to execute a custom query that cannot be build by providing
+  If you need to execute a custom query that cannot be built by providing a
   custom where clause via 'WherePlanner', you may want to use more
-  direct 'selectOperation' function.
+  direct 'selectOperation' functions.
 
 @since 1.0.0.0
 -}
@@ -196,17 +196,17 @@ data WherePlanner param = WherePlanner
   -- ^ 'executeManyWhereCondition' must build a where condition that will
   -- match only those rows that match any (not all!) of the input parameters.
   , explainOneWhereCondition :: Expr.BooleanExpr
-  -- ^ 'explainOneWhereCondition' must build a where condition that is
-  -- suitable to be used as an example of 'executeManyWhereCondition' would
-  -- return when given a parameter.  This where condition will be used for
-  -- when producing explanations of plans. For example, this could fill in
-  -- either an example or dummy value.
+  -- ^ 'explainOneWhereCondition' must build a where condition that is suitable
+  -- to be used as an example of what 'executeManyWhereCondition' would return
+  -- when given a parameter. This where condition will be used when producing
+  -- explanations of plans. For example, this could fill in either an example
+  -- or dummy value.
   , explainManyWhereCondition :: Expr.BooleanExpr
   -- ^ 'explainManyWhereCondition' must build a where condition that is
-  -- suitable to be used as an example of 'executeOneWhereCondition' would
-  -- return when given a list of parameters.  This where condition will be
-  -- used for when producing explanations of plans. For example, this could
-  -- fill in either an example or dummy value.
+  -- suitable to be used as an example of what 'executeOneWhereCondition' would
+  -- return when given a list of parameters. This where condition will be
+  -- used when producing explanations of plans. For example, this could fill in
+  -- either an example or dummy value.
   }
 
 {- |
@@ -294,10 +294,10 @@ dedupeFieldValues (first :| rest) =
 
 {- |
   'findOne' builds a planning primitive that finds (at most) one row from the
-  given table where the column value for the provided 'Core.FieldDefinition' matches
-  the plan's input parameter. When executed on multiple parameters it fetches
-  all rows where the field matches the inputs and arbitrarily picks at most one
-  of those rows to use as the result for each input.
+  given table where the column value for the provided 'Core.FieldDefinition'
+  matches the plan's input parameter. When executed on multiple parameters, it
+  fetches all rows where the field matches the inputs and arbitrarily picks at
+  most one of those rows to use as the result for each input.
 
 @since 1.0.0.0
 -}
@@ -326,7 +326,7 @@ findOneWhere tableDef wherePlanner cond =
   findOneWithOpts tableDef wherePlanner (Exec.where_ cond)
 
 {- |
-  'findOneWithOpts' is a internal helper used by 'findOne' and 'findOneWhere'
+  'findOneWithOpts' is a internal helper used by 'findOne' and 'findOneWhere'.
 
 @since 1.0.0.0
 -}
@@ -368,11 +368,11 @@ findOneWithOpts tableDef wherePlanner opts =
       (Schema.tableMarshaller tableDef)
 
 {- |
-  'findAll' builds a planning primitive that finds all the rows from the
-  given table where the column value for the provided field matches the
-  plan's input parameter. Where executed on multiple parameters all rows
-  are fetch in a single query and then associated with their respective
-  inputs after being fetched.
+  'findAll' builds a planning primitive that finds all the rows from the given
+  table where the column value for the provided field matches the plan's input
+  parameter. When executed on multiple parameters, all rows are fetched in a
+  single query and then associated with their respective inputs after being
+  fetched.
 
 @since 1.0.0.0
 -}
@@ -401,7 +401,7 @@ findAllWhere tableDef wherePlanner cond =
   findAllWithOpts tableDef wherePlanner (Exec.where_ cond)
 
 {- |
-  'findAllWithOpts' is an internal helper used by 'findAll' and 'findAllWhere'
+  'findAllWithOpts' is an internal helper used by 'findAll' and 'findAllWhere'.
 
 @since 1.0.0.0
 -}
@@ -461,7 +461,7 @@ stringifyField =
   'SelectOperation' is a helper type for building 'Operation' primitives that
   run 'Ex.cSelect' queries. Specifying the fields of 'SelectOperation' and then
   using the 'selectOperation' function to build an 'Operation' is more
-  convenient that building functions to execute the queries thate are required
+  convenient than building functions to execute the queries that are required
   by the 'Operation' type.
 
   Note: If you only need to build a custom where clause based on the
@@ -469,7 +469,7 @@ stringifyField =
   of the existing 'findOne' or 'findAll' functions.
 
   If you cannot respresent your custom operation using 'SelectOperation' then
-  you need build the 'Operation' value directly yourself.
+  you need to build the 'Operation' value directly yourself.
 
 @since 1.0.0.0
 -}
@@ -478,14 +478,14 @@ data SelectOperation param row result = SelectOperation
   -- ^ 'selectOne' will be called to build the 'Exec.Select' query that should
   -- be run when there is a single input parameter while executing a plan.
   -- Note that the "One-ness" here refers to the single input parameter
-  -- rather than result. See 'produceResult' below for more information
-  -- about returning one values vs. many from a 'SelectOperation'.
+  -- rather than the result. See 'produceResult' below for more information
+  -- about returning one value vs. many from a 'SelectOperation'.
   , selectMany :: NonEmpty param -> Exec.Select row
   -- ^ 'selectMany' will be called to build the 'Exec.Select' query that should
   -- be run when there are multiple parameters while executing a plan.
   -- Note that the "Many-ness" here refers to the multiple input parameters
-  -- rather than result. See 'produceResult' below for more information
-  -- about returning one values vs. many from a 'SelectOperation'.
+  -- rather than the result. See 'produceResult' below for more information
+  -- about returning one value vs. many from a 'SelectOperation'.
   , explainSelectOne :: Exec.Select row
   -- ^ 'explainSelectOne' should show a representative query of what will
   -- be returned when 'selectOne' is used. No input parameter is available
@@ -501,12 +501,12 @@ data SelectOperation param row result = SelectOperation
   -- parameters to determine which input parameter the row should be
   -- associated with.
   , produceResult :: [row] -> result
-  -- ^ 'produceResult' will be used convert the @row@ type returned by the
-  -- 'Exec.Select' queries for the operation input the @result@ type that is
+  -- ^ 'produceResult' will be used to convert the @row@ type returned by the
+  -- 'Exec.Select' queries for the operation input to the @result@ type that is
   -- present as the output of the operation. The input rows will be all the
-  -- inputs associated with a single parameter. The @result@ type
-  -- constructed here need not be a single value. For instance, 'findAll'
-  -- uses the list type as the @result@ type and 'findOne' uses 'Maybe'.
+  -- inputs associated with a single parameter. The @result@ type constructed
+  -- here need not be a single value. For instance, 'findAll' uses the list
+  -- type as the @result@ type and 'findOne' uses 'Maybe'.
   }
 
 {- |

--- a/orville-postgresql/src/Orville/PostgreSQL/Plan/Syntax.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Plan/Syntax.hs
@@ -30,9 +30,9 @@ findFooFamily = PlanSyntax.do $
   fooPets <- Plan.findAll fooPetTable fooIdField
 
   FooFamily
-    <$> Plan.use fooHeader
-    <*> Plan.use fooChildren
-    <*> Plan.use fooPets
+    \<$\> Plan.use fooHeader
+    \<*\> Plan.use fooChildren
+    \<*\> Plan.use fooPets
 @
 
 @since 1.0.0.0

--- a/orville-postgresql/src/Orville/PostgreSQL/Raw/Connection.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Raw/Connection.hs
@@ -54,7 +54,7 @@ import qualified Database.PostgreSQL.LibPQ as LibPQ
 import Orville.PostgreSQL.Raw.PgTextFormatValue (NULByteFoundError (NULByteFoundError), PgTextFormatValue, toBytesForLibPQ)
 
 {- |
-  An option for 'createConnectionPool' that indicates whether the LibPQ should
+  An option for 'createConnectionPool' that indicates whether LibPQ should
   print notice reports for warnings to the console.
 
 @since 1.0.0.0
@@ -122,23 +122,23 @@ createConnectionPool options = do
 #endif
 
 {- |
-Values for the 'connectionPoolStripes' field of 'ConnectionOptions'
+Values for the 'connectionPoolStripes' field of 'ConnectionOptions'.
 
 @since 1.0.0.0
 -}
 data StripeOption
   = -- | 'OneStripePerCapability' will cause the connection pool to be set up
     -- with one stripe for each capability (processor thread) available to the
-    -- runtime. This is the best option for multi-threaded connectin pool
+    -- runtime. This is the best option for multi-threaded connection pool
     -- performance.
     OneStripePerCapability
   | -- | 'StripeCount' will cause the connection pool to be set up with
     -- the specified number of stripes, regardless of how many capabilities
-    -- the runtime has
+    -- the runtime has.
     StripeCount Int
 
 {- |
-Values for the 'connectionMaxConnections' field of 'ConnectionOptions'
+Values for the 'connectionMaxConnections' field of 'ConnectionOptions'.
 
 @since 1.0.0.0
 -}
@@ -151,7 +151,7 @@ data MaxConnections
     MaxConnectionsTotal Int
   | -- | 'MaxConnectionsPerStripe' creates a connection pool that will
     -- allocate up to the specified number of connections in each stripe.
-    -- In this case the total possible number of simulaneous connections will
+    -- In this case the total possible number of simultaneous connections will
     -- be this value multiplied by the number of stripes.
     MaxConnectionsPerStripe Int
 
@@ -217,7 +217,7 @@ withPoolConnection (ConnectionPool pool) =
 {- |
   'executeRaw' runs a given SQL statement returning the raw underlying result.
 
- All handling of stepping through the result set is left to the caller.  This
+ All handling of stepping through the result set is left to the caller. This
  potentially leaves connections open much longer than one would expect if all
  of the results are not iterated through immediately *and* the data copied.
  Use with caution.
@@ -237,7 +237,7 @@ executeRaw connection bs params =
       underlyingExecute bs paramBytes connection
 
 {- |
-  An Orville handle for a LibPQ connection.
+  An Orville handler for a LibPQ connection.
 
 @since 1.0.0.0
 -}
@@ -248,7 +248,7 @@ newtype Connection = Connection (MVar LibPQ.Connection)
 
  This should not be exposed to end users, but instead wrapped in something to create a pool.
 
- Note that handling the libpq connection with the polling is described at
+ Note that handling the LibPQ connection with the polling is described at
  <https://hackage.haskell.org/package/postgresql-libpq-0.9.4.2/docs/Database-PostgreSQL-LibPQ.html>.
 
 @since 1.0.0.0
@@ -347,15 +347,15 @@ underlyingExecute bs params connection = do
 
 {- |
   Escapes and quotes a string for use as a literal within a SQL command that
-  will be execute on the given connection. This uses the @PQescapeStringConn@
-  function from libpq, which takes the character encoding of the connection
-  into account. Not that while @PQescapeStringConn@ does not surround the
+  will be executed on the given connection. This uses the @PQescapeStringConn@
+  function from LibPQ, which takes the character encoding of the connection
+  into account. Note that while @PQescapeStringConn@ does not surround the
   literal with quotes, this function does for the sake of symmetry with
   'quoteIdentifier'.
 
-  This function returns a `BSB.Buider` so that the result can be included in
+  This function returns a `BSB.Builder` so that the result can be included in
   a builder being constructed for the surrounding SQL command without making
-  an additional copy of the `BS.Bytestring` returned by LibPQ for the sake of
+  an additional copy of the `BS.ByteString` returned by LibPQ for the sake of
   adding the surrounding quotes.
 
 @since 1.0.0.0
@@ -377,8 +377,8 @@ quoteStringLiteral connection unquotedString = do
 
 {- |
   Escapes and quotes a string for use as an identifier within a SQL command
-  that will be execute on the given connection. This uses the
-  @PQescapeIdentifier@ function from libpq, which takes the character encoding
+  that will be executed on the given connection. This uses the
+  @PQescapeIdentifier@ function from LibPQ, which takes the character encoding
   of the connection into account and also applies the quotes.
 
   Although this function does not need to copy the `BS.ByteString` returned by
@@ -520,14 +520,14 @@ instance Exception ConnectionError
 -}
 data SqlExecutionError = SqlExecutionError
   { sqlExecutionErrorExecStatus :: Maybe LibPQ.ExecStatus
-  -- ^ The underlying LibPQ execution status
+  -- ^ The underlying LibPQ execution status.
   , sqlExecutionErrorMessage :: BS.ByteString
-  -- ^ Error message reported by PostgreSQL
+  -- ^ Error message reported by PostgreSQL.
   , sqlExecutionErrorSqlState :: Maybe BS.ByteString
   -- ^ Any SQL state value reported by PostgreSQL. This can be used to
-  -- programming determine what kind of error happening without needing to
-  -- parse the error message. See
-  -- https://www.postgresql.org/docs/current/errcodes-appendix.html
+  -- determine what kind of error happened without needing to parse the error
+  -- message. See
+  -- https://www.postgresql.org/docs/current/errcodes-appendix.html.
   , sqlExecutionErrorSqlQuery :: BS.ByteString
   -- ^ The SQL query that was being run when the error occurred.
   }

--- a/orville-postgresql/src/Orville/PostgreSQL/Raw/PgTextFormatValue.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Raw/PgTextFormatValue.hs
@@ -19,21 +19,21 @@ import Control.Exception (Exception)
 import qualified Data.ByteString as BS
 
 {- |
-  A 'PgTextFormatValue' represents raw bytes that will be passed to postgresql
-  via libpq. These bytes must conform to the TEXT format of values that
-  postgresql expects. In all cases postgresql will be allowed to infer the type
-  of the value based on its usage in the query.
+  A 'PgTextFormatValue' represents raw bytes that will be passed to PostgreSQL
+  via LibPQ. These bytes must conform to the TEXT format of values that
+  PostgreSQL expects. In all cases, PostgreSQL will be allowed to infer the
+  type of the value based on its usage in the query.
 
-  Note that postgresql does not allow NUL bytes in text values, and the LibPQ C
+  Note that PostgreSQL does not allow NUL bytes in text values, and the LibPQ C
   library expects text values to be given as NULL-terminated C Strings, so
   '\NUL' bytes cannot be included in a 'PgTextFormatValue'. If 'fromByteString'
   is used to construct the 'PgTextFormatValue' (normally what you should do),
-  an error will be raised before libpq is called to execute the query. If
+  an error will be raised before LibPQ is called to execute the query. If
   'unsafeFromByteString' is used, the caller is expected to ensure that no
   '\NUL' bytes are present. If a '\NUL' byte is included with
   'unsafeFromByteString', the value passed to the database will be truncated at
   the '\NUL' byte because it will be interpreted as the end of the C String by
-  libpq.
+  LibPQ.
 
 @since 1.0.0.0
 -}
@@ -56,7 +56,7 @@ instance Exception NULByteFoundError
   Constructs a 'PgTextFormatValue' from the given bytes directly, without checking
   whether any of the bytes are '\NUL' or not. If a 'BS.ByteString' containing
   a '\NUL' byte is given, the value will be truncated at the '\NUL' when it
-  is passed to libpq.
+  is passed to LibPQ.
 
   This function is only safe to use when you have generated the bytestring
   in a way that guarantees no '\NUL' bytes are present, such as when serializing
@@ -70,7 +70,7 @@ unsafeFromByteString =
 
 {- |
   Constructs a 'PgTextFormatValue' from the given bytes, which will be checked
-  to ensure none of them are '\NUL' before being passed to libpq. If a '\NUL'
+  to ensure none of them are '\NUL' before being passed to LibPQ. If a '\NUL'
   byte is found an error will be raised.
 
 @since 1.0.0.0
@@ -80,7 +80,7 @@ fromByteString =
   NoAssumptionsMade
 
 {- |
-  Converts the 'PgTextFormatValue' to bytes intended to be passed to libpq.
+  Converts the 'PgTextFormatValue' to bytes intended to be passed to LibPQ.
   If any '\NUL' bytes are found, 'NULByteFoundError' will be returned (unless
   'unsafeFromByteString' was used to construct the value).
 
@@ -97,7 +97,7 @@ toBytesForLibPQ value =
         else Right anyBytes
 
 {- |
-  Convents the 'PgTextFormatValue' back to the bytes that were used to
+  Converts the 'PgTextFormatValue' back to the bytes that were used to
   construct it, losing the information about whether it would be checked
   for '\NUL' bytes or not.
 

--- a/orville-postgresql/src/Orville/PostgreSQL/Raw/PgTime.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Raw/PgTime.hs
@@ -25,7 +25,7 @@ import qualified Data.Time as Time
 import qualified Data.Word as Word
 
 {- |
-  Renders a 'Time.Day' value to a textual representation for PostgreSQL
+  Renders a 'Time.Day' value to a textual representation for PostgreSQL.
 
 @since 1.0.0.0
 -}
@@ -35,7 +35,7 @@ dayToPostgreSQL =
 
 {- |
   An Attoparsec parser for parsing 'Time.Day' from YYYY-MM-DD format. Parsing
-  fails if given an invalid day.
+  fails if given an invalid 'Time.Day'.
 
 @since 1.0.0.0
 -}
@@ -50,7 +50,7 @@ day = do
       maybe (fail "invalid date format") pure $ Time.fromGregorianValid y m d
 
 {- |
-  An Attoparsec parser for parsing 2 digit integral numbers.
+  An Attoparsec parser for parsing 2-digit integral numbers.
 
 @since 1.0.0.0
 -}
@@ -64,7 +64,7 @@ fromChar :: Integral a => Char -> a
 fromChar c = fromIntegral $ Char.ord c - Char.ord '0'
 
 {- |
-  Renders a 'Time.UTCTime' value to a textual representation for PostgreSQL
+  Renders a 'Time.UTCTime' value to a textual representation for PostgreSQL.
 
 @since 1.0.0.0
 -}
@@ -73,9 +73,9 @@ utcTimeToPostgreSQL =
   B8.pack . Time.formatTime Time.defaultTimeLocale "%0Y-%m-%d %H:%M:%S%Q+00"
 
 {- |
-  An Attoparsec parser for parsing 'Time.UTCTime' from an ISO 8601 style
-  datetime and timezone with a few postgresql specific exceptions. See
-  localTime for more details
+  An Attoparsec parser for parsing 'Time.UTCTime' from an ISO-8601 style
+  datetime and timezone with a few PostgreSQL-specific exceptions. See
+  'localTime' for more details.
 
 @since 1.0.0.0
 -}
@@ -98,7 +98,7 @@ utcTime = do
       pure $ Time.addUTCTime offsetNominalDiffTime utcTimeWithoutOffset
 
 {- |
-  Renders a 'Time.LocalTime value to a textual representation for PostgreSQL
+  Renders a 'Time.LocalTime' value to a textual representation for PostgreSQL.
 
 @since 1.0.0.0
 -}
@@ -107,8 +107,8 @@ localTimeToPostgreSQL =
   B8.pack . Time.formatTime Time.defaultTimeLocale "%0Y-%m-%d %H:%M:%S%Q"
 
 {- |
-  An Attoparsec parser for parsing 'Time.LocalTime' from an ISO 8601 style
-  datetime with a few exceptions. The seperator between the date and time
+  An Attoparsec parser for parsing 'Time.LocalTime' from an ISO-8601 style
+  datetime with a few exceptions. The separator between the date and time
   is always @\' \'@ and never @\'T\'@.
 
 @since 1.0.0.0
@@ -118,7 +118,7 @@ localTime = do
   Time.LocalTime <$> day <* AttoB8.char ' ' <*> timeOfDay
 
 {- |
-  An Attoparsec parser for parsing 'Time.TimeOfDay' from an ISO 8601 style time.
+  An Attoparsec parser for parsing 'Time.TimeOfDay' from an ISO-8601 style time.
 
 @since 1.0.0.0
 -}
@@ -130,8 +130,8 @@ timeOfDay = do
   maybe (fail "invalid time format") pure $ Time.makeTimeOfDayValid h m s
 
 {- |
-  An Attoparsec parser for parsing a base 10 number and returns the number of
-  digits consumed. Based off of AttoB8.decimal.
+  An Attoparsec parser for parsing a base-10 number. Returns the number of
+  digits consumed. Based off of 'AttoB8.decimal'.
 
 @since 1.0.0.0
 -}
@@ -145,7 +145,7 @@ appendDigit a w = a * 10 + fromIntegral (w - 48)
 
 {- |
   An Attoparsec parser for parsing 'Fixed.Pico' from SS[.sss] format. This can
-  handle more resolution than postgres uses, and will truncate the seconds
+  handle more resolution than PostgreSQL uses, and will truncate the seconds
   fraction if more than 12 digits are present.
 
 @since 1.0.0.0

--- a/orville-postgresql/src/Orville/PostgreSQL/Raw/RawSql.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Raw/RawSql.hs
@@ -4,7 +4,7 @@ Copyright : Flipstone Technology Partners 2023
 License   : MIT
 Stability : Stable
 
-The funtions in this module are named with the intent that it is imported
+The functions in this module are named with the intent that it is imported
 qualified as 'RawSql'.
 
 @since 1.0.0.0
@@ -40,7 +40,7 @@ module Orville.PostgreSQL.Raw.RawSql
   , int32DecLiteral
   , int64DecLiteral
 
-    -- * Generic interface for generating sql
+    -- * Generic interface for generating SQL
   , SqlExpression (toRawSql, unsafeFromRawSql)
   , unsafeSqlExpression
   , toBytesAndParams
@@ -71,10 +71,10 @@ import Orville.PostgreSQL.Raw.SqlValue (SqlValue)
 import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 {- |
-  'RawSql' provides a type for efficiently constructing raw sql statements
-  from smaller parts and then executing them. It also supports using placeholder
-  values to pass parameters with a query without having to interpolate them
-  as part of the actual sql state and being exposed to sql injection.
+  'RawSql' provides a type for efficiently constructing raw SQL statements from
+  smaller parts and then executing them. It also supports using placeholder
+  values to pass parameters with a query without having to interpolate them as
+  part of the actual SQL state and being exposed to SQL injection.
 
 @since 1.0.0.0
 -}
@@ -99,12 +99,12 @@ instance Monoid RawSql where
  'RawSql', either via 'toRawSql' and 'unsafeFromRawSql', or the convenience
  function 'unsafeSqlExpression'. Orville defines a large number of types that
  represent various fragments of SQL statements as well as functions to help
- construct the safely. These funtions can be found in the
+ construct them safely. These functions can be found in
  'Orville.PostgreSQL.Expr'. These types all provide 'SqlExpression' instances
  as an escape hatch to allow you to pass any SQL you wish in place of what
- Orville directly supports. This should be use with great care as Orville
+ Orville directly supports. This should be used with great care as Orville
  cannot guarantee that the SQL you pass can be used to generate valid SQL in
- conjuction with the rest of the 'Orville.PostgreSQL.Expr' API.
+ conjunction with the rest of the 'Orville.PostgreSQL.Expr' API.
 
 @since 1.0.0.0
 -}
@@ -117,19 +117,18 @@ instance SqlExpression RawSql where
   unsafeFromRawSql = id
 
 {- |
-A conveinence function for creating an arbitrary 'SqlExpression' from a
-'String'. Great care should be exercised in use of this function as it cannot
+A convenience function for creating an arbitrary 'SqlExpression' from a
+'String'. Great care should be exercised when using this function as it cannot
 provide any sort of guarantee that the string passed is usable to generate
-valid SQL via the rest of Orville's 'Orville.PostgreSQL.Expr' API as the
-whatever 'SqlExpression' type is returned.
+valid SQL via the rest of Orville's 'Orville.PostgreSQL.Expr' API.
 
-For example, if one wanted build a boolean expression not support by Orville,
-you can do it like so
+For example, if one wanted build a boolean expression not supported by Orville,
+you can do it like so:
 
 > import qualified Orville.PostgreSQL.Expr as Expr
 >
 > a :: Expr.BooleanExpr
-> a RawSql.unsafeSqlExpression "foo BETWEEN 1  AND 3"
+> a RawSql.unsafeSqlExpression "foo BETWEEN 1 AND 3"
 @since 1.0.0.0
 -}
 unsafeSqlExpression :: SqlExpression a => String -> a
@@ -190,12 +189,11 @@ exampleQuoteString quoteChar =
         <> quoteBytes
 
 {- |
-  Quoting done in IO based using the quoting functions provided by the
-  connection, which can apply quoting based on the specific connection
-  properties.
+  Quoting done in IO using the quoting functions provided by the connection,
+  which can apply quoting based on the specific connection properties.
 
-  If you don't have a connection available and are only planning on using
-  the SQL for explanatory or example purposes, see 'exampleQuoting'.
+  If you don't have a connection available and are only planning on using the
+  SQL for explanatory or example purposes, see 'exampleQuoting'.
 
 @since 1.0.0.0
 -}
@@ -207,10 +205,10 @@ connectionQuoting connection =
     }
 
 {- |
-  Constructs the actual SQL bytestring and parameter values that will be
-  passed to the database to execute a 'RawSql' query. Any string
-  literals thar are included in the SQL expression will be quoting
-  using the given quoting directive.
+  Constructs the actual SQL bytestring and parameter values that will be passed
+  to the database to execute a 'RawSql' query. Any string literals that are
+  included in the SQL expression will be quoted using the given quoting
+  directive.
 
 @since 1.0.0.0
 -}
@@ -228,9 +226,9 @@ toBytesAndParams quoting sql = do
     )
 
 {- |
-  Builds the bytes that represent the raw sql. These bytes may not be executable
+  Builds the bytes that represent the raw SQL. These bytes may not be executable
   on their own, because they may contain placeholders that must be filled in,
-  but can be useful for inspecting sql queries.
+  but can be useful for inspecting SQL queries.
 
 @since 1.0.0.0
 -}
@@ -239,9 +237,9 @@ toExampleBytes =
   fst . runIdentity . toBytesAndParams exampleQuoting
 
 {- |
-  This is an internal datatype used during the sql building process to track
+  This is an internal datatype used during the SQL building process to track
   how many params have been seen so that placeholder indices (e.g. '$1', etc)
-  can be generated to include in the sql.
+  can be generated to include in the SQL.
 
 @since 1.0.0.0
 -}
@@ -280,7 +278,7 @@ snocParam (ParamsProgress count values) newValue =
   Constructs a bytestring builder that can be executed to get the bytes for a
   section of 'RawSql'. This function takes and returns a 'ParamsProgress' so
   that placeholder indices (e.g. '$1') and their corresponding parameter values
-  can be tracked across multiple sections of raw sql.
+  can be tracked across multiple sections of raw SQL.
 
 @since 1.0.0.0
 -}
@@ -312,11 +310,11 @@ buildSqlWithProgress quoting progress rawSql =
       pure (firstBuilder <> secondBuilder, finalProgress)
 
 {- |
-  Constructs a 'RawSql' from a 'String' value using utf8 encoding.
+  Constructs a 'RawSql' from a 'String' value using UTF-8 encoding.
 
-  Note that because the string is treated as raw sql it completely up to the
-  caller to protected againt sql-injections attacks when using this function.
-  Never use this function with input read from an untrusted source.
+  Note that because the string is treated as raw SQL, it is completely up to
+  the caller to protected againt SQL-injection attacks when using this
+  function. Never use this function with input read from an untrusted source.
 
 @since 1.0.0.0
 -}
@@ -325,10 +323,10 @@ fromString =
   SqlSection . BSB.stringUtf8
 
 {- |
-  Constructs a 'RawSql' from a 'T.Text' value using utf8 encoding.
+  Constructs a 'RawSql' from a 'T.Text' value using UTF-8 encoding.
 
-  Note that because the text is treated as raw sql it completely up to the
-  caller to protected againt sql-injections attacks when using this function.
+  Note that because the text is treated as raw SQL, it is completely up to the
+  caller to protected againt SQL-injection attacks when using this function.
   Never use this function with input read from an untrusted source.
 
 @since 1.0.0.0
@@ -341,9 +339,9 @@ fromText =
   Constructs a 'RawSql' from a 'BS.ByteString' value, which is assumed to be
   encoded sensibly for the database to handle.
 
-  Note that because the string is treated as raw sql it completely up to the
-  caller to protected againt sql-injections attacks when using this function.
-  Never use this function with input read from an untrusted source.
+  Note that because the string is treated as raw SQL, it is completely up to
+  the caller to protected againt SQL-injection attacks when using this
+  function. Never use this function with input read from an untrusted source.
 
 @since 1.0.0.0
 -}
@@ -353,7 +351,7 @@ fromBytes =
 
 {- |
   Includes an input parameter in the 'RawSql' statement that will be passed
-  using placeholders (e.g. '$1') rather than being included directly in the sql
+  using placeholders (e.g. '$1') rather than being included directly in the SQL
   statement. This is the correct way to include input from untrusted sources as
   part of a 'RawSql' query. The parameter must be formatted in a textual
   representation, which the database will interpret. The database type for the
@@ -366,8 +364,8 @@ parameter =
   Parameter
 
 {- |
-  Includes a bytestring value as string literal in the SQL statement. The
-  string literal will be quoted and escaped for you, the value provided should
+  Includes a bytestring value as a string literal in the SQL statement. The
+  string literal will be quoted and escaped for you; the value provided should
   not include surrounding quotes or quote special characters.
 
   Note: It's better to use the 'parameter' function where possible to pass
@@ -383,7 +381,7 @@ stringLiteral =
 
 {- |
   Includes a bytestring value as an identifier in the SQL statement. The
-  identifier will be quoted and escaped for you, the value provided should not
+  identifier will be quoted and escaped for you; the value provided should not
   include surrounding quotes or quote special characters.
 
 @since 1.0.0.0
@@ -393,8 +391,8 @@ identifier =
   Identifier
 
 {- |
-  Concatenates a list of 'RawSql' values using another 'RawSql' value as
-  the a separator between the items.
+  Concatenates a list of 'RawSql' values using another 'RawSql' value as the
+  separator between the items.
 
 @since 1.0.0.0
 -}
@@ -410,8 +408,8 @@ intercalate separator =
   to read the documentation of 'Conn.executeRaw' for caveats and warnings.
   Use with caution.
 
-  Note that because this is done in 'IO' no callback functions are available to
-  be called.
+  Note that because this is done in 'IO', no callback functions are available
+  to be called.
 
 @since 1.0.0.0
 -}
@@ -425,8 +423,8 @@ execute connection sql = do
   to read the documentation of 'Conn.executeRawVoid' for caveats and warnings.
   Use with caution.
 
-  Note that because this is done in 'IO' no callback functions are available to
-  be called.
+  Note that because this is done in 'IO', no callback functions are available
+  to be called.
 
 @since 1.0.0.0
 -}
@@ -434,42 +432,42 @@ executeVoid :: SqlExpression sql => Conn.Connection -> sql -> IO ()
 executeVoid connection sql = do
   void $ execute connection sql
 
--- | Just a plain old space, provided for convenience
+-- | Just a plain old space, provided for convenience.
 space :: RawSql
 space = fromString " "
 
--- | Just a plain old comma, provided for convenience
+-- | Just a plain old comma, provided for convenience.
 comma :: RawSql
 comma = fromString ","
 
--- | Comma space separator, provided for convenience
+-- | Comma space separator, provided for convenience.
 commaSpace :: RawSql
 commaSpace = fromString ", "
 
--- | Just a plain old left paren, provided for convenience
+-- | Just a plain old left paren, provided for convenience.
 leftParen :: RawSql
 leftParen = fromString "("
 
--- | Just a plain old right paren, provided for convenience
+-- | Just a plain old right paren, provided for convenience.
 rightParen :: RawSql
 rightParen = fromString ")"
 
--- | Just a plain period, provided for convenience
+-- | Just a plain period, provided for convenience.
 dot :: RawSql
 dot = fromString "."
 
--- | Just a plain double quote, provided for convenience
+-- | Just a plain double quote, provided for convenience.
 doubleQuote :: RawSql
 doubleQuote = fromString "\""
 
--- | Just two colons, provided for convenience
+-- | Just two colons, provided for convenience.
 doubleColon :: RawSql
 doubleColon = fromString "::"
 
 {- |
-  Constructs a 'RawSql' from an 'Int.Int8' value. The integral value is included
-  directly in the SQL string, not passed as a parameter. When dealing with user
-  input it is better to use 'parameter' rather whenever possible.
+  Constructs a 'RawSql' from an 'Int.Int8' value. The integral value is
+  included directly in the SQL string, not passed as a parameter. When dealing
+  with user input, it is better to use 'parameter' whenever possible.
 
 @since 1.0.0.0
 -}
@@ -478,9 +476,9 @@ int8DecLiteral =
   SqlSection . BSB.int8Dec
 
 {- |
-  Constructs a 'RawSql' from an 'Int.Int16' value. The integral value is included
-  directly in the SQL string, not passed as a parameter. When dealing with user
-  input it is better to use 'parameter' rather whenever possible.
+  Constructs a 'RawSql' from an 'Int.Int16' value. The integral value is
+  included directly in the SQL string, not passed as a parameter. When dealing
+  with user input, it is better to use 'parameter' whenever possible.
 
 @since 1.0.0.0
 -}
@@ -489,9 +487,9 @@ int16DecLiteral =
   SqlSection . BSB.int16Dec
 
 {- |
-  Constructs a 'RawSql' from an 'Int.Int32' value. The integral value is included
-  directly in the SQL string, not passed as a parameter. When dealing with user
-  input it is better to use 'parameter' rather whenever possible.
+  Constructs a 'RawSql' from an 'Int.Int32' value. The integral value is
+  included directly in the SQL string, not passed as a parameter. When dealing
+  with user input, it is better to use 'parameter' whenever possible.
 
 @since 1.0.0.0
 -}
@@ -500,9 +498,9 @@ int32DecLiteral =
   SqlSection . BSB.int32Dec
 
 {- |
-  Constructs a 'RawSql' from an 'Int.Int64' value. The integral value is included
-  directly in the SQL string, not passed as a parameter. When dealing with user
-  input it is better to use 'parameter' rather whenever possible.
+  Constructs a 'RawSql' from an 'Int.Int64' value. The integral value is
+  included directly in the SQL string, not passed as a parameter. When dealing
+  with user input, it is better to use 'parameter' whenever possible.
 
 @since 1.0.0.0
 -}
@@ -513,7 +511,7 @@ int64DecLiteral =
 {- |
   Constructs a 'RawSql' from an 'Int' value. The integral value is included
   directly in the SQL string, not passed as a parameter. When dealing with user
-  input it is better to use 'parameter' rather whenever possible.
+  input, it is better to use 'parameter' whenever possible.
 
 @since 1.0.0.0
 -}
@@ -523,8 +521,8 @@ intDecLiteral =
 
 {- |
   Constructs a 'RawSql' by putting parentheses around an arbitrary expression.
-  The result is returned as a 'RawSql'. It is up to the caller to decide whether
-  it should be wrapped in a more specific expression type.
+  The result is returned as a 'RawSql'. It is up to the caller to decide
+  whether it should be wrapped in a more-specific expression type.
 
 @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Raw/SqlValue.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Raw/SqlValue.hs
@@ -4,7 +4,7 @@ Copyright : Flipstone Technology Partners 2023
 License   : MIT
 Stability : Stable
 
-The funtions in this module are named with the intent that it is imported
+The functions in this module are named with the intent that it is imported
 qualified as 'SqlValue'.
 
 @since 1.0.0.0
@@ -70,9 +70,9 @@ import qualified Orville.PostgreSQL.Raw.PgTime as PgTime
 
 {- |
   'SqlValue' represents a value that is in encoded format for use with LibPQ.
-  It is used both for values passed to LibPQ and values parse from LibPQ. The
-  conversions functions in "Orville.PostgreSQL.Raw.SqlValue" can be used
-  to convert to and from the value.
+  It is used both for values passed to LibPQ and values parsed from LibPQ. The
+  conversion functions in "Orville.PostgreSQL.Raw.SqlValue" can be used to
+  convert to and from the value.
 
 @since 1.0.0.0
 -}
@@ -82,7 +82,7 @@ data SqlValue
   deriving (Eq)
 
 {- |
-  Checks whether the 'SqlValue' represents a sql NULL value in the database.
+  Checks whether the 'SqlValue' represents a SQL NULL value in the database.
 
 @since 1.0.0.0
 -}
@@ -93,8 +93,8 @@ isSqlNull sqlValue =
     SqlNull -> True
 
 {- |
-  A value of 'SqlValue' that will be interpreted as a sql NULL value when
-  pasesed to the database.
+  A value of 'SqlValue' that will be interpreted as a SQL NULL value when
+  passed to the database.
 
 @since 1.0.0.0
 -}
@@ -105,8 +105,8 @@ sqlNull =
 {- |
   Converts a 'SqlValue' to its underlying raw bytes as it will be represented
   when sent to the database. The output should be recognizable as similar to
-  to values you would write in query. If the value represents a sql NULL
-  value, 'Nothing' is returned
+  values you would write in a query. If the value represents a SQL NULL value,
+  'Nothing' is returned.
 
 @since 1.0.0.0
 -}
@@ -119,12 +119,12 @@ toPgValue sqlValue =
       Nothing
 
 {- |
-  Creates a 'SqlValue' from a raw byte string as if the bytes had returned
-  by the database. This function does not interpret the bytes in any way,
-  but the using decode functions on them might fail depending on whether the
-  bytes can be parsed as the requested type.
+  Creates a 'SqlValue' from a raw bytestring as if the bytes had been returned
+  by the database. This function does not interpret the bytes in any way, but
+  using decode functions on them might fail depending on whether the bytes can
+  be parsed as the requested type.
 
-  Note: A value to represent a sql NULL cannot be constructed using this
+  Note: A value to represent a SQL NULL cannot be constructed using this
   function. See 'fromRawBytesNullable' for how to represent a nullable
   raw value.
 
@@ -135,9 +135,9 @@ fromRawBytes =
   SqlValue . PgTextFormatValue.fromByteString
 
 {- |
-  Creates a 'SqlValue' from a raw byte string. If 'Nothing' is specified as the
+  Creates a 'SqlValue' from a raw bytestring. If 'Nothing' is specified as the
   input parameter then the resulting 'SqlValue' will represent a NULL value in
-  sql. Otherwise the bytes given are used in the same way as 'fromRawBytes'
+  SQL. Otherwise, the bytes given are used in the same way as 'fromRawBytes'.
 
 @since 1.0.0.0
 -}
@@ -146,7 +146,7 @@ fromRawBytesNullable =
   maybe sqlNull fromRawBytes
 
 {- |
-  Encodes an 'Int8' value for usage with database
+  Encodes an 'Int8' value for use with the database.
 
 @since 1.0.0.0
 -}
@@ -155,7 +155,7 @@ fromInt8 =
   fromBSBuilderWithNoNULs BSB.int8Dec
 
 {- |
-  Attempts to decode a 'SqlValue' as a Haskell 'Int8' value. If decoding fails
+  Attempts to decode a 'SqlValue' as a Haskell 'Int8' value. If decoding fails,
   'Nothing' is returned.
 
 @since 1.0.0.0
@@ -165,7 +165,7 @@ toInt8 =
   toParsedValue (AttoB8.signed AttoB8.decimal)
 
 {- |
-  Encodes an 'Int16' value for usage with database
+  Encodes an 'Int16' value for use with the database.
 
 @since 1.0.0.0
 -}
@@ -174,8 +174,8 @@ fromInt16 =
   fromBSBuilderWithNoNULs BSB.int16Dec
 
 {- |
-  Attempts to decode a 'SqlValue' as a Haskell 'Int16' value. If decoding fails
-  'Nothing' is returned.
+  Attempts to decode a 'SqlValue' as a Haskell 'Int16' value. If decoding
+  fails, 'Nothing' is returned.
 
 @since 1.0.0.0
 -}
@@ -184,7 +184,7 @@ toInt16 =
   toParsedValue (AttoB8.signed AttoB8.decimal)
 
 {- |
-  Encodes an 'Int32' value for usage with database
+  Encodes an 'Int32' value for use with the database.
 
 @since 1.0.0.0
 -}
@@ -193,8 +193,8 @@ fromInt32 =
   fromBSBuilderWithNoNULs BSB.int32Dec
 
 {- |
-  Attempts to decode a 'SqlValue' as a Haskell 'Int32' value. If decoding fails
-  'Nothing' is returned.
+  Attempts to decode a 'SqlValue' as a Haskell 'Int32' value. If decoding
+  fails, 'Nothing' is returned.
 
 @since 1.0.0.0
 -}
@@ -203,7 +203,7 @@ toInt32 =
   toParsedValue (AttoB8.signed AttoB8.decimal)
 
 {- |
-  Encodes an 'Int64' value for usage with database
+  Encodes an 'Int64' value for use with the database.
 
 @since 1.0.0.0
 -}
@@ -212,7 +212,7 @@ fromInt64 =
   fromBSBuilderWithNoNULs BSB.int64Dec
 
 {- |
-  Attempts to decode a 'SqlValue' as a Haskell 'Int' value. If decoding fails
+  Attempts to decode a 'SqlValue' as a Haskell 'Int' value. If decoding fails,
   'Nothing' is returned.
 
 @since 1.0.0.0
@@ -222,7 +222,7 @@ toInt64 =
   toParsedValue (AttoB8.signed AttoB8.decimal)
 
 {- |
-  Encodes an 'Int' value for usage with database
+  Encodes an 'Int' value for use with the database.
 
 @since 1.0.0.0
 -}
@@ -231,7 +231,7 @@ fromInt =
   fromBSBuilderWithNoNULs BSB.intDec
 
 {- |
-  Attempts to decode a 'SqlValue' as a Haskell 'Int' value. If decoding fails
+  Attempts to decode a 'SqlValue' as a Haskell 'Int' value. If decoding fails,
   'Nothing' is returned.
 
 @since 1.0.0.0
@@ -241,7 +241,7 @@ toInt =
   toParsedValue (AttoB8.signed AttoB8.decimal)
 
 {- |
-  Encodes an 'Word8' value for usage with database
+  Encodes a 'Word8' value for use with the database.
 
 @since 1.0.0.0
 -}
@@ -250,8 +250,8 @@ fromWord8 =
   fromBSBuilderWithNoNULs BSB.word8Dec
 
 {- |
-  Attempts to decode a 'SqlValue' as a Haskell 'Word8' value. If decoding fails
-  'Nothing' is returned.
+  Attempts to decode a 'SqlValue' as a Haskell 'Word8' value. If decoding
+  fails, 'Nothing' is returned.
 
 @since 1.0.0.0
 -}
@@ -260,7 +260,7 @@ toWord8 =
   toParsedValue (AttoB8.signed AttoB8.decimal)
 
 {- |
-  Encodes an 'Word16' value for usage with database
+  Encodes a 'Word16' value for use with the database.
 
 @since 1.0.0.0
 -}
@@ -269,8 +269,8 @@ fromWord16 =
   fromBSBuilderWithNoNULs BSB.word16Dec
 
 {- |
-  Attempts to decode a 'SqlValue' as a Haskell 'Word16' value. If decoding fails
-  'Nothing' is returned.
+  Attempts to decode a 'SqlValue' as a Haskell 'Word16' value. If decoding
+  fails, 'Nothing' is returned.
 
 @since 1.0.0.0
 -}
@@ -279,7 +279,7 @@ toWord16 =
   toParsedValue (AttoB8.signed AttoB8.decimal)
 
 {- |
-  Encodes an 'Word32' value for usage with database
+  Encodes a 'Word32' value for use with the database.
 
 @since 1.0.0.0
 -}
@@ -288,8 +288,8 @@ fromWord32 =
   fromBSBuilderWithNoNULs BSB.word32Dec
 
 {- |
-  Attempts to decode a 'SqlValue' as a Haskell 'Word32' value. If decoding fails
-  'Nothing' is returned.
+  Attempts to decode a 'SqlValue' as a Haskell 'Word32' value. If decoding
+  fails, 'Nothing' is returned.
 
 @since 1.0.0.0
 -}
@@ -298,7 +298,7 @@ toWord32 =
   toParsedValue (AttoB8.signed AttoB8.decimal)
 
 {- |
-  Encodes an 'Word64' value for usage with database
+  Encodes a 'Word64' value for use with the database.
 
 @since 1.0.0.0
 -}
@@ -307,8 +307,8 @@ fromWord64 =
   fromBSBuilderWithNoNULs BSB.word64Dec
 
 {- |
-  Attempts to decode a 'SqlValue' as a Haskell 'Word64' value. If decoding fails
-  'Nothing' is returned.
+  Attempts to decode a 'SqlValue' as a Haskell 'Word64' value. If decoding
+  fails, 'Nothing' is returned.
 
 @since 1.0.0.0
 -}
@@ -317,7 +317,7 @@ toWord64 =
   toParsedValue (AttoB8.signed AttoB8.decimal)
 
 {- |
-  Encodes an 'Word' value for usage with database
+  Encodes a 'Word' value for use with the database.
 
 @since 1.0.0.0
 -}
@@ -326,7 +326,7 @@ fromWord =
   fromBSBuilderWithNoNULs BSB.wordDec
 
 {- |
-  Attempts to decode a 'SqlValue' as a Haskell 'Word' value. If decoding fails
+  Attempts to decode a 'SqlValue' as a Haskell 'Word' value. If decoding fails,
   'Nothing' is returned.
 
 @since 1.0.0.0
@@ -336,7 +336,7 @@ toWord =
   toParsedValue (AttoB8.signed AttoB8.decimal)
 
 {- |
-  Encodes a 'Double' value for usage with database
+  Encodes a 'Double' value for use with the database.
 
 @since 1.0.0.0
 -}
@@ -345,8 +345,8 @@ fromDouble =
   fromBSBuilderWithNoNULs BSB.doubleDec
 
 {- |
-  Attempts to decode a 'SqlValue' as a Haskell 'Double' value. If decoding fails
-  'Nothing' is returned.
+  Attempts to decode a 'SqlValue' as a Haskell 'Double' value. If decoding
+  fails, 'Nothing' is returned.
 
 @since 1.0.0.0
 -}
@@ -355,7 +355,7 @@ toDouble =
   toParsedValue (AttoB8.signed AttoB8.double)
 
 {- |
-  Encodes a 'Bool' value for usage with database
+  Encodes a 'Bool' value for use with the database.
 
 @since 1.0.0.0
 -}
@@ -367,7 +367,7 @@ fromBool =
       False -> BSB.char8 'f'
 
 {- |
-  Attempts to decode a 'SqlValue' as a Haskell 'Bool' value. If decoding fails
+  Attempts to decode a 'SqlValue' as a Haskell 'Bool' value. If decoding fails,
   'Nothing' is returned.
 
 @since 1.0.0.0
@@ -382,7 +382,7 @@ toBool =
       _ -> fail "Invalid boolean character value"
 
 {- |
-  Encodes a 'T.Text' value as utf8 so that it can be used with the database.
+  Encodes a 'T.Text' value as UTF-8 so that it can be used with the database.
 
 @since 1.0.0.0
 -}
@@ -395,7 +395,7 @@ fromText =
   'Nothing' is returned.
 
   Note: This decoding _only_ fails if the bytes returned from the database
-  are not a value UTF-8 sequence of bytes. Otherwise it always succeeds.
+  are not a valid UTF-8 sequence of bytes. Otherwise it always succeeds.
 
 @since 1.0.0.0
 -}
@@ -418,7 +418,7 @@ fromDay =
 
 {- |
   Attempts to decode a 'SqlValue' as into a 'Time.Day' value by parsing it
-  from YYYY-MM-DD format. If the decoding fails 'Nothing' is returned.
+  from YYYY-MM-DD format. If the decoding fails, 'Nothing' is returned.
 
 @since 1.0.0.0
 -}
@@ -427,7 +427,7 @@ toDay =
   toParsedValue PgTime.day
 
 {- |
-  Encodes a 'Time.UTCTime' in ISO 8601 format for usage with the database.
+  Encodes a 'Time.UTCTime' in ISO-8601 format for use with the database.
 
 @since 1.0.0.0
 -}
@@ -438,7 +438,7 @@ fromUTCTime =
     . PgTime.utcTimeToPostgreSQL
 
 {- |
-  Encodes a 'Time.LocalTime' in ISO 8601 format for usage with the database.
+  Encodes a 'Time.LocalTime' in ISO-8601 format for use with the database.
 
 @since 1.0.0.0
 -}
@@ -449,8 +449,8 @@ fromLocalTime =
     . PgTime.localTimeToPostgreSQL
 
 {- |
-  Attempts to decode a 'SqlValue' as a 'Time.LocalTime' formatted in iso8601
-  format in the default Local. If the decoding fails, 'Nothing' is returned.
+  Attempts to decode a 'SqlValue' as a 'Time.LocalTime' formatted in ISO-8601
+  format in the default locale. If the decoding fails, 'Nothing' is returned.
 
 @since 1.0.0.0
 -}
@@ -459,7 +459,7 @@ toLocalTime =
   toParsedValue PgTime.localTime
 
 {- |
-  Attempts to decode a 'SqlValue' as a 'Time.UTCTime' formatted in iso8601
+  Attempts to decode a 'SqlValue' as a 'Time.UTCTime' formatted in ISO-8601
   format with time zone. If the decoding fails, 'Nothing' is returned.
 
 @since 1.0.0.0
@@ -469,7 +469,8 @@ toUTCTime =
   toParsedValue PgTime.utcTime
 
 {- |
-  A internal helper function that constructs a 'SqlValue' via a byte string builder
+  An internal helper function that constructs a 'SqlValue' via a bytestring
+  'BS8.Builder'.
 
 @since 1.0.0.0
 -}
@@ -482,7 +483,7 @@ fromBSBuilderWithNoNULs builder =
     . builder
 
 {- |
-  A internal helper function that parses 'SqlValue' via an Attoparsec parser.
+  An internal helper function that parses 'SqlValue' via an Attoparsec parser.
 
 @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema.hs
@@ -6,7 +6,7 @@ License   : MIT
 Stability : Stable
 
 You can import "Orville.PostgreSQL.Schema" to get access to all the functions
-related to representing a SQL schema. This includes a number of lowel-level
+related to representing a SQL schema. This includes a number of lower-level
 items not exported by "Orville.PostgreSQL" that give you more control (and
 therefore responsibility) over the definition of the schema.
 

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/ConstraintDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/ConstraintDefinition.hs
@@ -39,9 +39,9 @@ import qualified Orville.PostgreSQL.Internal.FieldName as FieldName
 import qualified Orville.PostgreSQL.Schema.TableIdentifier as TableIdentifier
 
 {- |
-  A collection of constraints to be able to a table. This collection is indexed
-  by 'ConstraintMigrationKey'. If multiple constraints with the same
-  'ConstraintMigrationKey' are added the most recently added one will be kept
+  A collection of constraints to be added to a table. This collection is
+  indexed by 'ConstraintMigrationKey'. If multiple constraints with the same
+  'ConstraintMigrationKey' are added, the most recently-added one will be kept
   and the previous one dropped.
 
 @since 1.0.0.0
@@ -51,7 +51,7 @@ newtype TableConstraints
   deriving (Semigroup, Monoid)
 
 {- |
-  Constructs an empty 'TableConstraints'
+  Constructs an empty 'TableConstraints'.
 
 @since 1.0.0.0
 -}
@@ -60,7 +60,7 @@ emptyTableConstraints = TableConstraints Map.empty
 
 {- |
   Adds a 'ConstraintDefinition' to an existing 'TableConstraints'. If a
-  constraint already exists with the same 'ConstraintMigrationKey' it is
+  constraint already exists with the same 'ConstraintMigrationKey', it is
   replaced with the new constraint.
 
 @since 1.0.0.0
@@ -75,7 +75,7 @@ addConstraint constraint (TableConstraints constraintMap) =
 
 {- |
   Gets the list of 'ConstraintDefinition's that have been added to the
-  'TableConstraints'
+  'TableConstraints'.
 
 @since 1.0.0.0
 -}
@@ -85,7 +85,7 @@ tableConstraintKeys (TableConstraints constraints) =
 
 {- |
   Gets the list of 'ConstraintDefinition's that have been added to the
-  'TableConstraints'
+  'TableConstraints'.
 
 @since 1.0.0.0
 -}
@@ -110,7 +110,7 @@ data ConstraintDefinition = ConstraintDefinition
 
 {- |
   The key used by Orville to determine whether a constraint should be added to
-  a table when performing auto migrations. For most use cases the constructor
+  a table when performing auto-migrations. For most use cases, the constructor
   functions that build a 'ConstraintDefinition' will create this automatically
   for you.
 
@@ -127,7 +127,8 @@ data ConstraintMigrationKey = ConstraintMigrationKey
   deriving (Eq, Ord, Show)
 
 {- |
-  The kind of constraint that is described by a 'ConstraintMigrationKey' (e.g. unique, foreign key).
+  The kind of constraint that is described by a 'ConstraintMigrationKey' (e.g.
+  unique, foreign key).
 
 @since 1.0.0.0
 -}
@@ -197,9 +198,9 @@ data ForeignReference = ForeignReference
 @since 1.0.0.0
 -}
 foreignReference ::
-  -- | The name of the field in the table with the constraint
+  -- | The name of the field in the table with the constraint.
   FieldName.FieldName ->
-  -- | The name of the field in the foreign table that the local field references
+  -- | The name of the field in the foreign table that the local field references.
   FieldName.FieldName ->
   ForeignReference
 foreignReference localName foreignName =
@@ -209,9 +210,8 @@ foreignReference localName foreignName =
     }
 
 {- |
-  Defines the options for a foreign key constraint.
-  To construct 'ForeignKeyOptions', perform a record update on
-  'defaultForeignKeyOptions'.
+  Defines the options for a foreign key constraint. To construct
+  'ForeignKeyOptions', perform a record update on 'defaultForeignKeyOptions'.
 
 @since 1.0.0.0
 -}
@@ -262,24 +262,24 @@ foreignKeyActionToExpr action = case action of
 @since 1.0.0.0
 -}
 foreignKeyConstraint ::
-  -- | Identifier of the table referenced by the foreign key
+  -- | Identifier of the table referenced by the foreign key.
   TableIdentifier.TableIdentifier ->
-  -- | The columns constrained by the foreign key and those that they reference in the foreign table
+  -- | The columns constrained by the foreign key and those that they reference in the foreign table.
   NonEmpty ForeignReference ->
   ConstraintDefinition
 foreignKeyConstraint foreignTableId foreignReferences =
   foreignKeyConstraintWithOptions foreignTableId foreignReferences defaultForeignKeyOptions
 
 {- |
-  Builds a 'ConstraintDefinition' for a @FOREIGN KEY@ constraint, with ON UPDATE and
-  ON DELETE actions.
+  Builds a 'ConstraintDefinition' for a @FOREIGN KEY@ constraint, with
+  ON UPDATE and ON DELETE actions.
 
 @since 1.0.0.0
 -}
 foreignKeyConstraintWithOptions ::
-  -- | Identifier of the table referenced by the foreign key
+  -- | Identifier of the table referenced by the foreign key.
   TableIdentifier.TableIdentifier ->
-  -- | The columns constrained by the foreign key and those that they reference in the foreign table
+  -- | The columns constrained by the foreign key and those that they reference in the foreign table.
   NonEmpty ForeignReference ->
   ForeignKeyOptions ->
   ConstraintDefinition

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/PrimaryKey.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/PrimaryKey.hs
@@ -45,7 +45,7 @@ data PrimaryKey key
 {- |
   A 'PrimaryKeyPart' describes one field of a composite primary key. Values
   are built using 'primaryKeyPart' and then used with 'compositePrimaryKey'
-  to build a 'PrimaryKey'
+  to build a 'PrimaryKey'.
 
 @since 1.0.0.0
 -}
@@ -82,7 +82,7 @@ primaryKeyFieldNames =
 
 {- |
   'primaryKeyToSql' converts a Haskell value for a primary key into the
-  (possibly multiple) sql values that represent the primary key in the
+  (possibly multiple) SQL values that represent the primary key in the
   database.
 
 @since 1.0.0.0
@@ -114,7 +114,7 @@ primaryKey fieldDef =
 
 {- |
   'compositePrimaryKey' constructs a multi-field primary key from the given
-  parts, each of which corresponds to one field in the primary key.  You should
+  parts, each of which corresponds to one field in the primary key. You should
   use this while building a 'Orville.PostgreSQL.TableDefinition' for a table
   that you want to have a multi-column primary key. See 'primaryKeyPart' for
   how to build the parts to be passed as parameters. Note: there is no special
@@ -151,7 +151,7 @@ primaryKeyPart =
   definition to extract information. The given function will be called on
   each part of the primary key in order and the list of results is returned.
   Note that single-field and multi-field primary keys are treated the same by
-  this function, with the single-field case simply behaving as composite key
+  this function, with the single-field case simply behaving as a composite key
   with just one part.
 
 @since 1.0.0.0
@@ -187,9 +187,9 @@ mkPrimaryKeyExpr keyDef =
 
 {- |
   'primaryKeyEquals' builds a 'Expr.BooleanExpr' that will match the row where
-  the primary key is equal to the given value. For single-field primary keys
-  this is equivalent to 'fieldEquals', but 'primaryKeyEquals' also handles composite
-  primary keys.
+  the primary key is equal to the given value. For single-field primary keys,
+  this is equivalent to 'fieldEquals', but 'primaryKeyEquals' also handles
+  composite primary keys.
 
 @since 1.0.0.0
 -}
@@ -200,8 +200,8 @@ primaryKeyEquals keyDef key =
     (mapPrimaryKeyParts (partEquals key) keyDef)
 
 {- |
-  'primaryKeyIn' builds a 'Expr.BooleanExpr' that will match rows where
-  the primary key is contained the given list. For single-field primary keys
+  'primaryKeyIn' builds a 'Expr.BooleanExpr' that will match rows where the
+  primary key is contained in the given list. For single-field primary keys,
   this is equivalent to 'fieldIn', but 'primaryKeyIn' also handles composite
   primary keys.
 

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/SequenceDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/SequenceDefinition.hs
@@ -72,7 +72,7 @@ mkSequenceDefinition name =
     }
 
 {- |
-  Sets the sequence's schema to the name in the given string, which will be
+  Sets the sequence's schema to the name in the given 'String', which will be
   treated as a SQL identifier. If a sequence has a schema name set, it will be
   included as a qualifier on the sequence name for all queries involving the
   sequence.
@@ -121,8 +121,8 @@ sequenceIncrement = i_sequenceIncrement
   @0@ (PostgreSQL will raise an error when trying to create or modify the
   sequence in this case).
 
-  If the increment is negative the sequence will be descending. When no
-  explicit start is set a descending sequence begins at the max value.
+  If the increment is negative, the sequence will be descending. When no
+  explicit start is set, a descending sequence begins at the max value.
 
 @since 1.0.0.0
 -}
@@ -131,7 +131,7 @@ setSequenceIncrement n sequenceDef =
   sequenceDef {i_sequenceIncrement = n}
 
 {- |
-  Retrieves the min value of the sequence. If no explicit minimum has been set
+  Retrieves the min value of the sequence. If no explicit minimum has been set,
   this returns @1@ for ascending sequences and 'minBound' for 'Int64' for
   descending sequences.
 
@@ -156,7 +156,7 @@ setSequenceMinValue n sequenceDef =
   sequenceDef {i_sequenceMinValue = Just n}
 
 {- |
-  Retrieves the max value of the sequence. If no explicit maximum has been set
+  Retrieves the max value of the sequence. If no explicit maximum has been set,
   this returns 'maxBound' for 'Int64' for ascending sequences and @-1@ for
   descending sequences.
 
@@ -182,7 +182,7 @@ setSequenceMaxValue n sequenceDef =
 
 {- |
   Retrieves the start value for the sequence. If no explicit start value has
-  been set this returns 'sequenceMinValue' for ascending sequences and
+  been set, this returns 'sequenceMinValue' for ascending sequences and
   'sequenceMaxValue' for descending sequences.
 
 @since 1.0.0.0
@@ -198,7 +198,7 @@ sequenceStart sequenceDef =
 
 {- |
   Sets the sequence start value. The start value must be at least the
-  minimum value and no greater than the max value.
+  minimum value and no greater than the maximum value.
 
 @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/SequenceIdentifier.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/SequenceIdentifier.hs
@@ -46,8 +46,8 @@ unqualifiedNameToSequenceId name =
     }
 
 {- |
-  Sets the schema of the 'SequenceIdentifier'. Wherever applicable, references to
-  the sequence will be qualified by the given scheme name.
+  Sets the schema of the 'SequenceIdentifier'. Wherever applicable, references
+  to the sequence will be qualified by the given schema name.
 
 @since 1.0.0.0
 -}
@@ -90,7 +90,7 @@ sequenceIdSchemaName =
   fmap Expr.schemaName . i_sequenceIdSchema
 
 {- |
-  Retrieves the unqualified name of the sequence as a string.
+  Retrieves the unqualified name of the sequence as a 'String'.
 
 @since 1.0.0.0
 -}
@@ -99,7 +99,7 @@ sequenceIdUnqualifiedNameString =
   i_sequenceIdName
 
 {- |
-  Retrieves the schema name of the sequence as a string.
+  Retrieves the schema name of the sequence as a 'String'.
 
 @since 1.0.0.0
 -}
@@ -108,7 +108,7 @@ sequenceIdSchemaNameString =
   i_sequenceIdSchema
 
 {- |
-  Converts a 'SequenceIdentifier' for a string for descriptive purposes. The
+  Converts a 'SequenceIdentifier' for a 'String' for descriptive purposes. The
   name will be qualified if a schema name has been set for the identifier.
 
   Note: You should not use this function for building SQL expressions. Use

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/TableDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/TableDefinition.hs
@@ -157,7 +157,7 @@ mkTableDefinitionWithoutKey name marshaller =
 
 {- |
   Annotates a 'TableDefinition' with a direction to drop columns if they are
-  found in the database. Orville does not drop columns during auto migration
+  found in the database. Orville does not drop columns during auto-migration
   unless they are explicitly requested to be dropped via 'dropColumns'.
 
   If you remove a reference to a column from the table's 'SqlMarshaller'
@@ -209,7 +209,7 @@ tableName =
   tableIdQualifiedName . i_tableIdentifier
 
 {- |
-  Sets the table's schema to the name in the given string, which will be
+  Sets the table's schema to the name in the given 'String', which will be
   treated as a SQL identifier. If a table has a schema name set, it will be
   included as a qualifier on the table name for all queries involving the
   table.
@@ -243,7 +243,7 @@ tableConstraints =
 {- |
   Retrieves all the table constraints that have been added to the table via
   'addTableConstraints'. This does NOT include any table constraints from the
-  table's 'SqlMarshaller'
+  table's 'SqlMarshaller'.
 
 @since 1.0.0.0
 -}
@@ -256,7 +256,7 @@ tableConstraintsFromTable =
 {- |
   Retrieves all the table constraints that were included in the table's
   'SqlMarshaller' when it was created. This does NOT include any table
-  constraints add via 'addTableConstraints'.
+  constraints added via 'addTableConstraints'.
 
 @since 1.0.0.0
 -}
@@ -279,7 +279,7 @@ tableConstraintsFromMarshaller =
 
   Note: If multiple constraints are added with the same
   'Orville.PostgreSQL.Schema.ConstraintMigrationKey', only the last one that is
-  added will be part of the 'TableDefinition'. Any previously added constraint
+  added will be part of the 'TableDefinition'. Any previously-added constraint
   with the same key is replaced by the new one.
 
 @since 1.0.0.0
@@ -314,7 +314,7 @@ tableIndexes =
 
   Note: If multiple indexes are added with the same 'IndexMigrationKey', only
   the last one that is added will be part of the 'TableDefinition'. Any
-  previously added index with the same key is replaced by the new one.
+  previously-added index with the same key is replaced by the new one.
 
 @since 1.0.0.0
 -}
@@ -332,7 +332,8 @@ addTableIndexes indexDefs tableDef =
       }
 
 {- |
-  Returns the primary key for the table, as defined at construction via 'mkTableDefinition'.
+  Returns the primary key for the table, as defined at construction via
+  'mkTableDefinition'.
 
 @since 1.0.0.0
 -}
@@ -342,7 +343,8 @@ tablePrimaryKey def =
     TableHasKey primaryKey -> primaryKey
 
 {- |
-  Returns the marshaller for the table, as defined at construction via 'mkTableDefinition'.
+  Returns the marshaller for the table, as defined at construction via
+  'mkTableDefinition'.
 
 @since 1.0.0.0
 -}
@@ -350,7 +352,8 @@ tableMarshaller :: TableDefinition key writeEntity readEntity -> AnnotatedSqlMar
 tableMarshaller = i_tableMarshaller
 
 {- |
-  Applies the provided function to the underlying 'SqlMarshaller' of the 'TableDefinition'
+  Applies the provided function to the underlying 'SqlMarshaller' of the
+  'TableDefinition'.
 
 @since 1.0.0.0
 -}
@@ -410,7 +413,7 @@ mkTablePrimaryKeyExpr tableDef =
 
 {- |
   When 'WithReturning' is given, builds a 'Expr.ReturningExpr' that will
-  return all the columns in the given table definition.
+  return all the columns in the given 'TableDefinition'.
 
 @since 1.0.0.0
 -}
@@ -433,8 +436,8 @@ mkTableReturningClause returningOption tableDef =
 
 {- |
   Builds an 'Expr.InsertExpr' that will insert the given entities into the SQL
-  table when it is executed. A @RETURNING@ clause with either be included to
-  return the insert rows or not, depending on the 'ReturningOption' given.
+  table when it is executed. A @RETURNING@ clause will either be included to
+  return the inserted rows or not, depending on the 'ReturningOption' given.
 
 @since 1.0.0.0
 -}
@@ -465,7 +468,7 @@ mkInsertExpr returningOption tableDef entities =
   insert statement in the order that they appear in the given 'SqlMarshaller'.
 
   In normal circumstances you will want to build the complete insert statement
-  via 'mkInsertExpr', but this is exported in case you are a composing SQL
+  via 'mkInsertExpr', but this is exported in case you are composing SQL
   yourself and need the column list of an insert as a fragment.
 
 @since 1.0.0.0
@@ -484,7 +487,7 @@ mkInsertColumnList marshaller =
   'mkInsertColumnList').
 
   In normal circumstances you will want to build the complete insert statement
-  via 'mkInsertExpr', but this is exported in case you are a composing SQL
+  via 'mkInsertExpr', but this is exported in case you are composing SQL
   yourself and need the column list of an insert as a fragment.
 
 @since 1.0.0.0

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/TableIdentifier.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/TableIdentifier.hs
@@ -47,7 +47,7 @@ unqualifiedNameToTableId name =
 
 {- |
   Sets the schema of the 'TableIdentifier'. Wherever applicable, references to
-  the table will be qualified by the given scheme name.
+  the table will be qualified by the given schema name.
 
 @since 1.0.0.0
 -}
@@ -58,8 +58,8 @@ setTableIdSchema schema tableId =
     }
 
 {- |
-  Returns the 'Expr.Qualified Expr.TableName' that should be used to refer to the
-  table in SQL queries.
+  Returns the 'Expr.Qualified Expr.TableName' that should be used to refer to
+  the table in SQL queries.
 
 @since 1.0.0.0
 -}
@@ -90,7 +90,7 @@ tableIdSchemaName =
   fmap Expr.schemaName . i_tableIdSchema
 
 {- |
-  Retrieves the unqualified name of the table as a string.
+  Retrieves the unqualified name of the table as a 'String'.
 
 @since 1.0.0.0
 -}
@@ -99,7 +99,7 @@ tableIdUnqualifiedNameString =
   i_tableIdName
 
 {- |
-  Retrieves the schema name of the table as a string
+  Retrieves the schema name of the table as a 'String'.
 
 @since 1.0.0.0
 -}
@@ -108,7 +108,7 @@ tableIdSchemaNameString =
   i_tableIdSchema
 
 {- |
-  Converts a 'TableIdentifier' to a string for descriptive purposes. The
+  Converts a 'TableIdentifier' to a 'String' for descriptive purposes. The
   name will be qualified if a schema name has been set for the identifier.
 
   Note: You should not use this function for building SQL expressions. Use

--- a/orville-postgresql/src/Orville/PostgreSQL/UnliftIO.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/UnliftIO.hs
@@ -5,9 +5,9 @@ Copyright : Flipstone Technology Partners 2023
 License   : MIT
 Stability : Stable
 
-This module provides function that can be used to implement
+This module provides functions that can be used to implement
 'Orville.PostgreSQL.MonadOrvilleControl' for monads that implement
-'UL.MonadUnliftIO'. For example,
+'UL.MonadUnliftIO'. For example:
 
 @
 module MyMonad
@@ -40,7 +40,7 @@ where
 import qualified Control.Monad.IO.Unlift as UL
 
 {- |
-  liftWithConnectionViaUnliftIO can be use as the implementation of
+  'liftWithConnectionViaUnliftIO' can be used as the implementation of
   'Orville.PostgreSQL.liftWithConnection' for
   'Orville.PostgreSQL.MonadOrvilleControl' when the 'Monad' implements
   'UL.MonadUnliftIO'.
@@ -56,7 +56,7 @@ liftWithConnectionViaUnliftIO ioWithConn action =
   UL.withRunInIO $ \runInIO -> ioWithConn (runInIO . action)
 
 {- |
-  liftCatchViaUnliftIO can be use as the implementation of
+  'liftCatchViaUnliftIO' can be used as the implementation of
   'Orville.PostgreSQL.liftCatch' for 'Orville.PostgreSQL.MonadOrvilleControl'
   when the 'Monad' implements 'UL.MonadUnliftIO'.
 
@@ -76,8 +76,8 @@ liftCatchViaUnliftIO ioCatch action handler = do
       (\ex -> UL.unliftIO unlio (handler ex))
 
 {- |
-  liftMaskViaUnliftIO can be use as the implementation of
-  'Orville.PostgreSQL.liftMask for 'Orville.PostgreSQL.MonadOrvilleControl'
+  'liftMaskViaUnliftIO' can be used as the implementation of
+  'Orville.PostgreSQL.liftMask' for 'Orville.PostgreSQL.MonadOrvilleControl'
   when the 'Monad' implements 'UL.MonadUnliftIO'.
 
   @since 1.0.0.0


### PR DESCRIPTION
This does one last proofreading pass to cover the remaining modules:

* `Orville.PostgreSQL.Expr` and its submodules
* `Orville.PostgreSQL.Marshall` and its submodules
* `Orville.PostgreSQL.Monad` and its submodules
* `Orville.PostgreSQL.OrvilleState`
* `Orville.PostgreSQL.PgCatalog`
* `Orville.PostgreSQL.Plan` and its submodules
* The submodules of `Orville.PostgreSQL.Raw`
* `Orville.PostgreSQL.Schema` and its submodules
* `Orville.PostgreSQL.UnliftIO`