### PR TITLE
Adds basic support for PostgreSQL extensions and particularly pg_trgm

### DIFF
--- a/orville-postgresql/orville-postgresql.cabal
+++ b/orville-postgresql/orville-postgresql.cabal
@@ -32,6 +32,7 @@ library
   exposed-modules:
       Orville.PostgreSQL
       Orville.PostgreSQL.AutoMigration
+      Orville.PostgreSQL.Extension.PgTrgm
       Orville.PostgreSQL.Execution
       Orville.PostgreSQL.Execution.Cursor
       Orville.PostgreSQL.Execution.Delete
@@ -109,10 +110,13 @@ library
       Orville.PostgreSQL.Schema.TableIdentifier
       Orville.PostgreSQL.UnliftIO
   other-modules:
+      Orville.PostgreSQL.Expr.Extension
       Orville.PostgreSQL.Expr.Function
+      Orville.PostgreSQL.Expr.IfNotExists
       Orville.PostgreSQL.Expr.Internal.Name.ColumnName
       Orville.PostgreSQL.Expr.Internal.Name.ConstraintName
       Orville.PostgreSQL.Expr.Internal.Name.CursorName
+      Orville.PostgreSQL.Expr.Internal.Name.ExtensionName
       Orville.PostgreSQL.Expr.Internal.Name.FunctionName
       Orville.PostgreSQL.Expr.Internal.Name.Identifier
       Orville.PostgreSQL.Expr.Internal.Name.IndexName
@@ -139,11 +143,13 @@ library
       Orville.PostgreSQL.PgCatalog.PgAttributeDefault
       Orville.PostgreSQL.PgCatalog.PgClass
       Orville.PostgreSQL.PgCatalog.PgConstraint
+      Orville.PostgreSQL.PgCatalog.PgExtension
       Orville.PostgreSQL.PgCatalog.PgIndex
       Orville.PostgreSQL.PgCatalog.PgNamespace
       Orville.PostgreSQL.PgCatalog.PgProc
       Orville.PostgreSQL.PgCatalog.PgSequence
       Orville.PostgreSQL.PgCatalog.PgTrigger
+      Orville.PostgreSQL.Schema.ExtensionIdentifier
       Orville.PostgreSQL.Schema.FunctionDefinition
       Orville.PostgreSQL.Schema.FunctionIdentifier
       Orville.PostgreSQL.Schema.TriggerDefinition

--- a/orville-postgresql/package.yaml
+++ b/orville-postgresql/package.yaml
@@ -28,6 +28,7 @@ library:
   exposed-modules:
     - Orville.PostgreSQL
     - Orville.PostgreSQL.AutoMigration
+    - Orville.PostgreSQL.Extension.PgTrgm
     - Orville.PostgreSQL.Execution
     - Orville.PostgreSQL.Execution.Cursor
     - Orville.PostgreSQL.Execution.Delete

--- a/orville-postgresql/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL.hs
@@ -1,5 +1,5 @@
 {- |
-Copyright : Flipstone Technology Partners 2023
+Copyright : Flipstone Technology Partners 2023-2024
 License   : MIT
 Stability : Stable
 
@@ -189,6 +189,7 @@ module Orville.PostgreSQL
   , SyntheticField.syntheticField
   , SyntheticField.nullableSyntheticField
   , SyntheticField.prefixSyntheticField
+  , SyntheticField.orderBySyntheticField
   , FieldDefinition.FieldDefinition
   , FieldDefinition.NotNull
   , FieldDefinition.Nullable
@@ -355,6 +356,12 @@ module Orville.PostgreSQL
   , FunctionIdentifier.functionIdToString
   , Expr.plpgsql
 
+    -- * Functions for working with PostgreSQL extensions
+  , ExtensionIdentifier.ExtensionIdentifier
+  , ExtensionIdentifier.nameToExtensionId
+  , ExtensionIdentifier.extensionIdName
+  , ExtensionIdentifier.extensionIdToString
+
     -- * Numeric types
   , SqlType.integer
   , SqlType.serial
@@ -422,6 +429,7 @@ import qualified Orville.PostgreSQL.OrvilleState as OrvilleState
 import qualified Orville.PostgreSQL.Raw.Connection as Connection
 import qualified Orville.PostgreSQL.Raw.SqlCommenter as SqlCommenter
 import qualified Orville.PostgreSQL.Schema.ConstraintDefinition as ConstraintDefinition
+import qualified Orville.PostgreSQL.Schema.ExtensionIdentifier as ExtensionIdentifier
 import qualified Orville.PostgreSQL.Schema.FunctionDefinition as FunctionDefinition
 import qualified Orville.PostgreSQL.Schema.FunctionIdentifier as FunctionIdentifier
 import qualified Orville.PostgreSQL.Schema.IndexDefinition as IndexDefinition

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr.hs
@@ -43,6 +43,7 @@ module Orville.PostgreSQL.Expr
   , module Orville.PostgreSQL.Expr.Delete
   , module Orville.PostgreSQL.Expr.GroupBy
   , module Orville.PostgreSQL.Expr.IfExists
+  , module Orville.PostgreSQL.Expr.IfNotExists
   , module Orville.PostgreSQL.Expr.Index
   , module Orville.PostgreSQL.Expr.Insert
   , module Orville.PostgreSQL.Expr.LimitExpr
@@ -66,6 +67,7 @@ module Orville.PostgreSQL.Expr
   , module Orville.PostgreSQL.Expr.Function
   , module Orville.PostgreSQL.Expr.OrReplace
   , module Orville.PostgreSQL.Expr.Vacuum
+  , module Orville.PostgreSQL.Expr.Extension
   )
 where
 
@@ -78,9 +80,11 @@ import Orville.PostgreSQL.Expr.Count
 import Orville.PostgreSQL.Expr.Cursor
 import Orville.PostgreSQL.Expr.DataType
 import Orville.PostgreSQL.Expr.Delete
+import Orville.PostgreSQL.Expr.Extension
 import Orville.PostgreSQL.Expr.Function
 import Orville.PostgreSQL.Expr.GroupBy
 import Orville.PostgreSQL.Expr.IfExists
+import Orville.PostgreSQL.Expr.IfNotExists
 import Orville.PostgreSQL.Expr.Index
 import Orville.PostgreSQL.Expr.Insert
 import Orville.PostgreSQL.Expr.LimitExpr

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Extension.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Extension.hs
@@ -1,0 +1,112 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+{- |
+Copyright : Flipstone Technology Partners 2024
+License   : MIT
+Stability : Stable
+
+Types and functionality related to loading PostgreSQL extensions. This does not contain features
+related to any specific extension, but serves as the basis for loading some extension.
+
+@since 1.1.0.0
+-}
+module Orville.PostgreSQL.Expr.Extension
+  ( CreateExtensionExpr
+  , createExtensionExpr
+  , DropExtensionExpr
+  , dropExtensionExpr
+  , ExtensionActionExpr
+  , extensionCascadeExpr
+  , extensionRestrictExpr
+  ) where
+
+import Orville.PostgreSQL.Expr.IfExists (IfExists)
+import Orville.PostgreSQL.Expr.IfNotExists (IfNotExists)
+import Orville.PostgreSQL.Expr.Name (ExtensionName)
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+
+{- |
+Type to represent a SQL "CREATE EXTENSION" statement. E.G.
+
+> CREATE EXTENSION foo
+
+'CreateIndexExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 1.1.0.0
+-}
+newtype CreateExtensionExpr = CreateExtensionExpr RawSql.RawSql
+  deriving (RawSql.SqlExpression)
+
+{- | Construct a SQL CREATE EXTENSION statement from the extension name and if the statement should
+not fail on loading an extension with the same name as an already loaded one.
+
+@since 1.1.0.0
+-}
+createExtensionExpr :: ExtensionName -> Maybe IfNotExists -> Maybe ExtensionActionExpr -> CreateExtensionExpr
+createExtensionExpr extension mbIfNotExists mbAction =
+  CreateExtensionExpr $
+    RawSql.fromString "CREATE EXTENSION "
+      <> maybe mempty (<> RawSql.space) (fmap RawSql.toRawSql mbIfNotExists)
+      <> RawSql.toRawSql extension
+      <> maybe mempty (<> RawSql.space) (fmap RawSql.toRawSql mbAction)
+
+{- |
+Type to represent a SQL "DROP EXTENSION" statement. E.G.
+
+> DROP EXTENSION foo
+
+'DropIndexExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 1.1.0.0
+-}
+newtype DropExtensionExpr = DropExtensionExpr RawSql.RawSql
+  deriving (RawSql.SqlExpression)
+
+{- | Construct a SQL DROP EXTENSION statement from the extension name and if the statement should
+not fail on loading an extension with the same name as an already loaded one.
+
+@since 1.1.0.0
+-}
+dropExtensionExpr :: ExtensionName -> Maybe IfExists -> Maybe ExtensionActionExpr -> DropExtensionExpr
+dropExtensionExpr extension mbIfExists mbAction =
+  DropExtensionExpr $
+    RawSql.fromString "DROP EXTENSION "
+      <> maybe mempty (<> RawSql.space) (fmap RawSql.toRawSql mbIfExists)
+      <> RawSql.toRawSql extension
+      <> maybe mempty (<> RawSql.space) (fmap RawSql.toRawSql mbAction)
+
+{- |
+Type to represent a extension action on a @EXTENSION@. E.G.
+the @CASCADE@ in
+
+> CREATE EXTENSION foo CASCADE
+
+'ExtensionActionExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 1.1.0.0
+-}
+newtype ExtensionActionExpr
+  = ExtensionActionExpr RawSql.RawSql
+  deriving (RawSql.SqlExpression)
+
+{- |
+  The extension action @RESTRICT@.
+
+  @since 1.1.0.0
+-}
+extensionRestrictExpr :: ExtensionActionExpr
+extensionRestrictExpr = ExtensionActionExpr $ RawSql.fromString "RESTRICT"
+
+{- |
+  The extension action @CASCADE@.
+
+  @since 1.1.0.0
+-}
+extensionCascadeExpr :: ExtensionActionExpr
+extensionCascadeExpr = ExtensionActionExpr $ RawSql.fromString "CASCADE"

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/IfNotExists.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/IfNotExists.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+{- |
+Copyright : Flipstone Technology Partners 2024
+License   : MIT
+Stability : Stable
+
+@since 1.1.0.0
+-}
+module Orville.PostgreSQL.Expr.IfNotExists
+  ( IfNotExists
+  , ifNotExists
+  )
+where
+
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+
+{- |
+Type to represent a SQL "IF NOT EXISTS" expression. E.G.
+
+> IF NOT EXISTS
+
+It is notable that 'IfNotExists' and 'Orville.PostgreSQL.Expr.IfExists' are not usable in all the
+same places.
+
+'IfNotExists' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 1.1.0.0
+-}
+newtype IfNotExists
+  = IfNotExists RawSql.RawSql
+  deriving
+    ( -- | @since 1.1.0.0
+      RawSql.SqlExpression
+    )
+
+{- |
+A value of the SQL "IF NOT EXISTS".
+
+@since 1.1.0.0
+-}
+ifNotExists :: IfNotExists
+ifNotExists =
+  IfNotExists $ RawSql.fromString "IF NOT EXISTS"

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Internal/Name/ExtensionName.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Internal/Name/ExtensionName.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+{- |
+Copyright : Flipstone Technology Partners 2024
+License   : MIT
+Stability : Stable
+
+@since 1.1.0.0
+-}
+module Orville.PostgreSQL.Expr.Internal.Name.ExtensionName
+  ( ExtensionName
+  , extensionName
+  )
+where
+
+import Orville.PostgreSQL.Expr.Internal.Name.Identifier (Identifier, IdentifierExpression, identifier)
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+
+{- |
+Type to represent a PostgreSQL extension name. 'ExtensionName' values constructed via the
+'extensionName' function will be properly escaped as part of the generated SQL. E.G.
+
+> "some_extension_name"
+
+'ExtensionName' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 1.1.0.0
+-}
+newtype ExtensionName
+  = ExtensionName Identifier
+  deriving
+    ( -- | @since 1.1.0.0
+      RawSql.SqlExpression
+    , -- | @since 1.1.0.0
+      IdentifierExpression
+    )
+
+{- |
+Construct an 'ExtensionName' from a 'String'.
+
+@since 1.1.0.0
+-}
+extensionName :: String -> ExtensionName
+extensionName = ExtensionName . identifier

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Name.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Name.hs
@@ -1,7 +1,7 @@
 {-# OPTIONS_GHC -Wno-missing-import-lists #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2023
+Copyright : Flipstone Technology Partners 2023-2024
 License   : MIT
 Stability : Stable
 
@@ -15,6 +15,7 @@ where
 import Orville.PostgreSQL.Expr.Internal.Name.ColumnName as Export
 import Orville.PostgreSQL.Expr.Internal.Name.ConstraintName as Export
 import Orville.PostgreSQL.Expr.Internal.Name.CursorName as Export
+import Orville.PostgreSQL.Expr.Internal.Name.ExtensionName as Export
 import Orville.PostgreSQL.Expr.Internal.Name.FunctionName as Export
 import Orville.PostgreSQL.Expr.Internal.Name.Identifier as Export
 import Orville.PostgreSQL.Expr.Internal.Name.IndexName as Export

--- a/orville-postgresql/src/Orville/PostgreSQL/Extension/PgTrgm.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Extension/PgTrgm.hs
@@ -1,0 +1,185 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+{- |
+Copyright : Flipstone Technology Partners 2024
+License   : MIT
+Stability : Stable
+
+Functionality for loading and using the
+[pg_trgm](https://www.postgresql.org/docs/current/pgtrgm.html) extension. While this extension is
+supplied by default with PostgreSQL, it is entirely up to users to ensure access to the extension.
+
+@since 1.1.0.0
+-}
+module Orville.PostgreSQL.Extension.PgTrgm
+  ( trigramSimilaritySyntheticField
+  , trigramWordSimilaritySyntheticField
+  , trigramStrictWordSimilaritySyntheticField
+  , mkNamedTrigramGinIndexDefinition
+  , mkNamedTrigramGistIndexDefinition
+  , trigramSimilarity
+  , trigramWordSimilarity
+  , trigramStrictWordSimilarity
+  ) where
+
+import qualified Data.List.NonEmpty as NEL
+
+import qualified Orville.PostgreSQL.Expr as Expr
+import qualified Orville.PostgreSQL.Internal.IndexDefinition as IndexDefinition
+import qualified Orville.PostgreSQL.Marshall as Marshall
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
+
+{- | Create a named GIN index over the given fields for fast text searching.
+
+@since 1.1.0.0
+-}
+mkNamedTrigramGinIndexDefinition ::
+  -- | The name of the index to be created.
+  String ->
+  -- | Field names to create the index over.
+  NEL.NonEmpty Marshall.FieldName ->
+  IndexDefinition.IndexDefinition
+mkNamedTrigramGinIndexDefinition name =
+  IndexDefinition.mkNamedIndexDefinition Expr.NonUniqueIndex name . RawSql.unsafeFromRawSql . trigramGinIndexFieldsExpr
+
+trigramGinIndexFieldsExpr :: NEL.NonEmpty Marshall.FieldName -> RawSql.RawSql
+trigramGinIndexFieldsExpr fields =
+  let
+    fieldExpr :: Marshall.FieldName -> RawSql.RawSql
+    fieldExpr name =
+      RawSql.toRawSql (Marshall.fieldNameToColumnName name)
+        <> RawSql.space
+        <> RawSql.fromString "gin_trgm_ops"
+  in
+    RawSql.fromString "USING GIN "
+      <> RawSql.parenthesized (RawSql.intercalate RawSql.commaSpace (fmap fieldExpr fields))
+
+{- | Create a named GIST index for fast text searching.  The index is created, over the fields each of
+  with an optional override of the index parameter "siglen". See [pg_trgm index
+  docs](https://www.postgresql.org/docs/current/pgtrgm.html#PGTRGM-INDEX) for more information.
+
+@since 1.1.0.0
+-}
+mkNamedTrigramGistIndexDefinition ::
+  -- | The name of the index to be created.
+  String ->
+  -- | Pairs of field name and optionally a value of the siglen parameter, to create the index over.
+  NEL.NonEmpty (Marshall.FieldName, Maybe Int) ->
+  IndexDefinition.IndexDefinition
+mkNamedTrigramGistIndexDefinition name =
+  IndexDefinition.mkNamedIndexDefinition Expr.NonUniqueIndex name . RawSql.unsafeFromRawSql . trigramGistIndexFieldsExpr
+
+trigramGistIndexFieldsExpr ::
+  NEL.NonEmpty (Marshall.FieldName, Maybe Int) ->
+  RawSql.RawSql
+trigramGistIndexFieldsExpr fields =
+  let
+    fieldExpr :: (Marshall.FieldName, Maybe Int) -> RawSql.RawSql
+    fieldExpr (name, mbSiglen) =
+      RawSql.toRawSql (Marshall.fieldNameToColumnName name)
+        <> RawSql.space
+        <> RawSql.fromString "gist_trgm_ops"
+        <> maybe
+          mempty
+          (\len -> RawSql.parenthesized (RawSql.fromString "siglen=" <> RawSql.intDecLiteral len))
+          mbSiglen
+  in
+    RawSql.fromString "USING GIST "
+      <> RawSql.parenthesized (RawSql.intercalate RawSql.commaSpace (fmap fieldExpr fields))
+
+{- | Create a synthetic field using the similarity function provided by pg_trgm.
+
+@since 1.1.0.0
+-}
+trigramSimilaritySyntheticField ::
+  -- | The column to be used in the similarity comparison
+  Expr.ColumnName ->
+  -- | The value to be compared against.
+  Expr.ValueExpression ->
+  -- | The alias to be used to name the similarity result.
+  String ->
+  -- | A field with the resulting similarity score between the column value and the comparison.
+  Marshall.SyntheticField Double
+trigramSimilaritySyntheticField colname compareVal fieldAlias =
+  Marshall.syntheticField
+    (trigramSimilarity (Expr.columnReference colname) compareVal)
+    fieldAlias
+    SqlValue.toDouble
+
+{- | Create a synthetic field using the word_similarity function provided by pg_trgm.
+
+@since 1.1.0.0
+-}
+trigramWordSimilaritySyntheticField ::
+  -- | The column to be used in the word_similarity comparison
+  Expr.ColumnName ->
+  -- | The value to be compared against.
+  Expr.ValueExpression ->
+  -- | The alias to be used to name the word_similarity result.
+  String ->
+  -- | A field with the resulting word_similarity score between the column value and the comparison.
+  Marshall.SyntheticField Double
+trigramWordSimilaritySyntheticField colname compareVal fieldAlias =
+  Marshall.syntheticField
+    (trigramWordSimilarity (Expr.columnReference colname) compareVal)
+    fieldAlias
+    SqlValue.toDouble
+
+{- | Create a synthetic field using the strict_word_similarity function provided by pg_trgm.
+
+@since 1.1.0.0
+-}
+trigramStrictWordSimilaritySyntheticField ::
+  -- | The column to be used in the strict_word_similarity comparison
+  Expr.ColumnName ->
+  -- | The value to be compared against.
+  Expr.ValueExpression ->
+  -- | The alias to be used to name the strict_word_similarity result.
+  String ->
+  -- | A field with the resulting strict_word_similarity score between the column value and the comparison.
+  Marshall.SyntheticField Double
+trigramStrictWordSimilaritySyntheticField colname compareVal fieldAlias =
+  Marshall.syntheticField
+    (trigramStrictWordSimilarity (Expr.columnReference colname) compareVal)
+    fieldAlias
+    SqlValue.toDouble
+
+{- | Call the similarity function provided by pg_trgm, comparing the pair of values.
+
+@since 1.1.0.0
+-}
+trigramSimilarity ::
+  Expr.ValueExpression ->
+  Expr.ValueExpression ->
+  Expr.ValueExpression
+trigramSimilarity firstVal secondVal =
+  Expr.functionCall
+    (Expr.functionName "similarity")
+    [firstVal, secondVal]
+
+{- | Call the word_similarity function provided by pg_trgm, comparing the pair of values.
+
+@since 1.1.0.0
+-}
+trigramWordSimilarity ::
+  Expr.ValueExpression ->
+  Expr.ValueExpression ->
+  Expr.ValueExpression
+trigramWordSimilarity firstVal secondVal =
+  Expr.functionCall
+    (Expr.functionName "word_similarity")
+    [firstVal, secondVal]
+
+{- | Call the strict_word_similarity function provided by pg_trgm, comparing the pair of values.
+
+@since 1.1.0.0
+-}
+trigramStrictWordSimilarity ::
+  Expr.ValueExpression ->
+  Expr.ValueExpression ->
+  Expr.ValueExpression
+trigramStrictWordSimilarity firstVal secondVal =
+  Expr.functionCall
+    (Expr.functionName "strict_word_similarity")
+    [firstVal, secondVal]

--- a/orville-postgresql/src/Orville/PostgreSQL/Marshall/FieldDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Marshall/FieldDefinition.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2023
+Copyright : Flipstone Technology Partners 2023-2024
 License   : MIT
 Stability : Stable
 
@@ -1125,9 +1125,11 @@ whereColumnComparison columnComparison fieldDef a =
     (fieldColumnReference fieldDef)
     (fieldValueToExpression fieldDef a)
 
-{-- |
+{- |
   Orders a query by the column name for the given field.
---}
+
+@since 1.0.0.0
+-}
 orderByField ::
   FieldDefinition nullability value ->
   Expr.OrderByDirection ->

--- a/orville-postgresql/src/Orville/PostgreSQL/Marshall/SyntheticField.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Marshall/SyntheticField.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2023
+Copyright : Flipstone Technology Partners 2023-2024
 License   : MIT
 Stability : Stable
 
@@ -15,12 +15,13 @@ module Orville.PostgreSQL.Marshall.SyntheticField
   , syntheticField
   , nullableSyntheticField
   , prefixSyntheticField
+  , orderBySyntheticField
   )
 where
 
 import qualified Data.ByteString.Char8 as B8
 import qualified Orville.PostgreSQL.Expr as Expr
-import Orville.PostgreSQL.Marshall.FieldDefinition (FieldName, byteStringToFieldName, fieldNameToByteString, stringToFieldName)
+import Orville.PostgreSQL.Marshall.FieldDefinition (FieldName, byteStringToFieldName, fieldNameToByteString, fieldNameToColumnName, stringToFieldName)
 import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 {- |
@@ -115,3 +116,12 @@ prefixSyntheticField prefix synthField =
   synthField
     { _syntheticFieldAlias = byteStringToFieldName (B8.pack prefix <> "_" <> fieldNameToByteString (syntheticFieldAlias synthField))
     }
+
+{- |
+  Orders a query by the alias for the given synthetic field.
+
+@since 1.1.0.0
+-}
+orderBySyntheticField :: SyntheticField a -> Expr.OrderByDirection -> Expr.OrderByExpr
+orderBySyntheticField =
+  Expr.orderByColumnName . fieldNameToColumnName . syntheticFieldAlias

--- a/orville-postgresql/src/Orville/PostgreSQL/PgCatalog.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/PgCatalog.hs
@@ -18,6 +18,7 @@ import Orville.PostgreSQL.PgCatalog.PgAttribute as Export
 import Orville.PostgreSQL.PgCatalog.PgAttributeDefault as Export
 import Orville.PostgreSQL.PgCatalog.PgClass as Export
 import Orville.PostgreSQL.PgCatalog.PgConstraint as Export
+import Orville.PostgreSQL.PgCatalog.PgExtension as Export
 import Orville.PostgreSQL.PgCatalog.PgIndex as Export
 import Orville.PostgreSQL.PgCatalog.PgNamespace as Export
 import Orville.PostgreSQL.PgCatalog.PgProc as Export

--- a/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/PgExtension.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/PgExtension.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+{- |
+Copyright : Flipstone Technology Partners 2024
+License   : MIT
+Stability : Stable
+
+@since 1.1.0.0
+-}
+module Orville.PostgreSQL.PgCatalog.PgExtension
+  ( PgExtension (..)
+  , ExtensionName
+  , pgExtensionTable
+  , extensionNameField
+  )
+where
+
+import qualified Data.String as String
+import qualified Data.Text as T
+
+import qualified Orville.PostgreSQL as Orville
+
+{- |
+  The Haskell representation of data read from the @pg_catalog.pg_extension@ table.
+  Rows in this table contain extended information about extensions.
+
+@since 1.1.0.0
+-}
+newtype PgExtension = PgExtension
+  { pgExtensionName :: ExtensionName
+  -- ^ The PostgreSQL name for this extension.
+  }
+
+{- |
+  A Haskell type for the name of the extension represented by a 'PgExtension'.
+
+@since 1.1.0.0
+-}
+newtype ExtensionName
+  = ExtensionName T.Text
+  deriving (Show, Eq, Ord, String.IsString)
+
+{- |
+  An Orville 'Orville.TableDefinition' for querying the
+  @pg_catalog.pg_extension@ table.
+
+@since 1.0.0.0
+-}
+pgExtensionTable :: Orville.TableDefinition Orville.NoKey PgExtension PgExtension
+pgExtensionTable =
+  Orville.setTableSchema "pg_catalog" $
+    Orville.mkTableDefinitionWithoutKey
+      "pg_extension"
+      pgExtensionMarshaller
+
+pgExtensionMarshaller :: Orville.SqlMarshaller PgExtension PgExtension
+pgExtensionMarshaller =
+  PgExtension
+    <$> Orville.marshallField pgExtensionName extensionNameField
+
+{- |
+  The @extname@ column of the @pg_extension@ table.
+
+@since 1.1.0.0
+-}
+extensionNameField :: Orville.FieldDefinition Orville.NotNull ExtensionName
+extensionNameField =
+  Orville.coerceField $
+    Orville.boundedTextField "extname" 63

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema.hs
@@ -28,6 +28,9 @@ module Orville.PostgreSQL.Schema
     -- * Definining Functions
   , module Orville.PostgreSQL.Schema.FunctionDefinition
   , module Orville.PostgreSQL.Schema.FunctionIdentifier
+
+    -- * Using PostgreSQL Extensions
+  , module Orville.PostgreSQL.Schema.ExtensionIdentifier
   )
 where
 
@@ -35,6 +38,7 @@ where
 -- appear in the generated haddock documentation.
 
 import Orville.PostgreSQL.Schema.ConstraintDefinition
+import Orville.PostgreSQL.Schema.ExtensionIdentifier
 import Orville.PostgreSQL.Schema.FunctionDefinition
 import Orville.PostgreSQL.Schema.FunctionIdentifier
 import Orville.PostgreSQL.Schema.IndexDefinition

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/ExtensionIdentifier.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/ExtensionIdentifier.hs
@@ -1,0 +1,58 @@
+{- |
+Copyright : Flipstone Technology Partners 2024
+License   : MIT
+Stability : Stable
+
+@since 1.1.0.0
+-}
+module Orville.PostgreSQL.Schema.ExtensionIdentifier
+  ( ExtensionIdentifier
+  , nameToExtensionId
+  , extensionIdName
+  , extensionIdToString
+  )
+where
+
+import qualified Orville.PostgreSQL.Expr as Expr
+
+{- |
+  An identifier used by Orville to identify a particular extension
+
+@since 1.1.0.0
+-}
+data ExtensionIdentifier = ExtensionIdentifier
+  { i_extensionName :: String
+  }
+  deriving (Eq, Ord, Show)
+
+{- |
+  Constructs a 'ExtensionIdentifier' with the given extension name string.
+
+@since 1.1.0.0
+-}
+nameToExtensionId :: String -> ExtensionIdentifier
+nameToExtensionId name =
+  ExtensionIdentifier
+    { i_extensionName = name
+    }
+
+{- |
+  Returns the 'Expr.ExtensionName' that should be used to refer to the extension in SQL queries.
+
+@since 1.1.0.0
+-}
+extensionIdName :: ExtensionIdentifier -> Expr.ExtensionName
+extensionIdName =
+  Expr.extensionName . extensionIdToString
+
+{- |
+  Converts a 'ExtensionIdentifier' to a 'String' for descriptive purposes. The
+  name will be qualified if a schema name has been set for the identifier.
+
+  Note: You should not use this function for building SQL expressions. Use
+  'extensionIdName' instead for that.
+
+@since 1.1.0.0
+-}
+extensionIdToString :: ExtensionIdentifier -> String
+extensionIdToString = i_extensionName

--- a/orville-postgresql/test/Test/PgCatalog.hs
+++ b/orville-postgresql/test/Test/PgCatalog.hs
@@ -217,7 +217,7 @@ prop_describeDatabaseRelations =
         ]
 
     desc <- HH.evalIO . Orville.runOrville pool $ do
-      PgCatalog.describeDatabase relationsToDescribe []
+      PgCatalog.describeDatabase relationsToDescribe [] []
 
     Map.keysSet (PgCatalog.databaseRelations desc) === Set.fromList relationsToDescribe
 


### PR DESCRIPTION
At the highest level this does four things:
- Adds support for extensions, including automigration
- Adds a 'IfNotExistsExpr' for use in some extension support.
- Adds support for a subset of functionality provided by the pg_trgm extension.
- Allows ordering to be done on a synthetic field.

Extension support is added at the expression level, as well as to the 'PgCatalog' tracking infrastructure to support 'AutoMigration' for loading/unloading extensions.

Support for cascading the load of extensions supported and used during automigration so that users can be sure to list the extension they want and any dependencies will be loaded as well.

To be used in conjection with the extension support is some functionality from pg_trgm. The ability to add both GIN and GIST indexes are included, as well as overriding the GIST index parameter, 'siglen'. Further, the similarity, word_similarity, and strict_word_similarity functions are exposed to compare value expressions. Higher level synthetic fields that compare a column with a value are also included. This hopefully covers a broad range of usage such as LIKE queries, column similarity, and the flexibility to use the function value in other ways.

Support for ordering by a synthetic field is added precisely be able sort by similarity.

pg_trgm has a few things **not** included here:

  - The notion of a similarity threshold for each of the three similarity functions. Including the ability to show and set the values.

  - Operators comparing a pair of values that each, implicitly use a corresponding threshold resulting in a boolean.

  - Operators that compute "distance", defined as 1 - similarity, for each of the three similarities.