### PR TITLE
Adds initial aliasing support- typeclassy

### DIFF
--- a/orville-postgresql/orville-postgresql.cabal
+++ b/orville-postgresql/orville-postgresql.cabal
@@ -139,6 +139,7 @@ library
       Orville.PostgreSQL.Internal.MonadOrville
       Orville.PostgreSQL.Internal.OrvilleState
       Orville.PostgreSQL.Internal.RowCountExpectation
+      Orville.PostgreSQL.Marshall.AliasName
       Orville.PostgreSQL.PgCatalog.DatabaseDescription
       Orville.PostgreSQL.PgCatalog.OidField
       Orville.PostgreSQL.PgCatalog.PgAttribute

--- a/orville-postgresql/orville-postgresql.cabal
+++ b/orville-postgresql/orville-postgresql.cabal
@@ -80,6 +80,7 @@ library
       Orville.PostgreSQL.Marshall.DefaultValue
       Orville.PostgreSQL.Marshall.FieldDefinition
       Orville.PostgreSQL.Marshall.MarshallError
+      Orville.PostgreSQL.Marshall.SqlComparable
       Orville.PostgreSQL.Marshall.SqlMarshaller
       Orville.PostgreSQL.Marshall.SqlType
       Orville.PostgreSQL.Marshall.SyntheticField
@@ -113,6 +114,7 @@ library
       Orville.PostgreSQL.Expr.Extension
       Orville.PostgreSQL.Expr.Function
       Orville.PostgreSQL.Expr.IfNotExists
+      Orville.PostgreSQL.Expr.Internal.Name.Alias
       Orville.PostgreSQL.Expr.Internal.Name.ColumnName
       Orville.PostgreSQL.Expr.Internal.Name.ConstraintName
       Orville.PostgreSQL.Expr.Internal.Name.CursorName

--- a/orville-postgresql/package.yaml
+++ b/orville-postgresql/package.yaml
@@ -76,6 +76,7 @@ library:
     - Orville.PostgreSQL.Marshall.DefaultValue
     - Orville.PostgreSQL.Marshall.FieldDefinition
     - Orville.PostgreSQL.Marshall.MarshallError
+    - Orville.PostgreSQL.Marshall.SqlComparable
     - Orville.PostgreSQL.Marshall.SqlMarshaller
     - Orville.PostgreSQL.Marshall.SqlType
     - Orville.PostgreSQL.Marshall.SyntheticField

--- a/orville-postgresql/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL.hs
@@ -178,6 +178,7 @@ module Orville.PostgreSQL
   , SqlMarshaller.marshallReadOnlyField
   , SqlMarshaller.marshallPartial
   , SqlMarshaller.marshallMaybe
+  , SqlMarshaller.marshallAlias
   , SqlMarshaller.prefixMarshaller
   , SqlMarshaller.foldMarshallerFields
   , SqlMarshaller.collectFromField
@@ -238,6 +239,10 @@ module Orville.PostgreSQL
   , FieldDefinition.setField
   , (FieldDefinition..:=)
   , FieldDefinition.FieldNullability (NotNullField, NullableField)
+  , FieldDefinition.AliasedFieldDefinition
+  , FieldDefinition.getFieldDefinition
+  , FieldDefinition.getAlias
+  , FieldDefinition.buildAliasedFieldDefinition
   , DefaultValue.DefaultValue
   , DefaultValue.integerDefault
   , DefaultValue.smallIntegerDefault
@@ -299,6 +304,8 @@ module Orville.PostgreSQL
   , Expr.descendingOrder
   , Expr.descendingOrderWith
   , FieldDefinition.orderByField
+  , FieldDefinition.orderByAliasedField
+  , Marshall.SqlComparable (toComparableSqlValue, referenceValueExpression)
   , Expr.orderByColumnName
   , Expr.andExpr
   , Expr.orExpr
@@ -417,6 +424,7 @@ import qualified Orville.PostgreSQL.Execution.SelectOptions as SelectOptions
 import qualified Orville.PostgreSQL.Execution.Sequence as Sequence
 import qualified Orville.PostgreSQL.Execution.Transaction as Transaction
 import qualified Orville.PostgreSQL.Expr as Expr
+import qualified Orville.PostgreSQL.Marshall as Marshall
 import qualified Orville.PostgreSQL.Marshall.DefaultValue as DefaultValue
 import qualified Orville.PostgreSQL.Marshall.FieldDefinition as FieldDefinition
 import qualified Orville.PostgreSQL.Marshall.SqlMarshaller as SqlMarshaller

--- a/orville-postgresql/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL.hs
@@ -243,6 +243,13 @@ module Orville.PostgreSQL
   , FieldDefinition.getFieldDefinition
   , FieldDefinition.getAlias
   , FieldDefinition.buildAliasedFieldDefinition
+  , Marshall.AliasName
+  , Marshall.stringToAliasName
+  , Marshall.aliasNameToString
+  , Marshall.aliasNameToAliasExpr
+  , Marshall.aliasNameAndFieldNameToColumnName
+  , Marshall.aliasNameToByteString
+  , Marshall.byteStringToAliasName
   , DefaultValue.DefaultValue
   , DefaultValue.integerDefault
   , DefaultValue.smallIntegerDefault

--- a/orville-postgresql/src/Orville/PostgreSQL/AutoMigration.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/AutoMigration.hs
@@ -691,7 +691,7 @@ mkAlterTableSteps currentNamespace relationDesc tableDef =
         Orville.foldMarshallerFields
           (Orville.unannotatedSqlMarshaller $ Orville.tableMarshaller tableDef)
           []
-          (Orville.collectFromField Orville.IncludeReadOnlyColumns (mkAddAlterColumnActions relationDesc))
+          (Orville.collectFromField Orville.IncludeReadOnlyColumns (const (mkAddAlterColumnActions relationDesc)))
 
     dropColumnActions =
       concatMap
@@ -857,7 +857,7 @@ mkAddAlterColumnActions relationDesc fieldDef =
                   || (Orville.sqlTypeMaximumLength sqlType /= PgCatalog.pgAttributeMaxLength attr)
 
               columnName =
-                Orville.fieldColumnName fieldDef
+                Orville.fieldNameToColumnName $ Orville.fieldName fieldDef
 
               dataType =
                 Orville.sqlTypeExpr sqlType
@@ -876,7 +876,7 @@ mkAddAlterColumnActions relationDesc fieldDef =
 
               alterNullability = do
                 guard nullabilityIsChanged
-                [Expr.alterColumnNullability (Orville.fieldColumnName fieldDef) nullabilityAction]
+                [Expr.alterColumnNullability columnName nullabilityAction]
 
               maybeExistingDefault =
                 PgCatalog.lookupAttributeDefault attr relationDesc
@@ -1512,7 +1512,7 @@ currentNamespaceQuery =
             -- put it in quotes it tries to treat it as a regular column name,
             -- which then can't be found as a column in the query.
             (RawSql.unsafeSqlExpression "current_schema")
-            (Orville.fieldColumnName PgCatalog.namespaceNameField)
+            (Orville.fieldNameToColumnName $ Orville.fieldName PgCatalog.namespaceNameField)
         ]
     )
     Nothing

--- a/orville-postgresql/src/Orville/PostgreSQL/Execution/Select.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Execution/Select.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE RankNTypes #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2023
+Copyright : Flipstone Technology Partners 2023-2024
 License   : MIT
 Stability : Stable
 
@@ -23,6 +23,8 @@ module Orville.PostgreSQL.Execution.Select
   , selectToQueryExpr
   , selectTable
   , selectMarshalledColumns
+  , selectTableWithAlias
+  , selectMarshalledColumnsWithAlias
   , rawSelectQueryExpr
   )
 where
@@ -31,7 +33,7 @@ import qualified Orville.PostgreSQL.Execution.Execute as Execute
 import qualified Orville.PostgreSQL.Execution.QueryType as QueryType
 import qualified Orville.PostgreSQL.Execution.SelectOptions as SelectOptions
 import qualified Orville.PostgreSQL.Expr as Expr
-import Orville.PostgreSQL.Marshall.SqlMarshaller (AnnotatedSqlMarshaller, marshallerDerivedColumns, unannotatedSqlMarshaller)
+import Orville.PostgreSQL.Marshall.SqlMarshaller (AnnotatedSqlMarshaller, marshallAlias, marshallerDerivedColumns, unannotatedSqlMarshaller)
 import qualified Orville.PostgreSQL.Monad as Monad
 import Orville.PostgreSQL.Schema (TableDefinition, tableMarshaller, tableName)
 
@@ -119,6 +121,44 @@ selectMarshalledColumns marshaller qualifiedTableName selectOptions =
     SelectOptions.selectOptionsQueryExpr
       (Expr.selectDerivedColumns (marshallerDerivedColumns . unannotatedSqlMarshaller $ marshaller))
       (Expr.referencesTable qualifiedTableName)
+      selectOptions
+
+{- | Builds a 'Select' that will select all the columns described in the 'TableDefinition', ensuring
+  they are qualified with the given alias. This is the safest way to build a 'Select', because table
+  name and columns are all read from the 'TableDefinition'. If the table is being managed with
+  Orville auto-migrations, this will match the schema in the database.
+
+@since 1.1.0.0
+-}
+selectTableWithAlias ::
+  Expr.Alias ->
+  TableDefinition key writeEntity readEntity ->
+  SelectOptions.SelectOptions ->
+  Select readEntity
+selectTableWithAlias alias tableDef =
+  selectMarshalledColumnsWithAlias alias (tableMarshaller tableDef) (tableName tableDef)
+
+{- |
+  Builds a 'Select' that will select the columns described by the marshaller from the specified
+  table with the given alias. It is up to the caller to ensure that the columns in the marshaller
+  make sense for the table.
+
+  This function is useful for querying a subset of table columns using a custom
+  marshaller.
+
+@since 1.1.0.0
+-}
+selectMarshalledColumnsWithAlias ::
+  Expr.Alias ->
+  AnnotatedSqlMarshaller writeEntity readEntity ->
+  Expr.Qualified Expr.TableName ->
+  SelectOptions.SelectOptions ->
+  Select readEntity
+selectMarshalledColumnsWithAlias alias marshaller qualifiedTableName selectOptions =
+  rawSelectQueryExpr marshaller $
+    SelectOptions.selectOptionsQueryExpr
+      (Expr.selectDerivedColumns (marshallerDerivedColumns . marshallAlias alias $ unannotatedSqlMarshaller marshaller))
+      (Expr.referencesTableWithAlias alias qualifiedTableName)
       selectOptions
 
 {- |

--- a/orville-postgresql/src/Orville/PostgreSQL/Execution/Select.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Execution/Select.hs
@@ -33,6 +33,7 @@ import qualified Orville.PostgreSQL.Execution.Execute as Execute
 import qualified Orville.PostgreSQL.Execution.QueryType as QueryType
 import qualified Orville.PostgreSQL.Execution.SelectOptions as SelectOptions
 import qualified Orville.PostgreSQL.Expr as Expr
+import Orville.PostgreSQL.Marshall.AliasName (AliasName, aliasNameToAliasExpr)
 import Orville.PostgreSQL.Marshall.SqlMarshaller (AnnotatedSqlMarshaller, marshallAlias, marshallerDerivedColumns, unannotatedSqlMarshaller)
 import qualified Orville.PostgreSQL.Monad as Monad
 import Orville.PostgreSQL.Schema (TableDefinition, tableMarshaller, tableName)
@@ -131,7 +132,7 @@ selectMarshalledColumns marshaller qualifiedTableName selectOptions =
 @since 1.1.0.0
 -}
 selectTableWithAlias ::
-  Expr.Alias ->
+  AliasName ->
   TableDefinition key writeEntity readEntity ->
   SelectOptions.SelectOptions ->
   Select readEntity
@@ -149,7 +150,7 @@ selectTableWithAlias alias tableDef =
 @since 1.1.0.0
 -}
 selectMarshalledColumnsWithAlias ::
-  Expr.Alias ->
+  AliasName ->
   AnnotatedSqlMarshaller writeEntity readEntity ->
   Expr.Qualified Expr.TableName ->
   SelectOptions.SelectOptions ->
@@ -158,7 +159,7 @@ selectMarshalledColumnsWithAlias alias marshaller qualifiedTableName selectOptio
   rawSelectQueryExpr marshaller $
     SelectOptions.selectOptionsQueryExpr
       (Expr.selectDerivedColumns (marshallerDerivedColumns . marshallAlias alias $ unannotatedSqlMarshaller marshaller))
-      (Expr.referencesTableWithAlias alias qualifiedTableName)
+      (Expr.referencesTableWithAlias (aliasNameToAliasExpr alias) qualifiedTableName)
       selectOptions
 
 {- |

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/ColumnDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/ColumnDefinition.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2023
+Copyright : Flipstone Technology Partners 2023-2024
 License   : MIT
 Stability : Stable
 

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Count.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Count.hs
@@ -1,5 +1,5 @@
 {- |
-Copyright : Flipstone Technology Partners 2023
+Copyright : Flipstone Technology Partners 2023-2024
 License   : MIT
 Stability : Stable
 
@@ -13,7 +13,7 @@ module Orville.PostgreSQL.Expr.Count
   )
 where
 
-import Orville.PostgreSQL.Expr.Name (ColumnName, FunctionName, functionName)
+import Orville.PostgreSQL.Expr.Name (ColumnName, FunctionName, Qualified, functionName)
 import Orville.PostgreSQL.Expr.ValueExpression (ValueExpression, columnReference, functionCall)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
@@ -44,6 +44,6 @@ count1 =
 
 @since 1.0.0.0
 -}
-countColumn :: ColumnName -> ValueExpression
+countColumn :: Qualified ColumnName -> ValueExpression
 countColumn =
   count . columnReference

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/GroupBy.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/GroupBy.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2023
+Copyright : Flipstone Technology Partners 2023-2024
 License   : MIT
 Stability : Stable
 
@@ -18,7 +18,7 @@ where
 
 import Data.List.NonEmpty (NonEmpty)
 
-import Orville.PostgreSQL.Expr.Name (ColumnName)
+import Orville.PostgreSQL.Expr.Name (ColumnName, Qualified)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 {- |
@@ -83,6 +83,6 @@ appendGroupByExpr (GroupByExpr a) (GroupByExpr b) =
 
 @since 1.0.0.0
 -}
-groupByColumnsExpr :: NonEmpty ColumnName -> GroupByExpr
+groupByColumnsExpr :: NonEmpty (Qualified ColumnName) -> GroupByExpr
 groupByColumnsExpr =
   GroupByExpr . RawSql.intercalate RawSql.commaSpace

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Insert.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Insert.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2023
+Copyright : Flipstone Technology Partners 2023-2024
 License   : MIT
 Stability : Stable
 
@@ -95,7 +95,7 @@ parens and commas are used to separate.
 
 @since 1.0.0.0
 -}
-insertColumnList :: [ColumnName] -> InsertColumnList
+insertColumnList :: [Qualified ColumnName] -> InsertColumnList
 insertColumnList columnNames =
   InsertColumnList $
     RawSql.leftParen

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Internal/Name/Alias.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Internal/Name/Alias.hs
@@ -1,0 +1,59 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+{- |
+Copyright : Flipstone Technology Partners 2024
+License   : MIT
+Stability : Stable
+
+@since 1.1.0.0
+-}
+module Orville.PostgreSQL.Expr.Internal.Name.Alias
+  ( Alias
+  , stringToAlias
+  , aliasToColumnName
+  )
+where
+
+import Orville.PostgreSQL.Expr.Internal.Name.ColumnName (ColumnName)
+import Orville.PostgreSQL.Expr.Internal.Name.Identifier (Identifier, IdentifierExpression, fromIdentifier, identifier, toIdentifier)
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+
+{- |
+Type to represent a SQL alias. 'Alias' values constructed
+via the 'alias' function will be properly escaped as part of the
+generated SQL. E.G.
+
+> "some_alias"
+
+'Alias' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 1.1.0.0
+-}
+newtype Alias
+  = Alias Identifier
+  deriving
+    ( -- | @since 1.1.0.0
+      RawSql.SqlExpression
+    , -- | @since 1.1.0.0
+      IdentifierExpression
+    )
+
+{- |
+Construct an 'Alias' from a 'String' with proper escaping as part of the generated SQL.
+
+@since 1.1.0.0
+-}
+stringToAlias :: String -> Alias
+stringToAlias =
+  Alias . identifier
+
+{- |
+It is occasionally appropriate to treat Construct an 'Alias' from a 'String' with proper escaping as part of the generated SQL.
+
+@since 1.1.0.0
+-}
+aliasToColumnName :: Alias -> ColumnName
+aliasToColumnName =
+  fromIdentifier . toIdentifier

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Internal/Name/Alias.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Internal/Name/Alias.hs
@@ -8,9 +8,9 @@ Stability : Stable
 @since 1.1.0.0
 -}
 module Orville.PostgreSQL.Expr.Internal.Name.Alias
-  ( Alias
-  , stringToAlias
-  , aliasToColumnName
+  ( AliasExpr
+  , stringToAliasExpr
+  , aliasExprToColumnName
   )
 where
 
@@ -19,20 +19,20 @@ import Orville.PostgreSQL.Expr.Internal.Name.Identifier (Identifier, IdentifierE
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 {- |
-Type to represent a SQL alias. 'Alias' values constructed
+Type to represent a SQL alias. 'AliasExpr' values constructed
 via the 'alias' function will be properly escaped as part of the
 generated SQL. E.G.
 
 > "some_alias"
 
-'Alias' provides a 'RawSql.SqlExpression' instance. See
+'AliasExpr' provides a 'RawSql.SqlExpression' instance. See
 'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
 SQL.
 
 @since 1.1.0.0
 -}
-newtype Alias
-  = Alias Identifier
+newtype AliasExpr
+  = AliasExpr Identifier
   deriving
     ( -- | @since 1.1.0.0
       RawSql.SqlExpression
@@ -41,19 +41,19 @@ newtype Alias
     )
 
 {- |
-Construct an 'Alias' from a 'String' with proper escaping as part of the generated SQL.
+Construct an 'AliasExpr' from a 'String' with proper escaping as part of the generated SQL.
 
 @since 1.1.0.0
 -}
-stringToAlias :: String -> Alias
-stringToAlias =
-  Alias . identifier
+stringToAliasExpr :: String -> AliasExpr
+stringToAliasExpr =
+  AliasExpr . identifier
 
 {- |
-It is occasionally appropriate to treat Construct an 'Alias' from a 'String' with proper escaping as part of the generated SQL.
+It is occasionally appropriate to treat Construct an 'AliasExpr' from a 'String' with proper escaping as part of the generated SQL.
 
 @since 1.1.0.0
 -}
-aliasToColumnName :: Alias -> ColumnName
-aliasToColumnName =
+aliasExprToColumnName :: AliasExpr -> ColumnName
+aliasExprToColumnName =
   fromIdentifier . toIdentifier

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Internal/Name/Qualified.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Internal/Name/Qualified.hs
@@ -17,7 +17,7 @@ module Orville.PostgreSQL.Expr.Internal.Name.Qualified
   )
 where
 
-import Orville.PostgreSQL.Expr.Internal.Name.Alias (Alias)
+import Orville.PostgreSQL.Expr.Internal.Name.Alias (AliasExpr)
 import Orville.PostgreSQL.Expr.Internal.Name.ColumnName (ColumnName)
 import Orville.PostgreSQL.Expr.Internal.Name.FunctionName (FunctionName)
 import Orville.PostgreSQL.Expr.Internal.Name.Identifier (IdentifierExpression (toIdentifier))
@@ -101,14 +101,14 @@ qualifyColumn mbSchemaName tableName unqualifiedName =
     . RawSql.unsafeFromRawSql
     $ RawSql.toRawSql (toIdentifier tableName) <> RawSql.dot <> RawSql.toRawSql (toIdentifier unqualifiedName)
 
-{- | Qualifies a 'ColumnName' optionally with an 'Alias'. This should be used to refer to the column
+{- | Qualifies a 'ColumnName' optionally with an 'AliasExpr'. This should be used to refer to the column
 in SQL queries where an aliased reference is appropriate.
 
 @since 1.1.0.0
 -}
-aliasQualifyColumn :: Maybe Alias -> ColumnName -> Qualified ColumnName
-aliasQualifyColumn mbAliasName unqualifiedName =
-  Qualified $ case mbAliasName of
+aliasQualifyColumn :: Maybe AliasExpr -> ColumnName -> Qualified ColumnName
+aliasQualifyColumn mbAliasExprName unqualifiedName =
+  Qualified $ case mbAliasExprName of
     Nothing ->
       RawSql.toRawSql $ toIdentifier unqualifiedName
     Just aliasName ->

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Internal/Name/Qualified.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Internal/Name/Qualified.hs
@@ -13,9 +13,11 @@ module Orville.PostgreSQL.Expr.Internal.Name.Qualified
   , qualifySequence
   , qualifyFunction
   , qualifyColumn
+  , aliasQualifyColumn
   )
 where
 
+import Orville.PostgreSQL.Expr.Internal.Name.Alias (Alias)
 import Orville.PostgreSQL.Expr.Internal.Name.ColumnName (ColumnName)
 import Orville.PostgreSQL.Expr.Internal.Name.FunctionName (FunctionName)
 import Orville.PostgreSQL.Expr.Internal.Name.Identifier (IdentifierExpression (toIdentifier))
@@ -98,6 +100,19 @@ qualifyColumn mbSchemaName tableName unqualifiedName =
   unsafeSchemaQualify mbSchemaName
     . RawSql.unsafeFromRawSql
     $ RawSql.toRawSql (toIdentifier tableName) <> RawSql.dot <> RawSql.toRawSql (toIdentifier unqualifiedName)
+
+{- | Qualifies a 'ColumnName' optionally with an 'Alias'. This should be used to refer to the column
+in SQL queries where an aliased reference is appropriate.
+
+@since 1.1.0.0
+-}
+aliasQualifyColumn :: Maybe Alias -> ColumnName -> Qualified ColumnName
+aliasQualifyColumn mbAliasName unqualifiedName =
+  Qualified $ case mbAliasName of
+    Nothing ->
+      RawSql.toRawSql $ toIdentifier unqualifiedName
+    Just aliasName ->
+      RawSql.toRawSql (toIdentifier aliasName) <> RawSql.dot <> RawSql.toRawSql (toIdentifier unqualifiedName)
 
 -- Note: Not everything actually makes sense to be qualified by _only_ a schema name, such as
 -- columns, as in 'qualifyColumn'. But this does give us a nice uniform way to provide the

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Name.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Name.hs
@@ -12,6 +12,7 @@ module Orville.PostgreSQL.Expr.Name
   )
 where
 
+import Orville.PostgreSQL.Expr.Internal.Name.Alias as Export
 import Orville.PostgreSQL.Expr.Internal.Name.ColumnName as Export
 import Orville.PostgreSQL.Expr.Internal.Name.ConstraintName as Export
 import Orville.PostgreSQL.Expr.Internal.Name.CursorName as Export

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/OrderBy.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/OrderBy.hs
@@ -27,7 +27,7 @@ where
 
 import qualified Data.List.NonEmpty as NEL
 
-import Orville.PostgreSQL.Expr.Name (Alias, ColumnName, Qualified)
+import Orville.PostgreSQL.Expr.Name (AliasExpr, ColumnName, Qualified)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 {- |
@@ -107,15 +107,15 @@ orderByColumnName :: Qualified ColumnName -> OrderByDirection -> OrderByExpr
 orderByColumnName =
   curry (orderByColumnsExpr . pure)
 
-{- | Create an 'OrderByExpr' for 'Alias' and 'OrderByDirection' pairs, ensuring commas as needed. For basic queries involving columns on some table(s), use 'orderByColumnsExpr'. This
+{- | Create an 'OrderByExpr' for 'AliasExpr' and 'OrderByDirection' pairs, ensuring commas as needed. For basic queries involving columns on some table(s), use 'orderByColumnsExpr'.
 
 @since 1.1.0.0
 -}
-orderByAliasesExpr :: NEL.NonEmpty (Alias, OrderByDirection) -> OrderByExpr
+orderByAliasesExpr :: NEL.NonEmpty (AliasExpr, OrderByDirection) -> OrderByExpr
 orderByAliasesExpr =
   OrderByExpr . RawSql.intercalate RawSql.commaSpace . fmap columnOrdering
  where
-  columnOrdering :: (Alias, OrderByDirection) -> RawSql.RawSql
+  columnOrdering :: (AliasExpr, OrderByDirection) -> RawSql.RawSql
   columnOrdering (alias, orderByDirection) =
     RawSql.toRawSql alias <> RawSql.space <> RawSql.toRawSql orderByDirection
 
@@ -124,7 +124,7 @@ orderByAliasesExpr =
 
 @since 1.1.0.0
 -}
-orderByAlias :: Alias -> OrderByDirection -> OrderByExpr
+orderByAlias :: AliasExpr -> OrderByDirection -> OrderByExpr
 orderByAlias =
   curry (orderByAliasesExpr . pure)
 

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Query.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Query.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2023
+Copyright : Flipstone Technology Partners 2023-2024
 License   : MIT
 Stability : Stable
 
@@ -15,6 +15,7 @@ module Orville.PostgreSQL.Expr.Query
   , DerivedColumn
   , deriveColumn
   , deriveColumnAs
+  , deriveColumnAsAlias
   , selectDerivedColumns
   , selectStar
   , TableExpr
@@ -26,7 +27,7 @@ import Data.Maybe (catMaybes, fromMaybe)
 
 import Orville.PostgreSQL.Expr.GroupBy (GroupByClause)
 import Orville.PostgreSQL.Expr.LimitExpr (LimitExpr)
-import Orville.PostgreSQL.Expr.Name (ColumnName)
+import Orville.PostgreSQL.Expr.Name (Alias, ColumnName, Qualified)
 import Orville.PostgreSQL.Expr.OffsetExpr (OffsetExpr)
 import Orville.PostgreSQL.Expr.OrderBy (OrderByClause)
 import Orville.PostgreSQL.Expr.Select (SelectClause)
@@ -110,7 +111,7 @@ selectStar =
 
   @since 1.0.0.0
 -}
-selectColumns :: [ColumnName] -> SelectList
+selectColumns :: [Qualified ColumnName] -> SelectList
 selectColumns =
   selectDerivedColumns . map (deriveColumn . columnReference)
 
@@ -162,6 +163,20 @@ deriveColumnAs valueExpr asColumn =
     ( RawSql.toRawSql valueExpr
         <> RawSql.fromString " AS "
         <> RawSql.toRawSql asColumn
+    )
+
+{- |
+  Constructs a 'DerivedColumn' that will select the given value and give it
+  the specified alias in the result set.
+
+@since 1.1.0.0
+-}
+deriveColumnAsAlias :: ValueExpression -> Alias -> DerivedColumn
+deriveColumnAsAlias valueExpr asAlias =
+  DerivedColumn
+    ( RawSql.toRawSql valueExpr
+        <> RawSql.fromString " AS "
+        <> RawSql.toRawSql asAlias
     )
 
 {- |

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Query.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Query.hs
@@ -27,7 +27,7 @@ import Data.Maybe (catMaybes, fromMaybe)
 
 import Orville.PostgreSQL.Expr.GroupBy (GroupByClause)
 import Orville.PostgreSQL.Expr.LimitExpr (LimitExpr)
-import Orville.PostgreSQL.Expr.Name (Alias, ColumnName, Qualified)
+import Orville.PostgreSQL.Expr.Name (AliasExpr, ColumnName, Qualified)
 import Orville.PostgreSQL.Expr.OffsetExpr (OffsetExpr)
 import Orville.PostgreSQL.Expr.OrderBy (OrderByClause)
 import Orville.PostgreSQL.Expr.Select (SelectClause)
@@ -171,7 +171,7 @@ deriveColumnAs valueExpr asColumn =
 
 @since 1.1.0.0
 -}
-deriveColumnAsAlias :: ValueExpression -> Alias -> DerivedColumn
+deriveColumnAsAlias :: ValueExpression -> AliasExpr -> DerivedColumn
 deriveColumnAsAlias valueExpr asAlias =
   DerivedColumn
     ( RawSql.toRawSql valueExpr

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/TableDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/TableDefinition.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2023
+Copyright : Flipstone Technology Partners 2023-2024
 License   : MIT
 Stability : Stable
 

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/TableReferenceList.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/TableReferenceList.hs
@@ -14,7 +14,7 @@ module Orville.PostgreSQL.Expr.TableReferenceList
   )
 where
 
-import Orville.PostgreSQL.Expr.Name (Alias, Qualified, TableName)
+import Orville.PostgreSQL.Expr.Name (AliasExpr, Qualified, TableName)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 {- |
@@ -53,7 +53,7 @@ referencesTable qualifiedTableName =
 
   @since 1.1.0.0
 -}
-referencesTableWithAlias :: Alias -> Qualified TableName -> TableReferenceList
+referencesTableWithAlias :: AliasExpr -> Qualified TableName -> TableReferenceList
 referencesTableWithAlias alias qualifiedTableName =
   TableReferenceList $
     RawSql.intercalate

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/TableReferenceList.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/TableReferenceList.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2023
+Copyright : Flipstone Technology Partners 2023-2024
 License   : MIT
 Stability : Stable
 
@@ -10,10 +10,11 @@ Stability : Stable
 module Orville.PostgreSQL.Expr.TableReferenceList
   ( TableReferenceList
   , referencesTable
+  , referencesTableWithAlias
   )
 where
 
-import Orville.PostgreSQL.Expr.Name (Qualified, TableName)
+import Orville.PostgreSQL.Expr.Name (Alias, Qualified, TableName)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 {- |
@@ -46,3 +47,18 @@ referencesTable :: Qualified TableName -> TableReferenceList
 referencesTable qualifiedTableName =
   TableReferenceList $
     RawSql.toRawSql qualifiedTableName
+
+{- |
+  Constructs a 'TableReferenceList' consisting of the specified table AS the given alias.
+
+  @since 1.1.0.0
+-}
+referencesTableWithAlias :: Alias -> Qualified TableName -> TableReferenceList
+referencesTableWithAlias alias qualifiedTableName =
+  TableReferenceList $
+    RawSql.intercalate
+      RawSql.space
+      [ RawSql.toRawSql qualifiedTableName
+      , RawSql.fromString "AS"
+      , RawSql.toRawSql alias
+      ]

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Update.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Update.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2023
+Copyright : Flipstone Technology Partners 2023-2024
 License   : MIT
 Stability : Stable
 
@@ -116,7 +116,7 @@ newtype SetClause
 
   @since 1.0.0.0
 -}
-setColumn :: ColumnName -> SqlValue.SqlValue -> SetClause
+setColumn :: Qualified ColumnName -> SqlValue.SqlValue -> SetClause
 setColumn columnName value =
   SetClause $
     RawSql.toRawSql columnName

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/ValueExpression.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/ValueExpression.hs
@@ -23,7 +23,7 @@ where
 import qualified Data.List.NonEmpty as NE
 
 import Orville.PostgreSQL.Expr.DataType (DataType)
-import Orville.PostgreSQL.Expr.Name (Alias, ColumnName, FunctionName, Qualified)
+import Orville.PostgreSQL.Expr.Name (AliasExpr, ColumnName, FunctionName, Qualified)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import Orville.PostgreSQL.Raw.SqlValue (SqlValue)
 
@@ -70,14 +70,14 @@ columnReference :: Qualified ColumnName -> ValueExpression
 columnReference = ValueExpression . RawSql.toRawSql
 
 {- |
-Uses an 'Alias' to reference an aliased expression as a 'ValueExpression'. This
+Uses an 'AliasExpr' to reference an aliased expression as a 'ValueExpression'. This
 is the equivalent of simply writing the alias as the expression. E.G.
 
 > foo
 
 @since 1.1.0.0
 -}
-aliasReference :: Alias -> ValueExpression
+aliasReference :: AliasExpr -> ValueExpression
 aliasReference = ValueExpression . RawSql.toRawSql
 
 {- |

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/ValueExpression.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/ValueExpression.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2023
+Copyright : Flipstone Technology Partners 2023-2024
 License   : MIT
 Stability : Stable
 
@@ -16,13 +16,14 @@ module Orville.PostgreSQL.Expr.ValueExpression
   , rowValueConstructor
   , functionCall
   , functionCallNamedParams
+  , aliasReference
   )
 where
 
 import qualified Data.List.NonEmpty as NE
 
 import Orville.PostgreSQL.Expr.DataType (DataType)
-import Orville.PostgreSQL.Expr.Name (ColumnName, FunctionName)
+import Orville.PostgreSQL.Expr.Name (Alias, ColumnName, FunctionName, Qualified)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import Orville.PostgreSQL.Raw.SqlValue (SqlValue)
 
@@ -65,8 +66,19 @@ is the equivalent of simply writing the column name as the expression. E.G.
 
 @since 1.0.0.0
 -}
-columnReference :: ColumnName -> ValueExpression
+columnReference :: Qualified ColumnName -> ValueExpression
 columnReference = ValueExpression . RawSql.toRawSql
+
+{- |
+Uses an 'Alias' to reference an aliased expression as a 'ValueExpression'. This
+is the equivalent of simply writing the alias as the expression. E.G.
+
+> foo
+
+@since 1.1.0.0
+-}
+aliasReference :: Alias -> ValueExpression
+aliasReference = ValueExpression . RawSql.toRawSql
 
 {- |
   Uses the given 'SqlValue' as a constant expression. The value will be passed

--- a/orville-postgresql/src/Orville/PostgreSQL/Extension/PgTrgm.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Extension/PgTrgm.hs
@@ -28,7 +28,6 @@ import qualified Orville.PostgreSQL.Expr as Expr
 import qualified Orville.PostgreSQL.Internal.IndexDefinition as IndexDefinition
 import qualified Orville.PostgreSQL.Marshall as Marshall
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
-import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 {- | Create a named GIN index over the given fields for fast text searching.
 
@@ -103,9 +102,9 @@ trigramSimilaritySyntheticField ::
   Marshall.SyntheticField Double
 trigramSimilaritySyntheticField colname compareVal fieldAlias =
   Marshall.syntheticField
-    (trigramSimilarity (Expr.columnReference colname) compareVal)
+    (trigramSimilarity (Expr.columnReference $ Expr.aliasQualifyColumn Nothing colname) compareVal)
     fieldAlias
-    SqlValue.toDouble
+    Marshall.double
 
 {- | Create a synthetic field using the word_similarity function provided by pg_trgm.
 
@@ -122,9 +121,9 @@ trigramWordSimilaritySyntheticField ::
   Marshall.SyntheticField Double
 trigramWordSimilaritySyntheticField colname compareVal fieldAlias =
   Marshall.syntheticField
-    (trigramWordSimilarity (Expr.columnReference colname) compareVal)
+    (trigramWordSimilarity (Expr.columnReference $ Expr.aliasQualifyColumn Nothing colname) compareVal)
     fieldAlias
-    SqlValue.toDouble
+    Marshall.double
 
 {- | Create a synthetic field using the strict_word_similarity function provided by pg_trgm.
 
@@ -141,9 +140,9 @@ trigramStrictWordSimilaritySyntheticField ::
   Marshall.SyntheticField Double
 trigramStrictWordSimilaritySyntheticField colname compareVal fieldAlias =
   Marshall.syntheticField
-    (trigramStrictWordSimilarity (Expr.columnReference colname) compareVal)
+    (trigramStrictWordSimilarity (Expr.columnReference $ Expr.aliasQualifyColumn Nothing colname) compareVal)
     fieldAlias
-    SqlValue.toDouble
+    Marshall.double
 
 {- | Call the similarity function provided by pg_trgm, comparing the pair of values.
 

--- a/orville-postgresql/src/Orville/PostgreSQL/Internal/FieldName.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Internal/FieldName.hs
@@ -34,8 +34,8 @@ newtype FieldName
 @since 1.0.0.0
 -}
 fieldNameToColumnName :: FieldName -> Expr.ColumnName
-fieldNameToColumnName (FieldName name) =
-  Expr.fromIdentifier (Expr.identifierFromBytes name)
+fieldNameToColumnName =
+  Expr.fromIdentifier . Expr.identifierFromBytes . fieldNameToByteString
 
 {- |
   Constructs a 'FieldName' from a 'String'.

--- a/orville-postgresql/src/Orville/PostgreSQL/Marshall.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Marshall.hs
@@ -20,6 +20,7 @@ module Orville.PostgreSQL.Marshall
   , module Orville.PostgreSQL.Marshall.SyntheticField
   , module Orville.PostgreSQL.Marshall.MarshallError
   , module Orville.PostgreSQL.Marshall.SqlType
+  , module Orville.PostgreSQL.Marshall.AliasName
   , module Orville.PostgreSQL.Marshall.SqlComparable
   )
 where
@@ -27,6 +28,7 @@ where
 -- Note: we list the re-exports explicity above to control the order that they
 -- appear in the generated haddock documentation.
 
+import Orville.PostgreSQL.Marshall.AliasName
 import Orville.PostgreSQL.Marshall.DefaultValue
 import Orville.PostgreSQL.Marshall.FieldDefinition
 import Orville.PostgreSQL.Marshall.MarshallError

--- a/orville-postgresql/src/Orville/PostgreSQL/Marshall.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Marshall.hs
@@ -1,7 +1,7 @@
 {-# OPTIONS_GHC -Wno-missing-import-lists #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2023
+Copyright : Flipstone Technology Partners 2023-2024
 License   : MIT
 Stability : Stable
 
@@ -20,6 +20,7 @@ module Orville.PostgreSQL.Marshall
   , module Orville.PostgreSQL.Marshall.SyntheticField
   , module Orville.PostgreSQL.Marshall.MarshallError
   , module Orville.PostgreSQL.Marshall.SqlType
+  , module Orville.PostgreSQL.Marshall.SqlComparable
   )
 where
 
@@ -29,6 +30,7 @@ where
 import Orville.PostgreSQL.Marshall.DefaultValue
 import Orville.PostgreSQL.Marshall.FieldDefinition
 import Orville.PostgreSQL.Marshall.MarshallError
+import Orville.PostgreSQL.Marshall.SqlComparable
 import Orville.PostgreSQL.Marshall.SqlMarshaller
 import Orville.PostgreSQL.Marshall.SqlType
 import Orville.PostgreSQL.Marshall.SyntheticField

--- a/orville-postgresql/src/Orville/PostgreSQL/Marshall/AliasName.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Marshall/AliasName.hs
@@ -1,0 +1,95 @@
+{- |
+Copyright : Flipstone Technology Partners 2024
+License   : MIT
+Stability : Stable
+
+@since 1.1.0.0
+-}
+module Orville.PostgreSQL.Marshall.AliasName
+  ( AliasName
+  , stringToAliasName
+  , aliasNameToString
+  , aliasNameToAliasExpr
+  , aliasNameAndFieldNameToColumnName
+  , aliasNameToByteString
+  , byteStringToAliasName
+  , aliasNameAsFieldName
+  ) where
+
+import qualified Data.ByteString.Char8 as B8
+
+import qualified Orville.PostgreSQL.Expr as Expr
+import Orville.PostgreSQL.Internal.FieldName (FieldName, byteStringToFieldName, fieldNameToColumnName)
+
+{- |
+  A simple type to represent the name of a field.
+
+@since 1.1.0.0
+-}
+newtype AliasName
+  = AliasName B8.ByteString
+  deriving (Eq, Ord, Show)
+
+{- | Convert an 'AliasName' and a 'FieldName' to a 'Expr.ColumnName' for usage in SQL expressions.
+  The result will be properly quoted and escaped.
+
+@since 1.1.0.0
+-}
+aliasNameAndFieldNameToColumnName :: AliasName -> FieldName -> Expr.Qualified Expr.ColumnName
+aliasNameAndFieldNameToColumnName aliasName =
+  Expr.aliasQualifyColumn
+    (Just $ aliasNameToAliasExpr aliasName)
+    . fieldNameToColumnName
+
+{- |
+  Constructs a 'AliasName' from a 'String'.
+
+@since 1.1.0.0
+-}
+stringToAliasName :: String -> AliasName
+stringToAliasName =
+  AliasName . B8.pack
+
+{- |
+  Converts a 'AliasName' to an 'AliasExpr'.
+
+@since 1.1.0.0
+-}
+aliasNameToAliasExpr :: AliasName -> Expr.AliasExpr
+aliasNameToAliasExpr =
+  Expr.fromIdentifier . Expr.identifierFromBytes . aliasNameToByteString
+
+{- |
+  Converts a 'AliasName' back to a 'String'.
+
+@since 1.1.0.0
+-}
+aliasNameToString :: AliasName -> String
+aliasNameToString =
+  B8.unpack . aliasNameToByteString
+
+{- |
+  Converts a 'AliasName' back to a 'B8.ByteString'.
+
+@since 1.1.0.0
+-}
+aliasNameToByteString :: AliasName -> B8.ByteString
+aliasNameToByteString (AliasName name) =
+  name
+
+{- |
+  Constructs a 'AliasName' from a 'B8.ByteString'.
+
+@since 1.1.0.0
+-}
+byteStringToAliasName :: B8.ByteString -> AliasName
+byteStringToAliasName = AliasName
+
+{- |
+  Allows to treat an 'AliasName' as a 'FieldName'.
+
+@since 1.1.0.0
+-}
+aliasNameAsFieldName :: AliasName -> FieldName
+aliasNameAsFieldName =
+  byteStringToFieldName . aliasNameToByteString

--- a/orville-postgresql/src/Orville/PostgreSQL/Marshall/SqlComparable.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Marshall/SqlComparable.hs
@@ -182,9 +182,6 @@ greaterThanOrEqualTo a =
     . Expr.valueExpression
     . toComparableSqlValue a
 
--- like
--- likeInsensitive
-
 {- | Checks that the referenced item from the first argument is in the list of the SQL values
   of the second argument. This is commonly used with columns as you might in a @WHERE@ clause such
   as @WHERE foo IN (1,2)@. Frequently you would not want to use this directly, but instead use

--- a/orville-postgresql/src/Orville/PostgreSQL/Marshall/SqlComparable.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Marshall/SqlComparable.hs
@@ -1,0 +1,296 @@
+{-# LANGUAGE FunctionalDependencies #-}
+
+{- |
+Copyright : Flipstone Technology Partners 2024
+License   : MIT
+Stability : Stable
+
+@since 1.1.0.0
+-}
+module Orville.PostgreSQL.Marshall.SqlComparable
+  ( SqlComparable (toComparableSqlValue, referenceValueExpression)
+  , toSqlValueTuple
+  , equals
+  , notEquals
+  , isDistinctFrom
+  , isNotDistinctFrom
+  , lessThan
+  , lessThanOrEqualTo
+  , greaterThan
+  , greaterThanOrEqualTo
+  , isIn
+  , isNotIn
+  , isNull
+  , isNotNull
+  , like
+  , likeInsensitive
+  , tupleIn
+  , tupleNotIn
+  ) where
+
+import Data.List.NonEmpty (NonEmpty ((:|)))
+import qualified Data.Text as T
+
+import qualified Orville.PostgreSQL.Expr as Expr
+import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
+
+{- | This provides a common interface to being able to produce a 'SqlValue.SqlValue' as well as having
+a way to reference the item in SQL. This can be something like a field of a table, a field that
+should be referenced via an alias, or a subquery.
+
+Here the first argument to the class should be some abstraction over some part of SQL that produces
+a Haskell value. With the type of the Haskell value as the second argument.
+
+@since 1.1.0.0
+-}
+class SqlComparable sqlAbstraction haskellValue | sqlAbstraction -> haskellValue where
+  -- | Uses the first argument to marshall a Haskell value its 'SqlValue.SqlValue' representation.
+  --
+  -- @since 1.1.0.0
+  toComparableSqlValue :: sqlAbstraction -> haskellValue -> SqlValue.SqlValue
+
+  -- | Constructs the 'Expr.ValueExpression' for use in SQL expressions from the
+  -- "Orville.PostgreSQL.Expr" module.
+  --
+  -- @since 1.1.0.0
+  referenceValueExpression :: sqlAbstraction -> Expr.ValueExpression
+
+{- |
+  Constructs a SqlValue "tuple" (i.e. NonEmpty list) for two items that can themselves be made to 'SqlValue.SqlValue'.
+
+@since 1.1.0.0
+-}
+toSqlValueTuple ::
+  (SqlComparable a c, SqlComparable b d) =>
+  a ->
+  b ->
+  (c, d) ->
+  NonEmpty Expr.ValueExpression
+toSqlValueTuple a b (c, d) =
+  (Expr.valueExpression $ toComparableSqlValue a c)
+    :| [Expr.valueExpression $ toComparableSqlValue b d]
+
+{- | Checks that the referenced item from the first argument does not equal the SQL value of the
+  second argument. This is commonly used in a @WHERE@ clause such as @WHERE foo = 1@. Frequently you
+  would not want to use this directly, but instead use
+  'Orville.PostgreSQL.Marshall.FieldDefinition.fieldEquals'.
+
+@since 1.1.0.0
+-}
+equals :: SqlComparable a b => a -> b -> Expr.BooleanExpr
+equals a =
+  Expr.equals
+    (referenceValueExpression a)
+    . Expr.valueExpression
+    . toComparableSqlValue a
+
+{- | Checks that the referenced item from the first argument does not equal the SQL value of the
+  second argument. This is commonly used with columns as you might in a @WHERE@ clause such as
+  @WHERE foo != 1@. Frequently you would not want to use this directly, but instead use
+  'Orville.PostgreSQL.Marshall.FieldDefinition.fieldNotEquals'.
+
+@since 1.1.0.0
+-}
+notEquals :: SqlComparable a b => a -> b -> Expr.BooleanExpr
+notEquals a =
+  Expr.notEquals
+    (referenceValueExpression a)
+    . Expr.valueExpression
+    . toComparableSqlValue a
+
+{- | Checks that the referenced item from the first argument is distinct from the SQL value of the
+  second argument. This is commonly used with columns as you might in a @WHERE@ clause such as
+  @WHERE foo IS DISTINCT FROM 1@. Frequently you would not want to use this directly, but instead use
+  'Orville.PostgreSQL.Marshall.FieldDefinition.fieldIsDistinctFrom'.
+
+@since 1.1.0.0
+-}
+isDistinctFrom :: SqlComparable a b => a -> b -> Expr.BooleanExpr
+isDistinctFrom a =
+  Expr.isDistinctFrom
+    (referenceValueExpression a)
+    . Expr.valueExpression
+    . toComparableSqlValue a
+
+{- | Checks that the referenced item from the first argument is not distinct from the SQL value of the
+  second argument. This is commonly used with columns as you might in a @WHERE@ clause such as
+  @WHERE foo IS NOT DISTINCT FROM 1@. Frequently you would not want to use this directly, but instead
+  use 'Orville.PostgreSQL.Marshall.FieldDefinition.fieldIsNotDistinctFrom'.
+
+@since 1.1.0.0
+-}
+isNotDistinctFrom :: SqlComparable a b => a -> b -> Expr.BooleanExpr
+isNotDistinctFrom a =
+  Expr.isNotDistinctFrom
+    (referenceValueExpression a)
+    . Expr.valueExpression
+    . toComparableSqlValue a
+
+{- | Checks that the referenced item from the first argument is less than the SQL value of the
+  second argument. This is commonly used with columns as you might in a @WHERE@ clause such as
+  @WHERE foo < 1@. Frequently you would not want to use this directly, but instead
+  use 'Orville.PostgreSQL.Marshall.FieldDefinition.fieldLessThan'.
+
+@since 1.1.0.0
+-}
+lessThan :: SqlComparable a b => a -> b -> Expr.BooleanExpr
+lessThan a =
+  Expr.lessThan
+    (referenceValueExpression a)
+    . Expr.valueExpression
+    . toComparableSqlValue a
+
+{- | Checks that the referenced item from the first argument is less than or equal to the SQL value of
+  the second argument. This is commonly used with columns as you might in a @WHERE@ clause such as
+  @WHERE foo <= 1@. Frequently you would not want to use this directly, but instead use
+  'Orville.PostgreSQL.Marshall.FieldDefinition.fieldLessThanOrEqualTo'.
+
+@since 1.1.0.0
+-}
+lessThanOrEqualTo :: SqlComparable a b => a -> b -> Expr.BooleanExpr
+lessThanOrEqualTo a =
+  Expr.lessThanOrEqualTo
+    (referenceValueExpression a)
+    . Expr.valueExpression
+    . toComparableSqlValue a
+
+{- | Checks that the referenced item from the first argument is greater than the SQL value of the
+  second argument. This is commonly used with columns as you might in a @WHERE@ clause such as
+  @WHERE foo > 1@. Frequently you would not want to use this directly, but instead use
+  'Orville.PostgreSQL.Marshall.FieldDefinition.fieldGreaterThan'.
+
+@since 1.1.0.0
+-}
+greaterThan :: SqlComparable a b => a -> b -> Expr.BooleanExpr
+greaterThan a =
+  Expr.greaterThan
+    (referenceValueExpression a)
+    . Expr.valueExpression
+    . toComparableSqlValue a
+
+{- | Checks that the referenced item from the first argument is greater than or equal to the SQL value
+  of the second argument. This is commonly used with columns as you might in a @WHERE@ clause such
+  as @WHERE foo >= 1@. Frequently you would not want to use this directly, but instead use
+  'Orville.PostgreSQL.Marshall.FieldDefinition.fieldGreaterThanOrEqualTo'.
+
+@since 1.1.0.0
+-}
+greaterThanOrEqualTo :: SqlComparable a b => a -> b -> Expr.BooleanExpr
+greaterThanOrEqualTo a =
+  Expr.greaterThanOrEqualTo
+    (referenceValueExpression a)
+    . Expr.valueExpression
+    . toComparableSqlValue a
+
+-- like
+-- likeInsensitive
+
+{- | Checks that the referenced item from the first argument is in the list of the SQL values
+  of the second argument. This is commonly used with columns as you might in a @WHERE@ clause such
+  as @WHERE foo IN (1,2)@. Frequently you would not want to use this directly, but instead use
+  'Orville.PostgreSQL.Marshall.FieldDefinition.fieldIn'.
+
+@since 1.1.0.0
+-}
+isIn :: SqlComparable a b => a -> NonEmpty b -> Expr.BooleanExpr
+isIn a =
+  Expr.valueIn
+    (referenceValueExpression a)
+    . fmap (Expr.valueExpression . toComparableSqlValue a)
+
+{- | Checks that the referenced item from the first argument is not in the list of the SQL values
+  of the second argument. This is commonly used with columns as you might in a @WHERE@ clause such
+  as @WHERE foo NOT IN (1,2)@. Frequently you would not want to use this directly, but instead use
+  'Orville.PostgreSQL.Marshall.FieldDefinition.fieldNotIn'.
+
+@since 1.1.0.0
+-}
+isNotIn :: SqlComparable a b => a -> NonEmpty b -> Expr.BooleanExpr
+isNotIn a =
+  Expr.valueNotIn
+    (referenceValueExpression a)
+    . fmap (Expr.valueExpression . toComparableSqlValue a)
+
+{- | Checks that the referenced item is null. This is commonly used with columns as you might in a
+  @WHERE@ clause such as @WHERE foo IS NULL@. Frequently you would not want to use this directly,
+  but instead use 'Orville.PostgreSQL.Marshall.FieldDefinition.fieldIsNull'.
+
+@since 1.1.0.0
+-}
+isNull :: SqlComparable a b => a -> Expr.BooleanExpr
+isNull =
+  Expr.isNull . referenceValueExpression
+
+{- | Checks that the referenced item is not null. This is commonly used with columns as you might in a
+  @WHERE@ clause such as @WHERE foo IS NOT NULL@. Frequently you would not want to use this
+  directly, but instead use 'Orville.PostgreSQL.Marshall.FieldDefinition.fieldIsNotNull'.
+
+@since 1.1.0.0
+-}
+isNotNull :: SqlComparable a b => a -> Expr.BooleanExpr
+isNotNull =
+  Expr.isNotNull . referenceValueExpression
+
+{- | Checks that the referenced item matches the given like pattern case sensitively. This is
+  commonly used with columns as you might in a @WHERE@ clause such as @WHERE foo LIKE
+  'bar'@. Frequently you would not want to use this directly, but instead use
+  'Orville.PostgreSQL.Marshall.FieldDefinition.fieldLike'.
+
+@since 1.1.0.0
+-}
+like :: SqlComparable a b => a -> T.Text -> Expr.BooleanExpr
+like a =
+  Expr.like
+    (referenceValueExpression a)
+    . Expr.valueExpression
+    . SqlValue.fromText
+
+{- | Checks that the referenced item matches the given like pattern case insensitively. This is
+  commonly used with columns as you might in a @WHERE@ clause such as @WHERE foo ILIKE
+  'bar'@. Frequently you would not want to use this directly, but instead use
+  'Orville.PostgreSQL.Marshall.FieldDefinition.fieldLikeInsensitive'.
+
+@since 1.1.0.0
+-}
+likeInsensitive :: SqlComparable a b => a -> T.Text -> Expr.BooleanExpr
+likeInsensitive a =
+  Expr.likeInsensitive
+    (referenceValueExpression a)
+    . Expr.valueExpression
+    . SqlValue.fromText
+
+{- | Checks that the referenced items from the first two arguments are in the SQL values of the
+  given list of tuples. This is commonly used with columns as you might in a @WHERE@ clause such as
+  @WHERE (foo, bar) IN ((1,2), (3,4))@. Frequently you would not want to use this directly, but
+  instead use 'Orville.PostgreSQL.Marshall.FieldDefinition.fieldTupleIn'.
+
+@since 1.1.0.0
+-}
+tupleIn ::
+  (SqlComparable a c, SqlComparable b d) =>
+  a ->
+  b ->
+  NonEmpty (c, d) ->
+  Expr.BooleanExpr
+tupleIn a b =
+  Expr.tupleIn
+    (referenceValueExpression a :| [referenceValueExpression b])
+    . fmap (toSqlValueTuple a b)
+
+{- | Checks that the referenced items from the first two arguments are not in the SQL values of the
+  given list of tuples. This is commonly used with columns as you might in a @WHERE@ clause such as
+  @WHERE (foo, bar) IN ((1,2), (3,4))@. Frequently you would not want to use this directly, but
+  instead use 'Orville.PostgreSQL.Marshall.FieldDefinition.fieldTupleNotIn'.
+
+@since 1.1.0.0
+-}
+tupleNotIn ::
+  (SqlComparable a c, SqlComparable b d) =>
+  a ->
+  b ->
+  NonEmpty (c, d) ->
+  Expr.BooleanExpr
+tupleNotIn a b =
+  Expr.tupleNotIn
+    (referenceValueExpression a :| [referenceValueExpression b])
+    . fmap (toSqlValueTuple a b)

--- a/orville-postgresql/src/Orville/PostgreSQL/Marshall/SyntheticField.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Marshall/SyntheticField.hs
@@ -23,7 +23,7 @@ where
 
 import qualified Data.ByteString.Char8 as B8
 import qualified Orville.PostgreSQL.Expr as Expr
-import Orville.PostgreSQL.Marshall.FieldDefinition (FieldName, byteStringToFieldName, fieldNameToByteString, fieldNameToColumnName, stringToFieldName)
+import Orville.PostgreSQL.Marshall.AliasName (AliasName, aliasNameToByteString, byteStringToAliasName, stringToAliasName)
 import qualified Orville.PostgreSQL.Marshall.SqlComparable as SqlComparable
 import qualified Orville.PostgreSQL.Marshall.SqlType as SqlType
 import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
@@ -37,7 +37,7 @@ import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 -}
 data SyntheticField a = SyntheticField
   { i_syntheticFieldExpression :: Expr.ValueExpression
-  , i_syntheticFieldAlias :: FieldName
+  , i_syntheticFieldAlias :: AliasName
   , i_syntheticFieldType :: SqlType.SqlType a
   }
 
@@ -67,7 +67,7 @@ syntheticFieldExpression =
 
 @since 1.0.0.0
 -}
-syntheticFieldAlias :: SyntheticField a -> FieldName
+syntheticFieldAlias :: SyntheticField a -> AliasName
 syntheticFieldAlias =
   i_syntheticFieldAlias
 
@@ -108,7 +108,7 @@ syntheticField ::
 syntheticField expression alias sqlType =
   SyntheticField
     { i_syntheticFieldExpression = expression
-    , i_syntheticFieldAlias = stringToFieldName alias
+    , i_syntheticFieldAlias = stringToAliasName alias
     , i_syntheticFieldType = sqlType
     }
 
@@ -147,7 +147,7 @@ prefixSyntheticField ::
   SyntheticField a
 prefixSyntheticField prefix synthField =
   synthField
-    { i_syntheticFieldAlias = byteStringToFieldName (B8.pack prefix <> "_" <> fieldNameToByteString (syntheticFieldAlias synthField))
+    { i_syntheticFieldAlias = byteStringToAliasName (B8.pack prefix <> "_" <> aliasNameToByteString (syntheticFieldAlias synthField))
     }
 
 {- |
@@ -157,4 +157,4 @@ prefixSyntheticField prefix synthField =
 -}
 orderBySyntheticField :: SyntheticField a -> Expr.OrderByDirection -> Expr.OrderByExpr
 orderBySyntheticField =
-  Expr.orderByColumnName . Expr.aliasQualifyColumn Nothing . fieldNameToColumnName . syntheticFieldAlias
+  Expr.orderByColumnName . Expr.aliasQualifyColumn Nothing . Expr.fromIdentifier . Expr.identifierFromBytes . aliasNameToByteString . syntheticFieldAlias

--- a/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/PgAttributeDefault.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/PgAttributeDefault.hs
@@ -1,5 +1,5 @@
 {- |
-Copyright : Flipstone Technology Partners 2023
+Copyright : Flipstone Technology Partners 2023-2024
 License   : MIT
 Stability : Stable
 
@@ -16,10 +16,10 @@ import qualified Data.Text as T
 import qualified Database.PostgreSQL.LibPQ as LibPQ
 
 import qualified Orville.PostgreSQL as Orville
+import qualified Orville.PostgreSQL.Marshall as Marshall
 import Orville.PostgreSQL.PgCatalog.OidField (oidField, oidTypeField)
 import Orville.PostgreSQL.PgCatalog.PgAttribute (AttributeNumber, attributeNumberTypeField)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
-import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 {- |
   The Haskell representation of data read from the @pg_catalog.pg_attrdef@
@@ -93,4 +93,4 @@ attributeDefaultExpressionField =
   Orville.syntheticField
     (RawSql.unsafeSqlExpression "pg_get_expr(adbin,adrelid)")
     "expression"
-    SqlValue.toText
+    Marshall.unboundedText

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/PrimaryKey.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/PrimaryKey.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE RankNTypes #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2023
+Copyright : Flipstone Technology Partners 2023-2024
 License   : MIT
 Stability : Stable
 
@@ -29,7 +29,7 @@ import Data.List.NonEmpty (NonEmpty ((:|)), toList)
 
 import qualified Orville.PostgreSQL.Expr as Expr
 import qualified Orville.PostgreSQL.Internal.Extra.NonEmpty as ExtraNonEmpty
-import Orville.PostgreSQL.Marshall.FieldDefinition (FieldDefinition, FieldName, NotNull, fieldColumnName, fieldEquals, fieldIn, fieldName, fieldNameToString, fieldValueToSqlValue)
+import Orville.PostgreSQL.Marshall.FieldDefinition (FieldDefinition, FieldName, NotNull, fieldEquals, fieldIn, fieldName, fieldNameToColumnName, fieldNameToString, fieldValueToSqlValue)
 import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
 {- |
@@ -181,7 +181,7 @@ mkPrimaryKeyExpr :: PrimaryKey key -> Expr.PrimaryKeyExpr
 mkPrimaryKeyExpr keyDef =
   let
     names =
-      mapPrimaryKeyParts (\_ field -> fieldColumnName field) keyDef
+      mapPrimaryKeyParts (\_ field -> fieldNameToColumnName $ fieldName field) keyDef
   in
     Expr.primaryKeyExpr names
 

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/TableDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/TableDefinition.hs
@@ -439,7 +439,7 @@ mkTableColumnDefinitions tableDef =
   foldMarshallerFields
     (unannotatedSqlMarshaller $ tableMarshaller tableDef)
     []
-    (collectFromField IncludeReadOnlyColumns fieldColumnDefinition)
+    (collectFromField IncludeReadOnlyColumns (const fieldColumnDefinition))
 
 {- |
   Builds the 'Expr.PrimaryKeyExpr' for this table, or none if this table has no
@@ -525,8 +525,9 @@ mkInsertColumnList ::
   SqlMarshaller writeEntity readEntity ->
   Expr.InsertColumnList
 mkInsertColumnList marshaller =
-  Expr.insertColumnList $
-    foldMarshallerFields marshaller [] (collectFromField ExcludeReadOnlyColumns fieldColumnName)
+  Expr.insertColumnList
+    . foldMarshallerFields marshaller []
+    $ collectFromField ExcludeReadOnlyColumns fieldColumnName
 
 {- |
   Builds an 'Expr.InsertSource' that will insert the given entities with their
@@ -565,9 +566,9 @@ collectSqlValue ::
   [SqlValue]
 collectSqlValue entry encodeRest entity =
   case entry of
-    Natural fieldDef (Just accessor) ->
+    Natural _ fieldDef (Just accessor) ->
       fieldValueToSqlValue fieldDef (accessor entity) : (encodeRest entity)
-    Natural _ Nothing ->
+    Natural _ _ Nothing ->
       encodeRest entity
     Synthetic _ ->
       encodeRest entity

--- a/orville-postgresql/test/Test/Expr/Count.hs
+++ b/orville-postgresql/test/Test/Expr/Count.hs
@@ -57,7 +57,7 @@ prop_countColumn =
           (Expr.selectClause (Expr.selectExpr Nothing))
           ( Expr.selectDerivedColumns
               [ Expr.deriveColumnAs
-                  (Expr.countColumn (Orville.fieldColumnName Foo.fooIdField))
+                  (Expr.countColumn (Orville.fieldColumnName Nothing Foo.fooIdField))
                   (Expr.columnName "count")
               ]
           )

--- a/orville-postgresql/test/Test/Expr/GroupBy.hs
+++ b/orville-postgresql/test/Test/Expr/GroupBy.hs
@@ -107,13 +107,13 @@ testTable :: Expr.Qualified Expr.TableName
 testTable =
   Expr.qualifyTable Nothing (Expr.tableName "expr_test")
 
-fooColumn :: Expr.ColumnName
+fooColumn :: Expr.Qualified Expr.ColumnName
 fooColumn =
-  Expr.columnName "foo"
+  Expr.aliasQualifyColumn Nothing (Expr.columnName "foo")
 
-barColumn :: Expr.ColumnName
+barColumn :: Expr.Qualified Expr.ColumnName
 barColumn =
-  Expr.columnName "bar"
+  Expr.aliasQualifyColumn Nothing (Expr.columnName "bar")
 
 dropAndRecreateTestTable :: Orville.Connection -> IO ()
 dropAndRecreateTestTable connection = do

--- a/orville-postgresql/test/Test/Expr/GroupByOrderBy.hs
+++ b/orville-postgresql/test/Test/Expr/GroupByOrderBy.hs
@@ -97,13 +97,13 @@ testTable :: Expr.Qualified Expr.TableName
 testTable =
   Expr.qualifyTable Nothing (Expr.tableName "expr_test")
 
-fooColumn :: Expr.ColumnName
+fooColumn :: Expr.Qualified Expr.ColumnName
 fooColumn =
-  Expr.columnName "foo"
+  Expr.aliasQualifyColumn Nothing (Expr.columnName "foo")
 
-barColumn :: Expr.ColumnName
+barColumn :: Expr.Qualified Expr.ColumnName
 barColumn =
-  Expr.columnName "bar"
+  Expr.aliasQualifyColumn Nothing (Expr.columnName "bar")
 
 dropAndRecreateTestTable :: Orville.Connection -> IO ()
 dropAndRecreateTestTable connection = do

--- a/orville-postgresql/test/Test/Expr/TestSchema.hs
+++ b/orville-postgresql/test/Test/Expr/TestSchema.hs
@@ -46,17 +46,21 @@ fooBarTable :: Expr.Qualified Expr.TableName
 fooBarTable =
   Expr.qualifyTable Nothing (Expr.tableName "foobar")
 
-fooColumn :: Expr.ColumnName
+fooColumn :: Expr.Qualified Expr.ColumnName
 fooColumn =
-  Expr.columnName "foo"
+  Expr.aliasQualifyColumn Nothing $ Expr.columnName "foo"
 
 fooColumnRef :: Expr.ValueExpression
 fooColumnRef =
   Expr.columnReference fooColumn
 
-barColumn :: Expr.ColumnName
+barColumn :: Expr.Qualified Expr.ColumnName
 barColumn =
-  Expr.columnName "bar"
+  Expr.aliasQualifyColumn Nothing $ Expr.columnName "bar"
+
+barColumnAliased :: Expr.Qualified Expr.ColumnName
+barColumnAliased =
+  Expr.aliasQualifyColumn (Just $ Expr.stringToAlias "b") $ Expr.columnName "bar"
 
 barColumnRef :: Expr.ValueExpression
 barColumnRef =
@@ -73,10 +77,13 @@ findAllFooBars =
 
 findAllFooBarsInTable :: Expr.Qualified Expr.TableName -> Expr.QueryExpr
 findAllFooBarsInTable tableName =
-  Expr.queryExpr
-    (Expr.selectClause $ Expr.selectExpr Nothing)
-    (Expr.selectColumns [fooColumn, barColumn])
-    (Just $ Expr.tableExpr (Expr.referencesTable tableName) Nothing Nothing (Just orderByFoo) Nothing Nothing)
+  let
+    tableRef = Expr.referencesTableWithAlias (Expr.stringToAlias "b") tableName
+  in
+    Expr.queryExpr
+      (Expr.selectClause $ Expr.selectExpr Nothing)
+      (Expr.selectColumns [fooColumn, barColumnAliased])
+      (Just $ Expr.tableExpr tableRef Nothing Nothing (Just orderByFoo) Nothing Nothing)
 
 encodeFooBar :: FooBar -> [(Maybe B8.ByteString, SqlValue.SqlValue)]
 encodeFooBar fooBar =

--- a/orville-postgresql/test/Test/Expr/TestSchema.hs
+++ b/orville-postgresql/test/Test/Expr/TestSchema.hs
@@ -60,7 +60,7 @@ barColumn =
 
 barColumnAliased :: Expr.Qualified Expr.ColumnName
 barColumnAliased =
-  Expr.aliasQualifyColumn (Just $ Expr.stringToAlias "b") $ Expr.columnName "bar"
+  Expr.aliasQualifyColumn (Just $ Expr.stringToAliasExpr "b") $ Expr.columnName "bar"
 
 barColumnRef :: Expr.ValueExpression
 barColumnRef =
@@ -78,7 +78,7 @@ findAllFooBars =
 findAllFooBarsInTable :: Expr.Qualified Expr.TableName -> Expr.QueryExpr
 findAllFooBarsInTable tableName =
   let
-    tableRef = Expr.referencesTableWithAlias (Expr.stringToAlias "b") tableName
+    tableRef = Expr.referencesTableWithAlias (Expr.stringToAliasExpr "b") tableName
   in
     Expr.queryExpr
       (Expr.selectClause $ Expr.selectExpr Nothing)

--- a/orville-postgresql/test/Test/FieldDefinition.hs
+++ b/orville-postgresql/test/Test/FieldDefinition.hs
@@ -248,7 +248,7 @@ runRoundTripTest pool testCase = do
       Expr.insertExpr
         testTable
         Nothing
-        (Expr.insertSqlValues [[Marshall.fieldValueToSqlValue fieldDef value]])
+        (Expr.insertSqlValues [[Marshall.toComparableSqlValue fieldDef value]])
         Nothing
         Nothing
 
@@ -256,7 +256,7 @@ runRoundTripTest pool testCase = do
       RawSql.execute connection $
         Expr.queryExpr
           (Expr.selectClause $ Expr.selectExpr Nothing)
-          (Expr.selectColumns [Marshall.fieldColumnName fieldDef])
+          (Expr.selectColumns [Marshall.fieldColumnName Nothing fieldDef])
           (Just $ Expr.tableExpr (Expr.referencesTable testTable) Nothing Nothing Nothing Nothing Nothing)
 
     Execution.readRows result
@@ -301,7 +301,7 @@ runNullableRoundTripTest pool testCase = do
       RawSql.execute connection $
         Expr.queryExpr
           (Expr.selectClause $ Expr.selectExpr Nothing)
-          (Expr.selectColumns [Marshall.fieldColumnName fieldDef])
+          (Expr.selectColumns [Marshall.fieldColumnName Nothing fieldDef])
           (Just $ Expr.tableExpr (Expr.referencesTable testTable) Nothing Nothing Nothing Nothing Nothing)
 
     Execution.readRows result
@@ -371,7 +371,7 @@ runDefaultValueFieldDefinitionTest pool testCase mkDefaultValue = do
       RawSql.execute connection $
         Expr.queryExpr
           (Expr.selectClause $ Expr.selectExpr Nothing)
-          (Expr.selectColumns [Marshall.fieldColumnName fieldDef])
+          (Expr.selectColumns [Marshall.fieldColumnName Nothing fieldDef])
           (Just $ Expr.tableExpr (Expr.referencesTable testTable) Nothing Nothing Nothing Nothing Nothing)
 
     Execution.readRows result

--- a/orville-postgresql/test/Test/SelectOptions.hs
+++ b/orville-postgresql/test/Test/SelectOptions.hs
@@ -13,6 +13,7 @@ import qualified Hedgehog as HH
 import Orville.PostgreSQL ((.&&), (./=), (.<), (.<-), (.</-), (.<=), (.==), (.>), (.>=), (.||))
 import qualified Orville.PostgreSQL as O
 import qualified Orville.PostgreSQL.Expr as Expr
+import qualified Orville.PostgreSQL.Marshall as Marshall
 import qualified Orville.PostgreSQL.Marshall.FieldDefinition as FieldDef
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import qualified Test.Property as Property
@@ -317,7 +318,7 @@ prop_orderByAliased =
     assertOrderByClauseEquals
       (Just "ORDER BY \"f\".\"foo\" ASC, \"bar\" DESC")
       ( O.orderBy
-          ( O.orderByAliasedField (O.buildAliasedFieldDefinition fooField (Just $ Expr.stringToAlias "f")) Expr.ascendingOrder
+          ( O.orderByAliasedField (O.buildAliasedFieldDefinition fooField (Just $ Marshall.stringToAliasName "f")) Expr.ascendingOrder
               <> O.orderByField barField Expr.descendingOrder
           )
       )

--- a/orville-postgresql/test/Test/SqlMarshaller.hs
+++ b/orville-postgresql/test/Test/SqlMarshaller.hs
@@ -18,7 +18,6 @@ import qualified Hedgehog.Range as Range
 
 import qualified Orville.PostgreSQL.ErrorDetailLevel as ErrorDetailLevel
 import qualified Orville.PostgreSQL.Execution.ExecutionResult as Result
-import qualified Orville.PostgreSQL.Expr as Expr
 import qualified Orville.PostgreSQL.Marshall as Marshall
 import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
@@ -316,11 +315,11 @@ fooMarshaller =
 
 fooMarshallerWithAliasOnEachField :: Marshall.SqlMarshaller Foo Foo
 fooMarshallerWithAliasOnEachField =
-  Marshall.marshallAlias (Expr.stringToAlias "f") $
+  Marshall.marshallAlias (Marshall.stringToAliasName "f") $
     Foo
-      <$> Marshall.marshallAlias (Expr.stringToAlias "f") (Marshall.marshallField fooName (Marshall.unboundedTextField "name"))
-      <*> Marshall.marshallAlias (Expr.stringToAlias "f") (Marshall.marshallField fooSize (Marshall.integerField "size"))
-      <*> Marshall.marshallAlias (Expr.stringToAlias "f") (Marshall.marshallField fooOption (Marshall.nullableField $ Marshall.booleanField "option"))
+      <$> Marshall.marshallAlias (Marshall.stringToAliasName "f") (Marshall.marshallField fooName (Marshall.unboundedTextField "name"))
+      <*> Marshall.marshallAlias (Marshall.stringToAliasName "f") (Marshall.marshallField fooSize (Marshall.integerField "size"))
+      <*> Marshall.marshallAlias (Marshall.stringToAliasName "f") (Marshall.marshallField fooOption (Marshall.nullableField $ Marshall.booleanField "option"))
 
 generateFoo :: HH.Gen Foo
 generateFoo =

--- a/orville-postgresql/test/Test/TableDefinition.hs
+++ b/orville-postgresql/test/Test/TableDefinition.hs
@@ -15,7 +15,7 @@ import qualified Hedgehog as HH
 import qualified Orville.PostgreSQL as Orville
 import qualified Orville.PostgreSQL.Execution.ReturningOption as ReturningOption
 import qualified Orville.PostgreSQL.Execution.Select as Select
-import qualified Orville.PostgreSQL.Expr as Expr
+import qualified Orville.PostgreSQL.Marshall as Marshall
 import qualified Orville.PostgreSQL.Raw.Connection as Conn
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import qualified Orville.PostgreSQL.Schema.ConstraintDefinition as ConstraintDefinition
@@ -77,7 +77,7 @@ prop_roundTripWithAlias =
           (originalFoo :| [])
 
       selectFoos =
-        Select.selectTableWithAlias (Expr.stringToAlias "some_alias") Foo.table mempty
+        Select.selectTableWithAlias (Marshall.stringToAliasName "some_alias") Foo.table mempty
 
     foosFromDB <-
       MIO.liftIO . Orville.runOrville pool $ do

--- a/orville-postgresql/test/Test/TableDefinition.hs
+++ b/orville-postgresql/test/Test/TableDefinition.hs
@@ -15,6 +15,7 @@ import qualified Hedgehog as HH
 import qualified Orville.PostgreSQL as Orville
 import qualified Orville.PostgreSQL.Execution.ReturningOption as ReturningOption
 import qualified Orville.PostgreSQL.Execution.Select as Select
+import qualified Orville.PostgreSQL.Expr as Expr
 import qualified Orville.PostgreSQL.Raw.Connection as Conn
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import qualified Orville.PostgreSQL.Schema.ConstraintDefinition as ConstraintDefinition
@@ -30,6 +31,7 @@ tableDefinitionTests pool =
   Property.group
     "TableDefinition"
     [ prop_roundTrip pool
+    , prop_roundTripWithAlias pool
     , prop_readOnlyFields pool
     , prop_primaryKey pool
     , prop_uniqueConstraint pool
@@ -51,6 +53,31 @@ prop_roundTrip =
 
       selectFoos =
         Select.selectTable Foo.table mempty
+
+    foosFromDB <-
+      MIO.liftIO . Orville.runOrville pool $ do
+        Orville.withConnection $ \connection -> do
+          MIO.liftIO $ TestTable.dropAndRecreateTableDef connection Foo.table
+        Orville.executeVoid Orville.InsertQuery insertFoo
+        Select.executeSelect selectFoos
+
+    foosFromDB === [originalFoo]
+
+prop_roundTripWithAlias :: Property.NamedDBProperty
+prop_roundTripWithAlias =
+  Property.namedDBProperty "Creates a table with an alias that can round trip an entity through it" $ \pool -> do
+    originalFoo <- HH.forAll Foo.generate
+
+    let
+      insertFoo =
+        TableDefinition.mkInsertExpr
+          ReturningOption.WithoutReturning
+          Foo.table
+          Nothing
+          (originalFoo :| [])
+
+      selectFoos =
+        Select.selectTableWithAlias (Expr.stringToAlias "some_alias") Foo.table mempty
 
     foosFromDB <-
       MIO.liftIO . Orville.runOrville pool $ do


### PR DESCRIPTION
This is an updated/reworked version of #346. the primary difference between that and this is the creation of the typeclass using that to support comparisons on synthetic and aliased fields.

The highlights:

- Moving to use 'Qualified ColumnName' in many/most places. This allows for the aliasing to be used naturally in those places.

- Add an alias type and function to create a 'Qualified ColumnName' with it. This signals that 'Alias' is in fact different than 'ColumnName' or 'TableName', and reusing them for aliasing is not always appropriate.

- Adding a 'MarshallAlias' constructor to the 'SqlMarshaller' so that an alias can be attached to all of the natural fields in a marshaller in a single function call from users. Synthetic fields could be refactored with this facility, but that was left out here to keep the already big changeset smaller.

- Adds 'AliasedFieldDefinition' for holding a field that should be referenced with an alias in SQL.

- Adds a 'SqlComparable' typeclass to allow for comparison in a polymorphic way. Instances are provided for 'FieldDefinition', 'SyntheticField' and the new 'AliasedFieldDefinition'. Comparison functions are exposed working with the class. The field definition functions and operators for comparison are now type restricted versions of the classy functions. In this way the "simple" case of FieldDefinitions has the most specific functions, but 'AliasedFieldDefinition' and 'SyntheticField' can both be compared against.

- A small number of helpers are added to make generation of bits of SQL, such as a 'TableReferenceList' that includes the 'AS alias' piece.