### PR TITLE
Add 'toRawBytes' in SqlValue

### DIFF
--- a/orville-postgresql/src/Orville/PostgreSQL/Raw/SqlValue.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Raw/SqlValue.hs
@@ -155,9 +155,9 @@ fromRawBytesNullable =
 
   @since 1.1.0.0
 -}
-toRawBytes
-  :: SqlValue
-  -> Either String BS.ByteString
+toRawBytes ::
+  SqlValue ->
+  Either String BS.ByteString
 toRawBytes sqlValue =
   case sqlValue of
     SqlNull ->


### PR DESCRIPTION
This could be useful if e.g. someone is using the 'bytea' type. Why force people to use Text/String if the API supports ByteStrings just fine?
