### PR TITLE
Add instance Semigroup SelectList

### DIFF
--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Query.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Query.hs
@@ -215,6 +215,11 @@ SQL.
 newtype SelectList = SelectList RawSql.RawSql
   deriving (RawSql.SqlExpression)
 
+-- | @since 1.1.0.0
+instance Semigroup SelectList where
+  SelectList a <> SelectList b =
+    SelectList $ RawSql.appendWithCommaSpace a b
+
 {- |
   Constructs a 'SelectList' that will select all colums (i.e. the @*@ in
   @SELECT *@").


### PR DESCRIPTION
Especially when doing `GROUP BY`, it would be nice to add derived and non-derived columns.
