### PR TITLE
Implements 'SqlComparable' instance for 'SqlMarshaller'

### DIFF
--- a/orville-postgresql/orville-postgresql.cabal
+++ b/orville-postgresql/orville-postgresql.cabal
@@ -225,6 +225,7 @@ test-suite spec
       Test.Expr.Window
       Test.FieldDefinition
       Test.MarshallError
+      Test.Orphans
       Test.PgAssert
       Test.PgCatalog
       Test.PgGen

--- a/orville-postgresql/test/Test/Orphans.hs
+++ b/orville-postgresql/test/Test/Orphans.hs
@@ -1,0 +1,17 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Orphans () where
+
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.List as List
+import qualified Data.List.NonEmpty as NE
+
+import qualified Orville.PostgreSQL.Raw.PgTextFormatValue as PgTextFormatValue
+import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
+
+instance Show SqlValue.SqlValue where
+  show =
+    SqlValue.foldSqlValue
+      (B8.unpack . PgTextFormatValue.toByteString)
+      (\vals -> "(" <> List.intercalate ", " (NE.toList vals) <> ")")
+      "NULL"


### PR DESCRIPTION
I added the instance and a number of helper functions for using it, including `Plan`s like `findAllWhereByMarshaller`.

PostgreSQL does not support the input of anonymous row values, and the instance methods need to produce row `SqlValue`s and `ValueExpression`s. This meant that I had to add support for row values at the `SqlValue` level. The `SqlRowValue` constructor will produce a row of placeholders:

```sql
($1, $2, $3)
```

See the changes to `Test/RawSql.hs` for more examples.