### PR TITLE
Exposes 'IndexMigrationKey' and related

### DIFF
--- a/orville-postgresql/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL.hs
@@ -144,6 +144,10 @@ module Orville.PostgreSQL
   , IndexDefinition.IndexCreationStrategy (Transactional, Concurrent)
   , IndexDefinition.setIndexCreationStrategy
   , IndexDefinition.indexCreationStrategy
+  , IndexDefinition.IndexMigrationKey (AttributeBasedIndexKey, NamedIndexKey)
+  , IndexDefinition.AttributeBasedIndexMigrationKey (AttributeBasedIndexMigrationKey, indexKeyUniqueness, indexKeyColumns)
+  , IndexDefinition.NamedIndexMigrationKey
+  , IndexDefinition.indexMigrationKey
   , PrimaryKey.PrimaryKey
   , PrimaryKey.primaryKey
   , PrimaryKey.compositePrimaryKey

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/IndexDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/IndexDefinition.hs
@@ -18,6 +18,10 @@ module Orville.PostgreSQL.Schema.IndexDefinition
   , Expr.IndexUniqueness (UniqueIndex, NonUniqueIndex)
   , IndexDefinition.indexCreateExpr
   , IndexDefinition.IndexCreationStrategy (Transactional, Concurrent)
+  , IndexDefinition.IndexMigrationKey (AttributeBasedIndexKey, NamedIndexKey)
+  , IndexDefinition.AttributeBasedIndexMigrationKey (AttributeBasedIndexMigrationKey, indexKeyUniqueness, indexKeyColumns)
+  , IndexDefinition.NamedIndexMigrationKey
+  , IndexDefinition.indexMigrationKey
   )
 where
 


### PR DESCRIPTION
We had previously exposed these.  As it stands we already have items at the top level that make use of the type, much like the similar type for constraints, that users cannot write the signature for themselves or otherwise use the values provided.