### PR TITLE
Several small additions

### DIFF
--- a/orville-postgresql/orville-postgresql.cabal
+++ b/orville-postgresql/orville-postgresql.cabal
@@ -120,6 +120,7 @@ library
       Orville.PostgreSQL.Expr.Internal.Name.SchemaName
       Orville.PostgreSQL.Expr.Internal.Name.SequenceName
       Orville.PostgreSQL.Expr.Internal.Name.TableName
+      Orville.PostgreSQL.Expr.Vacuum
       Orville.PostgreSQL.Internal.Bracket
       Orville.PostgreSQL.Internal.Extra.NonEmpty
       Orville.PostgreSQL.Internal.FieldName
@@ -187,6 +188,7 @@ test-suite spec
       Test.Expr.TableDefinition
       Test.Expr.TestSchema
       Test.Expr.Time
+      Test.Expr.Vacuum
       Test.Expr.Where
       Test.FieldDefinition
       Test.MarshallError

--- a/orville-postgresql/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL.hs
@@ -258,6 +258,8 @@ module Orville.PostgreSQL
   , (FieldDefinition..==)
   , FieldDefinition.fieldNotEquals
   , (FieldDefinition../=)
+  , FieldDefinition.fieldIsDistinctFrom
+  , FieldDefinition.fieldIsNotDistinctFrom
   , FieldDefinition.fieldGreaterThan
   , (FieldDefinition..>)
   , FieldDefinition.fieldLessThan

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr.hs
@@ -1,7 +1,7 @@
 {-# OPTIONS_GHC -Wno-missing-import-lists #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2023
+Copyright : Flipstone Technology Partners 2023-2024
 License   : MIT
 Stability : Stable
 
@@ -62,6 +62,7 @@ module Orville.PostgreSQL.Expr
   , module Orville.PostgreSQL.Expr.Update
   , module Orville.PostgreSQL.Expr.ValueExpression
   , module Orville.PostgreSQL.Expr.WhereClause
+  , module Orville.PostgreSQL.Expr.Vacuum
   )
 where
 
@@ -93,5 +94,6 @@ import Orville.PostgreSQL.Expr.TableReferenceList
 import Orville.PostgreSQL.Expr.Time
 import Orville.PostgreSQL.Expr.Transaction
 import Orville.PostgreSQL.Expr.Update
+import Orville.PostgreSQL.Expr.Vacuum
 import Orville.PostgreSQL.Expr.ValueExpression
 import Orville.PostgreSQL.Expr.WhereClause

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/BinaryOperator.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/BinaryOperator.hs
@@ -269,8 +269,8 @@ binaryOpExpression ::
 binaryOpExpression op left right =
   binaryOpExpressionUnparenthenizedArguments
     op
-    (RawSql.unsafeFromRawSql (RawSql.leftParen <> RawSql.toRawSql left <> RawSql.rightParen))
-    (RawSql.unsafeFromRawSql (RawSql.leftParen <> RawSql.toRawSql right <> RawSql.rightParen))
+    (RawSql.unsafeFromRawSql (RawSql.parenthesized left))
+    (RawSql.unsafeFromRawSql (RawSql.parenthesized right))
 
 -- internal helper function
 binaryOpExpressionUnparenthenizedArguments ::

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/BinaryOperator.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/BinaryOperator.hs
@@ -15,6 +15,8 @@ module Orville.PostgreSQL.Expr.BinaryOperator
   , binaryOperator
   , binaryOpExpression
   , equalsOp
+  , isDistinctFromOp
+  , isNotDistinctFromOp
   , notEqualsOp
   , greaterThanOp
   , lessThanOp
@@ -84,6 +86,20 @@ equalsOp =
 notEqualsOp :: BinaryOperator
 notEqualsOp =
   binaryOperator "<>"
+
+{- | The SQL 'IS DISTINCT FROM' binary 'operator'.
+
+@since 1.1.0.0
+-}
+isDistinctFromOp :: BinaryOperator
+isDistinctFromOp = binaryOperator "IS DISTINCT FROM"
+
+{- | The SQL 'IS NOT DISTINCT FROM' binary 'operator'.
+
+@since 1.1.0.0
+-}
+isNotDistinctFromOp :: BinaryOperator
+isNotDistinctFromOp = binaryOperator "IS NOT DISTINCT FROM"
 
 {- | The SQL strictly greater than binary operator.
 

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/TableDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/TableDefinition.hs
@@ -14,6 +14,7 @@ module Orville.PostgreSQL.Expr.TableDefinition
   , primaryKeyExpr
   , AlterTableExpr
   , alterTableExpr
+  , renameTableExpr
   , AlterTableAction
   , addColumn
   , dropColumn
@@ -157,6 +158,15 @@ alterTableExpr tableName actions =
       <> RawSql.toRawSql tableName
       <> RawSql.space
       <> RawSql.intercalate RawSql.commaSpace actions
+
+{- |
+  Given an existing table name and the desired name, construct an 'AlterTableExpr' that will rename to desired.
+
+  @since 1.1.0.0
+-}
+renameTableExpr :: Qualified TableName -> Qualified TableName -> AlterTableExpr
+renameTableExpr existingTableName newTableName =
+  alterTableExpr existingTableName . pure . AlterTableAction $ RawSql.fromString "RENAME TO " <> RawSql.toRawSql newTableName
 
 {- |
 Type to represent an action as part of an @ALTER TABLE@ statement. E.G.

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/TableDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/TableDefinition.hs
@@ -30,6 +30,8 @@ module Orville.PostgreSQL.Expr.TableDefinition
   , dropNotNull
   , DropTableExpr
   , dropTableExpr
+  , TruncateTableExpr
+  , truncateTablesExpr
   )
 where
 
@@ -386,4 +388,34 @@ dropTableExpr maybeIfExists tableName =
           , fmap RawSql.toRawSql maybeIfExists
           , Just (RawSql.toRawSql tableName)
           ]
+      )
+
+{- |
+Type to represent a @TRUNCATE TABLE@ statement. E.G.
+
+> TRUNCATE TABLE FOO
+
+'TruncateTableExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 1.1.0.0
+-}
+newtype TruncateTableExpr
+  = TruncateTableExpr RawSql.RawSql
+  deriving (RawSql.SqlExpression)
+
+{- |
+  Constructs a 'TruncateTableExpr' that will truncate the specified tables.
+
+  @since 1.1.0.0
+-}
+truncateTablesExpr :: NonEmpty (Qualified TableName) -> TruncateTableExpr
+truncateTablesExpr tableNames =
+  TruncateTableExpr $
+    RawSql.intercalate
+      RawSql.space
+      ( [ RawSql.fromString "TRUNCATE TABLE"
+        , RawSql.intercalate RawSql.commaSpace tableNames
+        ]
       )

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Vacuum.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Vacuum.hs
@@ -1,0 +1,111 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+{- |
+Copyright : Flipstone Technology Partners 2024
+License   : MIT
+Stability : Stable
+
+@since 1.1.0.0
+-}
+module Orville.PostgreSQL.Expr.Vacuum
+  ( VacuumExpr
+  , vacuumExpr
+  , VacuumOption
+  , vacuumFull
+  , vacuumFreeze
+  , vacuumVerbose
+  , vacuumAnalyze
+  )
+where
+
+import Data.List.NonEmpty (NonEmpty)
+
+import Orville.PostgreSQL.Expr.Name (Qualified, TableName)
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+
+{- |
+Type to represent a @VACUUM@ statement. E.G.
+
+> VACUUM foo
+
+'VacuumExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 1.1.0.0
+-}
+newtype VacuumExpr
+  = VacuumExpr RawSql.RawSql
+  deriving
+    ( -- | @since 1.1.0.0
+      RawSql.SqlExpression
+    )
+
+{- |
+  Constructs a 'VacuumExpr' with the given vacuum options on the given tables.
+
+  @since 1.1.0.0
+-}
+vacuumExpr :: [VacuumOption] -> NonEmpty (Qualified TableName) -> VacuumExpr
+vacuumExpr vacuumOptions tables =
+  let
+    optionsWithSpaceRawSql =
+      case vacuumOptions of
+        [] ->
+          RawSql.space
+        opts ->
+          RawSql.space
+            <> RawSql.parenthesized (RawSql.intercalate RawSql.commaSpace opts)
+            <> RawSql.space
+  in
+    VacuumExpr $
+      RawSql.fromString "VACUUM"
+        <> optionsWithSpaceRawSql
+        <> RawSql.intercalate RawSql.commaSpace tables
+
+newtype VacuumOption
+  = VacuumOption RawSql.RawSql
+  deriving
+    ( -- | @since 1.1.0.0
+      RawSql.SqlExpression
+    )
+
+{- |
+  Constructs a 'VaccumOption' that will instruct if the vacuum should be "full".
+
+  @since 1.1.0.0
+-}
+vacuumFull :: Bool -> VacuumOption
+vacuumFull bool =
+  VacuumOption $ RawSql.fromString "FULL " <> boolRawSql bool
+
+{- | Constructs a 'VaccumOption' that will instruct if the vacuum should be agressive in "freezing" of
+  tuples.
+
+  @since 1.1.0.0
+-}
+vacuumFreeze :: Bool -> VacuumOption
+vacuumFreeze bool =
+  VacuumOption $ RawSql.fromString "FREEZE " <> boolRawSql bool
+
+{- |
+  Constructs a 'VaccumOption' that will instruct if the vacuum should be verbose.
+
+  @since 1.1.0.0
+-}
+vacuumVerbose :: Bool -> VacuumOption
+vacuumVerbose bool =
+  VacuumOption $ RawSql.fromString "VERBOSE " <> boolRawSql bool
+
+{- | Constructs a 'VaccumOption' that will instruct if the vacuum should "analyze" to update statitics
+  used by the PostgreSQL query planner.
+
+  @since 1.1.0.0
+-}
+vacuumAnalyze :: Bool -> VacuumOption
+vacuumAnalyze bool =
+  VacuumOption $ RawSql.fromString "ANALYZE " <> boolRawSql bool
+
+boolRawSql :: Bool -> RawSql.RawSql
+boolRawSql bool =
+  if bool then RawSql.fromString "TRUE" else RawSql.fromString "FALSE"

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/WhereClause.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/WhereClause.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2023
+Copyright : Flipstone Technology Partners 2023-2024
 License   : MIT
 Stability : Stable
 
@@ -16,6 +16,7 @@ module Orville.PostgreSQL.Expr.WhereClause
   , (.&&)
   , orExpr
   , (.||)
+  , notExpr
   , parenthesized
   , equals
   , notEquals
@@ -160,6 +161,19 @@ andExpr left right =
 (.&&) = andExpr
 
 infixr 8 .&&
+
+{- |
+  The SQL @NOT@ operator. The argument will be surrounded with parentheses
+  to ensure that the associativity of expression in the resulting SQL matches
+  the associativity implied by this Haskell function.
+
+  @since 1.1.0.0
+-}
+notExpr :: BooleanExpr -> BooleanExpr
+notExpr bool =
+  BooleanExpr $
+    RawSql.fromString "NOT "
+      <> RawSql.parenthesized bool
 
 {- |
   The SQL @IN@ operator. The result will be @TRUE@ if the given value

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/WhereClause.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/WhereClause.hs
@@ -19,6 +19,8 @@ module Orville.PostgreSQL.Expr.WhereClause
   , parenthesized
   , equals
   , notEquals
+  , isDistinctFrom
+  , isNotDistinctFrom
   , greaterThan
   , lessThan
   , greaterThanOrEqualTo
@@ -40,7 +42,7 @@ where
 
 import qualified Data.List.NonEmpty as NE
 
-import Orville.PostgreSQL.Expr.BinaryOperator (andOp, binaryOpExpression, equalsOp, greaterThanOp, greaterThanOrEqualsOp, iLikeOp, lessThanOp, lessThanOrEqualsOp, likeOp, notEqualsOp, orOp)
+import Orville.PostgreSQL.Expr.BinaryOperator (andOp, binaryOpExpression, equalsOp, greaterThanOp, greaterThanOrEqualsOp, iLikeOp, isDistinctFromOp, isNotDistinctFromOp, lessThanOp, lessThanOrEqualsOp, likeOp, notEqualsOp, orOp)
 import Orville.PostgreSQL.Expr.ValueExpression (ValueExpression, rowValueConstructor)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
@@ -288,6 +290,24 @@ equals =
 notEquals :: ValueExpression -> ValueExpression -> BooleanExpr
 notEquals =
   binaryOpExpression notEqualsOp
+
+{- |
+  The SQL @IS DISTINCT FROM@ binary comparison.
+
+  @since 1.1.0.0
+-}
+isDistinctFrom :: ValueExpression -> ValueExpression -> BooleanExpr
+isDistinctFrom =
+  binaryOpExpression isDistinctFromOp
+
+{- |
+  The SQL @IS NOT DISTINCT FROM@ binary comparison.
+
+  @since 1.1.0.0
+-}
+isNotDistinctFrom :: ValueExpression -> ValueExpression -> BooleanExpr
+isNotDistinctFrom =
+  binaryOpExpression isNotDistinctFromOp
 
 {- |
   The SQL @>@ operator.

--- a/orville-postgresql/src/Orville/PostgreSQL/Marshall/FieldDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Marshall/FieldDefinition.hs
@@ -33,6 +33,8 @@ module Orville.PostgreSQL.Marshall.FieldDefinition
   , (.==)
   , fieldNotEquals
   , (./=)
+  , fieldIsDistinctFrom
+  , fieldIsNotDistinctFrom
   , fieldGreaterThan
   , (.>)
   , fieldLessThan
@@ -888,6 +890,24 @@ fieldNotEquals =
 (./=) = fieldNotEquals
 
 infixl 9 ./=
+
+{- |
+  Checks that the value in a field is distinct from a particular value.
+
+@since 1.1.0.0
+-}
+fieldIsDistinctFrom :: FieldDefinition nullability a -> a -> Expr.BooleanExpr
+fieldIsDistinctFrom =
+  whereColumnComparison Expr.isDistinctFrom
+
+{- |
+  Checks that the value in a field is not distinct from a particular value.
+
+@since 1.1.0.0
+-}
+fieldIsNotDistinctFrom :: FieldDefinition nullability a -> a -> Expr.BooleanExpr
+fieldIsNotDistinctFrom =
+  whereColumnComparison Expr.isNotDistinctFrom
 
 {- |
   Checks that the value in a field is greater than a particular value.

--- a/orville-postgresql/test/Main.hs
+++ b/orville-postgresql/test/Main.hs
@@ -26,6 +26,7 @@ import qualified Test.Expr.OrderBy as ExprOrderBy
 import qualified Test.Expr.SequenceDefinition as ExprSequenceDefinition
 import qualified Test.Expr.TableDefinition as ExprTableDefinition
 import qualified Test.Expr.Time as ExprTime
+import qualified Test.Expr.Vacuum as ExprVacuum
 import qualified Test.Expr.Where as ExprWhere
 import qualified Test.FieldDefinition as FieldDefinition
 import qualified Test.MarshallError as MarshallError
@@ -66,6 +67,7 @@ main = do
       , ExprCount.countTests pool
       , ExprMath.mathTests pool
       , ExprTime.timeTests pool
+      , ExprVacuum.vacuumTests
       , FieldDefinition.fieldDefinitionTests pool
       , SqlMarshaller.sqlMarshallerTests
       , MarshallError.marshallErrorTests pool

--- a/orville-postgresql/test/Test/Expr/InsertUpdateDelete.hs
+++ b/orville-postgresql/test/Test/Expr/InsertUpdateDelete.hs
@@ -14,13 +14,13 @@ import qualified Orville.PostgreSQL.Raw.Connection as Conn
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
-import Test.Expr.TestSchema (assertEqualFooBarRows, barColumn, barColumnRef, dropAndRecreateTestTable, findAllFooBars, fooBarTable, fooColumn, insertFooBarSource, mkFooBar)
+import Test.Expr.TestSchema (assertEqualFooBarRows, barColumn, barColumnRef, dropAndRecreateTestTable, findAllFooBars, findAllFooBarsInTable, fooBarTable, fooColumn, insertFooBarSource, mkFooBar)
 import qualified Test.Property as Property
 
 insertUpdateDeleteTests :: Orville.ConnectionPool -> Property.Group
 insertUpdateDeleteTests pool =
   Property.group
-    "Expr - Insert/Update/Delete"
+    "Expr - Insert/Update/Delete/Truncate"
     [ prop_insertExpr pool
     , prop_insertExprWithOnConflictDoNothing pool
     , prop_insertExprWithReturning pool
@@ -30,6 +30,7 @@ insertUpdateDeleteTests pool =
     , prop_deleteExpr pool
     , prop_deleteExprWithWhere pool
     , prop_deleteExprWithReturning pool
+    , prop_truncateTablesExpr pool
     ]
 
 prop_insertExpr :: Property.NamedDBProperty
@@ -271,3 +272,51 @@ prop_deleteExprWithReturning =
           Execution.readRows result
 
     assertEqualFooBarRows rows oldFooBars
+
+prop_truncateTablesExpr :: Property.NamedDBProperty
+prop_truncateTablesExpr =
+  Property.singletonNamedDBProperty "truncateTablesExpr clears out inserted values from all tables" $ \pool -> do
+    let
+      fooBars = [mkFooBar 1 "dog", mkFooBar 2 "cat"]
+      fooBar2Table =
+        Expr.qualifyTable Nothing (Expr.tableName "foobar2")
+      dropAndRecreateSecondTable connection = do
+        RawSql.executeVoid connection (RawSql.fromString "DROP TABLE IF EXISTS " <> RawSql.toRawSql fooBar2Table)
+        RawSql.executeVoid connection (RawSql.fromString "CREATE TABLE " <> RawSql.toRawSql fooBar2Table <> RawSql.fromString "(foo INTEGER, bar TEXT)")
+
+      recreateAndInsert =
+        MIO.liftIO $
+          Conn.withPoolConnection pool $ \connection -> do
+            dropAndRecreateTestTable connection
+            dropAndRecreateSecondTable connection
+
+            RawSql.executeVoid connection $
+              Expr.insertExpr fooBarTable Nothing (insertFooBarSource fooBars) Nothing Nothing
+            RawSql.executeVoid connection $
+              Expr.insertExpr fooBar2Table Nothing (insertFooBarSource fooBars) Nothing Nothing
+
+      truncateTables =
+        MIO.liftIO $
+          Conn.withPoolConnection pool $ \connection -> do
+            RawSql.executeVoid connection $
+              Expr.truncateTablesExpr (fooBarTable :| (pure fooBar2Table))
+
+    _ <- recreateAndInsert
+    _ <- truncateTables
+
+    fooBarRows <-
+      MIO.liftIO $
+        Conn.withPoolConnection pool $ \connection -> do
+          result <- RawSql.execute connection findAllFooBars
+
+          Execution.readRows result
+
+    fooBar2Rows <-
+      MIO.liftIO $
+        Conn.withPoolConnection pool $ \connection -> do
+          result <- RawSql.execute connection $ findAllFooBarsInTable fooBar2Table
+
+          Execution.readRows result
+
+    assertEqualFooBarRows fooBarRows []
+    assertEqualFooBarRows fooBar2Rows []

--- a/orville-postgresql/test/Test/Expr/TestSchema.hs
+++ b/orville-postgresql/test/Test/Expr/TestSchema.hs
@@ -2,6 +2,7 @@ module Test.Expr.TestSchema
   ( FooBar (..)
   , mkFooBar
   , findAllFooBars
+  , findAllFooBarsInTable
   , fooBarTable
   , fooColumn
   , fooColumnRef
@@ -68,10 +69,14 @@ orderByFoo =
 
 findAllFooBars :: Expr.QueryExpr
 findAllFooBars =
+  findAllFooBarsInTable fooBarTable
+
+findAllFooBarsInTable :: Expr.Qualified Expr.TableName -> Expr.QueryExpr
+findAllFooBarsInTable tableName =
   Expr.queryExpr
     (Expr.selectClause $ Expr.selectExpr Nothing)
     (Expr.selectColumns [fooColumn, barColumn])
-    (Just $ Expr.tableExpr (Expr.referencesTable fooBarTable) Nothing Nothing (Just orderByFoo) Nothing Nothing)
+    (Just $ Expr.tableExpr (Expr.referencesTable tableName) Nothing Nothing (Just orderByFoo) Nothing Nothing)
 
 encodeFooBar :: FooBar -> [(Maybe B8.ByteString, SqlValue.SqlValue)]
 encodeFooBar fooBar =

--- a/orville-postgresql/test/Test/Expr/Vacuum.hs
+++ b/orville-postgresql/test/Test/Expr/Vacuum.hs
@@ -1,0 +1,90 @@
+module Test.Expr.Vacuum
+  ( vacuumTests
+  )
+where
+
+import qualified Data.ByteString.Char8 as B8
+import Data.List.NonEmpty (NonEmpty ((:|)))
+import GHC.Stack (HasCallStack, withFrozenCallStack)
+import qualified Hedgehog as HH
+
+import qualified Orville.PostgreSQL.Expr as Expr
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+
+import qualified Test.Property as Property
+
+vacuumTests :: Property.Group
+vacuumTests =
+  Property.group
+    "Expr - Vacuum"
+    [ prop_vacuumNoOptionsSingleTable
+    , prop_vacuumNoOptionsTwoTables
+    , prop_vacuumOneOptionSingleTable
+    , prop_vacuumOneOptionTwoTables
+    , prop_vacuumTwoOptionsOneTable
+    , prop_vacuumTwoOptionsTwoTables
+    ]
+
+prop_vacuumNoOptionsSingleTable :: Property.NamedProperty
+prop_vacuumNoOptionsSingleTable =
+  Property.singletonNamedProperty "vacuumExpr with empty options and a single table generates expected sql" $
+    assertVacuumEquals
+      "VACUUM \"foo\""
+      []
+      singleTable
+
+prop_vacuumNoOptionsTwoTables :: Property.NamedProperty
+prop_vacuumNoOptionsTwoTables =
+  Property.singletonNamedProperty "vacuumExpr with empty options and a pair of tables generates expected sql" $
+    assertVacuumEquals
+      "VACUUM \"foo\", \"bar\""
+      []
+      twoTables
+
+prop_vacuumOneOptionSingleTable :: Property.NamedProperty
+prop_vacuumOneOptionSingleTable =
+  Property.singletonNamedProperty "vacuumExpr with one option and a single table generates expected sql" $
+    assertVacuumEquals
+      "VACUUM (FULL TRUE) \"foo\""
+      [Expr.vacuumFull True]
+      singleTable
+
+prop_vacuumOneOptionTwoTables :: Property.NamedProperty
+prop_vacuumOneOptionTwoTables =
+  Property.singletonNamedProperty "vacuumExpr with one option and a pair of tables generates expected sql" $
+    assertVacuumEquals
+      "VACUUM (FULL TRUE) \"foo\", \"bar\""
+      [Expr.vacuumFull True]
+      twoTables
+
+prop_vacuumTwoOptionsOneTable :: Property.NamedProperty
+prop_vacuumTwoOptionsOneTable =
+  Property.singletonNamedProperty "vacuumExpr with two options and a single table generates expected sql" $
+    assertVacuumEquals
+      "VACUUM (FULL TRUE, VERBOSE TRUE) \"foo\""
+      [ Expr.vacuumFull True
+      , Expr.vacuumVerbose True
+      ]
+      singleTable
+
+prop_vacuumTwoOptionsTwoTables :: Property.NamedProperty
+prop_vacuumTwoOptionsTwoTables =
+  Property.singletonNamedProperty "vacuumExpr with two options and a pair of tables generates expected sql" $
+    assertVacuumEquals
+      "VACUUM (FULL TRUE, VERBOSE TRUE) \"foo\", \"bar\""
+      [ Expr.vacuumFull True
+      , Expr.vacuumVerbose True
+      ]
+      twoTables
+
+assertVacuumEquals :: (HH.MonadTest m, HasCallStack) => String -> [Expr.VacuumOption] -> NonEmpty (Expr.Qualified Expr.TableName) -> m ()
+assertVacuumEquals mbVacuum vacuumOptions vacuumTables =
+  withFrozenCallStack $
+    RawSql.toExampleBytes (Expr.vacuumExpr vacuumOptions vacuumTables) HH.=== B8.pack mbVacuum
+
+singleTable :: NonEmpty (Expr.Qualified Expr.TableName)
+singleTable = pure . Expr.qualifyTable Nothing $ Expr.tableName "foo"
+
+twoTables :: NonEmpty (Expr.Qualified Expr.TableName)
+twoTables =
+  (Expr.qualifyTable Nothing $ Expr.tableName "foo") :| [Expr.qualifyTable Nothing $ Expr.tableName "bar"]

--- a/orville-postgresql/test/Test/Expr/Where.hs
+++ b/orville-postgresql/test/Test/Expr/Where.hs
@@ -31,6 +31,7 @@ whereTests pool =
     , prop_lessThanOrEqualsToOp pool
     , prop_andExpr pool
     , prop_orExpr pool
+    , prop_notExpr pool
     , prop_valueIn pool
     , prop_valueNotIn pool
     , prop_tupleIn pool
@@ -150,6 +151,19 @@ prop_orExpr =
             Expr.orExpr
               (Expr.equals fooColumnRef (int32ValueExpr 3))
               (Expr.equals barColumnRef (textValueExpr "dingo"))
+      }
+
+prop_notExpr :: Property.NamedDBProperty
+prop_notExpr =
+  whereConditionTest "notExpr inverts condition" $
+    WhereConditionTest
+      { whereValuesToInsert = [mkFooBar 1 "dog", mkFooBar 2 "dingo", mkFooBar 3 "dog"]
+      , whereExpectedQueryResults = [mkFooBar 2 "dingo"]
+      , whereClause =
+          Just . Expr.whereClause . Expr.notExpr $
+            Expr.orExpr
+              (Expr.equals fooColumnRef (int32ValueExpr 3))
+              (Expr.equals barColumnRef (textValueExpr "dog"))
       }
 
 prop_valueIn :: Property.NamedDBProperty

--- a/orville-postgresql/test/Test/SelectOptions.hs
+++ b/orville-postgresql/test/Test/SelectOptions.hs
@@ -26,6 +26,8 @@ selectOptionsTests =
     , prop_fieldEqualsOperator
     , prop_fieldNotEquals
     , prop_fieldNotEqualsOperator
+    , prop_fieldIsDistinctFrom
+    , prop_fieldIsNotDistinctFrom
     , prop_fieldLessThan
     , prop_fieldLessThanOperator
     , prop_fieldGreaterThan
@@ -83,6 +85,20 @@ prop_fieldNotEquals =
     assertWhereClauseEquals
       (Just "WHERE (\"foo\") <> ($1)")
       (O.where_ $ O.fieldNotEquals fooField 0)
+
+prop_fieldIsDistinctFrom :: Property.NamedProperty
+prop_fieldIsDistinctFrom =
+  Property.singletonNamedProperty "fieldIsDistinctFrom generates expected sql" $
+    assertWhereClauseEquals
+      (Just "WHERE (\"foo\") IS DISTINCT FROM ($1)")
+      (O.where_ $ O.fieldIsDistinctFrom fooField 0)
+
+prop_fieldIsNotDistinctFrom :: Property.NamedProperty
+prop_fieldIsNotDistinctFrom =
+  Property.singletonNamedProperty "fieldIsNotDistinctFrom generates expected sql" $
+    assertWhereClauseEquals
+      (Just "WHERE (\"foo\") IS NOT DISTINCT FROM ($1)")
+      (O.where_ $ O.fieldIsNotDistinctFrom fooField 0)
 
 prop_fieldNotEqualsOperator :: Property.NamedProperty
 prop_fieldNotEqualsOperator =


### PR DESCRIPTION
This adds a handful of small additions. The commits are separated out for each to make viewing, or if needed reverting, the changes in isolation easier.

Most of the changes are limited to the working on the expr level and do not go out beyond that.
A quick overview:
- 'notExpr' to invert the value of a given 'BooleanExpr'
- A basic 'VacuumExpr' type and some functionality to support options to a 'VACUUM', such as 'ANALYZE' and 'FULL'.
- Functionality to allow an 'AlterTableExpr' to be a rename operation. Some care was given to this to not mix it in with the other 'AlterTableExpr' functions as it is, apparently, an alternate form of the 'ALTER TABLE' statement.
- A 'TruncateTableExpr' that is again basic, but gives access at the expr level to the faster 'TRUNCATE TABLE' (versus 'DELETE').
- Support for the 'IS DISTINCT FROM' comparison which is treated as a binary "operator" since it is infix in SQL. This has support threaded up to the top level module, because it was so lightweight to do so and is not intrusive on anything else at that level.