### PR TITLE
Adds a basic 'OnConflictExpr'

### DIFF
--- a/orville-postgresql/orville-postgresql.cabal
+++ b/orville-postgresql/orville-postgresql.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           orville-postgresql
-version:        1.0.0.0
+version:        1.1.0.0
 synopsis:       A Haskell library for PostgreSQL
 description:    Orville's goal is to provide a powerful API for applications to access PostgreSQL databases with minimal use of sophisticated language techniques or extensions. See https://github.com/flipstone/orville for more details.
 category:       database, library, postgresql

--- a/orville-postgresql/package.yaml
+++ b/orville-postgresql/package.yaml
@@ -1,6 +1,6 @@
 ---
 name: orville-postgresql
-version: '1.0.0.0'
+version: '1.1.0.0'
 synopsis: A Haskell library for PostgreSQL
 description:
   Orville's goal is to provide a powerful API for applications to access

--- a/orville-postgresql/src/Orville/PostgreSQL/Execution/Insert.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Execution/Insert.hs
@@ -125,7 +125,7 @@ insertTable ::
   NonEmpty writeEntity ->
   Insert readEntity returningClause
 insertTable returningOption tableDef entities =
-  rawInsertExpr returningOption (tableMarshaller tableDef) (mkInsertExpr returningOption tableDef entities)
+  rawInsertExpr returningOption (tableMarshaller tableDef) (mkInsertExpr returningOption tableDef Nothing entities)
 
 {- |
   Builds an 'Insert' that will execute the specified query and use the given

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Insert.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Insert.hs
@@ -184,7 +184,7 @@ construct a value with your own custom SQL.
 newtype OnConflictExpr
   = OnConflictExpr RawSql.RawSql
   deriving
-    ( -- | @since 1.0.1.0
+    ( -- | @since 1.1.0.0
       RawSql.SqlExpression
     )
 

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/TableDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/TableDefinition.hs
@@ -444,9 +444,10 @@ mkTableReturningClause returningOption tableDef =
 mkInsertExpr ::
   ReturningOption returningClause ->
   TableDefinition key writeEntity readEntity ->
+  Maybe Expr.OnConflictExpr ->
   NonEmpty writeEntity ->
   Expr.InsertExpr
-mkInsertExpr returningOption tableDef entities =
+mkInsertExpr returningOption tableDef maybeOnConflict entities =
   let
     marshaller =
       unannotatedSqlMarshaller $ tableMarshaller tableDef
@@ -461,6 +462,7 @@ mkInsertExpr returningOption tableDef entities =
       (tableName tableDef)
       (Just insertColumnList)
       insertSource
+      maybeOnConflict
       (mkTableReturningClause returningOption tableDef)
 
 {- |

--- a/orville-postgresql/test/Test/Expr/GroupBy.hs
+++ b/orville-postgresql/test/Test/Expr/GroupBy.hs
@@ -90,7 +90,7 @@ groupByTest testName test =
       dropAndRecreateTestTable connection
 
       RawSql.executeVoid connection $
-        Expr.insertExpr testTable Nothing (mkGroupByTestInsertSource test) Nothing
+        Expr.insertExpr testTable Nothing (mkGroupByTestInsertSource test) Nothing Nothing
 
       result <-
         RawSql.execute connection $

--- a/orville-postgresql/test/Test/Expr/GroupByOrderBy.hs
+++ b/orville-postgresql/test/Test/Expr/GroupByOrderBy.hs
@@ -80,7 +80,7 @@ groupByOrderByTest testName test =
       dropAndRecreateTestTable connection
 
       RawSql.executeVoid connection $
-        Expr.insertExpr testTable Nothing (mkGroupByOrderByTestInsertSource test) Nothing
+        Expr.insertExpr testTable Nothing (mkGroupByOrderByTestInsertSource test) Nothing Nothing
 
       result <-
         RawSql.execute connection $

--- a/orville-postgresql/test/Test/Expr/OrderBy.hs
+++ b/orville-postgresql/test/Test/Expr/OrderBy.hs
@@ -120,7 +120,7 @@ orderByTest testName test =
           dropAndRecreateTestTable connection
 
           RawSql.executeVoid connection $
-            Expr.insertExpr fooBarTable Nothing (insertFooBarSource $ orderByValuesToInsert test) Nothing
+            Expr.insertExpr fooBarTable Nothing (insertFooBarSource $ orderByValuesToInsert test) Nothing Nothing
 
           result <-
             RawSql.execute connection $

--- a/orville-postgresql/test/Test/Expr/TestSchema.hs
+++ b/orville-postgresql/test/Test/Expr/TestSchema.hs
@@ -103,7 +103,7 @@ withFooBarData pool fooBars action =
       dropAndRecreateTestTable connection
 
       RawSql.executeVoid connection $
-        Expr.insertExpr fooBarTable Nothing (insertFooBarSource fooBars) Nothing
+        Expr.insertExpr fooBarTable Nothing (insertFooBarSource fooBars) Nothing Nothing
 
       action connection
 

--- a/orville-postgresql/test/Test/Expr/Where.hs
+++ b/orville-postgresql/test/Test/Expr/Where.hs
@@ -204,7 +204,7 @@ whereConditionTest testName test =
           dropAndRecreateTestTable connection
 
           RawSql.executeVoid connection $
-            Expr.insertExpr fooBarTable Nothing (insertFooBarSource $ whereValuesToInsert test) Nothing
+            Expr.insertExpr fooBarTable Nothing (insertFooBarSource $ whereValuesToInsert test) Nothing Nothing
 
           result <-
             RawSql.execute connection $

--- a/orville-postgresql/test/Test/FieldDefinition.hs
+++ b/orville-postgresql/test/Test/FieldDefinition.hs
@@ -250,6 +250,7 @@ runRoundTripTest pool testCase = do
         Nothing
         (Expr.insertSqlValues [[Marshall.fieldValueToSqlValue fieldDef value]])
         Nothing
+        Nothing
 
     result <-
       RawSql.execute connection $
@@ -294,6 +295,7 @@ runNullableRoundTripTest pool testCase = do
         Nothing
         (Expr.insertSqlValues [[Marshall.fieldValueToSqlValue fieldDef value]])
         Nothing
+        Nothing
 
     result <-
       RawSql.execute connection $
@@ -329,6 +331,7 @@ runNullCounterExampleTest pool testCase = do
           Nothing
           (Expr.insertSqlValues [[SqlValue.sqlNull]])
           Nothing
+          Nothing
 
   case result of
     Left err ->
@@ -361,6 +364,7 @@ runDefaultValueFieldDefinitionTest pool testCase mkDefaultValue = do
         testTable
         Nothing
         (RawSql.unsafeSqlExpression "VALUES(DEFAULT)")
+        Nothing
         Nothing
 
     result <-
@@ -400,6 +404,7 @@ runDefaultValueInsertOnlyTest pool testCase defaultValue =
         testTable
         Nothing
         (RawSql.unsafeSqlExpression "VALUES(DEFAULT)")
+        Nothing
         Nothing
 
 testTable :: Expr.Qualified Expr.TableName

--- a/orville-postgresql/test/Test/SqlCommenter.hs
+++ b/orville-postgresql/test/Test/SqlCommenter.hs
@@ -70,7 +70,7 @@ prop_sqlCommenterInsertExpr =
           dropAndRecreateTestTable connection
 
           let
-            insertExpr = Expr.insertExpr fooBarTable Nothing (insertFooBarSource fooBars) Nothing
+            insertExpr = Expr.insertExpr fooBarTable Nothing (insertFooBarSource fooBars) Nothing Nothing
           RawSql.executeVoid connection $
             SqlCommenter.addSqlCommenterAttributes staticSqlCommenterAttributes insertExpr
 

--- a/orville-postgresql/test/Test/SqlType.hs
+++ b/orville-postgresql/test/Test/SqlType.hs
@@ -538,6 +538,7 @@ runDecodingTest pool test =
           Nothing
           (Expr.insertSqlValues [[SqlValue.fromRawBytesNullable (rawSqlValue test)]])
           Nothing
+          Nothing
 
       result <-
         RawSql.execute connection $

--- a/orville-postgresql/test/Test/TableDefinition.hs
+++ b/orville-postgresql/test/Test/TableDefinition.hs
@@ -46,6 +46,7 @@ prop_roundTrip =
         TableDefinition.mkInsertExpr
           ReturningOption.WithoutReturning
           Foo.table
+          Nothing
           (originalFoo :| [])
 
       selectFoos =
@@ -67,7 +68,7 @@ prop_readOnlyFields =
 
     let
       insertBar =
-        TableDefinition.mkInsertExpr ReturningOption.WithoutReturning Bar.table (originalBar :| [])
+        TableDefinition.mkInsertExpr ReturningOption.WithoutReturning Bar.table Nothing (originalBar :| [])
 
       selectBars =
         Select.selectTable Bar.table mempty
@@ -94,6 +95,7 @@ prop_primaryKey =
         TableDefinition.mkInsertExpr
           ReturningOption.WithoutReturning
           Foo.table
+          Nothing
           (originalFoo :| [conflictingFoo])
 
     result <- MIO.liftIO . E.try . Conn.withPoolConnection pool $ \connection -> do
@@ -125,6 +127,7 @@ prop_uniqueConstraint =
         TableDefinition.mkInsertExpr
           ReturningOption.WithoutReturning
           Foo.table
+          Nothing
           (originalFoo :| [conflictingFoo])
 
     result <- MIO.liftIO . E.try . Conn.withPoolConnection pool $ \connection -> do


### PR DESCRIPTION
This adds very rudementary support for ON CONFLICT in the 'InsertExpr'. Adding only a type and a helper for 'ON CONFLICT DO NOTHING'.

The placement of the type alongside the insert related is somewhat arbitrary compared to being a separate module. It was placed within the insert because it would appear that postgresql, as of version 16, only supports it on insert statements so it is not really reusable elsewhere.

This also changes the 'insertExpr' function to optionally take the new 'OnConflictExpr'. As well as the 'mkInsertExpr' at the 'TableDefinition' level. However, this is not filtered to the highest levels of the api. The lower levels are changed because the ordering of the 'ON CONFLICT', must come before the 'RETURNING' part of an insert and without the change the only way to effectively use the change would have been to not use the existing expr level functionality at all. The highest level is unchanged so we think through how to evolve the api, particularly should we want good support for 'ON CONFLICT DO SET ...'. This set of low level/high level feels like a decent tradeoff but revisiting the decisions is without question, appropriate too.