### PR TITLE
Updates PostgreSQL versions tested with

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        pg-version: ["pg12", "pg13", "pg14", "pg15", "pg16"]
+        pg-version: ["pg13", "pg14", "pg15", "pg16", "pg17"]
         stack-yaml: ["stack-lts-18.28-ghc-8.10.7.yml","stack-lts-19.33-ghc-9.0.2.yml","stack-lts-20.26-ghc-9.2.8.yml","stack-lts-21.22-ghc-9.4.8.yml","stack-nightly-2024-04-06-ghc-9.8.2.yml","stack.yml"]
     permissions:
       packages: write

--- a/orville-postgresql/compose.yml
+++ b/orville-postgresql/compose.yml
@@ -8,9 +8,9 @@ services:
       - stack-root:/stack-root
     working_dir: /orville-postgresql
     depends_on:
-      - testdb-${PG_VERSION:-pg12}
+      - testdb-${PG_VERSION:-pg13}
     environment:
-      TEST_CONN_HOST: "host=testdb-${PG_VERSION:-pg12}"
+      TEST_CONN_HOST: "host=testdb-${PG_VERSION:-pg13}"
       STACK_ROOT: /stack-root
     command:
       - ./scripts/test-loop
@@ -19,12 +19,6 @@ services:
     # stack test. stdin_open would be sufficient, but
     # allocating a tty provides colorful test output :)
     tty: true
-
-  testdb-pg12:
-    image: postgres:12.20-alpine
-    environment:
-      POSTGRES_USER: orville_test
-      POSTGRES_PASSWORD: orville
 
   testdb-pg13:
     image: postgres:13.16-alpine
@@ -49,6 +43,13 @@ services:
     environment:
       POSTGRES_USER: orville_test
       POSTGRES_PASSWORD: orville
+
+  testdb-pg17:
+    image: postgres:17.0-alpine
+    environment:
+      POSTGRES_USER: orville_test
+      POSTGRES_PASSWORD: orville
+
 
 volumes:
   stack-root:

--- a/orville-postgresql/scripts/psql.sh
+++ b/orville-postgresql/scripts/psql.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-docker compose exec testdb-pg12 psql -U orville_test
+docker compose exec testdb-pg13 psql -U orville_test


### PR DESCRIPTION
PostgreSQL 17 has been released so we test against that. 12 is removed from the tests, as it only has about a month of upstream support left and to keep the test matrix somewhat manageable.