### PR TITLE
Adds support for adding and migrating table comments

### DIFF
--- a/orville-postgresql/orville-postgresql.cabal
+++ b/orville-postgresql/orville-postgresql.cabal
@@ -111,6 +111,7 @@ library
       Orville.PostgreSQL.Schema.TableIdentifier
       Orville.PostgreSQL.UnliftIO
   other-modules:
+      Orville.PostgreSQL.Expr.Comment
       Orville.PostgreSQL.Expr.ConditionalExpr
       Orville.PostgreSQL.Expr.Extension
       Orville.PostgreSQL.Expr.Function
@@ -149,6 +150,7 @@ library
       Orville.PostgreSQL.PgCatalog.PgAttributeDefault
       Orville.PostgreSQL.PgCatalog.PgClass
       Orville.PostgreSQL.PgCatalog.PgConstraint
+      Orville.PostgreSQL.PgCatalog.PgDescription
       Orville.PostgreSQL.PgCatalog.PgExtension
       Orville.PostgreSQL.PgCatalog.PgIndex
       Orville.PostgreSQL.PgCatalog.PgNamespace

--- a/orville-postgresql/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL.hs
@@ -97,6 +97,8 @@ module Orville.PostgreSQL
   , TableDefinition.mkTableDefinition
   , TableDefinition.mkTableDefinitionWithoutKey
   , TableDefinition.setTableSchema
+  , TableDefinition.setTableComment
+  , TableDefinition.tableComment
   , TableDefinition.tableConstraints
   , TableDefinition.addTableConstraints
   , TableDefinition.tableIndexes

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr.hs
@@ -37,6 +37,7 @@ added @SOME NEW ISOLATION LEVEL@ and Orville did not yet support it.
 module Orville.PostgreSQL.Expr
   ( module Orville.PostgreSQL.Expr.BinaryOperator
   , module Orville.PostgreSQL.Expr.ColumnDefinition
+  , module Orville.PostgreSQL.Expr.Comment
   , module Orville.PostgreSQL.Expr.Count
   , module Orville.PostgreSQL.Expr.Cursor
   , module Orville.PostgreSQL.Expr.DataType
@@ -79,6 +80,7 @@ where
 
 import Orville.PostgreSQL.Expr.BinaryOperator
 import Orville.PostgreSQL.Expr.ColumnDefinition
+import Orville.PostgreSQL.Expr.Comment
 import Orville.PostgreSQL.Expr.ConditionalExpr
 import Orville.PostgreSQL.Expr.Count
 import Orville.PostgreSQL.Expr.Cursor

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Comment.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Comment.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+{- |
+Copyright : Flipstone Technology Partners 2024
+License   : MIT
+Stability : Stable
+
+@since 1.1.0.0
+-}
+module Orville.PostgreSQL.Expr.Comment
+  ( Comment
+  , commentText
+  , CommentExpr
+  , commentTableExpr
+  ) where
+
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TEnc
+
+import Orville.PostgreSQL.Expr.Name (Qualified, TableName)
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+
+{- |
+Type to represent a PostgreSQL comment string literal.
+
+@since 1.1.0.0
+-}
+newtype Comment = Comment RawSql.RawSql
+  deriving (RawSql.SqlExpression)
+
+{- |
+Construct a 'Comment' from a 'T.Text' value. The value will be escaped and quoted.
+
+@since 1.1.0.0
+-}
+commentText :: T.Text -> Comment
+commentText = Comment . RawSql.stringLiteral . TEnc.encodeUtf8
+
+{- |
+Type to represent a PostgreSQL @COMMENT@ statement.
+
+@since 1.1.0.0
+-}
+newtype CommentExpr = CommentExpr RawSql.RawSql
+  deriving (RawSql.SqlExpression)
+
+{- |
+Construct a 'CommentExpr' for a @COMMENT ON TABLE@ statement.
+
+@since 1.1.0.0
+-}
+commentTableExpr :: Qualified TableName -> Maybe Comment -> CommentExpr
+commentTableExpr tableName mbComment =
+  CommentExpr $
+    RawSql.intercalate
+      RawSql.space
+      [ RawSql.fromString "COMMENT ON TABLE"
+      , RawSql.toRawSql tableName
+      , RawSql.fromString "IS"
+      , maybe RawSql.nullLiteral RawSql.toRawSql mbComment
+      ]

--- a/orville-postgresql/src/Orville/PostgreSQL/PgCatalog.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/PgCatalog.hs
@@ -18,6 +18,7 @@ import Orville.PostgreSQL.PgCatalog.PgAttribute as Export
 import Orville.PostgreSQL.PgCatalog.PgAttributeDefault as Export
 import Orville.PostgreSQL.PgCatalog.PgClass as Export
 import Orville.PostgreSQL.PgCatalog.PgConstraint as Export
+import Orville.PostgreSQL.PgCatalog.PgDescription as Export
 import Orville.PostgreSQL.PgCatalog.PgExtension as Export
 import Orville.PostgreSQL.PgCatalog.PgIndex as Export
 import Orville.PostgreSQL.PgCatalog.PgNamespace as Export

--- a/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/DatabaseDescription.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/DatabaseDescription.hs
@@ -129,20 +129,21 @@ lookupRelationOfKind kind key dbDesc =
 -}
 data RelationDescription = RelationDescription
   { relationRecord :: PgClass
-  -- ^ @ since 1.0.0.0
+  -- ^ @since 1.0.0.0
   , relationAttributes :: Map.Map AttributeName PgAttribute
-  -- ^ @ since 1.0.0.0
+  -- ^ @since 1.0.0.0
   , relationAttributeDefaults :: Map.Map AttributeNumber PgAttributeDefault
-  -- ^ @ since 1.0.0.0
+  -- ^ @since 1.0.0.0
   , relationConstraints :: [ConstraintDescription]
-  -- ^ @ since 1.0.0.0
+  -- ^ @since 1.0.0.0
   , relationIndexes :: [IndexDescription]
-  -- ^ @ since 1.0.0.0
+  -- ^ @since 1.0.0.0
   , relationTriggers :: [PgTrigger]
-  -- ^ @ since 1.1.0.0
+  -- ^ @since 1.1.0.0
   , relationSequence :: Maybe PgSequence
-  -- ^ @ since 1.0.0.0
+  -- ^ @since 1.0.0.0
   , relationComment :: Maybe T.Text
+  -- ^ @since 1.1.0.0
   }
 
 {- |
@@ -291,7 +292,7 @@ describeRelationByClass =
           <*> Plan.chain classAndAttributes findClassIndexes
           <*> Plan.using pgClass findClassTriggers
           <*> Plan.using pgClass findClassSequence
-          <*> Plan.using pgClass findClassTableDescription
+          <*> Plan.using pgClass findClassDescription
 
 findRelation :: Plan.Plan scope (PgNamespace, RelationName) (Maybe PgClass)
 findRelation =
@@ -490,8 +491,9 @@ findClassSequence =
   Plan.focusParam pgClassOid $
     Plan.findMaybeOne pgSequenceTable sequencePgClassOidField
 
-findClassTableDescription :: Plan.Plan scope PgClass (Maybe T.Text)
-findClassTableDescription =
+-- Find the description set by a @COMMENT@ statement in the @pg_description@ table.
+findClassDescription :: Plan.Plan scope PgClass (Maybe T.Text)
+findClassDescription =
   (fmap . fmap) pgDescriptionDescription
     . Plan.focusParam pgClassOid
     $ Plan.findMaybeOneWhere pgDescriptionTable objOidField (Orville.fieldEquals objSubIdField 0)

--- a/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/PgDescription.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/PgDescription.hs
@@ -20,17 +20,29 @@ import qualified Database.PostgreSQL.LibPQ as LibPQ
 import qualified Orville.PostgreSQL as Orville
 import Orville.PostgreSQL.PgCatalog.OidField (oidTypeField)
 
+{- |
+  The Haskell representation of data read from the @pg_catalog.pg_description@
+  table.
+
+@since 1.1.0.0
+-}
 data PgDescription = PgDescription
   { pgDescriptionObjOid :: LibPQ.Oid
+  -- ^ @since 1.1.0.0
   , pgDescriptionClassOid :: LibPQ.Oid
+  -- ^ @since 1.1.0.0
   , pgDescriptionObjSubId :: Int32
+  -- ^ @since 1.1.0.0
   , pgDescriptionDescription :: T.Text
+  -- ^ @since 1.1.0.0
   }
 
+-- | @since 1.1.0.0
 pgDescriptionTable :: Orville.TableDefinition (Orville.HasKey LibPQ.Oid) PgDescription PgDescription
 pgDescriptionTable =
   Orville.mkTableDefinition "pg_description" (Orville.primaryKey objOidField) pgDescriptionMarshaller
 
+-- | @since 1.1.0.0
 pgDescriptionMarshaller :: Orville.SqlMarshaller PgDescription PgDescription
 pgDescriptionMarshaller =
   PgDescription
@@ -39,14 +51,18 @@ pgDescriptionMarshaller =
     <*> Orville.marshallField pgDescriptionObjSubId objSubIdField
     <*> Orville.marshallField pgDescriptionDescription descriptionField
 
+-- | @since 1.1.0.0
 objOidField :: Orville.FieldDefinition Orville.NotNull LibPQ.Oid
 objOidField = oidTypeField "objoid"
 
+-- | @since 1.1.0.0
 classOidField :: Orville.FieldDefinition Orville.NotNull LibPQ.Oid
 classOidField = oidTypeField "classoid"
 
+-- | @since 1.1.0.0
 objSubIdField :: Orville.FieldDefinition Orville.NotNull Int32
 objSubIdField = Orville.integerField "objsubid"
 
+-- | @since 1.1.0.0
 descriptionField :: Orville.FieldDefinition Orville.NotNull T.Text
 descriptionField = Orville.unboundedTextField "description"

--- a/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/PgDescription.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/PgDescription.hs
@@ -1,0 +1,52 @@
+{- |
+Copyright : Flipstone Technology Partners 2023
+License   : MIT
+Stability : Stable
+
+@since 1.1.0.0
+-}
+module Orville.PostgreSQL.PgCatalog.PgDescription
+  ( PgDescription (..)
+  , pgDescriptionTable
+  , objOidField
+  , objSubIdField
+  , descriptionField
+  ) where
+
+import Data.Int (Int32)
+import qualified Data.Text as T
+import qualified Database.PostgreSQL.LibPQ as LibPQ
+
+import qualified Orville.PostgreSQL as Orville
+import Orville.PostgreSQL.PgCatalog.OidField (oidTypeField)
+
+data PgDescription = PgDescription
+  { pgDescriptionObjOid :: LibPQ.Oid
+  , pgDescriptionClassOid :: LibPQ.Oid
+  , pgDescriptionObjSubId :: Int32
+  , pgDescriptionDescription :: T.Text
+  }
+
+pgDescriptionTable :: Orville.TableDefinition (Orville.HasKey LibPQ.Oid) PgDescription PgDescription
+pgDescriptionTable =
+  Orville.mkTableDefinition "pg_description" (Orville.primaryKey objOidField) pgDescriptionMarshaller
+
+pgDescriptionMarshaller :: Orville.SqlMarshaller PgDescription PgDescription
+pgDescriptionMarshaller =
+  PgDescription
+    <$> Orville.marshallField pgDescriptionObjOid objOidField
+    <*> Orville.marshallField pgDescriptionClassOid classOidField
+    <*> Orville.marshallField pgDescriptionObjSubId objSubIdField
+    <*> Orville.marshallField pgDescriptionDescription descriptionField
+
+objOidField :: Orville.FieldDefinition Orville.NotNull LibPQ.Oid
+objOidField = oidTypeField "objoid"
+
+classOidField :: Orville.FieldDefinition Orville.NotNull LibPQ.Oid
+classOidField = oidTypeField "classoid"
+
+objSubIdField :: Orville.FieldDefinition Orville.NotNull Int32
+objSubIdField = Orville.integerField "objsubid"
+
+descriptionField :: Orville.FieldDefinition Orville.NotNull T.Text
+descriptionField = Orville.unboundedTextField "description"

--- a/orville-postgresql/src/Orville/PostgreSQL/Raw/RawSql.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Raw/RawSql.hs
@@ -32,6 +32,7 @@ module Orville.PostgreSQL.Raw.RawSql
   , stringLiteral
   , identifier
   , parenthesized
+  , nullLiteral
 
     -- * Integer values as literals
   , intDecLiteral
@@ -518,6 +519,14 @@ int64DecLiteral =
 intDecLiteral :: Int -> RawSql
 intDecLiteral =
   SqlSection . BSB.intDec
+
+{- |
+  Constructs a 'RawSql' representing the SQL @NULL@ literal.
+
+@since 1.1.0.0
+-}
+nullLiteral :: RawSql
+nullLiteral = fromString "NULL"
 
 {- |
   Constructs a 'RawSql' by putting parentheses around an arbitrary expression.

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/TableDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/TableDefinition.hs
@@ -18,7 +18,9 @@ module Orville.PostgreSQL.Schema.TableDefinition
   , columnsToDrop
   , tableIdentifier
   , tableName
+  , tableComment
   , setTableSchema
+  , setTableComment
   , tableConstraints
   , addTableConstraints
   , tableIndexes
@@ -41,6 +43,7 @@ where
 import Data.List.NonEmpty (NonEmpty, toList)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
+import qualified Data.Text as T
 
 import Orville.PostgreSQL.Execution.ReturningOption (ReturningOption (WithReturning, WithoutReturning))
 import qualified Orville.PostgreSQL.Expr as Expr
@@ -77,6 +80,7 @@ data TableDefinition key writeEntity readEntity = TableDefinition
   , i_tableConstraintsFromTable :: TableConstraints
   , i_tableIndexes :: Map.Map IndexMigrationKey IndexDefinition
   , i_tableTriggers :: Map.Map TriggerMigrationKey TriggerDefinition
+  , i_tableComment :: Maybe T.Text
   }
 
 {- |
@@ -133,6 +137,7 @@ mkTableDefinition name primaryKey marshaller =
     , i_tableConstraintsFromTable = emptyTableConstraints
     , i_tableIndexes = Map.empty
     , i_tableTriggers = Map.empty
+    , i_tableComment = Nothing
     }
 
 {- |
@@ -159,6 +164,7 @@ mkTableDefinitionWithoutKey name marshaller =
     , i_tableConstraintsFromTable = emptyTableConstraints
     , i_tableIndexes = Map.empty
     , i_tableTriggers = Map.empty
+    , i_tableComment = Nothing
     }
 
 {- |
@@ -215,6 +221,15 @@ tableName =
   tableIdQualifiedName . i_tableIdentifier
 
 {- |
+  Returns 'Just' the comment of the table, or 'Nothing' if it has not been set.
+
+@since 1.1.0.0
+-}
+tableComment :: TableDefinition key writeEntity readEntity -> Maybe T.Text
+tableComment =
+  i_tableComment
+
+{- |
   Sets the table's schema to the name in the given 'String', which will be
   treated as a SQL identifier. If a table has a schema name set, it will be
   included as a qualifier on the table name for all queries involving the
@@ -229,6 +244,20 @@ setTableSchema ::
 setTableSchema schemaName tableDef =
   tableDef
     { i_tableIdentifier = setTableIdSchema schemaName (i_tableIdentifier tableDef)
+    }
+
+{- |
+  Sets the table's comment.
+
+@since 1.1.0.0
+-}
+setTableComment ::
+  T.Text ->
+  TableDefinition key writeEntity readEntity ->
+  TableDefinition key writeEntity readEntity
+setTableComment comment tableDef =
+  tableDef
+    { i_tableComment = Just comment
     }
 
 {- |


### PR DESCRIPTION
Added:
- Expr-level support for comments
- Functions for getting and setting comments on a `TableDefinition`
- `AutoMigration` support for adding, removing, and modifying table comments