### PR TITLE
Added support for Insert ON CONFLICT DO UPDATE

### DIFF
--- a/orville-postgresql/orville-postgresql.cabal
+++ b/orville-postgresql/orville-postgresql.cabal
@@ -63,6 +63,7 @@ library
       Orville.PostgreSQL.Expr.Math
       Orville.PostgreSQL.Expr.Name
       Orville.PostgreSQL.Expr.OffsetExpr
+      Orville.PostgreSQL.Expr.OnConflict
       Orville.PostgreSQL.Expr.OrderBy
       Orville.PostgreSQL.Expr.Query
       Orville.PostgreSQL.Expr.ReturningExpr

--- a/orville-postgresql/package.yaml
+++ b/orville-postgresql/package.yaml
@@ -59,6 +59,7 @@ library:
     - Orville.PostgreSQL.Expr.Math
     - Orville.PostgreSQL.Expr.Name
     - Orville.PostgreSQL.Expr.OffsetExpr
+    - Orville.PostgreSQL.Expr.OnConflict
     - Orville.PostgreSQL.Expr.OrderBy
     - Orville.PostgreSQL.Expr.Query
     - Orville.PostgreSQL.Expr.ReturningExpr

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr.hs
@@ -48,6 +48,7 @@ module Orville.PostgreSQL.Expr
   , module Orville.PostgreSQL.Expr.IfNotExists
   , module Orville.PostgreSQL.Expr.Index
   , module Orville.PostgreSQL.Expr.Insert
+  , module Orville.PostgreSQL.Expr.OnConflict
   , module Orville.PostgreSQL.Expr.Join
   , module Orville.PostgreSQL.Expr.LimitExpr
   , module Orville.PostgreSQL.Expr.Math
@@ -100,6 +101,7 @@ import Orville.PostgreSQL.Expr.LimitExpr
 import Orville.PostgreSQL.Expr.Math
 import Orville.PostgreSQL.Expr.Name
 import Orville.PostgreSQL.Expr.OffsetExpr
+import Orville.PostgreSQL.Expr.OnConflict
 import Orville.PostgreSQL.Expr.OrReplace
 import Orville.PostgreSQL.Expr.OrderBy
 import Orville.PostgreSQL.Expr.Query

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Insert.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Insert.hs
@@ -16,24 +16,14 @@ module Orville.PostgreSQL.Expr.Insert
   , insertSqlValues
   , RowValues
   , rowValues
-  , OnConflictExpr
-  , onConflictDoNothing
-  , onConflictDoUpdate
-  , excludedColumnName
-  , setExcludedColumn
-  , setExcludedClauseList
-  , conflictTargetColumnName
-  , conflictTargetConstraintName
   )
 where
 
-import Data.List.NonEmpty (NonEmpty)
 import Data.Maybe (catMaybes)
 
-import Orville.PostgreSQL.Expr.Internal.Name.ConstraintName (ConstraintName)
 import Orville.PostgreSQL.Expr.Name (ColumnName, Qualified, TableName)
+import Orville.PostgreSQL.Expr.OnConflict (OnConflictExpr)
 import Orville.PostgreSQL.Expr.ReturningExpr (ReturningExpr)
-import Orville.PostgreSQL.Expr.WhereClause (WhereClause)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import Orville.PostgreSQL.Raw.SqlValue (SqlValue)
 
@@ -181,141 +171,3 @@ rowValues values =
       , RawSql.intercalate RawSql.comma (fmap RawSql.parameter values)
       , RawSql.rightParen
       ]
-
-{- |
-Type to represent the SQL for the 'ON CONFLICT' clause.
-
-'OnConflict' provides a 'RawSql.SqlExpression' instance. See 'RawSql.unsafeSqlExpression' for how to
-construct a value with your own custom SQL.
-
-@since 1.1.0.0
--}
-newtype OnConflictExpr
-  = OnConflictExpr RawSql.RawSql
-  deriving
-    ( -- | @since 1.1.0.0
-      RawSql.SqlExpression
-    )
-
-{- | Create an 'OnConflict' that specifies no action is to be taken during a conflicting insert.
-
-@since 1.1.0.0
--}
-onConflictDoNothing :: OnConflictExpr
-onConflictDoNothing =
-  OnConflictExpr $ RawSql.fromString "ON CONFLICT DO NOTHING"
-
-{- | Create `conflict target` that Specifies which conflicts ON CONFLICT takes
-   the alternative action on by choosing arbiter indexes or names a constraint explicitly.
-
-   Developer needs to take care whether provided column name is index or not.
--}
-data ConflictTarget
-  = CTColName (Qualified ColumnName)
-  | CTConstraintName ConstraintName
-
-{-
-Constructs a 'ConflictTarget' using qualified column name. This ConflictTarget can be used for
-On CONFLICT DO Update
--}
-conflictTargetColumnName :: Qualified ColumnName -> ConflictTarget
-conflictTargetColumnName = CTColName
-
-{-
-Constructs a 'ConflictTarget' using ConstraintName. This ConflictTarget can be used for
-On CONFLICT DO Update
--}
-conflictTargetConstraintName :: ConstraintName -> ConflictTarget
-conflictTargetConstraintName = CTConstraintName
-
-{- |
-Type to represent the list of updates to be made in an `ON CONFLICT _ DO UPDATE` statement. E.G.
-
-> foo = EXCLUDED.foo,
-> bar = EXCLUDED.bar
-
-'SetExcludedClauseList' provides a 'RawSql.SqlExpression' instance. See
-'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
-SQL.
--}
-newtype SetExcludedClauseList
-  = SetExcludedClauseList RawSql.RawSql
-  deriving (RawSql.SqlExpression)
-
-setExcludedClauseList :: NonEmpty SetExcludedClause -> SetExcludedClauseList
-setExcludedClauseList =
-  SetExcludedClauseList . RawSql.intercalate RawSql.comma
-
-{- |
-Type to represent a single update to be made in an `ON CONFLICT _ DO UPDATE` statement. E.G.
-
-> foo = EXCLUDED.foo
-
-'SetExcludedClause' provides a 'RawSql.SqlExpression' instance. See
-'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
-SQL.
--}
-newtype SetExcludedClause
-  = SetExcludedClause RawSql.RawSql
-  deriving (RawSql.SqlExpression)
-
-{- |
-  Constructs a 'SetExcludedClause' that will set the specified column to the specified
-  EXCLUDED columns.
--}
-setExcludedColumn ::
-  Qualified ColumnName ->
-  Excluded ColumnName ->
-  SetExcludedClause
-setExcludedColumn columnName excludedColumnName0 =
-  SetExcludedClause $
-    RawSql.toRawSql columnName
-      <> RawSql.fromString "="
-      <> RawSql.toRawSql excludedColumnName0
-
-{- |
-Type to represent an excluded SQL name. E.G.
-
-> "EXCLUDED"."some_column_name"
-
-'Excluded' provides a 'RawSql.SqlExpression' instance. See
-'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
-SQL.
--}
-newtype Excluded columnName = Excluded RawSql.RawSql
-  deriving (RawSql.SqlExpression)
-
-{- |
-Optionally excludes a 'ColumnName' with 'EXCLUDED'.
--}
-excludedColumnName :: Qualified ColumnName -> Excluded ColumnName
-excludedColumnName colName =
-  Excluded $ RawSql.fromString "EXCLUDED" <> RawSql.dot <> RawSql.toRawSql colName
-
-{- |
-   Constructs an 'ON CONFLICT' with the given options.
--}
-onConflictDoUpdate ::
-  ConflictTarget ->
-  SetExcludedClauseList ->
-  Maybe WhereClause ->
-  OnConflictExpr
-onConflictDoUpdate conflictTarget excludedClauseList maybeWhereClause =
-  OnConflictExpr $
-    RawSql.intercalate
-      RawSql.space
-      ( catMaybes
-          [ Just (RawSql.fromString "ON CONFLICT")
-          , Just conflictTargetToRawSql
-          , Just (RawSql.fromString "DO UPDATE SET")
-          , Just (RawSql.toRawSql excludedClauseList)
-          , RawSql.toRawSql <$> maybeWhereClause
-          ]
-      )
- where
-  conflictTargetToRawSql =
-    case conflictTarget of
-      CTColName colName ->
-        RawSql.leftParen <> RawSql.toRawSql colName <> RawSql.rightParen
-      CTConstraintName constraintName_ ->
-        RawSql.fromString "ON CONSTRAINT " <> RawSql.toRawSql constraintName_

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Insert.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Insert.hs
@@ -18,13 +18,22 @@ module Orville.PostgreSQL.Expr.Insert
   , rowValues
   , OnConflictExpr
   , onConflictDoNothing
+  , onConflictDoUpdate
+  , excludedColumnName
+  , setExcludedColumn
+  , setExcludedClauseList
+  , conflictTargetColumnName
+  , conflictTargetConstraintName
   )
 where
 
+import Data.List.NonEmpty (NonEmpty)
 import Data.Maybe (catMaybes)
 
+import Orville.PostgreSQL.Expr.Internal.Name.ConstraintName (ConstraintName)
 import Orville.PostgreSQL.Expr.Name (ColumnName, Qualified, TableName)
 import Orville.PostgreSQL.Expr.ReturningExpr (ReturningExpr)
+import Orville.PostgreSQL.Expr.WhereClause (WhereClause)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import Orville.PostgreSQL.Raw.SqlValue (SqlValue)
 
@@ -195,3 +204,118 @@ newtype OnConflictExpr
 onConflictDoNothing :: OnConflictExpr
 onConflictDoNothing =
   OnConflictExpr $ RawSql.fromString "ON CONFLICT DO NOTHING"
+
+{- | Create `conflict target` that Specifies which conflicts ON CONFLICT takes
+   the alternative action on by choosing arbiter indexes or names a constraint explicitly.
+
+   Developer needs to take care whether provided column name is index or not.
+-}
+data ConflictTarget
+  = CTColName (Qualified ColumnName)
+  | CTConstraintName ConstraintName
+
+{-
+Constructs a 'ConflictTarget' using qualified column name. This ConflictTarget can be used for
+On CONFLICT DO Update
+-}
+conflictTargetColumnName :: Qualified ColumnName -> ConflictTarget
+conflictTargetColumnName = CTColName
+
+{-
+Constructs a 'ConflictTarget' using ConstraintName. This ConflictTarget can be used for
+On CONFLICT DO Update
+-}
+conflictTargetConstraintName :: ConstraintName -> ConflictTarget
+conflictTargetConstraintName = CTConstraintName
+
+{- |
+Type to represent the list of updates to be made in an `ON CONFLICT _ DO UPDATE` statement. E.G.
+
+> foo = EXCLUDED.foo,
+> bar = EXCLUDED.bar
+
+'SetExcludedClauseList' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+-}
+newtype SetExcludedClauseList
+  = SetExcludedClauseList RawSql.RawSql
+  deriving (RawSql.SqlExpression)
+
+setExcludedClauseList :: NonEmpty SetExcludedClause -> SetExcludedClauseList
+setExcludedClauseList =
+  SetExcludedClauseList . RawSql.intercalate RawSql.comma
+
+{- |
+Type to represent a single update to be made in an `ON CONFLICT _ DO UPDATE` statement. E.G.
+
+> foo = EXCLUDED.foo
+
+'SetExcludedClause' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+-}
+newtype SetExcludedClause
+  = SetExcludedClause RawSql.RawSql
+  deriving (RawSql.SqlExpression)
+
+{- |
+  Constructs a 'SetExcludedClause' that will set the specified column to the specified
+  EXCLUDED columns.
+-}
+setExcludedColumn ::
+  Qualified ColumnName ->
+  Excluded ColumnName ->
+  SetExcludedClause
+setExcludedColumn columnName excludedColumnName0 =
+  SetExcludedClause $
+    RawSql.toRawSql columnName
+      <> RawSql.fromString "="
+      <> RawSql.toRawSql excludedColumnName0
+
+{- |
+Type to represent an excluded SQL name. E.G.
+
+> "EXCLUDED"."some_column_name"
+
+'Excluded' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+-}
+newtype Excluded columnName = Excluded RawSql.RawSql
+  deriving (RawSql.SqlExpression)
+
+{- |
+Optionally excludes a 'ColumnName' with 'EXCLUDED'.
+-}
+excludedColumnName :: Qualified ColumnName -> Excluded ColumnName
+excludedColumnName colName =
+  Excluded $ RawSql.fromString "EXCLUDED" <> RawSql.dot <> RawSql.toRawSql colName
+
+{- |
+   Constructs an 'ON CONFLICT' with the given options.
+-}
+onConflictDoUpdate ::
+  ConflictTarget ->
+  SetExcludedClauseList ->
+  Maybe WhereClause ->
+  OnConflictExpr
+onConflictDoUpdate conflictTarget excludedClauseList maybeWhereClause =
+  OnConflictExpr $
+    RawSql.intercalate
+      RawSql.space
+      ( catMaybes
+          [ Just (RawSql.fromString "ON CONFLICT")
+          , Just conflictTargetToRawSql
+          , Just (RawSql.fromString "DO UPDATE SET")
+          , Just (RawSql.toRawSql excludedClauseList)
+          , RawSql.toRawSql <$> maybeWhereClause
+          ]
+      )
+ where
+  conflictTargetToRawSql =
+    case conflictTarget of
+      CTColName colName ->
+        RawSql.leftParen <> RawSql.toRawSql colName <> RawSql.rightParen
+      CTConstraintName constraintName_ ->
+        RawSql.fromString "ON CONSTRAINT " <> RawSql.toRawSql constraintName_

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/OnConflict.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/OnConflict.hs
@@ -1,0 +1,193 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+{- |
+Copyright : Flipstone Technology Partners 2024
+License   : MIT
+Stability : Stable
+
+@since 1.1.0.0
+-}
+module Orville.PostgreSQL.Expr.OnConflict
+  ( OnConflictExpr
+  , onConflict
+  , onConflictDoNothing
+  , onConflictDoUpdate
+  , ConflictTargetExpr
+  , conflictTargetForIndexColumn
+  , conflictTargetForIndexExpr
+  , conflictTargetForConstraint
+  , ConflictActionExpr
+  , ConflictSetItemExpr
+  , setColumnNameExcluded
+  )
+where
+
+import Data.List.NonEmpty (NonEmpty)
+
+import Orville.PostgreSQL.Expr.Index (IndexBodyExpr)
+import Orville.PostgreSQL.Expr.Internal.Name.ConstraintName (ConstraintName)
+import Orville.PostgreSQL.Expr.Name (ColumnName, Qualified)
+import Orville.PostgreSQL.Expr.WhereClause (WhereClause)
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+
+{- |
+Type to represent the SQL for the 'ON CONFLICT' clause.
+
+'OnConflict' provides a 'RawSql.SqlExpression' instance. See 'RawSql.unsafeSqlExpression' for how to
+construct a value with your own custom SQL.
+
+@since 1.1.0.0
+-}
+newtype OnConflictExpr
+  = OnConflictExpr RawSql.RawSql
+  deriving
+    ( -- | @since 1.1.0.0
+      RawSql.SqlExpression
+    )
+
+{- | Create an 'OnConflict' that performs the specified action to be taken during a conflicting insert.
+
+@since 1.1.0.0
+-}
+onConflict :: Maybe ConflictTargetExpr -> ConflictActionExpr -> OnConflictExpr
+onConflict mbTarget action =
+  OnConflictExpr $
+    RawSql.fromString "ON CONFLICT "
+      <> case mbTarget of
+        Nothing ->
+          RawSql.toRawSql action
+        Just target ->
+          RawSql.toRawSql target <> RawSql.space <> RawSql.toRawSql action
+
+{- | A wrapper around 'onConflict' for no specific target and an explicit no action to perform.
+
+@since 1.1.0.0
+-}
+onConflictDoNothing :: OnConflictExpr
+onConflictDoNothing =
+  onConflict Nothing doNothingActionExpr
+
+{- | A wrapper around 'onConflict' to perform an update, with optional target and where clause. That
+   will use the given 'ConflictSetItemExpr's as the update body.
+
+@since 1.1.0.0
+-}
+onConflictDoUpdate :: Maybe ConflictTargetExpr -> NonEmpty ConflictSetItemExpr -> Maybe WhereClause -> OnConflictExpr
+onConflictDoUpdate mbTarget setItems =
+  onConflict mbTarget . doUpdateSetActionExpr setItems
+
+{- | Type to represent the target portion of the SQL 'ON CONFLICT target action'
+
+@since 1.1.0.0
+-}
+newtype ConflictTargetExpr
+  = ConflictTargetExpr RawSql.RawSql
+  deriving
+    ( -- | @since 1.1.0.0
+      RawSql.SqlExpression
+    )
+
+{- | Build a 'ConflictTargetExpr' that would conflict on a single 'ColumnName'. PostgreSQL will use
+   the column to infer which index to check for conflicts.
+
+@since 1.1.0.0
+-}
+conflictTargetForIndexColumn :: Qualified ColumnName -> Maybe WhereClause -> ConflictTargetExpr
+conflictTargetForIndexColumn colName mbWhere =
+  let
+    parensCol = RawSql.parenthesized $ RawSql.toRawSql colName
+  in
+    ConflictTargetExpr $
+      case mbWhere of
+        Nothing -> parensCol
+        Just whereClause -> parensCol <> RawSql.space <> RawSql.toRawSql whereClause
+
+{- | Build a 'ConflictTargetExpr' that would conflict on an 'IndexBodyExpr'. This can be used to check
+   for more than a single column. PostgreSQL will use the expression to infer which index to check for
+   conflicts.
+
+@since 1.1.0.0
+-}
+conflictTargetForIndexExpr :: IndexBodyExpr -> Maybe WhereClause -> ConflictTargetExpr
+conflictTargetForIndexExpr idxBody mbWhere =
+  let
+    parensBody = RawSql.parenthesized $ RawSql.toRawSql idxBody
+  in
+    ConflictTargetExpr $
+      case mbWhere of
+        Nothing -> parensBody
+        Just whereClause -> parensBody <> RawSql.space <> RawSql.toRawSql whereClause
+
+{- | Build a 'ConflictTargetExpr' for conflicting on the given 'ConstraintName'. For conflicing on an
+   index, see 'conflictTargetForIndexColumn' or 'conflictTargetForIndexExpr' instead.
+
+@since 1.1.0.0
+-}
+conflictTargetForConstraint :: ConstraintName -> ConflictTargetExpr
+conflictTargetForConstraint constraintName =
+  ConflictTargetExpr $ RawSql.fromString "ON CONSTRAINT " <> RawSql.toRawSql constraintName
+
+{- | Type to represent the action portion of the SQL 'ON CONFLICT target action'
+
+@since 1.1.0.0
+-}
+newtype ConflictActionExpr
+  = ConflictActionExpr RawSql.RawSql
+  deriving
+    ( -- | @since 1.1.0.0
+      RawSql.SqlExpression
+    )
+
+{- | A 'ConflictActionExpr' for the SQL 'DO NOTHING'.
+
+@since 1.1.0.0
+-}
+doNothingActionExpr :: ConflictActionExpr
+doNothingActionExpr =
+  ConflictActionExpr $ RawSql.fromString "DO NOTHING"
+
+{- | A 'ConflictActionExpr' for the SQL 'DO UPDATE SET', that will use the given 'ConflictSetItemExpr'
+   to determine which columns to update and the optional 'WhereClause' to peform filtering.
+
+@since 1.1.0.0
+-}
+doUpdateSetActionExpr :: NonEmpty ConflictSetItemExpr -> Maybe WhereClause -> ConflictActionExpr
+doUpdateSetActionExpr setItems mbWhere =
+  let
+    commaSeparatedItems = RawSql.intercalate RawSql.comma setItems
+  in
+    ConflictActionExpr $
+      RawSql.fromString "DO UPDATE SET "
+        <> case mbWhere of
+          Nothing -> commaSeparatedItems
+          Just whereClause -> commaSeparatedItems <> RawSql.space <> RawSql.toRawSql whereClause
+
+{- | Type to represent the item to be set in an 'ON CONFLICT DO UPDATE'. E.G.
+
+> ON CONFLICT DO UPDATE SET item
+
+@since 1.1.0.0
+-}
+newtype ConflictSetItemExpr
+  = ConflictSetItemExpr RawSql.RawSql
+  deriving
+    ( -- | @since 1.1.0.0
+      RawSql.SqlExpression
+    )
+
+{- | Builds a 'ConflictSetItemExpr' that will set the given 'ColumnName' to the excluded value using
+the special pseudo-table 'EXCLUDED'.
+
+@since 1.1.0.0
+-}
+setColumnNameExcluded :: Qualified ColumnName -> ConflictSetItemExpr
+setColumnNameExcluded colName =
+  let
+    rawName = RawSql.toRawSql colName
+  in
+    ConflictSetItemExpr $
+      rawName
+        <> RawSql.fromString " = "
+        <> RawSql.fromString "EXCLUDED"
+        <> RawSql.dot
+        <> rawName

--- a/orville-postgresql/test/Test/Expr/InsertUpdateDelete.hs
+++ b/orville-postgresql/test/Test/Expr/InsertUpdateDelete.hs
@@ -31,6 +31,7 @@ insertUpdateDeleteTests pool =
     , prop_deleteExprWithWhere pool
     , prop_deleteExprWithReturning pool
     , prop_truncateTablesExpr pool
+    , prop_insertExprWithOnConflictDoUpdate pool
     ]
 
 prop_insertExpr :: Property.NamedDBProperty
@@ -77,6 +78,39 @@ prop_insertExprWithOnConflictDoNothing =
           Execution.readRows result
 
     assertEqualFooBarRows rows fooBars
+
+prop_insertExprWithOnConflictDoUpdate :: Property.NamedDBProperty
+prop_insertExprWithOnConflictDoUpdate =
+  Property.singletonNamedDBProperty "insertExpr with on conflict do update updates conflicting row" $ \pool -> do
+    let
+      fooBars0 = [mkFooBar 1 "dog"]
+      fooBars1 = [mkFooBar 1 "eagel"]
+      addIndex = RawSql.fromString "CREATE UNIQUE INDEX ON " <> RawSql.toRawSql fooBarTable <> RawSql.fromString "( foo )"
+      fooColumnName = Expr.aliasQualifyColumn Nothing (Expr.columnName "foo")
+      barColumnName = Expr.aliasQualifyColumn Nothing (Expr.columnName "bar")
+      conflictTarget0 = Expr.conflictTargetColumnName fooColumnName
+      excludedColumn0 = Expr.excludedColumnName barColumnName
+      setExcludedColumn0 = Expr.setExcludedColumn barColumnName excludedColumn0
+      setExcludedClauseList0 = Expr.setExcludedClauseList (setExcludedColumn0 :| [])
+      onConflictDoUpdate0 = Expr.onConflictDoUpdate conflictTarget0 setExcludedClauseList0 Nothing
+
+    rows <-
+      MIO.liftIO $
+        Conn.withPoolConnection pool $ \connection -> do
+          dropAndRecreateTestTable connection
+          RawSql.executeVoid connection addIndex
+
+          RawSql.executeVoid connection $
+            Expr.insertExpr fooBarTable Nothing (insertFooBarSource fooBars0) (Just onConflictDoUpdate0) Nothing
+
+          RawSql.executeVoid connection $
+            Expr.insertExpr fooBarTable Nothing (insertFooBarSource fooBars1) (Just onConflictDoUpdate0) Nothing
+
+          result <- RawSql.execute connection findAllFooBars
+
+          Execution.readRows result
+
+    assertEqualFooBarRows rows fooBars1
 
 prop_insertExprWithReturning :: Property.NamedDBProperty
 prop_insertExprWithReturning =


### PR DESCRIPTION
### Added Support for `ON CONFLICT DO UPDATE` in Orville.

#### Summary
This pull request introduces support for the `ON CONFLICT DO UPDATE` clause to the Orville library. Previously, only the `onConflictDoNothing` function was available, which handled the `ON CONFLICT DO NOTHING` clause.

#### Changes
1. **New Features**
   - Added support for `ON CONFLICT (index_column_name) DO UPDATE`.
   - Added support for `ON CONFLICT ON CONSTRAINT constraint_name DO UPDATE`.

2. **Testing**
   - Added property test cases to ensure the new functionality works as expected.

#### Notes
- Please review the changes and let me know if any adjustments are needed.
- Looking forward to your feedback.

Thank you for your time and consideration!

---

Feel free to modify it according to your needs!

@jlavelle @telser 