### PR TITLE
Adds a RowLockingClause to SelectOptions

### DIFF
--- a/orville-postgresql/orville-postgresql.cabal
+++ b/orville-postgresql/orville-postgresql.cabal
@@ -127,6 +127,7 @@ library
       Orville.PostgreSQL.Expr.Internal.Name.TableName
       Orville.PostgreSQL.Expr.Internal.Name.TriggerName
       Orville.PostgreSQL.Expr.OrReplace
+      Orville.PostgreSQL.Expr.RowLocking
       Orville.PostgreSQL.Expr.Trigger
       Orville.PostgreSQL.Expr.Vacuum
       Orville.PostgreSQL.Internal.Bracket

--- a/orville-postgresql/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL.hs
@@ -268,6 +268,7 @@ module Orville.PostgreSQL
   , SelectOptions.where_
   , SelectOptions.emptySelectOptions
   , SelectOptions.appendSelectOptions
+  , SelectOptions.forRowLock
   , FieldDefinition.fieldEquals
   , (FieldDefinition..==)
   , FieldDefinition.fieldNotEquals
@@ -304,10 +305,18 @@ module Orville.PostgreSQL
   , Expr.orExpr
   , (Expr..&&)
   , (Expr..||)
+  , Expr.rowLockingClause
+  , Expr.updateStrength
+  , Expr.noKeyUpdateStrength
+  , Expr.shareStrength
+  , Expr.keyShareStrength
+  , Expr.noWaitRowLockingOption
+  , Expr.skipLockedRowLockingOption
   , SelectOptions.selectGroupByClause
   , SelectOptions.selectOrderByClause
   , SelectOptions.selectWhereClause
   , SelectOptions.selectDistinct
+  , SelectOptions.selectRowLockingClause
 
     -- * Functions for defining and working with sequences
   , Sequence.sequenceNextValue

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr.hs
@@ -68,6 +68,7 @@ module Orville.PostgreSQL.Expr
   , module Orville.PostgreSQL.Expr.OrReplace
   , module Orville.PostgreSQL.Expr.Vacuum
   , module Orville.PostgreSQL.Expr.Extension
+  , module Orville.PostgreSQL.Expr.RowLocking
   )
 where
 
@@ -95,6 +96,7 @@ import Orville.PostgreSQL.Expr.OrReplace
 import Orville.PostgreSQL.Expr.OrderBy
 import Orville.PostgreSQL.Expr.Query
 import Orville.PostgreSQL.Expr.ReturningExpr
+import Orville.PostgreSQL.Expr.RowLocking
 import Orville.PostgreSQL.Expr.Select
 import Orville.PostgreSQL.Expr.SequenceDefinition
 import Orville.PostgreSQL.Expr.TableConstraint

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Query.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Query.hs
@@ -29,6 +29,7 @@ import Orville.PostgreSQL.Expr.LimitExpr (LimitExpr)
 import Orville.PostgreSQL.Expr.Name (ColumnName)
 import Orville.PostgreSQL.Expr.OffsetExpr (OffsetExpr)
 import Orville.PostgreSQL.Expr.OrderBy (OrderByClause)
+import Orville.PostgreSQL.Expr.RowLocking (RowLockingClause)
 import Orville.PostgreSQL.Expr.Select (SelectClause)
 import Orville.PostgreSQL.Expr.TableReferenceList (TableReferenceList)
 import Orville.PostgreSQL.Expr.ValueExpression (ValueExpression, columnReference)
@@ -202,6 +203,8 @@ tableExpr ::
   Maybe LimitExpr ->
   -- | An optional @OFFSET@ to apply to the result set.
   Maybe OffsetExpr ->
+  -- | An optional locking clause to apply to the result set.
+  Maybe RowLockingClause ->
   TableExpr
 tableExpr
   tableReferenceList
@@ -209,7 +212,8 @@ tableExpr
   maybeGroupByClause
   maybeOrderByClause
   maybeLimitExpr
-  maybeOffsetExpr =
+  maybeOffsetExpr
+  maybeRowLockingClause =
     TableExpr
       . RawSql.intercalate RawSql.space
       $ RawSql.toRawSql tableReferenceList
@@ -219,4 +223,5 @@ tableExpr
           , RawSql.toRawSql <$> maybeOrderByClause
           , RawSql.toRawSql <$> maybeLimitExpr
           , RawSql.toRawSql <$> maybeOffsetExpr
+          , RawSql.toRawSql <$> maybeRowLockingClause
           ]

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/RowLocking.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/RowLocking.hs
@@ -1,0 +1,93 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+{- |
+Copyright : Flipstone Technology Partners 2024
+License   : MIT
+Stability : Stable
+
+@since 1.1.0.0
+-}
+module Orville.PostgreSQL.Expr.RowLocking
+  ( RowLockingClause
+  , rowLockingClause
+  , RowLockingStrengthExpr
+  , updateStrength
+  , noKeyUpdateStrength
+  , shareStrength
+  , keyShareStrength
+  , RowLockingOptionExpr
+  , noWaitRowLockingOption
+  , skipLockedRowLockingOption
+  )
+where
+
+import qualified Data.List.NonEmpty as NEL
+
+import Orville.PostgreSQL.Expr.Internal.Name.TableName (TableName)
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+
+{- |
+Type to represent the row locking part of a SQL @SELECT@ query. E.G.
+
+> FOR UPDATE
+
+'RowLockingClause' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom SQL.
+
+@since 1.1.0.0
+-}
+newtype RowLockingClause
+  = RowLockingClause RawSql.RawSql
+  deriving (RawSql.SqlExpression)
+
+rowLockingClause ::
+  RowLockingStrengthExpr ->
+  Maybe (NEL.NonEmpty TableName) ->
+  Maybe RowLockingOptionExpr ->
+  RowLockingClause
+rowLockingClause strength mbTables mbOpt =
+  RowLockingClause $
+    RawSql.fromString "FOR "
+      <> RawSql.toRawSql strength
+      <> maybe
+        mempty
+        ( \tables ->
+            RawSql.fromString " OF "
+              <> RawSql.intercalate
+                RawSql.commaSpace
+                (fmap RawSql.toRawSql tables)
+        )
+        mbTables
+      <> maybe mempty (\opt -> RawSql.space <> RawSql.toRawSql opt) mbOpt
+
+newtype RowLockingStrengthExpr
+  = RowLockingStrengthExpr RawSql.RawSql
+  deriving (RawSql.SqlExpression)
+
+updateStrength :: RowLockingStrengthExpr
+updateStrength =
+  RowLockingStrengthExpr $ RawSql.fromString "UPDATE"
+
+noKeyUpdateStrength :: RowLockingStrengthExpr
+noKeyUpdateStrength =
+  RowLockingStrengthExpr $ RawSql.fromString "NO KEY UPDATE"
+
+shareStrength :: RowLockingStrengthExpr
+shareStrength =
+  RowLockingStrengthExpr $ RawSql.fromString "SHARE"
+
+keyShareStrength :: RowLockingStrengthExpr
+keyShareStrength =
+  RowLockingStrengthExpr $ RawSql.fromString "KEY SHARE"
+
+newtype RowLockingOptionExpr
+  = RowLockingOptionExpr RawSql.RawSql
+  deriving (RawSql.SqlExpression)
+
+noWaitRowLockingOption :: RowLockingOptionExpr
+noWaitRowLockingOption =
+  RowLockingOptionExpr $ RawSql.fromString "NO WAIT"
+
+skipLockedRowLockingOption :: RowLockingOptionExpr
+skipLockedRowLockingOption =
+  RowLockingOptionExpr $ RawSql.fromString "SKIP LOCKED"

--- a/orville-postgresql/test/Test/Expr/Count.hs
+++ b/orville-postgresql/test/Test/Expr/Count.hs
@@ -61,7 +61,7 @@ prop_countColumn =
                   (Expr.columnName "count")
               ]
           )
-          (Just (Expr.tableExpr (Expr.referencesTable $ Orville.tableName Foo.table) Nothing Nothing Nothing Nothing Nothing))
+          (Just (Expr.tableExpr (Expr.referencesTable $ Orville.tableName Foo.table) Nothing Nothing Nothing Nothing Nothing Nothing))
 
       marshaller =
         Orville.annotateSqlMarshallerEmptyAnnotation $

--- a/orville-postgresql/test/Test/Expr/GroupBy.hs
+++ b/orville-postgresql/test/Test/Expr/GroupBy.hs
@@ -97,7 +97,7 @@ groupByTest testName test =
           Expr.queryExpr
             (Expr.selectClause $ Expr.selectExpr Nothing)
             (Expr.selectColumns [fooColumn, barColumn])
-            (Just $ Expr.tableExpr (Expr.referencesTable testTable) Nothing (groupByClause test) Nothing Nothing Nothing)
+            (Just $ Expr.tableExpr (Expr.referencesTable testTable) Nothing (groupByClause test) Nothing Nothing Nothing Nothing)
 
       Execution.readRows result
 

--- a/orville-postgresql/test/Test/Expr/GroupByOrderBy.hs
+++ b/orville-postgresql/test/Test/Expr/GroupByOrderBy.hs
@@ -87,7 +87,7 @@ groupByOrderByTest testName test =
           Expr.queryExpr
             (Expr.selectClause $ Expr.selectExpr Nothing)
             (Expr.selectColumns [fooColumn, barColumn])
-            (Just $ Expr.tableExpr (Expr.referencesTable testTable) Nothing (groupByClause test) (orderByClause test) Nothing Nothing)
+            (Just $ Expr.tableExpr (Expr.referencesTable testTable) Nothing (groupByClause test) (orderByClause test) Nothing Nothing Nothing)
 
       Execution.readRows result
 

--- a/orville-postgresql/test/Test/Expr/OrderBy.hs
+++ b/orville-postgresql/test/Test/Expr/OrderBy.hs
@@ -127,7 +127,7 @@ orderByTest testName test =
               Expr.queryExpr
                 (Expr.selectClause $ Expr.selectExpr Nothing)
                 (Expr.selectColumns [fooColumn, barColumn])
-                (Just $ Expr.tableExpr (Expr.referencesTable fooBarTable) Nothing Nothing (orderByClause test) Nothing Nothing)
+                (Just $ Expr.tableExpr (Expr.referencesTable fooBarTable) Nothing Nothing (orderByClause test) Nothing Nothing Nothing)
 
           Execution.readRows result
 

--- a/orville-postgresql/test/Test/Expr/TestSchema.hs
+++ b/orville-postgresql/test/Test/Expr/TestSchema.hs
@@ -76,7 +76,7 @@ findAllFooBarsInTable tableName =
   Expr.queryExpr
     (Expr.selectClause $ Expr.selectExpr Nothing)
     (Expr.selectColumns [fooColumn, barColumn])
-    (Just $ Expr.tableExpr (Expr.referencesTable tableName) Nothing Nothing (Just orderByFoo) Nothing Nothing)
+    (Just $ Expr.tableExpr (Expr.referencesTable tableName) Nothing Nothing (Just orderByFoo) Nothing Nothing Nothing)
 
 encodeFooBar :: FooBar -> [(Maybe B8.ByteString, SqlValue.SqlValue)]
 encodeFooBar fooBar =

--- a/orville-postgresql/test/Test/Expr/Where.hs
+++ b/orville-postgresql/test/Test/Expr/Where.hs
@@ -252,7 +252,7 @@ whereConditionTest testName test =
               Expr.queryExpr
                 (Expr.selectClause $ Expr.selectExpr Nothing)
                 (Expr.selectColumns [fooColumn, barColumn])
-                (Just $ Expr.tableExpr (Expr.referencesTable fooBarTable) (whereClause test) Nothing Nothing Nothing Nothing)
+                (Just $ Expr.tableExpr (Expr.referencesTable fooBarTable) (whereClause test) Nothing Nothing Nothing Nothing Nothing)
 
           Execution.readRows result
 

--- a/orville-postgresql/test/Test/FieldDefinition.hs
+++ b/orville-postgresql/test/Test/FieldDefinition.hs
@@ -257,7 +257,7 @@ runRoundTripTest pool testCase = do
         Expr.queryExpr
           (Expr.selectClause $ Expr.selectExpr Nothing)
           (Expr.selectColumns [Marshall.fieldColumnName fieldDef])
-          (Just $ Expr.tableExpr (Expr.referencesTable testTable) Nothing Nothing Nothing Nothing Nothing)
+          (Just $ Expr.tableExpr (Expr.referencesTable testTable) Nothing Nothing Nothing Nothing Nothing Nothing)
 
     Execution.readRows result
 
@@ -302,7 +302,7 @@ runNullableRoundTripTest pool testCase = do
         Expr.queryExpr
           (Expr.selectClause $ Expr.selectExpr Nothing)
           (Expr.selectColumns [Marshall.fieldColumnName fieldDef])
-          (Just $ Expr.tableExpr (Expr.referencesTable testTable) Nothing Nothing Nothing Nothing Nothing)
+          (Just $ Expr.tableExpr (Expr.referencesTable testTable) Nothing Nothing Nothing Nothing Nothing Nothing)
 
     Execution.readRows result
 
@@ -372,7 +372,7 @@ runDefaultValueFieldDefinitionTest pool testCase mkDefaultValue = do
         Expr.queryExpr
           (Expr.selectClause $ Expr.selectExpr Nothing)
           (Expr.selectColumns [Marshall.fieldColumnName fieldDef])
-          (Just $ Expr.tableExpr (Expr.referencesTable testTable) Nothing Nothing Nothing Nothing Nothing)
+          (Just $ Expr.tableExpr (Expr.referencesTable testTable) Nothing Nothing Nothing Nothing Nothing Nothing)
 
     Execution.readRows result
 

--- a/orville-postgresql/test/Test/SelectOptions.hs
+++ b/orville-postgresql/test/Test/SelectOptions.hs
@@ -56,6 +56,7 @@ selectOptionsTests =
     , prop_orderByCombined
     , prop_groupBy
     , prop_groupByCombined
+    , prop_forRowLock
     ]
 
 prop_emptyWhereClause :: Property.NamedProperty
@@ -337,6 +338,13 @@ prop_groupByCombined =
           <> (O.groupBy . Expr.groupByColumnsExpr $ (FieldDef.fieldColumnName barField :| []))
       )
 
+prop_forRowLock :: Property.NamedProperty
+prop_forRowLock =
+  Property.singletonNamedProperty "forRowLock generates expected sql" $
+    assertRowLockingClauseEquals
+      (Just "FOR UPDATE SKIP LOCKED")
+      (O.forRowLock $ Expr.rowLockingClause Expr.updateStrength Nothing (Just Expr.skipLockedRowLockingOption))
+
 assertDistinctEquals :: (HH.MonadTest m, HasCallStack) => String -> O.SelectOptions -> m ()
 assertDistinctEquals mbDistinct selectOptions =
   withFrozenCallStack $
@@ -356,6 +364,11 @@ assertGroupByClauseEquals :: (HH.MonadTest m, HasCallStack) => Maybe String -> O
 assertGroupByClauseEquals mbGroupByClause selectOptions =
   withFrozenCallStack $
     fmap RawSql.toExampleBytes (O.selectGroupByClause selectOptions) HH.=== fmap B8.pack mbGroupByClause
+
+assertRowLockingClauseEquals :: (HH.MonadTest m, HasCallStack) => Maybe String -> O.SelectOptions -> m ()
+assertRowLockingClauseEquals mbRowLockingClause selectOptions =
+  withFrozenCallStack $
+    fmap RawSql.toExampleBytes (O.selectRowLockingClause selectOptions) HH.=== fmap B8.pack mbRowLockingClause
 
 fooField :: FieldDef.FieldDefinition FieldDef.NotNull Int.Int32
 fooField =

--- a/orville-postgresql/test/Test/SqlType.hs
+++ b/orville-postgresql/test/Test/SqlType.hs
@@ -545,7 +545,7 @@ runDecodingTest pool test =
           Expr.queryExpr
             (Expr.selectClause $ Expr.selectExpr Nothing)
             Expr.selectStar
-            (Just $ Expr.tableExpr (Expr.referencesTable tableName) Nothing Nothing Nothing Nothing Nothing)
+            (Just $ Expr.tableExpr (Expr.referencesTable tableName) Nothing Nothing Nothing Nothing Nothing Nothing)
 
       Execution.readRows result
 


### PR DESCRIPTION
This is to address #340.

Support for the various forms of locking in a select statements is added, as documented by PostgrSQL at:
https://www.postgresql.org/docs/12/sql-select.html#SQL-FOR-UPDATE-SHARE

This is another case of a select option being left preferred, much like limit.