### PR TITLE
Add conditional expression support

### DIFF
--- a/orville-postgresql/orville-postgresql.cabal
+++ b/orville-postgresql/orville-postgresql.cabal
@@ -111,6 +111,7 @@ library
       Orville.PostgreSQL.Schema.TableIdentifier
       Orville.PostgreSQL.UnliftIO
   other-modules:
+      Orville.PostgreSQL.Expr.ConditionalExpr
       Orville.PostgreSQL.Expr.Extension
       Orville.PostgreSQL.Expr.Function
       Orville.PostgreSQL.Expr.IfNotExists

--- a/orville-postgresql/orville-postgresql.cabal
+++ b/orville-postgresql/orville-postgresql.cabal
@@ -198,6 +198,7 @@ test-suite spec
       Test.Entities.User
       Test.EntityOperations
       Test.Execution
+      Test.Expr.ConditionalExpr
       Test.Expr.Count
       Test.Expr.Cursor
       Test.Expr.GroupBy

--- a/orville-postgresql/src/Orville/PostgreSQL/Execution.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Execution.hs
@@ -15,7 +15,7 @@ executed.
 -}
 module Orville.PostgreSQL.Execution
   ( -- * High-level modules for most common tasks
-    module Orville.PostgreSQL.Execution.EntityOperations
+      module Orville.PostgreSQL.Execution.EntityOperations
   , module Orville.PostgreSQL.Execution.SelectOptions
   , module Orville.PostgreSQL.Execution.Sequence
   , module Orville.PostgreSQL.Execution.Transaction

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr.hs
@@ -67,6 +67,7 @@ module Orville.PostgreSQL.Expr
   , module Orville.PostgreSQL.Expr.Trigger
   , module Orville.PostgreSQL.Expr.Function
   , module Orville.PostgreSQL.Expr.OrReplace
+  , module Orville.PostgreSQL.Expr.ConditionalExpr
   , module Orville.PostgreSQL.Expr.Vacuum
   , module Orville.PostgreSQL.Expr.Extension
   , module Orville.PostgreSQL.Expr.RowLocking
@@ -78,6 +79,7 @@ where
 
 import Orville.PostgreSQL.Expr.BinaryOperator
 import Orville.PostgreSQL.Expr.ColumnDefinition
+import Orville.PostgreSQL.Expr.ConditionalExpr
 import Orville.PostgreSQL.Expr.Count
 import Orville.PostgreSQL.Expr.Cursor
 import Orville.PostgreSQL.Expr.DataType

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/ConditionalExpr.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/ConditionalExpr.hs
@@ -78,6 +78,7 @@ caseExpr ::
 caseExpr whens mbElse =
   RawSql.unsafeFromRawSql $
     RawSql.fromString "CASE"
+      <> RawSql.space
       <> RawSql.intercalate RawSql.space (fmap RawSql.toRawSql whens)
       <> RawSql.space
       <> case mbElse of
@@ -100,8 +101,7 @@ nullIf leftVal rightVal =
     RawSql.fromString "NULLIF"
       <> RawSql.leftParen
       <> RawSql.toRawSql leftVal
-      <> RawSql.comma
-      <> RawSql.space
+      <> RawSql.commaSpace
       <> RawSql.toRawSql rightVal
       <> RawSql.rightParen
 

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/ConditionalExpr.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/ConditionalExpr.hs
@@ -1,0 +1,130 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+{- |
+Copyright : Flipstone Technology Partners 2024
+License   : MIT
+Stability : Stable
+
+@since 1.1.0.0
+-}
+module Orville.PostgreSQL.Expr.ConditionalExpr
+  ( coalesce
+  , WhenExpr
+  , whenExpr
+  , caseExpr
+  , nullIf
+  , greatest
+  , least
+  ) where
+
+import qualified Data.List.NonEmpty as NE
+
+import Orville.PostgreSQL.Expr.ValueExpression (ValueExpression)
+import Orville.PostgreSQL.Expr.WhereClause (BooleanExpr)
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+
+{- | Creates a 'ValueExpression' corresponding to the SQL @COALESE@.
+
+@since 1.1.0.0
+-}
+coalesce :: NE.NonEmpty ValueExpression -> ValueExpression
+coalesce valExprs =
+  RawSql.unsafeFromRawSql $
+    RawSql.fromString "COALESCE"
+      <> RawSql.leftParen
+      <> RawSql.intercalate RawSql.comma (fmap RawSql.toRawSql valExprs)
+      <> RawSql.rightParen
+
+{- |
+Type to represent the @WHEN@ portion of a SQL @CASE@ expressions.
+E.G.
+
+> WHEN condition THEN result
+
+'WhenExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 1.1.0.0
+-}
+newtype WhenExpr = WhenExpr RawSql.RawSql
+  deriving (RawSql.SqlExpression)
+
+{- |
+Builds a 'WhenExpr' that will apply when the given 'BooleanExpr' evaluates to @TRUE@, resulting in the 'ValueExpression'
+
+@since 1.1.0.0
+-}
+whenExpr :: BooleanExpr -> ValueExpression -> WhenExpr
+whenExpr boolExpr resultExpr =
+  WhenExpr $
+    RawSql.fromString "WHEN"
+      <> RawSql.space
+      <> RawSql.toRawSql boolExpr
+      <> RawSql.space
+      <> RawSql.fromString "THEN"
+      <> RawSql.space
+      <> RawSql.toRawSql resultExpr
+
+{- |
+Builds a 'ValueExpression' corresponding to a SQL @CASE@ using the given 'WhenExpr' as the tested value with results and an optional 'ValueExpression' that corresponds to the @ELSE@ portion of the @CASE@.
+
+@since 1.1.0.0
+-}
+caseExpr ::
+  NE.NonEmpty WhenExpr ->
+  Maybe ValueExpression ->
+  ValueExpression
+caseExpr whens mbElse =
+  RawSql.unsafeFromRawSql $
+    RawSql.fromString "CASE"
+      <> RawSql.intercalate RawSql.space (fmap RawSql.toRawSql whens)
+      <> RawSql.space
+      <> case mbElse of
+        Nothing ->
+          RawSql.fromString "END"
+        Just elseVal ->
+          RawSql.fromString "ELSE"
+            <> RawSql.space
+            <> RawSql.toRawSql elseVal
+            <> RawSql.space
+            <> RawSql.fromString "END"
+
+{- | Creates a 'ValueExpression' corresponding to the SQL @NULLIF@.
+
+@since 1.1.0.0
+-}
+nullIf :: ValueExpression -> ValueExpression -> ValueExpression
+nullIf leftVal rightVal =
+  RawSql.unsafeFromRawSql $
+    RawSql.fromString "NULLIF"
+      <> RawSql.leftParen
+      <> RawSql.toRawSql leftVal
+      <> RawSql.comma
+      <> RawSql.space
+      <> RawSql.toRawSql rightVal
+      <> RawSql.rightParen
+
+{- | Creates a 'ValueExpression' corresponding to the SQL @GREATEST@.
+
+@since 1.1.0.0
+-}
+greatest :: NE.NonEmpty ValueExpression -> ValueExpression
+greatest valExprs =
+  RawSql.unsafeFromRawSql $
+    RawSql.fromString "GREATEST"
+      <> RawSql.leftParen
+      <> RawSql.intercalate RawSql.comma (fmap RawSql.toRawSql valExprs)
+      <> RawSql.rightParen
+
+{- | Creates a 'ValueExpression' corresponding to the SQL @LEAST@.
+
+@since 1.1.0.0
+-}
+least :: NE.NonEmpty ValueExpression -> ValueExpression
+least valExprs =
+  RawSql.unsafeFromRawSql $
+    RawSql.fromString "LEAST"
+      <> RawSql.leftParen
+      <> RawSql.intercalate RawSql.comma (fmap RawSql.toRawSql valExprs)
+      <> RawSql.rightParen

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema.hs
@@ -14,7 +14,7 @@ therefore responsibility) over the definition of the schema.
 -}
 module Orville.PostgreSQL.Schema
   ( -- * Defining Tables
-    module Orville.PostgreSQL.Schema.TableDefinition
+      module Orville.PostgreSQL.Schema.TableDefinition
   , module Orville.PostgreSQL.Schema.TableIdentifier
   , module Orville.PostgreSQL.Schema.PrimaryKey
   , module Orville.PostgreSQL.Schema.IndexDefinition

--- a/orville-postgresql/test/Main.hs
+++ b/orville-postgresql/test/Main.hs
@@ -16,6 +16,7 @@ import qualified Test.Connection as Connection
 import qualified Test.Cursor as Cursor
 import qualified Test.EntityOperations as EntityOperations
 import qualified Test.Execution as Execution
+import qualified Test.Expr.ConditionalExpr as ExprConditional
 import qualified Test.Expr.Count as ExprCount
 import qualified Test.Expr.Cursor as ExprCursor
 import qualified Test.Expr.GroupBy as ExprGroupBy
@@ -72,6 +73,7 @@ main = do
       , ExprTrigger.triggerTests pool
       , ExprVacuum.vacuumTests
       , ExprJoin.joinTests
+      , ExprConditional.conditionalTests
       , FieldDefinition.fieldDefinitionTests pool
       , SqlMarshaller.sqlMarshallerTests
       , MarshallError.marshallErrorTests pool

--- a/orville-postgresql/test/Test/Expr/ConditionalExpr.hs
+++ b/orville-postgresql/test/Test/Expr/ConditionalExpr.hs
@@ -1,0 +1,75 @@
+module Test.Expr.ConditionalExpr
+  ( conditionalTests
+  )
+where
+
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.List.NonEmpty as NE
+import GHC.Stack (HasCallStack, withFrozenCallStack)
+import qualified Hedgehog as HH
+
+import qualified Orville.PostgreSQL.Expr as Expr
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
+
+import qualified Test.Property as Property
+
+conditionalTests :: Property.Group
+conditionalTests =
+  Property.group
+    "Expr - Conditional"
+    [ prop_caseWithNoElse
+    , prop_caseWithElse
+    , prop_caseMultipleWhenWithElse
+    ]
+
+prop_caseWithNoElse :: Property.NamedProperty
+prop_caseWithNoElse =
+  let
+    whenTrueThen1 =
+      Expr.whenExpr (Expr.literalBooleanExpr True) (Expr.valueExpression $ SqlValue.fromInt32 1)
+    caseExpr = Expr.caseExpr (pure whenTrueThen1) Nothing
+  in
+    Property.singletonNamedProperty "caseExpr with a trivial WHEN and no ELSE generates expected sql." $
+      assertConditionalEquals
+        "CASE WHEN TRUE THEN $1 END"
+        caseExpr
+
+prop_caseWithElse :: Property.NamedProperty
+prop_caseWithElse =
+  let
+    firstEqualsSecond =
+      Expr.equals (Expr.valueExpression $ SqlValue.fromInt32 1) (Expr.valueExpression $ SqlValue.fromInt32 1)
+    whenExpr =
+      Expr.whenExpr firstEqualsSecond (Expr.valueExpression $ SqlValue.fromInt32 1)
+    caseExpr = Expr.caseExpr (pure whenExpr) (Just . Expr.valueExpression $ SqlValue.fromInt32 1)
+  in
+    Property.singletonNamedProperty "caseExpr with a simple WHEN and simple ELSE generates expected sql." $
+      assertConditionalEquals
+        "CASE WHEN ($1) = ($2) THEN $3 ELSE $4 END"
+        caseExpr
+
+prop_caseMultipleWhenWithElse :: Property.NamedProperty
+prop_caseMultipleWhenWithElse =
+  let
+    firstVal = Expr.valueExpression $ SqlValue.fromInt32 1
+    secondVal = Expr.valueExpression $ SqlValue.fromInt32 1
+    firstGreaterSecond =
+      Expr.greaterThan firstVal secondVal
+    firstLessSecond =
+      Expr.lessThan firstVal secondVal
+    whenGreaterExpr =
+      Expr.whenExpr firstGreaterSecond (Expr.valueExpression $ SqlValue.fromInt32 1)
+    whenLessExpr =
+      Expr.whenExpr firstLessSecond (Expr.valueExpression $ SqlValue.fromInt32 1)
+    caseExpr = Expr.caseExpr (whenGreaterExpr NE.:| [whenLessExpr]) (Just . Expr.valueExpression $ SqlValue.fromInt32 1)
+  in
+    Property.singletonNamedProperty "caseExpr with a simple WHEN and simple ELSE generates expected sql." $
+      assertConditionalEquals
+        "CASE WHEN ($1) > ($2) THEN $3 WHEN ($4) < ($5) THEN $6 ELSE $7 END"
+        caseExpr
+
+assertConditionalEquals :: (HH.MonadTest m, HasCallStack) => String -> Expr.ValueExpression -> m ()
+assertConditionalEquals valueExpressionStr valueExpr =
+  withFrozenCallStack $
+    RawSql.toExampleBytes valueExpr HH.=== B8.pack valueExpressionStr


### PR DESCRIPTION
Adds support for "conditional expressions" as seen at https://www.postgresql.org/docs/13/functions-conditional.html

These are not typical SQL functions, in that they must not be quoted the same way. As such these cannot use the pre-existing support for functions.

The module name of 'ConditionalExpr' is a bit odd in that there is no type of the same name. However grouping these items does seem natural as the PostgreSQL documentation groups them.