### PR TITLE
Build with postgresql-libpq-0.11.0

### DIFF
--- a/orville-postgresql/orville-postgresql.cabal
+++ b/orville-postgresql/orville-postgresql.cabal
@@ -177,7 +177,7 @@ library
     , containers >=0.6 && <0.8
     , dlist >=0.8 && <1.1
     , network-uri ==2.6.*
-    , postgresql-libpq >=0.9.4.2 && <0.11
+    , postgresql-libpq >=0.9.4.2 && <0.12
     , random >=1.0 && <2
     , resource-pool <0.3 || >=0.4 && <0.5
     , safe-exceptions >=0.1.7 && <0.2
@@ -255,7 +255,7 @@ test-suite spec
     , containers >=0.6 && <0.8
     , hedgehog >=1.0.5 && <1.5
     , orville-postgresql
-    , postgresql-libpq >=0.9.4.2 && <0.11
+    , postgresql-libpq >=0.9.4.2 && <0.12
     , resource-pool <0.3 || >=0.4 && <0.5
     , safe-exceptions >=0.1.7 && <0.2
     , text >=1.2 && <1.3 || >=2.0 && <2.2

--- a/orville-postgresql/package.yaml
+++ b/orville-postgresql/package.yaml
@@ -138,7 +138,7 @@ library:
     - attoparsec >=0.10 && <0.15
     - bytestring >=0.10 && <0.13
     - dlist >= 0.8 && < 1.1
-    - postgresql-libpq >= 0.9.4.2 && <0.11
+    - postgresql-libpq >= 0.9.4.2 && <0.12
     - containers >= 0.6 && < 0.8
     - network-uri >= 2.6 && < 2.7
     - random >= 1.0 && <2
@@ -160,7 +160,7 @@ tests:
       - bytestring >=0.10 && <0.13
       - containers >= 0.6 && < 0.8
       - hedgehog >= 1.0.5 && <1.5
-      - postgresql-libpq >= 0.9.4.2 && <0.11
+      - postgresql-libpq >= 0.9.4.2 && <0.12
       - orville-postgresql
       - resource-pool <0.3 || (>= 0.4  && <0.5)
       - safe-exceptions >=0.1.7 && < 0.2

--- a/orville-postgresql/src/Orville/PostgreSQL/Raw/Connection.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Raw/Connection.hs
@@ -496,6 +496,10 @@ isRowReadableStatus status =
     LibPQ.BadResponse -> False
     LibPQ.NonfatalError -> False -- NonfatalError never returned from LibPQ query execution functions. It passes them to the notice processor instead.
     LibPQ.FatalError -> False
+#if MIN_VERSION_postgresql_libpq(0,11,0)
+    LibPQ.PipelineSync -> False
+    LibPQ.PipelineAbort -> False
+#endif
 
 {- |
   Packages a bytestring parameter value (which is assumed to be a value encoded


### PR DESCRIPTION
The relevant change in 0.11.0 is supports PostgreSQL pipelining feature. This skips support for that feature. For now this doesn't attempt to support the pipelining.

Fixes #370 