### PR TITLE
Add warning to fromRawBytes

### DIFF
--- a/orville-postgresql/src/Orville/PostgreSQL/Raw/SqlValue.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Raw/SqlValue.hs
@@ -128,8 +128,9 @@ toPgValue sqlValue =
   function. See 'fromRawBytesNullable' for how to represent a nullable
   raw value.
 
-  Warning: You can't use this to e.g. insert into a BYTEA column.
-  See https://www.postgresql.org/docs/current/datatype-binary.html#DATATYPE-BINARY-BYTEA-HEX-FORMAT
+  Warning: Will throw NULByteFoundError if there is a NULL byte. For arbitrary
+           binary data see:
+           https://www.postgresql.org/docs/current/datatype-binary.html#DATATYPE-BINARY-BYTEA-HEX-FORMAT
 
 @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Raw/SqlValue.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Raw/SqlValue.hs
@@ -128,6 +128,9 @@ toPgValue sqlValue =
   function. See 'fromRawBytesNullable' for how to represent a nullable
   raw value.
 
+  Warning: You can't use this to e.g. insert into a BYTEA column.
+  See https://www.postgresql.org/docs/current/datatype-binary.html#DATATYPE-BINARY-BYTEA-HEX-FORMAT
+
 @since 1.0.0.0
 -}
 fromRawBytes :: BS.ByteString -> SqlValue


### PR DESCRIPTION
The signature of this function could lead users to think they could provide arbitrary ByteStrings. But that is not the case, as this program demonstrates:

```
import qualified Orville.PostgreSQL as O
import qualified Orville.PostgreSQL.Execution as Execution
import qualified Orville.PostgreSQL.Raw.Connection as Connection
import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
import qualified Data.ByteString as BS
import qualified Data.ByteString.Base16 as Base16
import qualified Data.Base16.Types as Base16

hexEncode :: BS.ByteString -> BS.ByteString
hexEncode = (BS.pack [92, 120] <>) . Base16.extractBase16 . Base16.encodeBase16'

main :: IO ()
main = do
  pool <-
    O.createConnectionPool
        O.ConnectionOptions
          { O.connectionString = ""
          , O.connectionNoticeReporting = O.DisableNoticeReporting
          , O.connectionPoolStripes = O.OneStripePerCapability
          , O.connectionPoolLingerTime = 10
          , O.connectionPoolMaxConnections = O.MaxConnectionsPerStripe 1
          }

  Connection.withPoolConnection pool $ \connection -> do
    _ <- RawSql.execute connection (RawSql.fromString "SET bytea_output to ESCAPE;")
    result <- RawSql.execute connection $
      RawSql.fromString "SELECT "
      <> RawSql.parameter (SqlValue.fromRawBytes . hexEncode $ BS.pack [0x00, 0xc3, 0xb1])
      <> RawSql.fromString "::bytea"
    putStrLn "Executed statement, reading reply"
    [[(_, sqlValue)]] <- Execution.readRows result
    print (SqlValue.toPgValue sqlValue)
    _ <- RawSql.execute connection (RawSql.fromString "SELECT " <> RawSql.parameter (SqlValue.fromRawBytes $ BS.pack [0x00, 0xc3, 0xb1]))
    putStrLn "Success!!!"
```

It's output is:

```
Executed statement, reading reply
Just (NoAssumptionsMade "\\000\\303\\261")
orville-getting-started: NULByteFoundError
```

So as you can see, the function only works if data is hex encoded first.

If you don't hex encode, you'll get an exception (I don't really know where it's from, though).

Because we don't support `BYTEA` very well, and I don't know whether we want
to, I have refrained from adding hexEncode in a PR. However I could do that if
desired.
