### PR TITLE
Adds initial aliasing support.

### DIFF
--- a/orville-postgresql/orville-postgresql.cabal
+++ b/orville-postgresql/orville-postgresql.cabal
@@ -109,6 +109,7 @@ library
       Orville.PostgreSQL.Schema.TableIdentifier
       Orville.PostgreSQL.UnliftIO
   other-modules:
+      Orville.PostgreSQL.Expr.Internal.Name.Alias
       Orville.PostgreSQL.Expr.Internal.Name.ColumnName
       Orville.PostgreSQL.Expr.Internal.Name.ConstraintName
       Orville.PostgreSQL.Expr.Internal.Name.CursorName

--- a/orville-postgresql/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL.hs
@@ -1,5 +1,5 @@
 {- |
-Copyright : Flipstone Technology Partners 2023
+Copyright : Flipstone Technology Partners 2023-2024
 License   : MIT
 Stability : Stable
 
@@ -165,6 +165,7 @@ module Orville.PostgreSQL
   , SqlMarshaller.marshallReadOnlyField
   , SqlMarshaller.marshallPartial
   , SqlMarshaller.marshallMaybe
+  , SqlMarshaller.marshallAlias
   , SqlMarshaller.prefixMarshaller
   , SqlMarshaller.foldMarshallerFields
   , SqlMarshaller.collectFromField
@@ -205,6 +206,7 @@ module Orville.PostgreSQL
   , FieldDefinition.fieldOfType
   , FieldDefinition.fieldColumnName
   , FieldDefinition.fieldColumnReference
+  , FieldDefinition.fieldColumnReferenceWithAlias
   , FieldDefinition.fieldName
   , FieldDefinition.setFieldName
   , FieldDefinition.fieldDescription
@@ -278,6 +280,20 @@ module Orville.PostgreSQL
   , (FieldDefinition..</-)
   , FieldDefinition.fieldTupleIn
   , FieldDefinition.fieldTupleNotIn
+  , FieldDefinition.fieldEqualsWithAlias
+  , FieldDefinition.fieldNotEqualsWithAlias
+  , FieldDefinition.fieldIsDistinctFromWithAlias
+  , FieldDefinition.fieldIsNotDistinctFromWithAlias
+  , FieldDefinition.fieldGreaterThanWithAlias
+  , FieldDefinition.fieldLessThanWithAlias
+  , FieldDefinition.fieldGreaterThanOrEqualToWithAlias
+  , FieldDefinition.fieldLessThanOrEqualToWithAlias
+  , FieldDefinition.fieldLikeWithAlias
+  , FieldDefinition.fieldLikeInsensitiveWithAlias
+  , FieldDefinition.fieldIsNullWithAlias
+  , FieldDefinition.fieldIsNotNullWithAlias
+  , FieldDefinition.fieldInWithAlias
+  , FieldDefinition.fieldNotInWithAlias
   , Expr.OrderByDirection
   , Expr.NullsOrder (..)
   , Expr.ascendingOrder
@@ -285,6 +301,7 @@ module Orville.PostgreSQL
   , Expr.descendingOrder
   , Expr.descendingOrderWith
   , FieldDefinition.orderByField
+  , FieldDefinition.orderByFieldWithAlias
   , Expr.orderByColumnName
   , Expr.andExpr
   , Expr.orExpr

--- a/orville-postgresql/src/Orville/PostgreSQL/AutoMigration.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/AutoMigration.hs
@@ -690,7 +690,7 @@ mkAddAlterColumnActions relationDesc fieldDef =
                   || (Orville.sqlTypeMaximumLength sqlType /= PgCatalog.pgAttributeMaxLength attr)
 
               columnName =
-                Orville.fieldColumnName Nothing fieldDef
+                Orville.fieldNameToColumnName $ Orville.fieldName fieldDef
 
               dataType =
                 Orville.sqlTypeExpr sqlType
@@ -760,7 +760,7 @@ mkAddAlterColumnActions relationDesc fieldDef =
         -- must rely on the database to raise the error because the table
         -- does not yet exist for us to discover a conflict with system
         -- attributes.
-        [Expr.addColumn (Orville.fieldColumnDefinition Nothing fieldDef)]
+        [Expr.addColumn (Orville.fieldColumnDefinition fieldDef)]
 
 {- |
   Builds 'Expr.AlterTableAction' expressions for the given attribute to make

--- a/orville-postgresql/src/Orville/PostgreSQL/Execution/Select.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Execution/Select.hs
@@ -123,12 +123,10 @@ selectMarshalledColumns marshaller qualifiedTableName selectOptions =
       (Expr.referencesTable qualifiedTableName)
       selectOptions
 
-{- |
-  Builds a 'Select' that will select all the columns described in the
-  'TableDefinition'. This is the safest way to build a 'Select', because table
-  name and columns are all read from the 'TableDefinition'. If the table is
-  being managed with Orville auto-migrations, this will match the schema in the
-  database.
+{- | Builds a 'Select' that will select all the columns described in the 'TableDefinition', ensuring
+  they are qualified with the given alias. This is the safest way to build a 'Select', because table
+  name and columns are all read from the 'TableDefinition'. If the table is being managed with
+  Orville auto-migrations, this will match the schema in the database.
 
 @since 1.1.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/ColumnDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/ColumnDefinition.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2023
+Copyright : Flipstone Technology Partners 2023-2024
 License   : MIT
 Stability : Stable
 
@@ -21,7 +21,7 @@ where
 import qualified Data.Maybe as Maybe
 
 import Orville.PostgreSQL.Expr.DataType (DataType)
-import Orville.PostgreSQL.Expr.Name (ColumnName)
+import Orville.PostgreSQL.Expr.Name (ColumnName, Qualified)
 import Orville.PostgreSQL.Expr.ValueExpression (ValueExpression)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
@@ -49,7 +49,7 @@ newtype ColumnDefinition
 -}
 columnDefinition ::
   -- | The name the resulting column should have.
-  ColumnName ->
+  Qualified ColumnName ->
   -- | The SQL type of the column.
   DataType ->
   -- | The constraint on the column, if any.

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/ColumnDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/ColumnDefinition.hs
@@ -21,7 +21,7 @@ where
 import qualified Data.Maybe as Maybe
 
 import Orville.PostgreSQL.Expr.DataType (DataType)
-import Orville.PostgreSQL.Expr.Name (ColumnName, Qualified)
+import Orville.PostgreSQL.Expr.Name (ColumnName)
 import Orville.PostgreSQL.Expr.ValueExpression (ValueExpression)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
@@ -49,7 +49,7 @@ newtype ColumnDefinition
 -}
 columnDefinition ::
   -- | The name the resulting column should have.
-  Qualified ColumnName ->
+  ColumnName ->
   -- | The SQL type of the column.
   DataType ->
   -- | The constraint on the column, if any.

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Count.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Count.hs
@@ -1,5 +1,5 @@
 {- |
-Copyright : Flipstone Technology Partners 2023
+Copyright : Flipstone Technology Partners 2023-2024
 License   : MIT
 Stability : Stable
 
@@ -13,7 +13,7 @@ module Orville.PostgreSQL.Expr.Count
   )
 where
 
-import Orville.PostgreSQL.Expr.Name (ColumnName, FunctionName, functionName)
+import Orville.PostgreSQL.Expr.Name (ColumnName, FunctionName, Qualified, functionName)
 import Orville.PostgreSQL.Expr.ValueExpression (ValueExpression, columnReference, functionCall)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
@@ -44,6 +44,6 @@ count1 =
 
 @since 1.0.0.0
 -}
-countColumn :: ColumnName -> ValueExpression
+countColumn :: Qualified ColumnName -> ValueExpression
 countColumn =
   count . columnReference

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/GroupBy.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/GroupBy.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2023
+Copyright : Flipstone Technology Partners 2023-2024
 License   : MIT
 Stability : Stable
 
@@ -18,7 +18,7 @@ where
 
 import Data.List.NonEmpty (NonEmpty)
 
-import Orville.PostgreSQL.Expr.Name (ColumnName)
+import Orville.PostgreSQL.Expr.Name (ColumnName, Qualified)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 {- |
@@ -83,6 +83,6 @@ appendGroupByExpr (GroupByExpr a) (GroupByExpr b) =
 
 @since 1.0.0.0
 -}
-groupByColumnsExpr :: NonEmpty ColumnName -> GroupByExpr
+groupByColumnsExpr :: NonEmpty (Qualified ColumnName) -> GroupByExpr
 groupByColumnsExpr =
   GroupByExpr . RawSql.intercalate RawSql.commaSpace

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Insert.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Insert.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2023
+Copyright : Flipstone Technology Partners 2023-2024
 License   : MIT
 Stability : Stable
 
@@ -95,7 +95,7 @@ parens and commas are used to separate.
 
 @since 1.0.0.0
 -}
-insertColumnList :: [ColumnName] -> InsertColumnList
+insertColumnList :: [Qualified ColumnName] -> InsertColumnList
 insertColumnList columnNames =
   InsertColumnList $
     RawSql.leftParen

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Internal/Name/Alias.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Internal/Name/Alias.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+{- |
+Copyright : Flipstone Technology Partners 2024
+License   : MIT
+Stability : Stable
+
+@since 1.1.0.0
+-}
+module Orville.PostgreSQL.Expr.Internal.Name.Alias
+  ( Alias
+  , alias
+  )
+where
+
+import Orville.PostgreSQL.Expr.Internal.Name.Identifier (Identifier, IdentifierExpression, identifier)
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+
+{- |
+Type to represent a SQL alias. 'Alias' values constructed
+via the 'alias' function will be properly escaped as part of the
+generated SQL. E.G.
+
+> "some_alias"
+
+'Alias' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 1.1.0.0
+-}
+newtype Alias
+  = Alias Identifier
+  deriving
+    ( -- | @since 1.1.0.0
+      RawSql.SqlExpression
+    , -- | @since 1.1.0.0
+      IdentifierExpression
+    )
+
+{- |
+Construct an 'Alias' from a 'String' with proper escaping as part of the generated SQL.
+
+@since 1.1.0.0
+-}
+alias :: String -> Alias
+alias =
+  Alias . identifier

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Internal/Name/Qualified.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Internal/Name/Qualified.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2023
+Copyright : Flipstone Technology Partners 2023-2024
 License   : MIT
 Stability : Stable
 
@@ -12,9 +12,11 @@ module Orville.PostgreSQL.Expr.Internal.Name.Qualified
   , qualifyTable
   , qualifySequence
   , qualifyColumn
+  , aliasQualifyColumn
   )
 where
 
+import Orville.PostgreSQL.Expr.Internal.Name.Alias (Alias)
 import Orville.PostgreSQL.Expr.Internal.Name.ColumnName (ColumnName)
 import Orville.PostgreSQL.Expr.Internal.Name.Identifier (IdentifierExpression (toIdentifier))
 import Orville.PostgreSQL.Expr.Internal.Name.SchemaName (SchemaName)
@@ -81,6 +83,14 @@ qualifyColumn mbSchemaName tableName unqualifiedName =
   unsafeSchemaQualify mbSchemaName
     . RawSql.unsafeFromRawSql
     $ RawSql.toRawSql (toIdentifier tableName) <> RawSql.dot <> RawSql.toRawSql (toIdentifier unqualifiedName)
+
+aliasQualifyColumn :: Maybe Alias -> ColumnName -> Qualified ColumnName
+aliasQualifyColumn mbAliasName unqualifiedName =
+  Qualified $ case mbAliasName of
+    Nothing ->
+      RawSql.toRawSql $ toIdentifier unqualifiedName
+    Just aliasName ->
+      RawSql.toRawSql (toIdentifier aliasName) <> RawSql.dot <> RawSql.toRawSql (toIdentifier unqualifiedName)
 
 -- Note: Not everything actually makes sense to be qualified by _only_ a schema name, such as
 -- columns, as in 'qualifyColumn'. But this does give us a nice uniform way to provide the

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Name.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Name.hs
@@ -12,6 +12,7 @@ module Orville.PostgreSQL.Expr.Name
   )
 where
 
+import Orville.PostgreSQL.Expr.Internal.Name.Alias as Export
 import Orville.PostgreSQL.Expr.Internal.Name.ColumnName as Export
 import Orville.PostgreSQL.Expr.Internal.Name.ConstraintName as Export
 import Orville.PostgreSQL.Expr.Internal.Name.CursorName as Export

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/OrderBy.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/OrderBy.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2023
+Copyright : Flipstone Technology Partners 2023-2024
 License   : MIT
 Stability : Stable
 
@@ -25,7 +25,7 @@ where
 
 import qualified Data.List.NonEmpty as NEL
 
-import Orville.PostgreSQL.Expr.Name (ColumnName)
+import Orville.PostgreSQL.Expr.Name (ColumnName, Qualified)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 {- |
@@ -83,11 +83,11 @@ appendOrderByExpr (OrderByExpr a) (OrderByExpr b) =
 
 @since 1.0.0.0
 -}
-orderByColumnsExpr :: NEL.NonEmpty (ColumnName, OrderByDirection) -> OrderByExpr
+orderByColumnsExpr :: NEL.NonEmpty (Qualified ColumnName, OrderByDirection) -> OrderByExpr
 orderByColumnsExpr =
   OrderByExpr . RawSql.intercalate RawSql.commaSpace . fmap columnOrdering
  where
-  columnOrdering :: (ColumnName, OrderByDirection) -> RawSql.RawSql
+  columnOrdering :: (Qualified ColumnName, OrderByDirection) -> RawSql.RawSql
   columnOrdering (columnName, orderByDirection) =
     RawSql.toRawSql columnName <> RawSql.space <> RawSql.toRawSql orderByDirection
 
@@ -96,7 +96,7 @@ orderByColumnsExpr =
 
 @since 1.0.0.0
 -}
-orderByColumnName :: ColumnName -> OrderByDirection -> OrderByExpr
+orderByColumnName :: Qualified ColumnName -> OrderByDirection -> OrderByExpr
 orderByColumnName =
   curry (orderByColumnsExpr . pure)
 

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Query.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Query.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2023
+Copyright : Flipstone Technology Partners 2023-2024
 License   : MIT
 Stability : Stable
 
@@ -26,7 +26,7 @@ import Data.Maybe (catMaybes, fromMaybe)
 
 import Orville.PostgreSQL.Expr.GroupBy (GroupByClause)
 import Orville.PostgreSQL.Expr.LimitExpr (LimitExpr)
-import Orville.PostgreSQL.Expr.Name (ColumnName)
+import Orville.PostgreSQL.Expr.Name (ColumnName, Qualified)
 import Orville.PostgreSQL.Expr.OffsetExpr (OffsetExpr)
 import Orville.PostgreSQL.Expr.OrderBy (OrderByClause)
 import Orville.PostgreSQL.Expr.Select (SelectClause)
@@ -110,7 +110,7 @@ selectStar =
 
   @since 1.0.0.0
 -}
-selectColumns :: [ColumnName] -> SelectList
+selectColumns :: [Qualified ColumnName] -> SelectList
 selectColumns =
   selectDerivedColumns . map (deriveColumn . columnReference)
 

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/TableDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/TableDefinition.hs
@@ -121,7 +121,7 @@ newtype PrimaryKeyExpr
 
   @since 1.0.0.0
 -}
-primaryKeyExpr :: NonEmpty (Qualified ColumnName) -> PrimaryKeyExpr
+primaryKeyExpr :: NonEmpty ColumnName -> PrimaryKeyExpr
 primaryKeyExpr columnNames =
   PrimaryKeyExpr $
     mconcat
@@ -235,7 +235,7 @@ dropConstraint constraintName =
 -}
 alterColumnType ::
   -- | The name of the column whose type will be altered.
-  Qualified ColumnName ->
+  ColumnName ->
   -- | The new type to use for the column.
   DataType ->
   -- | An optional 'UsingClause' to indicate to the database how data from the
@@ -274,7 +274,7 @@ newtype UsingClause
 
   @since 1.0.0.0
 -}
-usingCast :: Qualified ColumnName -> DataType -> UsingClause
+usingCast :: ColumnName -> DataType -> UsingClause
 usingCast columnName dataType =
   UsingClause $
     RawSql.fromString "USING "
@@ -288,7 +288,7 @@ usingCast columnName dataType =
 
   @since 1.0.0.0
 -}
-alterColumnNullability :: Qualified ColumnName -> AlterNotNull -> AlterTableAction
+alterColumnNullability :: ColumnName -> AlterNotNull -> AlterTableAction
 alterColumnNullability columnName alterNotNull =
   AlterTableAction $
     RawSql.intercalate
@@ -337,7 +337,7 @@ dropNotNull =
 
   @since 1.0.0.0
 -}
-alterColumnDropDefault :: Qualified ColumnName -> AlterTableAction
+alterColumnDropDefault :: ColumnName -> AlterTableAction
 alterColumnDropDefault columnName =
   AlterTableAction $
     RawSql.intercalate
@@ -355,7 +355,7 @@ alterColumnDropDefault columnName =
 -}
 alterColumnSetDefault ::
   RawSql.SqlExpression valueExpression =>
-  Qualified ColumnName ->
+  ColumnName ->
   valueExpression ->
   AlterTableAction
 alterColumnSetDefault columnName defaultValue =

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/TableDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/TableDefinition.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2023
+Copyright : Flipstone Technology Partners 2023-2024
 License   : MIT
 Stability : Stable
 
@@ -121,7 +121,7 @@ newtype PrimaryKeyExpr
 
   @since 1.0.0.0
 -}
-primaryKeyExpr :: NonEmpty ColumnName -> PrimaryKeyExpr
+primaryKeyExpr :: NonEmpty (Qualified ColumnName) -> PrimaryKeyExpr
 primaryKeyExpr columnNames =
   PrimaryKeyExpr $
     mconcat
@@ -235,7 +235,7 @@ dropConstraint constraintName =
 -}
 alterColumnType ::
   -- | The name of the column whose type will be altered.
-  ColumnName ->
+  Qualified ColumnName ->
   -- | The new type to use for the column.
   DataType ->
   -- | An optional 'UsingClause' to indicate to the database how data from the
@@ -274,7 +274,7 @@ newtype UsingClause
 
   @since 1.0.0.0
 -}
-usingCast :: ColumnName -> DataType -> UsingClause
+usingCast :: Qualified ColumnName -> DataType -> UsingClause
 usingCast columnName dataType =
   UsingClause $
     RawSql.fromString "USING "
@@ -288,7 +288,7 @@ usingCast columnName dataType =
 
   @since 1.0.0.0
 -}
-alterColumnNullability :: ColumnName -> AlterNotNull -> AlterTableAction
+alterColumnNullability :: Qualified ColumnName -> AlterNotNull -> AlterTableAction
 alterColumnNullability columnName alterNotNull =
   AlterTableAction $
     RawSql.intercalate
@@ -337,7 +337,7 @@ dropNotNull =
 
   @since 1.0.0.0
 -}
-alterColumnDropDefault :: ColumnName -> AlterTableAction
+alterColumnDropDefault :: Qualified ColumnName -> AlterTableAction
 alterColumnDropDefault columnName =
   AlterTableAction $
     RawSql.intercalate
@@ -355,7 +355,7 @@ alterColumnDropDefault columnName =
 -}
 alterColumnSetDefault ::
   RawSql.SqlExpression valueExpression =>
-  ColumnName ->
+  Qualified ColumnName ->
   valueExpression ->
   AlterTableAction
 alterColumnSetDefault columnName defaultValue =

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/TableReferenceList.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/TableReferenceList.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2023
+Copyright : Flipstone Technology Partners 2023-2024
 License   : MIT
 Stability : Stable
 
@@ -10,10 +10,11 @@ Stability : Stable
 module Orville.PostgreSQL.Expr.TableReferenceList
   ( TableReferenceList
   , referencesTable
+  , referencesTableWithAlias
   )
 where
 
-import Orville.PostgreSQL.Expr.Name (Qualified, TableName)
+import Orville.PostgreSQL.Expr.Name (Alias, Qualified, TableName)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 {- |
@@ -46,3 +47,18 @@ referencesTable :: Qualified TableName -> TableReferenceList
 referencesTable qualifiedTableName =
   TableReferenceList $
     RawSql.toRawSql qualifiedTableName
+
+{- |
+  Constructs a 'TableReferenceList' consisting of the specified table AS the given alias.
+
+  @since 1.1.0.0
+-}
+referencesTableWithAlias :: Alias -> Qualified TableName -> TableReferenceList
+referencesTableWithAlias alias qualifiedTableName =
+  TableReferenceList $
+    RawSql.intercalate
+      RawSql.space
+      [ RawSql.toRawSql qualifiedTableName
+      , RawSql.fromString "AS"
+      , RawSql.toRawSql alias
+      ]

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Update.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Update.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2023
+Copyright : Flipstone Technology Partners 2023-2024
 License   : MIT
 Stability : Stable
 
@@ -116,7 +116,7 @@ newtype SetClause
 
   @since 1.0.0.0
 -}
-setColumn :: ColumnName -> SqlValue.SqlValue -> SetClause
+setColumn :: Qualified ColumnName -> SqlValue.SqlValue -> SetClause
 setColumn columnName value =
   SetClause $
     RawSql.toRawSql columnName

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/ValueExpression.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/ValueExpression.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2023
+Copyright : Flipstone Technology Partners 2023-2024
 License   : MIT
 Stability : Stable
 
@@ -22,7 +22,7 @@ where
 import qualified Data.List.NonEmpty as NE
 
 import Orville.PostgreSQL.Expr.DataType (DataType)
-import Orville.PostgreSQL.Expr.Name (ColumnName, FunctionName)
+import Orville.PostgreSQL.Expr.Name (ColumnName, FunctionName, Qualified)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import Orville.PostgreSQL.Raw.SqlValue (SqlValue)
 
@@ -65,7 +65,7 @@ is the equivalent of simply writing the column name as the expression. E.G.
 
 @since 1.0.0.0
 -}
-columnReference :: ColumnName -> ValueExpression
+columnReference :: Qualified ColumnName -> ValueExpression
 columnReference = ValueExpression . RawSql.toRawSql
 
 {- |

--- a/orville-postgresql/src/Orville/PostgreSQL/Marshall/FieldDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Marshall/FieldDefinition.hs
@@ -426,10 +426,10 @@ fieldColumnReferenceWithAlias mbAlias =
 
 @since 1.0.0.0
 -}
-fieldColumnDefinition :: Maybe Expr.Alias -> FieldDefinition nullability a -> Expr.ColumnDefinition
-fieldColumnDefinition mbAlias fieldDef =
+fieldColumnDefinition :: FieldDefinition nullability a -> Expr.ColumnDefinition
+fieldColumnDefinition fieldDef =
   Expr.columnDefinition
-    (fieldColumnName mbAlias fieldDef)
+    (fieldNameToColumnName $ fieldName fieldDef)
     (SqlType.sqlTypeExpr $ fieldType fieldDef)
     (Just $ fieldColumnConstraint fieldDef)
     (fmap (Expr.columnDefault . DefaultValue.defaultValueExpression) $ i_fieldDefaultValue fieldDef)

--- a/orville-postgresql/src/Orville/PostgreSQL/Marshall/SqlMarshaller.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Marshall/SqlMarshaller.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE RankNTypes #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2023
+Copyright : Flipstone Technology Partners 2023-2024
 License   : MIT
 Stability : Stable
 
@@ -35,6 +35,7 @@ module Orville.PostgreSQL.Marshall.SqlMarshaller
   , marshallNested
   , marshallMaybe
   , marshallPartial
+  , marshallAlias
   , prefixMarshaller
   , ReadOnlyColumnOption (IncludeReadOnlyColumns, ExcludeReadOnlyColumns)
   , collectFromField
@@ -61,7 +62,7 @@ import Orville.PostgreSQL.ErrorDetailLevel (ErrorDetailLevel)
 import Orville.PostgreSQL.Execution.ExecutionResult (Column (Column), ExecutionResult, Row (Row))
 import qualified Orville.PostgreSQL.Execution.ExecutionResult as Result
 import qualified Orville.PostgreSQL.Expr as Expr
-import Orville.PostgreSQL.Marshall.FieldDefinition (FieldDefinition, FieldName, FieldNullability (NotNullField, NullableField), asymmetricNullableField, fieldColumnName, fieldName, fieldNameToByteString, fieldNameToColumnName, fieldNullability, fieldTableConstraints, fieldValueFromSqlValue, nullableField, prefixField, setField)
+import Orville.PostgreSQL.Marshall.FieldDefinition (FieldDefinition, FieldName, FieldNullability (NotNullField, NullableField), asymmetricNullableField, fieldColumnName, fieldName, fieldNameToByteString, fieldNameToColumnName, fieldNullability, fieldTableConstraints, fieldValueFromSqlValue, nullableField, prefixField, setFieldWithAlias)
 import qualified Orville.PostgreSQL.Marshall.MarshallError as MarshallError
 import Orville.PostgreSQL.Marshall.SyntheticField (SyntheticField, nullableSyntheticField, prefixSyntheticField, syntheticFieldAlias, syntheticFieldExpression, syntheticFieldValueFromSqlValue)
 import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
@@ -156,6 +157,8 @@ data SqlMarshaller a b where
   MarshallPartial :: SqlMarshaller a (Either String b) -> SqlMarshaller a b
   -- | Marshall a column that is read-only, like auto-incrementing ids.
   MarshallReadOnly :: SqlMarshaller a b -> SqlMarshaller c b
+  -- | Apply an alias to a marshaller
+  MarshallAlias :: Expr.Alias -> SqlMarshaller a b -> SqlMarshaller a b
 
 instance Functor (SqlMarshaller a) where
   fmap f marsh = MarshallApply (MarshallPure f) marsh
@@ -182,8 +185,8 @@ marshallerDerivedColumns marshaller =
       [Expr.DerivedColumn]
     collectDerivedColumn entry columns =
       case entry of
-        Natural fieldDef _ ->
-          (Expr.deriveColumn . Expr.columnReference . fieldColumnName $ fieldDef)
+        Natural mbAlias fieldDef _ ->
+          (Expr.deriveColumn . Expr.columnReference $ fieldColumnName mbAlias fieldDef)
             : columns
         Synthetic synthField ->
           Expr.deriveColumnAs
@@ -210,7 +213,7 @@ marshallerTableConstraints marshaller =
       ConstraintDefinition.TableConstraints
     collectTableConstraints entry constraints =
       case entry of
-        Natural fieldDef _ -> constraints <> fieldTableConstraints fieldDef
+        Natural _ fieldDef _ -> constraints <> fieldTableConstraints fieldDef
         Synthetic _synthField -> constraints
   in
     foldMarshallerFields
@@ -226,7 +229,7 @@ marshallerTableConstraints marshaller =
 @since 1.0.0.0
 -}
 data MarshallerField writeEntity where
-  Natural :: FieldDefinition nullability a -> Maybe (writeEntity -> a) -> MarshallerField writeEntity
+  Natural :: Maybe Expr.Alias -> FieldDefinition nullability a -> Maybe (writeEntity -> a) -> MarshallerField writeEntity
   Synthetic :: SyntheticField a -> MarshallerField writeEntity
 
 {- |
@@ -242,17 +245,17 @@ data MarshallerField writeEntity where
 -}
 collectFromField ::
   ReadOnlyColumnOption ->
-  (forall nullability a. FieldDefinition nullability a -> result) ->
+  (forall nullability a. Maybe Expr.Alias -> FieldDefinition nullability a -> result) ->
   MarshallerField entity ->
   [result] ->
   [result]
 collectFromField readOnlyColumnOption fromField entry results =
   case entry of
-    Natural fieldDef (Just _) ->
-      fromField fieldDef : results
-    Natural fieldDef Nothing ->
+    Natural mbAlias fieldDef (Just _) ->
+      fromField mbAlias fieldDef : results
+    Natural mbAlias fieldDef Nothing ->
       case readOnlyColumnOption of
-        IncludeReadOnlyColumns -> fromField fieldDef : results
+        IncludeReadOnlyColumns -> fromField mbAlias fieldDef : results
         ExcludeReadOnlyColumns -> results
     Synthetic _ ->
       results
@@ -287,9 +290,9 @@ collectSetClauses ::
   [Expr.SetClause]
 collectSetClauses entity entry clauses =
   case entry of
-    Natural fieldDef (Just accessor) ->
-      setField fieldDef (accessor entity) : clauses
-    Natural _ Nothing ->
+    Natural mbAlias fieldDef (Just accessor) ->
+      setFieldWithAlias mbAlias fieldDef (accessor entity) : clauses
+    Natural _ _ Nothing ->
       clauses
     Synthetic _ ->
       clauses
@@ -318,7 +321,7 @@ foldMarshallerFields ::
   (MarshallerField writeEntity -> result -> result) ->
   result
 foldMarshallerFields marshaller =
-  foldMarshallerFieldsPart marshaller (Just id)
+  foldMarshallerFieldsPart Nothing marshaller (Just id)
 
 {- |
   The internal helper function that actually implements 'foldMarshallerFields'.
@@ -329,33 +332,36 @@ foldMarshallerFields marshaller =
 @since 1.0.0.0
 -}
 foldMarshallerFieldsPart ::
+  Maybe Expr.Alias ->
   SqlMarshaller entityPart readEntity ->
   Maybe (writeEntity -> entityPart) ->
   result ->
   (MarshallerField writeEntity -> result -> result) ->
   result
-foldMarshallerFieldsPart marshaller getPart currentResult addToResult =
+foldMarshallerFieldsPart mbAlias marshaller getPart currentResult addToResult =
   case marshaller of
     MarshallPure _ ->
       currentResult
     MarshallApply submarshallerA submarshallerB ->
       let
         subresultB =
-          foldMarshallerFieldsPart submarshallerB getPart currentResult addToResult
+          foldMarshallerFieldsPart mbAlias submarshallerB getPart currentResult addToResult
       in
-        foldMarshallerFieldsPart submarshallerA getPart subresultB addToResult
+        foldMarshallerFieldsPart mbAlias submarshallerA getPart subresultB addToResult
     MarshallNest nestingFunction submarshaller ->
-      foldMarshallerFieldsPart submarshaller (fmap (nestingFunction .) getPart) currentResult addToResult
+      foldMarshallerFieldsPart mbAlias submarshaller (fmap (nestingFunction .) getPart) currentResult addToResult
     MarshallField fieldDefinition ->
-      addToResult (Natural fieldDefinition getPart) currentResult
+      addToResult (Natural mbAlias fieldDefinition getPart) currentResult
     MarshallSyntheticField syntheticField ->
       addToResult (Synthetic syntheticField) currentResult
     MarshallMaybeTag m ->
-      foldMarshallerFieldsPart m getPart currentResult addToResult
+      foldMarshallerFieldsPart mbAlias m getPart currentResult addToResult
     MarshallPartial m ->
-      foldMarshallerFieldsPart m getPart currentResult addToResult
+      foldMarshallerFieldsPart mbAlias m getPart currentResult addToResult
     MarshallReadOnly m ->
-      foldMarshallerFieldsPart m Nothing currentResult addToResult
+      foldMarshallerFieldsPart mbAlias m Nothing currentResult addToResult
+    MarshallAlias a m ->
+      foldMarshallerFieldsPart (Just a) m getPart currentResult addToResult
 
 {- |
   Decodes all the rows found in an execution result at once. The first row that
@@ -551,8 +557,8 @@ mkRowSource marshaller result = do
   columnMap <- prepareColumnMap result
 
   let
-    mkSource :: SqlMarshaller a b -> RowSource b
-    mkSource marshallerPart =
+    mkSource :: Maybe Expr.Alias -> SqlMarshaller a b -> RowSource b
+    mkSource mbAlias marshallerPart =
       -- Note, this case statement is evaluated before the row argument is
       -- ever passed to a 'RowSource' to ensure that a single 'RowSource'
       -- operation is build and re-used when decoding many rows.
@@ -560,9 +566,9 @@ mkRowSource marshaller result = do
         MarshallPure readEntity ->
           constRowSource readEntity
         MarshallApply marshallAToB marshallA ->
-          mkSource marshallAToB <*> mkSource marshallA
+          mkSource mbAlias marshallAToB <*> mkSource mbAlias marshallA
         MarshallNest _ someMarshaller ->
-          mkSource someMarshaller
+          mkSource mbAlias someMarshaller
         MarshallField fieldDef ->
           mkFieldNameSource
             (fieldName fieldDef)
@@ -576,22 +582,24 @@ mkRowSource marshaller result = do
             columnMap
             result
         MarshallMaybeTag m ->
-          mkSource m
+          mkSource mbAlias m
         MarshallPartial m ->
           let
             fieldNames =
               foldMarshallerFields m [] $ \marshallerField names ->
                 case marshallerField of
-                  Natural field _ ->
+                  Natural _ field _ ->
                     fieldName field : names
                   Synthetic field ->
                     syntheticFieldAlias field : names
           in
-            partialRowSource fieldNames columnMap result (mkSource m)
+            partialRowSource fieldNames columnMap result (mkSource mbAlias m)
         MarshallReadOnly m ->
-          mkSource m
+          mkSource mbAlias m
+        MarshallAlias a m ->
+          mkSource (Just a) m
 
-  pure . mkSource $ marshaller
+  pure . mkSource Nothing $ marshaller
 
 partialRowSource ::
   ExecutionResult result =>
@@ -907,6 +915,8 @@ marshallMaybe =
         MarshallPartial (fmap sequence $ go m)
       MarshallReadOnly m ->
         MarshallReadOnly (go m)
+      MarshallAlias a m ->
+        MarshallAlias a (go m)
 
 {- |
   Builds a 'SqlMarshaller' that will raise a decoding error when the value
@@ -916,6 +926,18 @@ marshallMaybe =
 -}
 marshallPartial :: SqlMarshaller a (Either String b) -> SqlMarshaller a b
 marshallPartial = MarshallPartial
+
+{- |
+  Builds a 'SqlMarshaller' that will qualifiy the fields contained with the given alias.
+
+@since 1.1.0.0
+-}
+marshallAlias ::
+  Expr.Alias ->
+  SqlMarshaller a b ->
+  SqlMarshaller a b
+marshallAlias =
+  MarshallAlias
 
 {- |
   Adds a prefix, followed by an underscore, to the names of all of the fields
@@ -943,6 +965,7 @@ prefixMarshaller prefix = go
     MarshallMaybeTag m -> MarshallMaybeTag $ go m
     MarshallPartial m -> MarshallPartial $ go m
     MarshallReadOnly m -> MarshallReadOnly $ go m
+    MarshallAlias a m -> MarshallAlias a $ go m
 
 {- |
   Marks a 'SqlMarshaller' as read-only so that it will not attempt to

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/PrimaryKey.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/PrimaryKey.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE RankNTypes #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2023
+Copyright : Flipstone Technology Partners 2023-2024
 License   : MIT
 Stability : Stable
 
@@ -181,7 +181,7 @@ mkPrimaryKeyExpr :: PrimaryKey key -> Expr.PrimaryKeyExpr
 mkPrimaryKeyExpr keyDef =
   let
     names =
-      mapPrimaryKeyParts (\_ field -> fieldColumnName field) keyDef
+      mapPrimaryKeyParts (\_ field -> fieldColumnName Nothing field) keyDef
   in
     Expr.primaryKeyExpr names
 

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/PrimaryKey.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/PrimaryKey.hs
@@ -29,7 +29,7 @@ import Data.List.NonEmpty (NonEmpty ((:|)), toList)
 
 import qualified Orville.PostgreSQL.Expr as Expr
 import qualified Orville.PostgreSQL.Internal.Extra.NonEmpty as ExtraNonEmpty
-import Orville.PostgreSQL.Marshall.FieldDefinition (FieldDefinition, FieldName, NotNull, fieldColumnName, fieldEquals, fieldIn, fieldName, fieldNameToString, fieldValueToSqlValue)
+import Orville.PostgreSQL.Marshall.FieldDefinition (FieldDefinition, FieldName, NotNull, fieldEquals, fieldIn, fieldName,fieldNameToColumnName, fieldNameToString, fieldValueToSqlValue)
 import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 {- |
@@ -181,7 +181,7 @@ mkPrimaryKeyExpr :: PrimaryKey key -> Expr.PrimaryKeyExpr
 mkPrimaryKeyExpr keyDef =
   let
     names =
-      mapPrimaryKeyParts (\_ field -> fieldColumnName Nothing field) keyDef
+      mapPrimaryKeyParts (\_ field -> fieldNameToColumnName $ fieldName field) keyDef
   in
     Expr.primaryKeyExpr names
 

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/PrimaryKey.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/PrimaryKey.hs
@@ -29,7 +29,7 @@ import Data.List.NonEmpty (NonEmpty ((:|)), toList)
 
 import qualified Orville.PostgreSQL.Expr as Expr
 import qualified Orville.PostgreSQL.Internal.Extra.NonEmpty as ExtraNonEmpty
-import Orville.PostgreSQL.Marshall.FieldDefinition (FieldDefinition, FieldName, NotNull, fieldEquals, fieldIn, fieldName,fieldNameToColumnName, fieldNameToString, fieldValueToSqlValue)
+import Orville.PostgreSQL.Marshall.FieldDefinition (FieldDefinition, FieldName, NotNull, fieldEquals, fieldIn, fieldName, fieldNameToColumnName, fieldNameToString, fieldValueToSqlValue)
 import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 {- |

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/TableDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/TableDefinition.hs
@@ -393,7 +393,7 @@ mkTableColumnDefinitions tableDef =
   foldMarshallerFields
     (unannotatedSqlMarshaller $ tableMarshaller tableDef)
     []
-    (collectFromField IncludeReadOnlyColumns fieldColumnDefinition)
+    (collectFromField IncludeReadOnlyColumns (const fieldColumnDefinition))
 
 {- |
   Builds the 'Expr.PrimaryKeyExpr' for this table, or none if this table has no

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/TableDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/TableDefinition.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE RankNTypes #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2023
+Copyright : Flipstone Technology Partners 2023-2024
 License   : MIT
 Stability : Stable
 
@@ -479,8 +479,9 @@ mkInsertColumnList ::
   SqlMarshaller writeEntity readEntity ->
   Expr.InsertColumnList
 mkInsertColumnList marshaller =
-  Expr.insertColumnList $
-    foldMarshallerFields marshaller [] (collectFromField ExcludeReadOnlyColumns fieldColumnName)
+  Expr.insertColumnList
+    . foldMarshallerFields marshaller []
+    $ collectFromField ExcludeReadOnlyColumns fieldColumnName
 
 {- |
   Builds an 'Expr.InsertSource' that will insert the given entities with their
@@ -519,9 +520,9 @@ collectSqlValue ::
   [SqlValue]
 collectSqlValue entry encodeRest entity =
   case entry of
-    Natural fieldDef (Just accessor) ->
+    Natural _ fieldDef (Just accessor) ->
       fieldValueToSqlValue fieldDef (accessor entity) : (encodeRest entity)
-    Natural _ Nothing ->
+    Natural _ _ Nothing ->
       encodeRest entity
     Synthetic _ ->
       encodeRest entity

--- a/orville-postgresql/test/Test/AutoMigration.hs
+++ b/orville-postgresql/test/Test/AutoMigration.hs
@@ -245,7 +245,7 @@ data SomeField where
 
 describeField :: SomeField -> String
 describeField (SomeField field) =
-  B8.unpack (RawSql.toExampleBytes $ Orville.fieldColumnDefinition Nothing field)
+  B8.unpack (RawSql.toExampleBytes $ Orville.fieldColumnDefinition field)
 
 prop_altersColumnDataType :: Property.NamedDBProperty
 prop_altersColumnDataType =

--- a/orville-postgresql/test/Test/AutoMigration.hs
+++ b/orville-postgresql/test/Test/AutoMigration.hs
@@ -245,7 +245,7 @@ data SomeField where
 
 describeField :: SomeField -> String
 describeField (SomeField field) =
-  B8.unpack (RawSql.toExampleBytes $ Orville.fieldColumnDefinition field)
+  B8.unpack (RawSql.toExampleBytes $ Orville.fieldColumnDefinition Nothing field)
 
 prop_altersColumnDataType :: Property.NamedDBProperty
 prop_altersColumnDataType =

--- a/orville-postgresql/test/Test/Expr/Count.hs
+++ b/orville-postgresql/test/Test/Expr/Count.hs
@@ -57,7 +57,7 @@ prop_countColumn =
           (Expr.selectClause (Expr.selectExpr Nothing))
           ( Expr.selectDerivedColumns
               [ Expr.deriveColumnAs
-                  (Expr.countColumn (Orville.fieldColumnName Foo.fooIdField))
+                  (Expr.countColumn (Orville.fieldColumnName Nothing Foo.fooIdField))
                   (Expr.columnName "count")
               ]
           )

--- a/orville-postgresql/test/Test/Expr/GroupBy.hs
+++ b/orville-postgresql/test/Test/Expr/GroupBy.hs
@@ -107,13 +107,13 @@ testTable :: Expr.Qualified Expr.TableName
 testTable =
   Expr.qualifyTable Nothing (Expr.tableName "expr_test")
 
-fooColumn :: Expr.ColumnName
+fooColumn :: Expr.Qualified Expr.ColumnName
 fooColumn =
-  Expr.columnName "foo"
+  Expr.aliasQualifyColumn Nothing (Expr.columnName "foo")
 
-barColumn :: Expr.ColumnName
+barColumn :: Expr.Qualified Expr.ColumnName
 barColumn =
-  Expr.columnName "bar"
+  Expr.aliasQualifyColumn Nothing (Expr.columnName "bar")
 
 dropAndRecreateTestTable :: Orville.Connection -> IO ()
 dropAndRecreateTestTable connection = do

--- a/orville-postgresql/test/Test/Expr/GroupByOrderBy.hs
+++ b/orville-postgresql/test/Test/Expr/GroupByOrderBy.hs
@@ -97,13 +97,13 @@ testTable :: Expr.Qualified Expr.TableName
 testTable =
   Expr.qualifyTable Nothing (Expr.tableName "expr_test")
 
-fooColumn :: Expr.ColumnName
+fooColumn :: Expr.Qualified Expr.ColumnName
 fooColumn =
-  Expr.columnName "foo"
+  Expr.aliasQualifyColumn Nothing (Expr.columnName "foo")
 
-barColumn :: Expr.ColumnName
+barColumn :: Expr.Qualified Expr.ColumnName
 barColumn =
-  Expr.columnName "bar"
+  Expr.aliasQualifyColumn Nothing (Expr.columnName "bar")
 
 dropAndRecreateTestTable :: Orville.Connection -> IO ()
 dropAndRecreateTestTable connection = do

--- a/orville-postgresql/test/Test/Expr/TableDefinition.hs
+++ b/orville-postgresql/test/Test/Expr/TableDefinition.hs
@@ -97,7 +97,7 @@ tableNameString =
 column1Definition :: Expr.ColumnDefinition
 column1Definition =
   Expr.columnDefinition
-    (Expr.columnName column1NameString)
+    (Expr.aliasQualifyColumn Nothing (Expr.columnName column1NameString))
     Expr.text
     Nothing
     Nothing
@@ -109,7 +109,7 @@ column1NameString =
 column2Definition :: Expr.ColumnDefinition
 column2Definition =
   Expr.columnDefinition
-    (Expr.columnName column2NameString)
+    (Expr.aliasQualifyColumn Nothing (Expr.columnName column2NameString))
     Expr.text
     Nothing
     Nothing

--- a/orville-postgresql/test/Test/Expr/TableDefinition.hs
+++ b/orville-postgresql/test/Test/Expr/TableDefinition.hs
@@ -97,7 +97,7 @@ tableNameString =
 column1Definition :: Expr.ColumnDefinition
 column1Definition =
   Expr.columnDefinition
-    (Expr.aliasQualifyColumn Nothing (Expr.columnName column1NameString))
+    (Expr.columnName column1NameString)
     Expr.text
     Nothing
     Nothing
@@ -109,7 +109,7 @@ column1NameString =
 column2Definition :: Expr.ColumnDefinition
 column2Definition =
   Expr.columnDefinition
-    (Expr.aliasQualifyColumn Nothing (Expr.columnName column2NameString))
+    (Expr.columnName column2NameString)
     Expr.text
     Nothing
     Nothing

--- a/orville-postgresql/test/Test/Expr/TestSchema.hs
+++ b/orville-postgresql/test/Test/Expr/TestSchema.hs
@@ -46,17 +46,21 @@ fooBarTable :: Expr.Qualified Expr.TableName
 fooBarTable =
   Expr.qualifyTable Nothing (Expr.tableName "foobar")
 
-fooColumn :: Expr.ColumnName
+fooColumn :: Expr.Qualified Expr.ColumnName
 fooColumn =
-  Expr.columnName "foo"
+  Expr.aliasQualifyColumn Nothing $ Expr.columnName "foo"
 
 fooColumnRef :: Expr.ValueExpression
 fooColumnRef =
   Expr.columnReference fooColumn
 
-barColumn :: Expr.ColumnName
+barColumn :: Expr.Qualified Expr.ColumnName
 barColumn =
-  Expr.columnName "bar"
+  Expr.aliasQualifyColumn Nothing $ Expr.columnName "bar"
+
+barColumnAliased :: Expr.Qualified Expr.ColumnName
+barColumnAliased =
+  Expr.aliasQualifyColumn (Just $ Expr.alias "b") $ Expr.columnName "bar"
 
 barColumnRef :: Expr.ValueExpression
 barColumnRef =
@@ -73,10 +77,13 @@ findAllFooBars =
 
 findAllFooBarsInTable :: Expr.Qualified Expr.TableName -> Expr.QueryExpr
 findAllFooBarsInTable tableName =
-  Expr.queryExpr
-    (Expr.selectClause $ Expr.selectExpr Nothing)
-    (Expr.selectColumns [fooColumn, barColumn])
-    (Just $ Expr.tableExpr (Expr.referencesTable tableName) Nothing Nothing (Just orderByFoo) Nothing Nothing)
+  let
+    tableRef = Expr.referencesTableWithAlias (Expr.alias "b") tableName
+  in
+    Expr.queryExpr
+      (Expr.selectClause $ Expr.selectExpr Nothing)
+      (Expr.selectColumns [fooColumn, barColumnAliased])
+      (Just $ Expr.tableExpr tableRef Nothing Nothing (Just orderByFoo) Nothing Nothing)
 
 encodeFooBar :: FooBar -> [(Maybe B8.ByteString, SqlValue.SqlValue)]
 encodeFooBar fooBar =

--- a/orville-postgresql/test/Test/FieldDefinition.hs
+++ b/orville-postgresql/test/Test/FieldDefinition.hs
@@ -256,7 +256,7 @@ runRoundTripTest pool testCase = do
       RawSql.execute connection $
         Expr.queryExpr
           (Expr.selectClause $ Expr.selectExpr Nothing)
-          (Expr.selectColumns [Marshall.fieldColumnName fieldDef])
+          (Expr.selectColumns [Marshall.fieldColumnName Nothing fieldDef])
           (Just $ Expr.tableExpr (Expr.referencesTable testTable) Nothing Nothing Nothing Nothing Nothing)
 
     Execution.readRows result
@@ -301,7 +301,7 @@ runNullableRoundTripTest pool testCase = do
       RawSql.execute connection $
         Expr.queryExpr
           (Expr.selectClause $ Expr.selectExpr Nothing)
-          (Expr.selectColumns [Marshall.fieldColumnName fieldDef])
+          (Expr.selectColumns [Marshall.fieldColumnName Nothing fieldDef])
           (Just $ Expr.tableExpr (Expr.referencesTable testTable) Nothing Nothing Nothing Nothing Nothing)
 
     Execution.readRows result
@@ -371,7 +371,7 @@ runDefaultValueFieldDefinitionTest pool testCase mkDefaultValue = do
       RawSql.execute connection $
         Expr.queryExpr
           (Expr.selectClause $ Expr.selectExpr Nothing)
-          (Expr.selectColumns [Marshall.fieldColumnName fieldDef])
+          (Expr.selectColumns [Marshall.fieldColumnName Nothing fieldDef])
           (Just $ Expr.tableExpr (Expr.referencesTable testTable) Nothing Nothing Nothing Nothing Nothing)
 
     Execution.readRows result
@@ -416,4 +416,4 @@ dropAndRecreateTestTable fieldDef connection = do
   RawSql.executeVoid connection (RawSql.fromString "DROP TABLE IF EXISTS " <> RawSql.toRawSql testTable)
 
   RawSql.executeVoid connection $
-    Expr.createTableExpr testTable [Marshall.fieldColumnDefinition fieldDef] Nothing []
+    Expr.createTableExpr testTable [Marshall.fieldColumnDefinition Nothing fieldDef] Nothing []

--- a/orville-postgresql/test/Test/FieldDefinition.hs
+++ b/orville-postgresql/test/Test/FieldDefinition.hs
@@ -416,4 +416,4 @@ dropAndRecreateTestTable fieldDef connection = do
   RawSql.executeVoid connection (RawSql.fromString "DROP TABLE IF EXISTS " <> RawSql.toRawSql testTable)
 
   RawSql.executeVoid connection $
-    Expr.createTableExpr testTable [Marshall.fieldColumnDefinition Nothing fieldDef] Nothing []
+    Expr.createTableExpr testTable [Marshall.fieldColumnDefinition fieldDef] Nothing []

--- a/orville-postgresql/test/Test/SelectOptions.hs
+++ b/orville-postgresql/test/Test/SelectOptions.hs
@@ -53,6 +53,7 @@ selectOptionsTests =
     , prop_fieldNotInOperator
     , prop_distinct
     , prop_orderBy
+    , prop_orderByAliased
     , prop_orderByCombined
     , prop_groupBy
     , prop_groupByCombined
@@ -310,12 +311,23 @@ prop_orderBy =
           )
       )
 
+prop_orderByAliased :: Property.NamedProperty
+prop_orderByAliased =
+  Property.singletonNamedProperty "orderBy generates expected sql" $
+    assertOrderByClauseEquals
+      (Just "ORDER BY \"f\".\"foo\" ASC, \"bar\" DESC")
+      ( O.orderBy
+          ( O.orderByFieldWithAlias (Just $ Expr.alias "f") fooField Expr.ascendingOrder
+              <> O.orderByField barField Expr.descendingOrder
+          )
+      )
+
 prop_orderByCombined :: Property.NamedProperty
 prop_orderByCombined =
   Property.singletonNamedProperty "orderBy generates expected sql with multiple selectOptions" $
     assertOrderByClauseEquals
       (Just "ORDER BY \"foo\" ASC, \"bar\" DESC")
-      ( (O.orderBy $ O.orderByColumnName (Expr.columnName "foo") O.ascendingOrder)
+      ( (O.orderBy $ O.orderByColumnName (Expr.aliasQualifyColumn Nothing (Expr.columnName "foo")) O.ascendingOrder)
           <> (O.orderBy $ O.orderByField barField O.descendingOrder)
       )
 
@@ -325,7 +337,7 @@ prop_groupBy =
     assertGroupByClauseEquals
       (Just "GROUP BY \"foo\", \"bar\"")
       ( O.groupBy . Expr.groupByColumnsExpr $
-          FieldDef.fieldColumnName fooField :| [FieldDef.fieldColumnName barField]
+          FieldDef.fieldColumnName Nothing fooField :| [FieldDef.fieldColumnName Nothing barField]
       )
 
 prop_groupByCombined :: Property.NamedProperty
@@ -334,7 +346,7 @@ prop_groupByCombined =
     assertGroupByClauseEquals
       (Just "GROUP BY foo, \"bar\"")
       ( (O.groupBy . RawSql.unsafeSqlExpression $ "foo")
-          <> (O.groupBy . Expr.groupByColumnsExpr $ (FieldDef.fieldColumnName barField :| []))
+          <> (O.groupBy . Expr.groupByColumnsExpr $ (FieldDef.fieldColumnName Nothing barField :| []))
       )
 
 assertDistinctEquals :: (HH.MonadTest m, HasCallStack) => String -> O.SelectOptions -> m ()

--- a/orville-postgresql/test/Test/SqlMarshaller.hs
+++ b/orville-postgresql/test/Test/SqlMarshaller.hs
@@ -18,6 +18,7 @@ import qualified Hedgehog.Range as Range
 
 import qualified Orville.PostgreSQL.ErrorDetailLevel as ErrorDetailLevel
 import qualified Orville.PostgreSQL.Execution.ExecutionResult as Result
+import qualified Orville.PostgreSQL.Expr as Expr
 import qualified Orville.PostgreSQL.Marshall as Marshall
 import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
@@ -35,6 +36,7 @@ sqlMarshallerTests =
     , prop_marshallField_missingColumn
     , prop_marshallField_decodeValueFailure
     , prop_marshallResultFromSql_Foo
+    , prop_marshallResultFromSql_FooWithAlias
     , prop_marshallResultFromSql_Bar
     , prop_foldMarshallerFields
     , prop_passMaybeThrough
@@ -161,6 +163,26 @@ prop_marshallResultFromSql_Foo =
     result <- marshallTestRowFromSql fooMarshaller input
     Bifunctor.first show result === Right foos
 
+prop_marshallResultFromSql_FooWithAlias :: Property.NamedProperty
+prop_marshallResultFromSql_FooWithAlias =
+  Property.namedProperty "marshallResultFromSql decodes all rows in Foo result set, when given an alias for each field" $ do
+    foos <- HH.forAll $ Gen.list (Range.linear 0 10) generateFoo
+
+    let
+      mkRowValues foo =
+        [ SqlValue.fromText (fooName foo)
+        , SqlValue.fromInt32 (fooSize foo)
+        , maybe SqlValue.sqlNull SqlValue.fromBool (fooOption foo)
+        ]
+
+      input =
+        Result.mkFakeLibPQResult
+          [B8.pack "name", B8.pack "size", B8.pack "option"]
+          (map mkRowValues foos)
+
+    result <- marshallTestRowFromSql fooMarshallerWithAliasOnEachField input
+    Bifunctor.first show result === Right foos
+
 prop_marshallResultFromSql_Bar :: Property.NamedProperty
 prop_marshallResultFromSql_Bar =
   Property.namedProperty "marshallResultFromSql decodes all rows in Bar result set" $ do
@@ -189,9 +211,9 @@ prop_foldMarshallerFields =
     let
       addField entry fields =
         case entry of
-          Marshall.Natural fieldDef (Just getValue) ->
+          Marshall.Natural _ fieldDef (Just getValue) ->
             (Marshall.fieldName fieldDef, Marshall.fieldValueToSqlValue fieldDef (getValue foo)) : fields
-          Marshall.Natural _ Nothing ->
+          Marshall.Natural _ _ Nothing ->
             fields
           Marshall.Synthetic _ ->
             fields
@@ -291,6 +313,14 @@ fooMarshaller =
     <$> Marshall.marshallField fooName (Marshall.unboundedTextField "name")
     <*> Marshall.marshallField fooSize (Marshall.integerField "size")
     <*> Marshall.marshallField fooOption (Marshall.nullableField $ Marshall.booleanField "option")
+
+fooMarshallerWithAliasOnEachField :: Marshall.SqlMarshaller Foo Foo
+fooMarshallerWithAliasOnEachField =
+  Marshall.marshallAlias (Expr.alias "f") $
+    Foo
+      <$> Marshall.marshallAlias (Expr.alias "f") (Marshall.marshallField fooName (Marshall.unboundedTextField "name"))
+      <*> Marshall.marshallAlias (Expr.alias "f") (Marshall.marshallField fooSize (Marshall.integerField "size"))
+      <*> Marshall.marshallAlias (Expr.alias "f") (Marshall.marshallField fooOption (Marshall.nullableField $ Marshall.booleanField "option"))
 
 generateFoo :: HH.Gen Foo
 generateFoo =

--- a/orville-postgresql/test/Test/TableDefinition.hs
+++ b/orville-postgresql/test/Test/TableDefinition.hs
@@ -15,6 +15,7 @@ import qualified Hedgehog as HH
 import qualified Orville.PostgreSQL as Orville
 import qualified Orville.PostgreSQL.Execution.ReturningOption as ReturningOption
 import qualified Orville.PostgreSQL.Execution.Select as Select
+import qualified Orville.PostgreSQL.Expr as Expr
 import qualified Orville.PostgreSQL.Raw.Connection as Conn
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import qualified Orville.PostgreSQL.Schema.ConstraintDefinition as ConstraintDefinition
@@ -30,6 +31,7 @@ tableDefinitionTests pool =
   Property.group
     "TableDefinition"
     [ prop_roundTrip pool
+    , prop_roundTripWithAlias pool
     , prop_readOnlyFields pool
     , prop_primaryKey pool
     , prop_uniqueConstraint pool
@@ -51,6 +53,31 @@ prop_roundTrip =
 
       selectFoos =
         Select.selectTable Foo.table mempty
+
+    foosFromDB <-
+      MIO.liftIO . Orville.runOrville pool $ do
+        Orville.withConnection $ \connection -> do
+          MIO.liftIO $ TestTable.dropAndRecreateTableDef connection Foo.table
+        Orville.executeVoid Orville.InsertQuery insertFoo
+        Select.executeSelect selectFoos
+
+    foosFromDB === [originalFoo]
+
+prop_roundTripWithAlias :: Property.NamedDBProperty
+prop_roundTripWithAlias =
+  Property.namedDBProperty "Creates a table with an alias that can round trip an entity through it" $ \pool -> do
+    originalFoo <- HH.forAll Foo.generate
+
+    let
+      insertFoo =
+        TableDefinition.mkInsertExpr
+          ReturningOption.WithoutReturning
+          Foo.table
+          Nothing
+          (originalFoo :| [])
+
+      selectFoos =
+        Select.selectTableWithAlias (Expr.alias "some_alias") Foo.table mempty
 
     foosFromDB <-
       MIO.liftIO . Orville.runOrville pool $ do


### PR DESCRIPTION
The highlights:

- Moving to use 'Qualified ColumnName' in many/most places. This allows for the aliasing to be used naturally in those places.

- Add an alias type and function to create a 'Qualified ColumnName' with it. This signals that 'Alias' is in fact different than 'ColumnName' or 'TableName', and reusing them for aliasing is not always appropriate.

- Adding a 'MarshallAlias' constructor to the 'SqlMarshaller' so that an alias can be attached to all of the natural fields in a marshaller in a single function call from users. Synthetic fields could be refactored with this facility, but that was left out here to keep the already big changeset smaller.

- Many of the fieldDefinition helpers now have a version to support generating various subexpressions with an alias along with the fieldDefinition. This is a choice to allow the simple case to not deal with the complexity of the alias, but make it easier for when aliases are needed.

- A small number of helpers are added to make generation of bits of SQL, such as a 'TableReferenceList' that includes the 'AS alias' piece.