### PR TITLE
Adds initial support for triggers and functions.

### DIFF
--- a/orville-postgresql/orville-postgresql.cabal
+++ b/orville-postgresql/orville-postgresql.cabal
@@ -109,6 +109,7 @@ library
       Orville.PostgreSQL.Schema.TableIdentifier
       Orville.PostgreSQL.UnliftIO
   other-modules:
+      Orville.PostgreSQL.Expr.Function
       Orville.PostgreSQL.Expr.Internal.Name.ColumnName
       Orville.PostgreSQL.Expr.Internal.Name.ConstraintName
       Orville.PostgreSQL.Expr.Internal.Name.CursorName
@@ -120,6 +121,9 @@ library
       Orville.PostgreSQL.Expr.Internal.Name.SchemaName
       Orville.PostgreSQL.Expr.Internal.Name.SequenceName
       Orville.PostgreSQL.Expr.Internal.Name.TableName
+      Orville.PostgreSQL.Expr.Internal.Name.TriggerName
+      Orville.PostgreSQL.Expr.OrReplace
+      Orville.PostgreSQL.Expr.Trigger
       Orville.PostgreSQL.Expr.Vacuum
       Orville.PostgreSQL.Internal.Bracket
       Orville.PostgreSQL.Internal.Extra.NonEmpty
@@ -137,7 +141,12 @@ library
       Orville.PostgreSQL.PgCatalog.PgConstraint
       Orville.PostgreSQL.PgCatalog.PgIndex
       Orville.PostgreSQL.PgCatalog.PgNamespace
+      Orville.PostgreSQL.PgCatalog.PgProc
       Orville.PostgreSQL.PgCatalog.PgSequence
+      Orville.PostgreSQL.PgCatalog.PgTrigger
+      Orville.PostgreSQL.Schema.FunctionDefinition
+      Orville.PostgreSQL.Schema.FunctionIdentifier
+      Orville.PostgreSQL.Schema.TriggerDefinition
       Paths_orville_postgresql
   hs-source-dirs:
       src
@@ -188,6 +197,7 @@ test-suite spec
       Test.Expr.TableDefinition
       Test.Expr.TestSchema
       Test.Expr.Time
+      Test.Expr.Trigger
       Test.Expr.Vacuum
       Test.Expr.Where
       Test.FieldDefinition

--- a/orville-postgresql/scripts/gen-local-docs.sh
+++ b/orville-postgresql/scripts/gen-local-docs.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-docker-compose run \
+docker compose run \
   --no-deps --rm dev \
   stack --stack-yaml stack.yml \
   haddock --force-dirty --no-haddock-deps --haddock-arguments --odir=local-docs

--- a/orville-postgresql/scripts/ghci.sh
+++ b/orville-postgresql/scripts/ghci.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-docker-compose run --rm dev \
+docker compose run --rm dev \
   stack --stack-yaml stack-lts-17.3.yml \
   ghci \
   orville-postgresql:lib \

--- a/orville-postgresql/scripts/psql.sh
+++ b/orville-postgresql/scripts/psql.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-docker-compose exec testdb-pg12 psql -U orville_test
+docker compose exec testdb-pg12 psql -U orville_test

--- a/orville-postgresql/scripts/release.sh
+++ b/orville-postgresql/scripts/release.sh
@@ -2,8 +2,8 @@
 
 case "$1" in
   prepare-candidate)
-    docker-compose run --rm dev cabal sdist
-    docker-compose run --rm dev \
+    docker compose run --rm dev cabal sdist
+    docker compose run --rm dev \
       sh -c \
       'cabal update && \
          cabal \
@@ -20,7 +20,7 @@ case "$1" in
       echo "Please specify the version number to upload."
       exit 1
     else
-      docker-compose run --rm dev \
+      docker compose run --rm dev \
         sh -c \
         "cabal upload dist-newstyle/sdist/orville-postgresql-$version.tar.gz && \
          cabal upload -d dist-newstyle/docs/orville-postgresql-$version-docs.tar.gz"

--- a/orville-postgresql/scripts/test-all
+++ b/orville-postgresql/scripts/test-all
@@ -10,7 +10,7 @@
 # development.
 #
 # You can run it via docker by running:
-#   docker-compose run --rm dev ./test-all
+#   docker compose run --rm dev ./test-all
 #
 
 rm -rf test-all-logs

--- a/orville-postgresql/scripts/test-loop
+++ b/orville-postgresql/scripts/test-loop
@@ -3,13 +3,13 @@
 set -e
 
 if [ $# != 1 ]; then
-  echo "Usage: docker-compose run --rm dev ./test-loop <stack-yaml>"
+  echo "Usage: docker compose run --rm dev ./test-loop <stack-yaml>"
   exit 1
 fi
 
 STACK_YAML="$1"
 
-echo "Starting test loop using $STACK_YAML. Use \`docker-compose run --rm dev ./test-loop <stack-yaml>\` to change the stack file used."
+echo "Starting test loop using $STACK_YAML. Use \`docker compose run --rm dev ./test-loop <stack-yaml>\` to change the stack file used."
 
 # This used to use ghcid, but I was not able to get ghcid to both run the test
 # suite *and* compile the sample project to detect errors there.  stack test

--- a/orville-postgresql/scripts/up.sh
+++ b/orville-postgresql/scripts/up.sh
@@ -2,11 +2,11 @@
 
 export STACK_YAML_FILE=$1
 
-# dev is specified here so that docker-compose up will only attached to the dev
+# dev is specified here so that docker compose up will only attached to the dev
 # container and not the db container. A number of the tests produce errors logs
 # in the database container which are expected for negative testing (e.g.
 # primary key violations, not null violations). These logs end up interspersed
 # throughout the test results, which is annoying. If you need to see the logs
-# for debugging, you can run `docker-compose logs testdb`, or just run
-# `docker-compose up` directly.
-docker-compose up dev
+# for debugging, you can run `docker compose logs testdb`, or just run
+# `docker compose up` directly.
+docker compose up dev

--- a/orville-postgresql/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL.hs
@@ -101,6 +101,8 @@ module Orville.PostgreSQL
   , TableDefinition.addTableConstraints
   , TableDefinition.tableIndexes
   , TableDefinition.addTableIndexes
+  , TableDefinition.tableTriggers
+  , TableDefinition.addTableTriggers
   , TableDefinition.dropColumns
   , TableDefinition.columnsToDrop
   , TableDefinition.tableIdentifier
@@ -148,6 +150,12 @@ module Orville.PostgreSQL
   , IndexDefinition.AttributeBasedIndexMigrationKey (AttributeBasedIndexMigrationKey, indexKeyUniqueness, indexKeyColumns)
   , IndexDefinition.NamedIndexMigrationKey
   , IndexDefinition.indexMigrationKey
+  , TriggerDefinition.TriggerDefinition
+  , TriggerDefinition.beforeInsert
+  , TriggerDefinition.mkTriggerDefinition
+  , TriggerDefinition.mkCreateTriggerExpr
+  , TriggerDefinition.TriggerMigrationKey (NamedTriggerKey)
+  , TriggerDefinition.triggerMigrationKey
   , PrimaryKey.PrimaryKey
   , PrimaryKey.primaryKey
   , PrimaryKey.compositePrimaryKey
@@ -325,6 +333,23 @@ module Orville.PostgreSQL
   , SequenceIdentifier.sequenceIdSchemaNameString
   , SequenceIdentifier.sequenceIdToString
 
+    -- * Functions for defining and working with PostgreSQL functions
+  , FunctionDefinition.FunctionDefinition
+  , FunctionDefinition.setFunctionSchema
+  , FunctionDefinition.mkTriggerFunction
+  , FunctionDefinition.mkCreateFunctionExpr
+  , FunctionDefinition.functionName
+  , FunctionDefinition.functionIdentifier
+  , FunctionDefinition.functionSource
+  , FunctionIdentifier.FunctionIdentifier
+  , FunctionIdentifier.unqualifiedNameToFunctionId
+  , FunctionIdentifier.functionIdUnqualifiedNameString
+  , FunctionIdentifier.functionIdQualifiedName
+  , FunctionIdentifier.setFunctionIdSchema
+  , FunctionIdentifier.functionIdSchemaNameString
+  , FunctionIdentifier.functionIdToString
+  , Expr.plpgsql
+
     -- * Numeric types
   , SqlType.integer
   , SqlType.serial
@@ -392,9 +417,12 @@ import qualified Orville.PostgreSQL.OrvilleState as OrvilleState
 import qualified Orville.PostgreSQL.Raw.Connection as Connection
 import qualified Orville.PostgreSQL.Raw.SqlCommenter as SqlCommenter
 import qualified Orville.PostgreSQL.Schema.ConstraintDefinition as ConstraintDefinition
+import qualified Orville.PostgreSQL.Schema.FunctionDefinition as FunctionDefinition
+import qualified Orville.PostgreSQL.Schema.FunctionIdentifier as FunctionIdentifier
 import qualified Orville.PostgreSQL.Schema.IndexDefinition as IndexDefinition
 import qualified Orville.PostgreSQL.Schema.PrimaryKey as PrimaryKey
 import qualified Orville.PostgreSQL.Schema.SequenceDefinition as SequenceDefinition
 import qualified Orville.PostgreSQL.Schema.SequenceIdentifier as SequenceIdentifier
 import qualified Orville.PostgreSQL.Schema.TableDefinition as TableDefinition
 import qualified Orville.PostgreSQL.Schema.TableIdentifier as TableIdentifier
+import qualified Orville.PostgreSQL.Schema.TriggerDefinition as TriggerDefinition

--- a/orville-postgresql/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL.hs
@@ -152,6 +152,11 @@ module Orville.PostgreSQL
   , IndexDefinition.indexMigrationKey
   , TriggerDefinition.TriggerDefinition
   , TriggerDefinition.beforeInsert
+  , TriggerDefinition.afterInsert
+  , TriggerDefinition.beforeUpdate
+  , TriggerDefinition.afterUpdate
+  , TriggerDefinition.beforeDelete
+  , TriggerDefinition.afterDelete
   , TriggerDefinition.mkTriggerDefinition
   , TriggerDefinition.mkCreateTriggerExpr
   , TriggerDefinition.TriggerMigrationKey (NamedTriggerKey)

--- a/orville-postgresql/src/Orville/PostgreSQL/AutoMigration.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/AutoMigration.hs
@@ -528,8 +528,8 @@ calculateMigrationSteps currentNamespace dbDesc schemaItem =
                   AddFunctions
                   (Orville.mkCreateFunctionExpr Nothing functionDef)
               ]
-            Just proc ->
-              if PgCatalog.pgProcSource proc == T.pack (Orville.functionSource functionDef)
+            Just pgProc ->
+              if PgCatalog.pgProcSource pgProc == T.pack (Orville.functionSource functionDef)
                 then []
                 else
                   [ mkMigrationStepWithType

--- a/orville-postgresql/src/Orville/PostgreSQL/AutoMigration.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/AutoMigration.hs
@@ -526,7 +526,7 @@ calculateMigrationSteps currentNamespace dbDesc schemaItem =
             Nothing ->
               [ mkMigrationStepWithType
                   AddFunctions
-                  (Orville.mkCreateFunctionExpr Nothing functionDef)
+                  (Orville.mkCreateFunctionExpr functionDef Nothing)
               ]
             Just pgProc ->
               if PgCatalog.pgProcSource pgProc == T.pack (Orville.functionSource functionDef)
@@ -534,7 +534,7 @@ calculateMigrationSteps currentNamespace dbDesc schemaItem =
                 else
                   [ mkMigrationStepWithType
                       AddFunctions
-                      (Orville.mkCreateFunctionExpr (Just Expr.orReplace) functionDef)
+                      (Orville.mkCreateFunctionExpr funcitonDef (Just Expr.orReplace))
                   ]
     SchemaDropFunction functionId ->
       Right $

--- a/orville-postgresql/src/Orville/PostgreSQL/AutoMigration.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/AutoMigration.hs
@@ -534,7 +534,7 @@ calculateMigrationSteps currentNamespace dbDesc schemaItem =
                 else
                   [ mkMigrationStepWithType
                       AddFunctions
-                      (Orville.mkCreateFunctionExpr funcitonDef (Just Expr.orReplace))
+                      (Orville.mkCreateFunctionExpr functionDef (Just Expr.orReplace))
                   ]
     SchemaDropFunction functionId ->
       Right $

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr.hs
@@ -62,6 +62,9 @@ module Orville.PostgreSQL.Expr
   , module Orville.PostgreSQL.Expr.Update
   , module Orville.PostgreSQL.Expr.ValueExpression
   , module Orville.PostgreSQL.Expr.WhereClause
+  , module Orville.PostgreSQL.Expr.Trigger
+  , module Orville.PostgreSQL.Expr.Function
+  , module Orville.PostgreSQL.Expr.OrReplace
   , module Orville.PostgreSQL.Expr.Vacuum
   )
 where
@@ -75,6 +78,7 @@ import Orville.PostgreSQL.Expr.Count
 import Orville.PostgreSQL.Expr.Cursor
 import Orville.PostgreSQL.Expr.DataType
 import Orville.PostgreSQL.Expr.Delete
+import Orville.PostgreSQL.Expr.Function
 import Orville.PostgreSQL.Expr.GroupBy
 import Orville.PostgreSQL.Expr.IfExists
 import Orville.PostgreSQL.Expr.Index
@@ -83,6 +87,7 @@ import Orville.PostgreSQL.Expr.LimitExpr
 import Orville.PostgreSQL.Expr.Math
 import Orville.PostgreSQL.Expr.Name
 import Orville.PostgreSQL.Expr.OffsetExpr
+import Orville.PostgreSQL.Expr.OrReplace
 import Orville.PostgreSQL.Expr.OrderBy
 import Orville.PostgreSQL.Expr.Query
 import Orville.PostgreSQL.Expr.ReturningExpr
@@ -93,6 +98,7 @@ import Orville.PostgreSQL.Expr.TableDefinition
 import Orville.PostgreSQL.Expr.TableReferenceList
 import Orville.PostgreSQL.Expr.Time
 import Orville.PostgreSQL.Expr.Transaction
+import Orville.PostgreSQL.Expr.Trigger
 import Orville.PostgreSQL.Expr.Update
 import Orville.PostgreSQL.Expr.Vacuum
 import Orville.PostgreSQL.Expr.ValueExpression

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Function.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Function.hs
@@ -104,15 +104,17 @@ createFunction maybeOrReplace name functionReturns functionLanguage definition =
   CreateFunctionExpr $
     RawSql.intercalate
       RawSql.space
-      [ RawSql.fromString "CREATE"
-      , maybe mempty RawSql.toRawSql maybeOrReplace
-      , RawSql.fromString "FUNCTION"
-      , RawSql.toRawSql name
-      , RawSql.fromString "()" -- currently we don't support specifying arguments
-      , RawSql.toRawSql functionReturns
-      , RawSql.toRawSql functionLanguage
-      , RawSql.toRawSql definition
-      ]
+      ( catMaybes
+          [ Just $ RawSql.fromString "CREATE"
+          , RawSql.toRawSql <$> maybeOrReplace
+          , Just $ RawSql.fromString "FUNCTION"
+          , Just $ RawSql.toRawSql name
+          , Just $ RawSql.fromString "()" -- currently we don't support specifying arguments
+          , Just $ RawSql.toRawSql functionReturns
+          , Just $ RawSql.toRawSql functionLanguage
+          , Just $ RawSql.toRawSql definition
+          ]
+      )
 
 {- |
 Type to represent the return specifier given as part of a SQL "CREATE

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Function.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Function.hs
@@ -1,0 +1,257 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+{- |
+Copyright : Flipstone Technology Partners 2024
+License   : MIT
+Stability : Stable
+
+@since 1.1.0.0
+-}
+module Orville.PostgreSQL.Expr.Function
+  ( DropFunctionExpr
+  , dropFunction
+  , CreateFunctionExpr
+  , createFunction
+  , FunctionReturns
+  , returns
+  , ReturnType
+  , returnTypeTrigger
+  , FunctionLanguage
+  , language
+  , LanguageName
+  , plpgsql
+  , FunctionDefinition
+  , asDefinition
+  ) where
+
+import qualified Data.ByteString.Char8 as BS8
+import Data.Maybe (catMaybes)
+
+import Orville.PostgreSQL.Expr.IfExists (IfExists)
+import Orville.PostgreSQL.Expr.Name (FunctionName, Qualified)
+import Orville.PostgreSQL.Expr.OrReplace (OrReplace)
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+
+{- |
+Type to represent a SQL "DROP FUNCTION" statement. E.G.
+
+> DROP FUNCTION my_function
+
+'DropFunctionExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 1.1.0.0
+-}
+newtype DropFunctionExpr
+  = DropFunctionExpr RawSql.RawSql
+  deriving
+    ( -- | @since 1.1.0.0
+      RawSql.SqlExpression
+    )
+
+{- |
+Constructs a SQL @DROP FUNCTION@ statement from a function name.
+
+@since 1.1.0.0
+-}
+dropFunction :: Maybe IfExists -> Qualified FunctionName -> DropFunctionExpr
+dropFunction maybeIfExists name =
+  DropFunctionExpr $
+    RawSql.intercalate
+      RawSql.space
+      ( catMaybes
+          [ Just (RawSql.fromString "DROP FUNCTION")
+          , fmap RawSql.toRawSql maybeIfExists
+          , Just (RawSql.toRawSql name)
+          ]
+      )
+
+{- |
+Type to represent a SQL "CREATE FUNCTION" statement. E.G.
+
+> CREATE FUNCTION my_function RETURNS trigger AS '<definition>'
+
+'CreateFunctionExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 1.1.0.0
+-}
+newtype CreateFunctionExpr
+  = CreateFunctionExpr RawSql.RawSql
+  deriving
+    ( -- | @since 1.1.0.0
+      RawSql.SqlExpression
+    )
+
+{- |
+Constructs a SQL @CREATE FUNCTION@ statement from a function name, return type,
+language and definiton.
+
+@since 1.1.0.0
+-}
+createFunction ::
+  Maybe OrReplace ->
+  Qualified FunctionName ->
+  FunctionReturns ->
+  FunctionLanguage ->
+  FunctionDefinition ->
+  CreateFunctionExpr
+createFunction maybeOrReplace name functionReturns functionLanguage definition =
+  CreateFunctionExpr $
+    RawSql.intercalate
+      RawSql.space
+      [ RawSql.fromString "CREATE"
+      , maybe mempty RawSql.toRawSql maybeOrReplace
+      , RawSql.fromString "FUNCTION"
+      , RawSql.toRawSql name
+      , RawSql.fromString "()" -- currently we don't support specifying arguments
+      , RawSql.toRawSql functionReturns
+      , RawSql.toRawSql functionLanguage
+      , RawSql.toRawSql definition
+      ]
+
+{- |
+Type to represent the return specifier given as part of a SQL "CREATE
+FUNCTION" statement. E.G. the @RETURNS trigger@ in
+
+> CREATE FUNCTION my_function RETURNS trigger
+
+'FunctionReturns' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 1.1.0.0
+-}
+newtype FunctionReturns
+  = FunctionReturns RawSql.RawSql
+  deriving
+    ( -- | @since 1.1.0.0
+      RawSql.SqlExpression
+    )
+
+{- |
+  Constructs a @RETURNS@ specifier for a @CREATE FUNCTION@ statement with the
+  given return type.
+
+@since 1.1.0.0
+-}
+returns :: ReturnType -> FunctionReturns
+returns returnType =
+  FunctionReturns $ (RawSql.fromString "RETURNS ") <> RawSql.toRawSql returnType
+
+{- |
+Type to represent the return type given as part of a SQL "CREATE
+FUNCTION" statement. E.G. the @trigger@ in
+
+> CREATE FUNCTION my_function RETURNS trigger
+
+'ReturnType' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 1.1.0.0
+-}
+newtype ReturnType
+  = ReturnType RawSql.RawSql
+  deriving
+    ( -- | @since 1.1.0.0
+      RawSql.SqlExpression
+    )
+
+{- |
+The @trigger@ return type.
+
+@since 1.1.0.0
+-}
+returnTypeTrigger :: ReturnType
+returnTypeTrigger =
+  ReturnType (RawSql.fromString "trigger")
+
+{- |
+Type to represent the language specifier given as part of a SQL "CREATE
+FUNCTION" statement. E.G. the @LANGUAGE plpgsql@ in
+
+> CREATE FUNCTION my_function LANGUAGE plpgsql
+
+'FunctionLanguage' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 1.1.0.0
+-}
+newtype FunctionLanguage
+  = FunctionLanguage RawSql.RawSql
+  deriving
+    ( -- | @since 1.1.0.0
+      RawSql.SqlExpression
+    )
+
+{- |
+  Constructs a @LANGUAGE@ specifier for a @CREATE FUNCTION@ statement with the
+  given language name as the language.
+
+@since 1.1.0.0
+-}
+language :: LanguageName -> FunctionLanguage
+language name =
+  FunctionLanguage $ (RawSql.fromString "LANGUAGE ") <> RawSql.toRawSql name
+
+{- |
+Type to represent the language that the function definition is given in as part
+of a SQL "CREATE FUNCTION" statement. E.G. the @plpgsql@ in
+
+> CREATE FUNCTION my_function LANGUAGE plpgsql
+
+'LanguageName' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 1.1.0.0
+-}
+newtype LanguageName
+  = LanguageName RawSql.RawSql
+  deriving
+    ( -- | @since 1.1.0.0
+      RawSql.SqlExpression
+    )
+
+{- |
+The @plpgsql@ language.
+
+@since 1.1.0.0
+-}
+plpgsql :: LanguageName
+plpgsql =
+  LanguageName (RawSql.fromString "plpgsql")
+
+{- |
+Type to represent the definition body of a a SQL "CREATE FUNCTION" statement. E.G. the
+@AS <definition>@ in
+
+> CREATE FUNCTION my_function AS <definition>
+
+'FunctionDefinition' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 1.1.0.0
+-}
+newtype FunctionDefinition
+  = FunctionDefinition RawSql.RawSql
+  deriving
+    ( -- | @since 1.1.0.0
+      RawSql.SqlExpression
+    )
+
+{- |
+  Constructs a 'FunctionDefinition' from a 'String', which will be passed as an
+  escaped string literal to PosgreSQL.
+
+@since 1.1.0.0
+-}
+asDefinition :: String -> FunctionDefinition
+asDefinition body =
+  FunctionDefinition $
+    RawSql.fromString "AS " <> RawSql.stringLiteral (BS8.pack body)

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Function.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Function.hs
@@ -89,6 +89,8 @@ newtype CreateFunctionExpr
 Constructs a SQL @CREATE FUNCTION@ statement from a function name, return type,
 language and definiton.
 
+Note: Orville does not currently support creating functions with arguments.
+
 @since 1.1.0.0
 -}
 createFunction ::

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Internal/Name/Qualified.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Internal/Name/Qualified.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2023
+Copyright : Flipstone Technology Partners 2023-2024
 License   : MIT
 Stability : Stable
 
@@ -11,11 +11,13 @@ module Orville.PostgreSQL.Expr.Internal.Name.Qualified
   ( Qualified
   , qualifyTable
   , qualifySequence
+  , qualifyFunction
   , qualifyColumn
   )
 where
 
 import Orville.PostgreSQL.Expr.Internal.Name.ColumnName (ColumnName)
+import Orville.PostgreSQL.Expr.Internal.Name.FunctionName (FunctionName)
 import Orville.PostgreSQL.Expr.Internal.Name.Identifier (IdentifierExpression (toIdentifier))
 import Orville.PostgreSQL.Expr.Internal.Name.SchemaName (SchemaName)
 import Orville.PostgreSQL.Expr.Internal.Name.SequenceName (SequenceName)
@@ -68,6 +70,21 @@ qualifySequence ::
   SequenceName ->
   Qualified SequenceName
 qualifySequence = unsafeSchemaQualify
+
+{- |
+Optionally qualifies a 'FunctionName' with a 'SchemaName'.
+
+Note: If you already have a 'Orville.PostgreSQL.Schema.FunctionIdentifier' in
+hand you should probably use
+'Orville.PostgreSQL.Schema.functionIdQualifiedName' instead.
+
+@since 1.1.0.0
+-}
+qualifyFunction ::
+  Maybe SchemaName ->
+  FunctionName ->
+  Qualified FunctionName
+qualifyFunction = unsafeSchemaQualify
 
 {- |
 Qualifies a 'ColumnName' with a 'TableName' and, optionally, a 'SchemaName'.

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Internal/Name/TriggerName.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Internal/Name/TriggerName.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+{- |
+Copyright : Flipstone Technology Partners 2024
+License   : MIT
+Stability : Stable
+
+@since 1.1.0.0
+-}
+module Orville.PostgreSQL.Expr.Internal.Name.TriggerName
+  ( TriggerName
+  , triggerName
+  )
+where
+
+import Orville.PostgreSQL.Expr.Internal.Name.Identifier (Identifier, IdentifierExpression, identifier)
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+
+{- |
+Type to represent a SQL trigger name. 'TriggerName' values constructed via the
+'triggerName' function will be properly escaped as part of the generated SQL.
+E.G.
+
+> "some_trigger_name"
+
+'TriggerName' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 1.1.0.0
+-}
+newtype TriggerName
+  = TriggerName Identifier
+  deriving
+    ( -- | @since 1.1.0.0
+      RawSql.SqlExpression
+    , -- | @since 1.1.0.0
+      IdentifierExpression
+    )
+
+{- |
+Construct a 'TriggerName' from a 'String' with proper escaping as part of the generated SQL.
+
+@since 1.1.0.0
+-}
+triggerName :: String -> TriggerName
+triggerName =
+  TriggerName . identifier

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Name.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Name.hs
@@ -23,3 +23,4 @@ import Orville.PostgreSQL.Expr.Internal.Name.SavepointName as Export
 import Orville.PostgreSQL.Expr.Internal.Name.SchemaName as Export
 import Orville.PostgreSQL.Expr.Internal.Name.SequenceName as Export
 import Orville.PostgreSQL.Expr.Internal.Name.TableName as Export
+import Orville.PostgreSQL.Expr.Internal.Name.TriggerName as Export

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/OrReplace.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/OrReplace.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+{- |
+Copyright : Flipstone Technology Partners 2024
+License   : MIT
+Stability : Stable
+
+@since 1.1.0.0
+-}
+module Orville.PostgreSQL.Expr.OrReplace
+  ( OrReplace
+  , orReplace
+  )
+where
+
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+
+{- |
+Type to represent a SQL "OR REPLACE" expression. E.G.
+
+> OR REPLACE
+
+'OrReplace' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 1.1.0.0
+-}
+newtype OrReplace
+  = OrReplace RawSql.RawSql
+  deriving
+    ( -- | @since 1.0.0.0
+      RawSql.SqlExpression
+    )
+
+{- |
+A value of the SQL "OR REPLACE".
+
+@since 1.1.0.0
+-}
+orReplace :: OrReplace
+orReplace =
+  OrReplace $ RawSql.fromString "OR REPLACE"

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/OrReplace.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/OrReplace.hs
@@ -29,7 +29,7 @@ SQL.
 newtype OrReplace
   = OrReplace RawSql.RawSql
   deriving
-    ( -- | @since 1.0.0.0
+    ( -- | @since 1.1.0.0
       RawSql.SqlExpression
     )
 

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Trigger.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Trigger.hs
@@ -1,0 +1,279 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+{- |
+Copyright : Flipstone Technology Partners 2024
+License   : MIT
+Stability : Stable
+
+@since 1.1.0.0
+-}
+module Orville.PostgreSQL.Expr.Trigger
+  ( DropTriggerExpr
+  , dropTrigger
+  , CreateTriggerExpr
+  , createTrigger
+  , TriggerTiming
+  , triggerBefore
+  , triggerAfter
+  , triggerInsteadOf
+  , TriggerEvent
+  , triggerOnInsert
+  , triggerOnUpdate
+  , triggerOnUpdateOf
+  , triggerOnDelete
+  , triggerOnTruncate
+  , TriggerFireScope
+  , triggerForEachRow
+  , triggerForEachStatement
+  ) where
+
+import qualified Data.List.NonEmpty as NEL
+import Data.Maybe (catMaybes)
+
+import Orville.PostgreSQL.Expr.IfExists (IfExists)
+import Orville.PostgreSQL.Expr.Name (ColumnName, FunctionName, Qualified, TableName, TriggerName)
+import Orville.PostgreSQL.Expr.OrReplace (OrReplace)
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+
+{- |
+Type to represent a SQL "DROP TRIGGER" statement. E.G.
+
+> DROP TRIGGER my_trigger ON my_table
+
+'DropTriggerExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 1.1.0.0
+-}
+newtype DropTriggerExpr
+  = DropTriggerExpr RawSql.RawSql
+  deriving
+    ( -- | @since 1.1.0.0
+      RawSql.SqlExpression
+    )
+
+{- |
+Constructs a SQL @DROP TRIGGER@ statement from the trigger name and table name
+
+@since 1.1.0.0
+-}
+dropTrigger ::
+  Maybe IfExists ->
+  TriggerName ->
+  Qualified TableName ->
+  DropTriggerExpr
+dropTrigger maybeIfExists name tableName =
+  DropTriggerExpr $
+    RawSql.intercalate
+      RawSql.space
+      ( catMaybes
+          [ Just (RawSql.fromString "DROP TRIGGER")
+          , fmap RawSql.toRawSql maybeIfExists
+          , Just (RawSql.toRawSql name)
+          , Just (RawSql.fromString "ON")
+          , Just (RawSql.toRawSql tableName)
+          ]
+      )
+
+{- |
+Type to represent a SQL "CREATE TRIGGER" statement. E.G.
+
+> CREATE TRIGGER my_trigger BEFORE UPDATE ON my_table EXECUTE PROCEDURE my_trigger_function
+
+'CreateTriggerExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 1.1.0.0
+-}
+newtype CreateTriggerExpr
+  = CreateTriggerExpr RawSql.RawSql
+  deriving
+    ( -- | @since 1.1.0.0
+      RawSql.SqlExpression
+    )
+
+{- |
+Constructs a SQL @CREATE TRIGGER@ statement from the trigger name and its defining
+attributes.
+
+@since 1.1.0.0
+-}
+createTrigger ::
+  Maybe OrReplace ->
+  TriggerName ->
+  TriggerTiming ->
+  NEL.NonEmpty TriggerEvent ->
+  Qualified TableName ->
+  TriggerFireScope ->
+  Qualified FunctionName ->
+  CreateTriggerExpr
+createTrigger maybeOrReplace name timing events tableName fireScope functionName =
+  CreateTriggerExpr $
+    RawSql.intercalate
+      RawSql.space
+      [ RawSql.fromString "CREATE"
+      , maybe mempty RawSql.toRawSql maybeOrReplace
+      , RawSql.fromString "TRIGGER"
+      , RawSql.toRawSql name
+      , RawSql.toRawSql timing
+      , RawSql.intercalate (RawSql.fromString " OR ") events
+      , RawSql.fromString "ON"
+      , RawSql.toRawSql tableName
+      , RawSql.toRawSql fireScope
+      , RawSql.fromString "EXECUTE FUNCTION"
+      , RawSql.toRawSql functionName
+      , RawSql.fromString "()" -- we don't currently support objects
+      ]
+
+{- |
+Type to represent the time at which a trigger will fire in releation to the
+event that caused it. E.G. the @BEFORE@ in
+
+> CREATE TRIGGER my_trigger BEFORE UPDATE ON my_table FOR EACH ROW EXECUTE PROCEDURE my_trigger_function
+
+'TriggerTiming' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 1.1.0.0
+-}
+newtype TriggerTiming
+  = TriggerTiming RawSql.RawSql
+  deriving
+    ( -- | @since 1.1.0.0
+      RawSql.SqlExpression
+    )
+
+{- |
+The @BEFORE@ 'TriggerTiming'.
+
+@since 1.1.0.0
+-}
+triggerBefore :: TriggerTiming
+triggerBefore =
+  TriggerTiming (RawSql.fromString "BEFORE")
+
+{- |
+The @AFTER@ 'TriggerTiming'.
+
+@since 1.1.0.0
+-}
+triggerAfter :: TriggerTiming
+triggerAfter =
+  TriggerTiming (RawSql.fromString "AFTER")
+
+{- |
+The @INSTEAD OF@ 'TriggerTiming'.
+
+@since 1.1.0.0
+-}
+triggerInsteadOf :: TriggerTiming
+triggerInsteadOf =
+  TriggerTiming (RawSql.fromString "INSTEAD OF")
+
+{- |
+Type to represent the an event that will cause a trigger to fire in a SQL "CREATE
+TRIGGER" statement. E.G. the @UPDATE@ in
+
+> CREATE TRIGGER my_trigger BEFORE UPDATE ON my_table FOR EACH ROW EXECUTE PROCEDURE my_trigger_function
+
+'TriggerEvent' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 1.1.0.0
+-}
+newtype TriggerEvent
+  = TriggerEvent RawSql.RawSql
+  deriving
+    ( -- | @since 1.1.0.0
+      RawSql.SqlExpression
+    )
+
+{- |
+The @INSERT@ 'TriggerEvent'
+
+@since 1.1.0.0
+-}
+triggerOnInsert :: TriggerEvent
+triggerOnInsert =
+  TriggerEvent (RawSql.fromString "INSERT")
+
+{- |
+The @UPDATE@ 'TriggerEvent'
+
+@since 1.1.0.0
+-}
+triggerOnUpdate :: TriggerEvent
+triggerOnUpdate =
+  TriggerEvent (RawSql.fromString "UPDATE")
+
+{- |
+The @UPDATE OF@ 'TriggerEvent'. This causes the trigger only to fire when on of
+the specified columns is mentioned of affected by an update.
+
+@since 1.1.0.0
+-}
+triggerOnUpdateOf :: NEL.NonEmpty ColumnName -> TriggerEvent
+triggerOnUpdateOf columnNames =
+  TriggerEvent $
+    RawSql.fromString "UPDATE OF"
+      <> RawSql.intercalate RawSql.comma (fmap RawSql.toRawSql columnNames)
+
+{- |
+The @DELETE@ 'TriggerEvent'
+
+@since 1.1.0.0
+-}
+triggerOnDelete :: TriggerEvent
+triggerOnDelete =
+  TriggerEvent (RawSql.fromString "DELETE")
+
+{- |
+The @TRUNCATE@ 'TriggerEvent'
+
+@since 1.1.0.0
+-}
+triggerOnTruncate :: TriggerEvent
+triggerOnTruncate =
+  TriggerEvent (RawSql.fromString "TRUNCATE")
+
+{- |
+Type to represent the part of a SQL "CREATE TRIGGER" statement that indicates whether
+the trigger will be fired once for each row or once for each statement. E.G. the
+@FOR EACH ROW@ in
+
+> CREATE TRIGGER my_trigger BEFORE UPDATE ON my_table FOR EACH ROW EXECUTE PROCEDURE my_trigger_function
+
+'TriggerFireScope' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 1.1.0.0
+-}
+newtype TriggerFireScope
+  = TriggerFireScope RawSql.RawSql
+  deriving
+    ( -- | @since 1.1.0.0
+      RawSql.SqlExpression
+    )
+
+{- |
+The @FOR EACH ROW@ 'TriggerFireScope'
+
+@since 1.1.0.0
+-}
+triggerForEachRow :: TriggerFireScope
+triggerForEachRow =
+  TriggerFireScope (RawSql.fromString "FOR EACH ROW")
+
+{- |
+The @FOR EACH STATEMENT@ 'TriggerFireScope'
+
+@since 1.1.0.0
+-}
+triggerForEachStatement :: TriggerFireScope
+triggerForEachStatement =
+  TriggerFireScope (RawSql.fromString "FOR EACH STATEMENT")

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Trigger.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Trigger.hs
@@ -119,19 +119,21 @@ createTrigger maybeOrReplace name timing events tableName fireScope functionName
   CreateTriggerExpr $
     RawSql.intercalate
       RawSql.space
-      [ RawSql.fromString "CREATE"
-      , maybe mempty RawSql.toRawSql maybeOrReplace
-      , RawSql.fromString "TRIGGER"
-      , RawSql.toRawSql name
-      , RawSql.toRawSql timing
-      , RawSql.intercalate (RawSql.fromString " OR ") events
-      , RawSql.fromString "ON"
-      , RawSql.toRawSql tableName
-      , RawSql.toRawSql fireScope
-      , RawSql.fromString "EXECUTE FUNCTION"
-      , RawSql.toRawSql functionName
-      , RawSql.fromString "()" -- we don't currently support arguments
-      ]
+      ( catMaybes
+          [ Just $ RawSql.fromString "CREATE"
+          , RawSql.toRawSql <$> maybeOrReplace
+          , Just $ RawSql.fromString "TRIGGER"
+          , Just $ RawSql.toRawSql name
+          , Just $ RawSql.toRawSql timing
+          , Just $ RawSql.intercalate (RawSql.fromString " OR ") events
+          , Just $ RawSql.fromString "ON"
+          , Just $ RawSql.toRawSql tableName
+          , Just $ RawSql.toRawSql fireScope
+          , Just $ RawSql.fromString "EXECUTE FUNCTION"
+          , Just $ RawSql.toRawSql functionName
+          , Just $ RawSql.fromString "()" -- we don't currently support arguments
+          ]
+      )
 
 {- |
 Type to represent the time at which a trigger will fire in releation to the

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Trigger.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Trigger.hs
@@ -98,6 +98,10 @@ newtype CreateTriggerExpr
 Constructs a SQL @CREATE TRIGGER@ statement from the trigger name and its defining
 attributes.
 
+Note: Before PostgreSQL 14, there is no @CREATE OR REPLACE TRIGGER@ syntax in
+PsotgreSQL. If you're using a version of PostgreSQL prior to 14 then you must
+specify 'Nothing' for the 'OrReplace' property.
+
 @since 1.1.0.0
 -}
 createTrigger ::

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Trigger.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Trigger.hs
@@ -98,6 +98,8 @@ newtype CreateTriggerExpr
 Constructs a SQL @CREATE TRIGGER@ statement from the trigger name and its defining
 attributes.
 
+Note: Orville does not currently support creating triggers with arguments.
+
 Note: Before PostgreSQL 14, there is no @CREATE OR REPLACE TRIGGER@ syntax in
 PsotgreSQL. If you're using a version of PostgreSQL prior to 14 then you must
 specify 'Nothing' for the 'OrReplace' property.
@@ -128,7 +130,7 @@ createTrigger maybeOrReplace name timing events tableName fireScope functionName
       , RawSql.toRawSql fireScope
       , RawSql.fromString "EXECUTE FUNCTION"
       , RawSql.toRawSql functionName
-      , RawSql.fromString "()" -- we don't currently support objects
+      , RawSql.fromString "()" -- we don't currently support arguments
       ]
 
 {- |

--- a/orville-postgresql/src/Orville/PostgreSQL/PgCatalog.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/PgCatalog.hs
@@ -1,7 +1,7 @@
 {-# OPTIONS_GHC -Wno-missing-import-lists #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2023
+Copyright : Flipstone Technology Partners 2023-2024
 License   : MIT
 Stability : Stable
 
@@ -20,4 +20,6 @@ import Orville.PostgreSQL.PgCatalog.PgClass as Export
 import Orville.PostgreSQL.PgCatalog.PgConstraint as Export
 import Orville.PostgreSQL.PgCatalog.PgIndex as Export
 import Orville.PostgreSQL.PgCatalog.PgNamespace as Export
+import Orville.PostgreSQL.PgCatalog.PgProc as Export
 import Orville.PostgreSQL.PgCatalog.PgSequence as Export
+import Orville.PostgreSQL.PgCatalog.PgTrigger as Export

--- a/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/DatabaseDescription.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/DatabaseDescription.hs
@@ -74,7 +74,7 @@ lookupRelation key =
 {- |
   Lookup a procedure by its qualified name in the @pg_catalog@ schema.
 
-@since 1.0.0.0
+@since 1.1.0.0
 -}
 lookupProcedure ::
   (NamespaceName, ProcName) ->

--- a/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/PgProc.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/PgProc.hs
@@ -1,0 +1,103 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+{- |
+Copyright : Flipstone Technology Partners 2024
+License   : MIT
+Stability : Stable
+
+@since 1.1.0.0
+-}
+module Orville.PostgreSQL.PgCatalog.PgProc
+  ( PgProc (..)
+  , ProcName
+  , pgProcTable
+  , procNameField
+  , procNamespaceOidField
+  ) where
+
+import qualified Data.String as String
+import qualified Data.Text as T
+
+import qualified Database.PostgreSQL.LibPQ as LibPQ
+import qualified Orville.PostgreSQL as Orville
+import Orville.PostgreSQL.PgCatalog.OidField (oidField, oidTypeField)
+
+{- |
+  The Haskell representation of data read from the @pg_catalog.pg_proc@ table.
+  Rows in this table reperesent functions, procedures, aggregate functions, and
+  window functions (collectively also known as routines), such as those created
+  via @CREATE FUNCTION@ or @CREATE PROCEDUCE.
+
+@since 1.1.0.0
+-}
+data PgProc = PgProc
+  { pgProcOid :: LibPQ.Oid
+  -- ^ The PostgreSQL @oid@ for the relation.
+  , pgProcNamespaceOid :: LibPQ.Oid
+  -- ^ The PostgreSQL @oid@ of the namespace that the relation belongs to.
+  -- References @pg_namespace.oid@.
+  , pgProcName :: ProcName
+  -- ^ The name of the proceduce or function.
+  , pgProcSource :: T.Text
+  -- ^ How the function is executed by the PostgreSQL function handler. This
+  -- made the actual source code for interpreted languages, but could be almost
+  -- anything depending on the language.
+  }
+
+{- |
+  A Haskell type for the name of the trigger represented by a 'PgProc'.
+
+@since 1.1.0.0
+-}
+newtype ProcName
+  = ProcName T.Text
+  deriving (Show, Eq, Ord, String.IsString)
+
+{- |
+  An Orville 'Orville.TableDefinition' for querying the
+  @pg_catalog.pg_proc@ table.
+
+@since 1.1.0.0
+-}
+pgProcTable :: Orville.TableDefinition Orville.NoKey PgProc PgProc
+pgProcTable =
+  Orville.setTableSchema "pg_catalog" $
+    Orville.mkTableDefinitionWithoutKey
+      "pg_proc"
+      pgProcMarshaller
+
+pgProcMarshaller :: Orville.SqlMarshaller PgProc PgProc
+pgProcMarshaller =
+  PgProc
+    <$> Orville.marshallField pgProcOid oidField
+    <*> Orville.marshallField pgProcNamespaceOid procNamespaceOidField
+    <*> Orville.marshallField pgProcName procNameField
+    <*> Orville.marshallField pgProcSource procSourceField
+
+{- |
+  The @pronamespace@ column of the @pg_catalog.pg_proc@ table.
+
+@since 1.0.0.0
+-}
+procNamespaceOidField :: Orville.FieldDefinition Orville.NotNull LibPQ.Oid
+procNamespaceOidField =
+  oidTypeField "pronamespace"
+
+{- |
+  The @proname@ column of the @pg_catalog.pg_proc@ table.
+
+@since 1.1.0.0
+-}
+procNameField :: Orville.FieldDefinition Orville.NotNull ProcName
+procNameField =
+  Orville.coerceField $
+    Orville.unboundedTextField "proname"
+
+{- |
+  The @prosrc@ column of the @pg_catalog.pg_proc@ table.
+
+@since 1.1.0.0
+-}
+procSourceField :: Orville.FieldDefinition Orville.NotNull T.Text
+procSourceField =
+  Orville.unboundedTextField "prosrc"

--- a/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/PgTrigger.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/PgTrigger.hs
@@ -1,0 +1,107 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+{- |
+Copyright : Flipstone Technology Partners 2024
+License   : MIT
+Stability : Stable
+
+@since 1.1.0.0
+-}
+module Orville.PostgreSQL.PgCatalog.PgTrigger
+  ( PgTrigger (..)
+  , TriggerName
+  , triggerNameToString
+  , pgTriggerTable
+  , triggerRelationOidField
+  ) where
+
+import qualified Data.String as String
+import qualified Data.Text as T
+
+import qualified Database.PostgreSQL.LibPQ as LibPQ
+import qualified Orville.PostgreSQL as Orville
+import Orville.PostgreSQL.PgCatalog.OidField (oidField, oidTypeField)
+
+{- |
+  The Haskell representation of data read from the @pg_catalog.pg_trigger@
+  table. Rows in this table correspond to triggers created on tables and views.
+@since 1.1.0.0
+-}
+data PgTrigger = PgTrigger
+  { pgTriggerOid :: LibPQ.Oid
+  -- ^ The PostgreSQL @oid@ for the relation.
+  , pgTriggerRelationOid :: LibPQ.Oid
+  -- ^ The PostgreSQL @oid@ of the relation that the trigger is onto.
+  -- References @pg_class.oid@.
+  , pgTriggerName :: TriggerName
+  -- ^ The name of the trigger.
+  , pgTriggerIsInternal :: Bool
+  -- ^ The whether the trigger is internal accounting to PostgreSQL.
+  }
+
+{- |
+  A Haskell type for the name of the trigger represented by a 'PgTrigger'.
+
+@since 1.1.0.0
+-}
+newtype TriggerName
+  = TriggerName T.Text
+  deriving (Show, Eq, Ord, String.IsString)
+
+{- |
+  Convert a 'TriggerName' to a plain 'String'.
+
+@since 1.1.0.0
+-}
+triggerNameToString :: TriggerName -> String
+triggerNameToString (TriggerName name) =
+  T.unpack name
+
+{- |
+  An Orville 'Orville.TableDefinition' for querying the
+  @pg_catalog.pg_trigger@ table.
+
+@since 1.1.0.0
+-}
+pgTriggerTable :: Orville.TableDefinition Orville.NoKey PgTrigger PgTrigger
+pgTriggerTable =
+  Orville.setTableSchema "pg_catalog" $
+    Orville.mkTableDefinitionWithoutKey
+      "pg_trigger"
+      pgTriggerMarshaller
+
+pgTriggerMarshaller :: Orville.SqlMarshaller PgTrigger PgTrigger
+pgTriggerMarshaller =
+  PgTrigger
+    <$> Orville.marshallField pgTriggerOid oidField
+    <*> Orville.marshallField pgTriggerRelationOid triggerRelationOidField
+    <*> Orville.marshallField pgTriggerName triggerNameField
+    <*> Orville.marshallField pgTriggerIsInternal triggerIsInternalField
+
+{- |
+  The @tgrelid@ column of the @pg_trigger@ table.
+
+@since 1.1.0.0
+-}
+triggerRelationOidField :: Orville.FieldDefinition Orville.NotNull LibPQ.Oid
+triggerRelationOidField =
+  oidTypeField "tgrelid"
+
+{- |
+  The @tgname@ column of the @pg_catalog.pg_trigger@ table.
+
+@since 1.1.0.0
+-}
+triggerNameField :: Orville.FieldDefinition Orville.NotNull TriggerName
+triggerNameField =
+  Orville.coerceField $
+    Orville.unboundedTextField "tgname"
+
+{- |
+  The @tgisinternal@ column of the @pg_catalog.pg_trigger@ table.
+
+@since 1.1.0.0
+-}
+triggerIsInternalField :: Orville.FieldDefinition Orville.NotNull Bool
+triggerIsInternalField =
+  Orville.booleanField "tgisinternal"

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema.hs
@@ -1,7 +1,7 @@
 {-# OPTIONS_GHC -Wno-missing-import-lists #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2023
+Copyright : Flipstone Technology Partners 2023-2024
 License   : MIT
 Stability : Stable
 
@@ -19,10 +19,15 @@ module Orville.PostgreSQL.Schema
   , module Orville.PostgreSQL.Schema.PrimaryKey
   , module Orville.PostgreSQL.Schema.IndexDefinition
   , module Orville.PostgreSQL.Schema.ConstraintDefinition
+  , module Orville.PostgreSQL.Schema.TriggerDefinition
 
     -- * Defining Sequences
   , module Orville.PostgreSQL.Schema.SequenceDefinition
   , module Orville.PostgreSQL.Schema.SequenceIdentifier
+
+    -- * Definining Functions
+  , module Orville.PostgreSQL.Schema.FunctionDefinition
+  , module Orville.PostgreSQL.Schema.FunctionIdentifier
   )
 where
 
@@ -30,9 +35,12 @@ where
 -- appear in the generated haddock documentation.
 
 import Orville.PostgreSQL.Schema.ConstraintDefinition
+import Orville.PostgreSQL.Schema.FunctionDefinition
+import Orville.PostgreSQL.Schema.FunctionIdentifier
 import Orville.PostgreSQL.Schema.IndexDefinition
 import Orville.PostgreSQL.Schema.PrimaryKey
 import Orville.PostgreSQL.Schema.SequenceDefinition
 import Orville.PostgreSQL.Schema.SequenceIdentifier
 import Orville.PostgreSQL.Schema.TableDefinition
 import Orville.PostgreSQL.Schema.TableIdentifier
+import Orville.PostgreSQL.Schema.TriggerDefinition

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/FunctionDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/FunctionDefinition.hs
@@ -1,0 +1,122 @@
+{- |
+Copyright : Flipstone Technology Partners 2024
+License   : MIT
+Stability : Stable
+
+@since 1.1.0.0
+-}
+module Orville.PostgreSQL.Schema.FunctionDefinition
+  ( FunctionDefinition
+  , setFunctionSchema
+  , functionIdentifier
+  , functionName
+  , functionSource
+  , mkTriggerFunction
+  , mkCreateFunctionExpr
+  ) where
+
+import qualified Orville.PostgreSQL.Expr as Expr
+import Orville.PostgreSQL.Schema.FunctionIdentifier (FunctionIdentifier, functionIdQualifiedName, setFunctionIdSchema, unqualifiedNameToFunctionId)
+
+{- |
+  Contains the definition of a PostgreSQL function for Orville to use when creating
+  the function. Currently only functionality for creating trigger functions for use
+  with 'Orville.PostgreSQL.Schema.TriggerDefinition' is supported. You can create a
+  'FunctionDefintion' with for a trigger via 'mkTriggerFunction'.
+
+  When a 'FunctionDefinition' is included in a schema item list for auto-migration
+  the function will be created if it does not exist, or recreated if the source
+  code for the function does not match what is found in the database catalog.
+
+@since 1.1.0.0
+-}
+data FunctionDefinition = FunctionDefinition
+  { i_functionIdentifier :: FunctionIdentifier
+  , i_functionReturnType :: Expr.ReturnType
+  , i_functionLanguage :: Expr.LanguageName
+  , i_functionSource :: String
+  }
+
+{- |
+  Sets the function's schema to the name in the given 'String', which will be
+  treated as a SQL identifier. If a function has a schema name set, it will be
+  included as a qualifier on the function name for all queries involving the
+  function.
+
+@since 1.0.0.0
+-}
+setFunctionSchema ::
+  String ->
+  FunctionDefinition ->
+  FunctionDefinition
+setFunctionSchema schemaName functionDef =
+  functionDef
+    { i_functionIdentifier = setFunctionIdSchema schemaName (i_functionIdentifier functionDef)
+    }
+
+{- |
+  Retrieves the 'FunctionIdentifier' for this sequence, which is set by the
+  name provided to 'mkTriggerFunction' and any calls made to
+  'setFunctionSchema' thereafter.
+@since 1.1.0.0
+-}
+functionIdentifier :: FunctionDefinition -> FunctionIdentifier
+functionIdentifier =
+  i_functionIdentifier
+
+{- |
+  Retrieves the 'Expr.Qualified' 'Expr.FunctionName' for the sequence that
+  should be used to build SQL expressions involving it.
+
+@since 1.1.0.0
+-}
+functionName :: FunctionDefinition -> Expr.Qualified Expr.FunctionName
+functionName =
+  functionIdQualifiedName . i_functionIdentifier
+
+{- |
+  Retrieves the source that was passed to 'mkTriggerFunction' when the
+  'FunctionDefinition' was created.
+
+@since 1.1.0.0
+-}
+functionSource :: FunctionDefinition -> String
+functionSource =
+  i_functionSource
+
+{- |
+  Constructs a 'FunctionDefinition' that will create a PostgreSQL function
+  with a return type of @trigger@ using the specified lanugage and function
+  body.
+@since 1.1.0.0
+-}
+mkTriggerFunction ::
+  String ->
+  Expr.LanguageName ->
+  String ->
+  FunctionDefinition
+mkTriggerFunction name language source =
+  FunctionDefinition
+    { i_functionIdentifier = unqualifiedNameToFunctionId name
+    , i_functionReturnType = Expr.returnTypeTrigger
+    , i_functionLanguage = language
+    , i_functionSource = source
+    }
+
+{- |
+  Builds a 'Expr.CreateFunctionExpr' that will create a SQL sequence matching
+  the given 'FunctionDefinition' when it is executed.
+
+@since 1.1.0.0
+-}
+mkCreateFunctionExpr ::
+  Maybe Expr.OrReplace ->
+  FunctionDefinition ->
+  Expr.CreateFunctionExpr
+mkCreateFunctionExpr maybeOrReplace functionDef =
+  Expr.createFunction
+    maybeOrReplace
+    (functionName functionDef)
+    (Expr.returns (i_functionReturnType functionDef))
+    (Expr.language (i_functionLanguage functionDef))
+    (Expr.asDefinition (i_functionSource functionDef))

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/FunctionDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/FunctionDefinition.hs
@@ -22,7 +22,7 @@ import Orville.PostgreSQL.Schema.FunctionIdentifier (FunctionIdentifier, functio
   Contains the definition of a PostgreSQL function for Orville to use when creating
   the function. Currently only functionality for creating trigger functions for use
   with 'Orville.PostgreSQL.Schema.TriggerDefinition' is supported. You can create a
-  'FunctionDefintion' with for a trigger via 'mkTriggerFunction'.
+  'FunctionDefintion' for a trigger via 'mkTriggerFunction'.
 
   When a 'FunctionDefinition' is included in a schema item list for auto-migration
   the function will be created if it does not exist, or recreated if the source
@@ -43,7 +43,7 @@ data FunctionDefinition = FunctionDefinition
   included as a qualifier on the function name for all queries involving the
   function.
 
-@since 1.0.0.0
+@since 1.1.0.0
 -}
 setFunctionSchema ::
   String ->

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/FunctionDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/FunctionDefinition.hs
@@ -110,10 +110,10 @@ mkTriggerFunction name language source =
 @since 1.1.0.0
 -}
 mkCreateFunctionExpr ::
-  Maybe Expr.OrReplace ->
   FunctionDefinition ->
+  Maybe Expr.OrReplace ->
   Expr.CreateFunctionExpr
-mkCreateFunctionExpr maybeOrReplace functionDef =
+mkCreateFunctionExpr functionDef maybeOrReplace =
   Expr.createFunction
     maybeOrReplace
     (functionName functionDef)

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/FunctionDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/FunctionDefinition.hs
@@ -55,7 +55,7 @@ setFunctionSchema schemaName functionDef =
     }
 
 {- |
-  Retrieves the 'FunctionIdentifier' for this sequence, which is set by the
+  Retrieves the 'FunctionIdentifier' for this function, which is set by the
   name provided to 'mkTriggerFunction' and any calls made to
   'setFunctionSchema' thereafter.
 @since 1.1.0.0
@@ -65,7 +65,7 @@ functionIdentifier =
   i_functionIdentifier
 
 {- |
-  Retrieves the 'Expr.Qualified' 'Expr.FunctionName' for the sequence that
+  Retrieves the 'Expr.Qualified' 'Expr.FunctionName' for the function that
   should be used to build SQL expressions involving it.
 
 @since 1.1.0.0
@@ -104,7 +104,7 @@ mkTriggerFunction name language source =
     }
 
 {- |
-  Builds a 'Expr.CreateFunctionExpr' that will create a SQL sequence matching
+  Builds a 'Expr.CreateFunctionExpr' that will create a SQL function matching
   the given 'FunctionDefinition' when it is executed.
 
 @since 1.1.0.0

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/FunctionIdentifier.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/FunctionIdentifier.hs
@@ -1,0 +1,125 @@
+{- |
+Copyright : Flipstone Technology Partners 2024
+License   : MIT
+Stability : Stable
+
+@since 1.1.0.0
+-}
+module Orville.PostgreSQL.Schema.FunctionIdentifier
+  ( FunctionIdentifier
+  , unqualifiedNameToFunctionId
+  , setFunctionIdSchema
+  , functionIdQualifiedName
+  , functionIdUnqualifiedName
+  , functionIdSchemaName
+  , functionIdToString
+  , functionIdUnqualifiedNameString
+  , functionIdSchemaNameString
+  )
+where
+
+import qualified Orville.PostgreSQL.Expr as Expr
+
+{- |
+  An identifier used by Orville to identify a particular function in a particular
+  schema.
+
+@since 1.1.0.0
+-}
+data FunctionIdentifier = FunctionIdentifier
+  { i_functionIdName :: String
+  , i_functionIdSchema :: Maybe String
+  }
+  deriving (Eq, Ord, Show)
+
+{- |
+  Constructs a 'FunctionIdentifier' where the function's name will not be qualified
+  by a particular schema.
+
+@since 1.1.0.0
+-}
+unqualifiedNameToFunctionId :: String -> FunctionIdentifier
+unqualifiedNameToFunctionId name =
+  FunctionIdentifier
+    { i_functionIdName = name
+    , i_functionIdSchema = Nothing
+    }
+
+{- |
+  Sets the schema of the 'FunctionIdentifier'. Wherever applicable, references to
+  the function will be qualified by the given schema name.
+
+@since 1.1.0.0
+-}
+setFunctionIdSchema :: String -> FunctionIdentifier -> FunctionIdentifier
+setFunctionIdSchema schema functionId =
+  functionId
+    { i_functionIdSchema = Just schema
+    }
+
+{- |
+  Returns the 'Expr.Qualified Expr.FunctionName' that should be used to refer to
+  the function in SQL queries.
+
+@since 1.1.0.0
+-}
+functionIdQualifiedName :: FunctionIdentifier -> Expr.Qualified Expr.FunctionName
+functionIdQualifiedName functionId =
+  Expr.qualifyFunction
+    (functionIdSchemaName functionId)
+    (functionIdUnqualifiedName functionId)
+
+{- |
+  Returns the unqualified 'Expr.FunctionName' that should be used to refer to the
+  function in SQL queries where an unqualified reference is appropriate.
+
+@since 1.1.0.0
+-}
+functionIdUnqualifiedName :: FunctionIdentifier -> Expr.FunctionName
+functionIdUnqualifiedName =
+  Expr.functionName . i_functionIdName
+
+{- |
+  Returns the 'Expr.SchemaName' (if any) that should be used to qualify
+  references to the function in SQL queries.
+
+@since 1.1.0.0
+-}
+functionIdSchemaName :: FunctionIdentifier -> Maybe Expr.SchemaName
+functionIdSchemaName =
+  fmap Expr.schemaName . i_functionIdSchema
+
+{- |
+  Retrieves the unqualified name of the function as a 'String'.
+
+@since 1.1.0.0
+-}
+functionIdUnqualifiedNameString :: FunctionIdentifier -> String
+functionIdUnqualifiedNameString =
+  i_functionIdName
+
+{- |
+  Retrieves the schema name of the function as a 'String'.
+
+@since 1.1.0.0
+-}
+functionIdSchemaNameString :: FunctionIdentifier -> Maybe String
+functionIdSchemaNameString =
+  i_functionIdSchema
+
+{- |
+  Converts a 'FunctionIdentifier' to a 'String' for descriptive purposes. The
+  name will be qualified if a schema name has been set for the identifier.
+
+  Note: You should not use this function for building SQL expressions. Use
+  'functionIdQualifiedName' instead for that.
+
+@since 1.1.0.0
+-}
+functionIdToString :: FunctionIdentifier -> String
+functionIdToString functionId =
+  case i_functionIdSchema functionId of
+    Nothing ->
+      i_functionIdName functionId
+    Just schema ->
+      schema <> "." <> i_functionIdName functionId

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/TriggerDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/TriggerDefinition.hs
@@ -1,0 +1,204 @@
+{- |
+Copyright : Flipstone Technology Partners 2024
+License   : MIT
+Stability : Stable
+
+@since 1.1.0.0
+-}
+module Orville.PostgreSQL.Schema.TriggerDefinition
+  ( TriggerDefinition
+  , beforeInsert
+  , afterInsert
+  , beforeUpdate
+  , afterUpdate
+  , beforeDelete
+  , afterDelete
+  , mkTriggerDefinition
+  , TriggerMigrationKey (NamedTriggerKey)
+  , triggerMigrationKey
+  , mkCreateTriggerExpr
+  ) where
+
+import Data.List.NonEmpty (NonEmpty ((:|)))
+
+import qualified Orville.PostgreSQL.Expr as Expr
+
+{- |
+  Defines a trigger that can be added to a
+  'Orville.PostgreSQL.TableDefinition'. Use one of the constructor functions
+  below (such as 'mkNamedTriggerDefinition') to construct the constraint
+  definition you wish to have and then use 'Orville.PostgreSQL.addTableTriggers'
+  to add them to your table definition. Orville will then add the trigger next
+  time you run auto-migrations.
+
+  Note that currently Orville will only add triggers when it sees that no trigger
+  with the same name exists. If you want to change the definition of the trigger
+  you should also change the name that you specify when making the 'TriggerDefinition'
+  so that Orville will drop the old trigger and create a new trigger with the new
+  name.
+
+@since 1.1.0.0
+-}
+data TriggerDefinition = TriggerDefinition
+  { i_triggerMigrationKey :: TriggerMigrationKey
+  , i_triggerCreateExpr ::
+      Maybe Expr.OrReplace ->
+      Expr.Qualified Expr.TableName ->
+      Expr.CreateTriggerExpr
+  }
+
+{- |
+  Orville uses 'TriggerMigration' values while performing auto migrations to
+  determine whether an trigger needs to be added or dropped. For most use cases
+  the constructor functions that build an 'TriggerDefinition' will create this
+  automatically for you.
+
+@since 1.1.0.0
+-}
+newtype TriggerMigrationKey
+  = NamedTriggerKey String
+  deriving (Eq, Ord)
+
+{- |
+  Gets the 'TriggerMigrationKey' for the 'TriggerDefinition'
+
+@since 1.1.0.0
+-}
+triggerMigrationKey :: TriggerDefinition -> TriggerMigrationKey
+triggerMigrationKey =
+  i_triggerMigrationKey
+
+{- |
+  Builds a 'TriggerDefinition' that will execute the named function for each row
+  being inserted before it is inserted.
+
+@since 1.1.0.0
+-}
+beforeInsert :: String -> Expr.Qualified Expr.FunctionName -> TriggerDefinition
+beforeInsert name functionName =
+  mkTriggerDefinition
+    name
+    Expr.triggerBefore
+    (Expr.triggerOnInsert :| [])
+    Expr.triggerForEachRow
+    functionName
+
+{- |
+  Builds a 'TriggerDefinition' that will execute the named function for each row
+  being inserted after it is inserted.
+
+@since 1.1.0.0
+-}
+afterInsert :: String -> Expr.Qualified Expr.FunctionName -> TriggerDefinition
+afterInsert name functionName =
+  mkTriggerDefinition
+    name
+    Expr.triggerAfter
+    (Expr.triggerOnInsert :| [])
+    Expr.triggerForEachRow
+    functionName
+
+{- |
+  Builds a 'TriggerDefinition' that will execute the named function for each row
+  being updated before it is updated.
+
+@since 1.1.0.0
+-}
+beforeUpdate :: String -> Expr.Qualified Expr.FunctionName -> TriggerDefinition
+beforeUpdate name functionName =
+  mkTriggerDefinition
+    name
+    Expr.triggerBefore
+    (Expr.triggerOnUpdate :| [])
+    Expr.triggerForEachRow
+    functionName
+
+{- |
+  Builds a 'TriggerDefinition' that will execute the named function for each row
+  being updated after it is updated.
+
+@since 1.1.0.0
+-}
+afterUpdate :: String -> Expr.Qualified Expr.FunctionName -> TriggerDefinition
+afterUpdate name functionName =
+  mkTriggerDefinition
+    name
+    Expr.triggerAfter
+    (Expr.triggerOnUpdate :| [])
+    Expr.triggerForEachRow
+    functionName
+
+{- |
+  Builds a 'TriggerDefinition' that will execute the named function for each row
+  being deleted before it is deleted.
+
+@since 1.1.0.0
+-}
+beforeDelete :: String -> Expr.Qualified Expr.FunctionName -> TriggerDefinition
+beforeDelete name functionName =
+  mkTriggerDefinition
+    name
+    Expr.triggerBefore
+    (Expr.triggerOnDelete :| [])
+    Expr.triggerForEachRow
+    functionName
+
+{- |
+  Builds a 'TriggerDefinition' that will execute the named function for each row
+  being deleted after it is deleted.
+
+@since 1.1.0.0
+-}
+afterDelete :: String -> Expr.Qualified Expr.FunctionName -> TriggerDefinition
+afterDelete name functionName =
+  mkTriggerDefinition
+    name
+    Expr.triggerAfter
+    (Expr.triggerOnDelete :| [])
+    Expr.triggerForEachRow
+    functionName
+
+{- |
+  Constructs a 'TriggerDefinition' definining a trigger with the specified name.
+  Note that orville is currently not capable of migrating triggers based on their
+  structure. The trigger will be created if no trigger exists on the table with
+  the specificed name. If a trigger already exists with the same name on the table
+  then nothing will be done.
+
+@since 1.1.0.0
+-}
+mkTriggerDefinition ::
+  String ->
+  Expr.TriggerTiming ->
+  NonEmpty Expr.TriggerEvent ->
+  Expr.TriggerFireScope ->
+  Expr.Qualified Expr.FunctionName ->
+  TriggerDefinition
+mkTriggerDefinition name timing events fireScope functionName =
+  TriggerDefinition
+    { i_triggerMigrationKey = NamedTriggerKey name
+    , i_triggerCreateExpr =
+        \orReplace tableName ->
+          Expr.createTrigger
+            orReplace
+            (Expr.triggerName name)
+            timing
+            events
+            tableName
+            fireScope
+            functionName
+    }
+
+{- |
+  Builds a 'Expr.CreateTriggerExpr' that will create a SQL trigger matching
+  the given 'TriggerDefinition' when it is executed.
+
+@since 1.1.0.0
+-}
+mkCreateTriggerExpr ::
+  TriggerDefinition ->
+  Maybe Expr.OrReplace ->
+  Expr.Qualified Expr.TableName ->
+  Expr.CreateTriggerExpr
+mkCreateTriggerExpr =
+  i_triggerCreateExpr

--- a/orville-postgresql/test/Main.hs
+++ b/orville-postgresql/test/Main.hs
@@ -26,6 +26,7 @@ import qualified Test.Expr.OrderBy as ExprOrderBy
 import qualified Test.Expr.SequenceDefinition as ExprSequenceDefinition
 import qualified Test.Expr.TableDefinition as ExprTableDefinition
 import qualified Test.Expr.Time as ExprTime
+import qualified Test.Expr.Trigger as ExprTrigger
 import qualified Test.Expr.Vacuum as ExprVacuum
 import qualified Test.Expr.Where as ExprWhere
 import qualified Test.FieldDefinition as FieldDefinition
@@ -67,6 +68,7 @@ main = do
       , ExprCount.countTests pool
       , ExprMath.mathTests pool
       , ExprTime.timeTests pool
+      , ExprTrigger.triggerTests pool
       , ExprVacuum.vacuumTests
       , FieldDefinition.fieldDefinitionTests pool
       , SqlMarshaller.sqlMarshallerTests

--- a/orville-postgresql/test/Test/AutoMigration.hs
+++ b/orville-postgresql/test/Test/AutoMigration.hs
@@ -981,7 +981,7 @@ prop_dropsRequestedFunctions =
     firstTimePlan <-
       HH.evalIO $
         Orville.runOrville pool $ do
-          Orville.executeVoid Orville.DDLQuery $ Orville.mkCreateFunctionExpr (Just Expr.orReplace) functionDef
+          Orville.executeVoid Orville.DDLQuery $ Orville.mkCreateFunctionExpr functionDef (Just Expr.orReplace)
           AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaDropFunction functionId]
 
     secondTimePlan <-

--- a/orville-postgresql/test/Test/AutoMigration.hs
+++ b/orville-postgresql/test/Test/AutoMigration.hs
@@ -17,6 +17,7 @@ import qualified Data.List as List
 import qualified Data.List.NonEmpty as NEL
 import qualified Data.Maybe as Maybe
 import qualified Data.String as String
+import qualified Data.Text as T
 import Hedgehog ((===))
 import qualified Hedgehog as HH
 import qualified Hedgehog.Gen as Gen
@@ -58,6 +59,11 @@ autoMigrationTests pool =
     , prop_altersModifiedSequences pool
     , prop_addsAndRemovesMixedIndexes pool
     , prop_arbitrarySchemaInitialMigration pool
+    , prop_createsMissingFunctions pool
+    , prop_recreatesAlteredFunctions pool
+    , prop_dropsRequestedFunctions pool
+    , prop_createsMissingTriggers pool
+    , prop_dropsUnrequestedTriggers pool
     ]
 
 prop_raisesErrorIfMigrationLockIsLocked :: Property.NamedDBProperty
@@ -727,7 +733,7 @@ prop_createsMissingSequences =
 
 prop_dropsRequestedSequences :: Property.NamedDBProperty
 prop_dropsRequestedSequences =
-  Property.singletonNamedDBProperty "Drops requested tables" $ \pool -> do
+  Property.singletonNamedDBProperty "Drops requested sequences" $ \pool -> do
     let
       sequenceDef =
         Orville.mkSequenceDefinition "migration_test_sequence"
@@ -883,6 +889,203 @@ prop_arbitrarySchemaInitialMigration =
 
     migrationPlanStepStrings migrationPlanAfterMigration === []
     Fold.traverse_ (assertTableStructure pool) testTables
+
+prop_createsMissingFunctions :: Property.NamedDBProperty
+prop_createsMissingFunctions =
+  Property.singletonNamedDBProperty "Creates missing functions" $ \pool -> do
+    let
+      functionDef =
+        Orville.mkTriggerFunction
+          "test_create_function"
+          Orville.plpgsql
+          "BEGIN return NEW; END"
+
+      functionId =
+        Orville.functionIdentifier functionDef
+
+    firstTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          Orville.executeVoid Orville.DDLQuery $
+            Expr.dropFunction
+              (Just Expr.ifExists)
+              (Orville.functionName functionDef)
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaFunction functionDef]
+
+    secondTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          AutoMigration.executeMigrationPlan AutoMigration.defaultOptions firstTimePlan
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaFunction functionDef]
+
+    length (AutoMigration.migrationPlanSteps firstTimePlan) === 1
+
+    proc <- PgAssert.assertFunctionExists pool (Orville.functionIdUnqualifiedNameString functionId)
+    PgCatalog.pgProcSource proc === T.pack "BEGIN return NEW; END"
+
+    migrationPlanStepStrings secondTimePlan === []
+
+prop_recreatesAlteredFunctions :: Property.NamedDBProperty
+prop_recreatesAlteredFunctions =
+  Property.singletonNamedDBProperty "Recreates functions with altered source code" $ \pool -> do
+    let
+      oldFunctionDef =
+        Orville.mkTriggerFunction
+          "test_recreate_function"
+          Orville.plpgsql
+          "BEGIN return OLD; END"
+
+      newFunctionDef =
+        Orville.mkTriggerFunction
+          "test_recreate_function"
+          Orville.plpgsql
+          "BEGIN return NEW; END"
+
+      functionId =
+        Orville.functionIdentifier oldFunctionDef
+
+    firstTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          Orville.executeVoid Orville.DDLQuery $
+            Expr.dropFunction (Just Expr.ifExists) (Orville.functionName oldFunctionDef)
+          AutoMigration.autoMigrateSchema AutoMigration.defaultOptions [AutoMigration.SchemaFunction oldFunctionDef]
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaFunction newFunctionDef]
+
+    secondTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          AutoMigration.executeMigrationPlan AutoMigration.defaultOptions firstTimePlan
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaFunction newFunctionDef]
+
+    length (AutoMigration.migrationPlanSteps firstTimePlan) === 1
+
+    proc <- PgAssert.assertFunctionExists pool (Orville.functionIdUnqualifiedNameString functionId)
+    PgCatalog.pgProcSource proc === T.pack "BEGIN return NEW; END"
+
+    migrationPlanStepStrings secondTimePlan === []
+
+prop_dropsRequestedFunctions :: Property.NamedDBProperty
+prop_dropsRequestedFunctions =
+  Property.singletonNamedDBProperty "Drops requested functions" $ \pool -> do
+    let
+      functionDef =
+        Orville.mkTriggerFunction
+          "test_drop_function"
+          Orville.plpgsql
+          "BEGIN return NEW; END"
+
+      functionId =
+        Orville.functionIdentifier functionDef
+
+    firstTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          Orville.executeVoid Orville.DDLQuery $ Orville.mkCreateFunctionExpr (Just Expr.orReplace) functionDef
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaDropFunction functionId]
+
+    secondTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          AutoMigration.executeMigrationPlan AutoMigration.defaultOptions firstTimePlan
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaDropFunction functionId]
+
+    length (AutoMigration.migrationPlanSteps firstTimePlan) === 1
+    PgAssert.assertFunctionDoesNotExist pool (Orville.functionIdUnqualifiedNameString functionId)
+    migrationPlanStepStrings secondTimePlan === []
+
+prop_createsMissingTriggers :: Property.NamedDBProperty
+prop_createsMissingTriggers =
+  Property.singletonNamedDBProperty "Creates missing triggers" $ \pool -> do
+    let
+      functionDef =
+        Orville.mkTriggerFunction
+          "test_create_trigger_function"
+          Orville.plpgsql
+          "BEGIN return NEW; END"
+
+      testTrigger =
+        Orville.beforeInsert
+          "before_insert_trigger"
+          (Orville.functionName functionDef)
+
+      tableWithTrigger =
+        Orville.addTableTriggers [testTrigger] Foo.table
+
+      schemaItems =
+        [ AutoMigration.SchemaFunction functionDef
+        , AutoMigration.SchemaTable tableWithTrigger
+        ]
+
+    firstTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          Orville.executeVoid Orville.DDLQuery $ TestTable.dropTableDefSql tableWithTrigger
+          Orville.executeVoid Orville.DDLQuery $ Expr.dropFunction (Just Expr.ifExists) (Orville.functionName functionDef)
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions schemaItems
+
+    secondTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          AutoMigration.executeMigrationPlan AutoMigration.defaultOptions firstTimePlan
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions schemaItems
+
+    length (AutoMigration.migrationPlanSteps firstTimePlan) === 3
+
+    fooRelation <- PgAssert.assertTableExists pool "foo"
+    _ <- PgAssert.assertTriggerExists fooRelation "before_insert_trigger"
+
+    migrationPlanStepStrings secondTimePlan === []
+
+prop_dropsUnrequestedTriggers :: Property.NamedDBProperty
+prop_dropsUnrequestedTriggers =
+  Property.singletonNamedDBProperty "Drops unrequested triggers" $ \pool -> do
+    let
+      functionDef =
+        Orville.mkTriggerFunction
+          "test_drop_trigger_function"
+          Orville.plpgsql
+          "BEGIN return NEW; END"
+
+      testTrigger =
+        Orville.beforeInsert
+          "before_insert_trigger"
+          (Orville.functionName functionDef)
+
+      tableWithoutTrigger =
+        Foo.table
+
+      tableWithTrigger =
+        Orville.addTableTriggers [testTrigger] tableWithoutTrigger
+
+      schemaItemsWithTrigger =
+        [ AutoMigration.SchemaFunction functionDef
+        , AutoMigration.SchemaTable tableWithTrigger
+        ]
+
+      schemaItemsWithoutTrigger =
+        [ AutoMigration.SchemaFunction functionDef
+        , AutoMigration.SchemaTable tableWithoutTrigger
+        ]
+
+    firstTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          Orville.executeVoid Orville.DDLQuery $ TestTable.dropTableDefSql tableWithoutTrigger
+          Orville.executeVoid Orville.DDLQuery $ Expr.dropFunction (Just Expr.ifExists) (Orville.functionName functionDef)
+          AutoMigration.autoMigrateSchema AutoMigration.defaultOptions schemaItemsWithTrigger
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions schemaItemsWithoutTrigger
+
+    secondTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          AutoMigration.executeMigrationPlan AutoMigration.defaultOptions firstTimePlan
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions schemaItemsWithoutTrigger
+
+    length (AutoMigration.migrationPlanSteps firstTimePlan) === 1
+    fooRelation <- PgAssert.assertTableExists pool "foo"
+    _ <- PgAssert.assertTriggerDoesNotExist fooRelation "before_insert_trigger"
+    migrationPlanStepStrings secondTimePlan === []
 
 assertTableStructure ::
   (HH.MonadTest m, MIO.MonadIO m) =>

--- a/orville-postgresql/test/Test/Expr/Trigger.hs
+++ b/orville-postgresql/test/Test/Expr/Trigger.hs
@@ -1,0 +1,74 @@
+module Test.Expr.Trigger
+  ( triggerTests
+  ) where
+
+import qualified Control.Monad.IO.Class as MIO
+import Data.List.NonEmpty (NonEmpty ((:|)))
+
+import qualified Orville.PostgreSQL as Orville
+import qualified Orville.PostgreSQL.Execution as Execution
+import qualified Orville.PostgreSQL.Expr as Expr
+import qualified Orville.PostgreSQL.Raw.Connection as Conn
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+
+import Test.Expr.TestSchema (assertEqualFooBarRows, dropAndRecreateTestTable, findAllFooBars, fooBarTable, insertFooBarSource, mkFooBar)
+import qualified Test.Property as Property
+
+triggerTests :: Orville.ConnectionPool -> Property.Group
+triggerTests pool =
+  Property.group
+    "Expr - Trigger"
+    [ prop_triggers pool
+    ]
+
+prop_triggers :: Property.NamedDBProperty
+prop_triggers =
+  Property.singletonNamedDBProperty "creates a trigger on a table" $ \pool -> do
+    let
+      fooBars =
+        [mkFooBar 1 "dog"]
+
+      expectedFooBars =
+        [mkFooBar 1 "god"]
+
+      triggerBody =
+        "BEGIN \
+        \  NEW.bar = reverse (NEW.bar); \
+        \  return NEW; \
+        \END"
+
+      triggerFunctionName =
+        Expr.qualifyFunction Nothing $ Expr.functionName "test_trigger_function"
+
+      createTriggerFunction =
+        Expr.createFunction
+          (Just Expr.orReplace)
+          triggerFunctionName
+          (Expr.returns Expr.returnTypeTrigger)
+          (Expr.language Expr.plpgsql)
+          (Expr.asDefinition triggerBody)
+
+      createTrigger =
+        Expr.createTrigger
+          Nothing
+          (Expr.triggerName "test_trigger")
+          Expr.triggerBefore
+          (Expr.triggerOnInsert :| [])
+          fooBarTable
+          Expr.triggerForEachRow
+          triggerFunctionName
+
+    rows <-
+      MIO.liftIO $
+        Conn.withPoolConnection pool $ \connection -> do
+          dropAndRecreateTestTable connection
+          RawSql.executeVoid connection createTriggerFunction
+          RawSql.executeVoid connection createTrigger
+          RawSql.executeVoid connection $
+            Expr.insertExpr fooBarTable Nothing (insertFooBarSource fooBars) Nothing Nothing
+
+          result <- RawSql.execute connection findAllFooBars
+
+          Execution.readRows result
+
+    assertEqualFooBarRows rows expectedFooBars


### PR DESCRIPTION
This adds `Expr` functions for building SQL expressions related to
triggers and functions along with schema level `FunctionDefinition`
and `TriggerDefinition` abstractions.

`FunctionDefinition`s are meant be included directly in `SchemaItem`
lists for auto migration purposes to create the functions that triggers
will call. For the purposes of this change we provide only `mkTriggerFunction`
for construction a new `FunctionDefinition` for a trigger function.

`TriggerDefinition`s are added to a `TableDefinition` via the new
`addTableTriggers` function, similar to indexes and constraints.
For the time being migration of trigger's is done by name only --
existing triggers are never altered. This is due both to the complexity
involved in interpreting the `pg_trigger` catalog entries to determine
whether the trigger needs to be migration and also the fact that
`CREATE OR REPLACE TRIGGER` is not available in PostgreSQL 14 and
would be required for changing most of the properties on triggers.

Co-Authored-By: Paul <paul@flipstone.com>
