### PR TITLE
Added helper functions for tableExpr

### DIFF
--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Select.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Select.hs
@@ -13,6 +13,8 @@ module Orville.PostgreSQL.Expr.Select
   , SelectExpr
   , selectExpr
   , Distinct (Distinct)
+  , selectClauseDefault
+  , selectClauseDistinct
   )
 where
 
@@ -37,8 +39,8 @@ newtype SelectClause
   deriving (RawSql.SqlExpression)
 
 {- |
-  Constructs a 'SelectClause' using the given 'SelectExpr', which may indicate
-  that this is a @DISTINCT@ select.
+ Constructs a 'SelectClause' using the given 'SelectExpr', which may indicate
+ that this is a @DISTINCT@ select.
 
 @since 1.0.0.0
 -}
@@ -59,16 +61,16 @@ newtype SelectExpr = SelectExpr RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
 {- |
-  A simple value type used to indicate that a @SELECT@ should be distinct when
-  constructing a 'SelectExpr'.
+ A simple value type used to indicate that a @SELECT@ should be distinct when
+ constructing a 'SelectExpr'.
 
 @since 1.0.0.0
 -}
 data Distinct = Distinct
 
 {- |
-  Constructs a 'SelectExpr' that may or may not make the @SELECT@ distinct,
-  depending on whether 'Just Distinct' is passed or not.
+ Constructs a 'SelectExpr' that may or may not make the @SELECT@ distinct,
+ depending on whether 'Just Distinct' is passed or not.
 
 @since 1.0.0.0
 -}
@@ -78,3 +80,19 @@ selectExpr mbDistinct =
     case mbDistinct of
       Just Distinct -> "DISTINCT "
       Nothing -> ""
+
+{-
+    Helper function for constructing SelectClause
+
+@since 1.1.0.0
+-}
+selectClauseDefault :: SelectClause
+selectClauseDefault = selectClause (selectExpr Nothing)
+
+{-
+    Helper function for constructing SelectClause with Distinct
+
+@since 1.1.0.0
+-}
+selectClauseDistinct :: SelectClause
+selectClauseDistinct = selectClause (selectExpr $ Just Distinct)


### PR DESCRIPTION
### Added Helper Functions for `tableExpr` and `selectClause`

#### Summary

This pull request introduces helper functions to streamline the usage of `tableExpr` and `selectClause`.

#### Added Functions:

- **`mkTableExpr`**  
  This function takes a `FromItemExpr` and a new `Clauses` type, which can be constructed using `defaultClauses`. You can modify only the required clauses, leaving others as `Nothing`.

  Example:
  ```haskell
  fromTable :: Maybe WhereClause -> TableExpr
  fromTable wClause = mkTableExpr myFromItemExpr (defaultClauses { _whereClause = wClause })
  ```

- **`selectClauseDefault`** and **`selectClauseDistinct`**  
  These are helper functions for `selectClause`, simplifying the use of `SelectExpr`.

#### Testing

- No test cases have been added, as these functions primarily wrap core functionality.

#### Notes

- Please review the changes and suggest any adjustments if necessary.
- Feel free to modify as needed.
- Looking forward to your feedback!

Thank you for your time and consideration!

PS: Apologies for auto-formatting! 
--- 
@telser @jlavelle 