### PR TITLE
Add more precise 'Qualified' tracking.

### DIFF
--- a/orville-postgresql/src/Orville/PostgreSQL/AutoMigration.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/AutoMigration.hs
@@ -852,7 +852,7 @@ mkAlterTableSteps currentNamespace relationDesc tableDef =
 @since 1.0.0.0
 -}
 mkConstraintSteps ::
-  Expr.Qualified Expr.TableName ->
+  Expr.QualifiedOrUnqualified Expr.TableName ->
   [(StepType, Expr.AlterTableAction)] ->
   [MigrationStepWithType]
 mkConstraintSteps tableName actions =
@@ -878,7 +878,7 @@ mkConstraintSteps tableName actions =
 @since 1.0.0.0
 -}
 mkAlterColumnSteps ::
-  Expr.Qualified Expr.TableName ->
+  Expr.QualifiedOrUnqualified Expr.TableName ->
   [Expr.AlterTableAction] ->
   [MigrationStepWithType]
 mkAlterColumnSteps tableName actionExprs =
@@ -1174,7 +1174,7 @@ pgConstraintMigrationKey constraintDesc =
 -}
 mkAddIndexSteps ::
   Set.Set IndexDefinition.IndexMigrationKey ->
-  Expr.Qualified Expr.TableName ->
+  Expr.QualifiedOrUnqualified Expr.TableName ->
   Orville.IndexDefinition ->
   [MigrationStepWithType]
 mkAddIndexSteps existingIndexes tableName indexDef =
@@ -1231,7 +1231,7 @@ mkDropIndexSteps indexesToKeep systemIndexOids indexDesc =
 -}
 mkAddTriggerSteps ::
   Set.Set Schema.TriggerMigrationKey ->
-  Expr.Qualified Expr.TableName ->
+  Expr.QualifiedOrUnqualified Expr.TableName ->
   Orville.TriggerDefinition ->
   [MigrationStepWithType]
 mkAddTriggerSteps existingTriggers tableName triggerDef =
@@ -1250,7 +1250,7 @@ mkAddTriggerSteps existingTriggers tableName triggerDef =
 -}
 mkDropTriggerSteps ::
   Set.Set Schema.TriggerMigrationKey ->
-  Expr.Qualified Expr.TableName ->
+  Expr.QualifiedOrUnqualified Expr.TableName ->
   PgCatalog.PgTrigger ->
   [MigrationStepWithType]
 mkDropTriggerSteps triggersToKeep tableName pgTrigger =

--- a/orville-postgresql/src/Orville/PostgreSQL/Execution/Select.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Execution/Select.hs
@@ -114,7 +114,7 @@ selectTable tableDef =
 -}
 selectMarshalledColumns ::
   AnnotatedSqlMarshaller writeEntity readEntity ->
-  Expr.Qualified Expr.TableName ->
+  Expr.QualifiedOrUnqualified Expr.TableName ->
   SelectOptions.SelectOptions ->
   Select readEntity
 selectMarshalledColumns marshaller qualifiedTableName selectOptions =
@@ -152,7 +152,7 @@ selectTableWithAlias alias tableDef =
 selectMarshalledColumnsWithAlias ::
   AliasName ->
   AnnotatedSqlMarshaller writeEntity readEntity ->
-  Expr.Qualified Expr.TableName ->
+  Expr.QualifiedOrUnqualified Expr.TableName ->
   SelectOptions.SelectOptions ->
   Select readEntity
 selectMarshalledColumnsWithAlias alias marshaller qualifiedTableName selectOptions =

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Comment.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Comment.hs
@@ -18,7 +18,7 @@ module Orville.PostgreSQL.Expr.Comment
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TEnc
 
-import Orville.PostgreSQL.Expr.Name (ColumnName, Qualified, SchemaName, TableName, qualifyColumn)
+import Orville.PostgreSQL.Expr.Name (ColumnName, QualifiedOrUnqualified, SchemaName, TableName, qualifyColumn)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 {- |
@@ -56,7 +56,7 @@ Construct a 'CommentExpr' for a @COMMENT ON TABLE@ statement.
 
 @since 1.1.0.0
 -}
-commentTableExpr :: Qualified TableName -> Maybe Comment -> CommentExpr
+commentTableExpr :: QualifiedOrUnqualified TableName -> Maybe Comment -> CommentExpr
 commentTableExpr tableName mbComment =
   CommentExpr $
     RawSql.intercalate

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Count.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Count.hs
@@ -13,7 +13,7 @@ module Orville.PostgreSQL.Expr.Count
   )
 where
 
-import Orville.PostgreSQL.Expr.Name (ColumnName, FunctionName, Qualified, functionName)
+import Orville.PostgreSQL.Expr.Name (ColumnName, FunctionName, QualifiedOrUnqualified, functionName)
 import Orville.PostgreSQL.Expr.ValueExpression (ValueExpression, columnReference, functionCall)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
@@ -44,6 +44,6 @@ count1 =
 
 @since 1.0.0.0
 -}
-countColumn :: Qualified ColumnName -> ValueExpression
+countColumn :: QualifiedOrUnqualified ColumnName -> ValueExpression
 countColumn =
   count . columnReference

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Delete.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Delete.hs
@@ -17,7 +17,7 @@ where
 
 import Data.Maybe (catMaybes)
 
-import Orville.PostgreSQL.Expr.Name (Qualified, TableName)
+import Orville.PostgreSQL.Expr.Name (QualifiedOrUnqualified, TableName)
 import Orville.PostgreSQL.Expr.ReturningExpr (ReturningExpr)
 import Orville.PostgreSQL.Expr.WhereClause (WhereClause)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
@@ -48,7 +48,7 @@ returning a 'ReturningExpr'.
 @since 1.0.0.0
 -}
 deleteExpr ::
-  Qualified TableName ->
+  QualifiedOrUnqualified TableName ->
   Maybe WhereClause ->
   Maybe ReturningExpr ->
   DeleteExpr

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/FromItemExpr.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/FromItemExpr.hs
@@ -14,7 +14,7 @@ module Orville.PostgreSQL.Expr.FromItemExpr
   )
 where
 
-import Orville.PostgreSQL.Expr.Name (AliasExpr, Qualified, TableName)
+import Orville.PostgreSQL.Expr.Name (AliasExpr, QualifiedOrUnqualified, TableName)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 {- |
@@ -55,17 +55,17 @@ instance Monoid FromItemExpr where
 
   @since 1.1.0.0
 -}
-tableFromItem :: Qualified TableName -> FromItemExpr
-tableFromItem qualifiedTableName =
-  FromItemExpr $
-    RawSql.toRawSql qualifiedTableName
+tableFromItem :: QualifiedOrUnqualified TableName -> FromItemExpr
+tableFromItem =
+  FromItemExpr
+    . RawSql.toRawSql
 
 {- |
   Constructs a 'FromItemExpr' consisting of the specified table AS the given alias.
 
   @since 1.1.0.0
 -}
-tableFromItemWithAlias :: AliasExpr -> Qualified TableName -> FromItemExpr
+tableFromItemWithAlias :: AliasExpr -> QualifiedOrUnqualified TableName -> FromItemExpr
 tableFromItemWithAlias alias qualifiedTableName =
   FromItemExpr $
     RawSql.intercalate

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Function.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Function.hs
@@ -28,7 +28,7 @@ import qualified Data.ByteString.Char8 as BS8
 import Data.Maybe (catMaybes)
 
 import Orville.PostgreSQL.Expr.IfExists (IfExists)
-import Orville.PostgreSQL.Expr.Name (FunctionName, Qualified)
+import Orville.PostgreSQL.Expr.Name (FunctionName, QualifiedOrUnqualified)
 import Orville.PostgreSQL.Expr.OrReplace (OrReplace)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
@@ -55,7 +55,7 @@ Constructs a SQL @DROP FUNCTION@ statement from a function name.
 
 @since 1.1.0.0
 -}
-dropFunction :: Maybe IfExists -> Qualified FunctionName -> DropFunctionExpr
+dropFunction :: Maybe IfExists -> QualifiedOrUnqualified FunctionName -> DropFunctionExpr
 dropFunction maybeIfExists name =
   DropFunctionExpr $
     RawSql.intercalate
@@ -95,7 +95,7 @@ Note: Orville does not currently support creating functions with arguments.
 -}
 createFunction ::
   Maybe OrReplace ->
-  Qualified FunctionName ->
+  QualifiedOrUnqualified FunctionName ->
   FunctionReturns ->
   FunctionLanguage ->
   FunctionDefinition ->
@@ -106,7 +106,7 @@ createFunction maybeOrReplace name functionReturns functionLanguage definition =
       RawSql.space
       ( catMaybes
           [ Just $ RawSql.fromString "CREATE"
-          , RawSql.toRawSql <$> maybeOrReplace
+          , fmap RawSql.toRawSql maybeOrReplace
           , Just $ RawSql.fromString "FUNCTION"
           , Just $ RawSql.toRawSql name
           , Just $ RawSql.fromString "()" -- currently we don't support specifying arguments

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/GroupBy.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/GroupBy.hs
@@ -18,7 +18,7 @@ where
 
 import Data.List.NonEmpty (NonEmpty)
 
-import Orville.PostgreSQL.Expr.Name (ColumnName, Qualified)
+import Orville.PostgreSQL.Expr.Name (ColumnName, QualifiedOrUnqualified)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 {- |
@@ -83,6 +83,6 @@ appendGroupByExpr (GroupByExpr a) (GroupByExpr b) =
 
 @since 1.0.0.0
 -}
-groupByColumnsExpr :: NonEmpty (Qualified ColumnName) -> GroupByExpr
+groupByColumnsExpr :: NonEmpty (QualifiedOrUnqualified ColumnName) -> GroupByExpr
 groupByColumnsExpr =
   GroupByExpr . RawSql.intercalate RawSql.commaSpace

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Index.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Index.hs
@@ -23,7 +23,7 @@ where
 
 import Data.List.NonEmpty (NonEmpty)
 
-import Orville.PostgreSQL.Expr.Name (ColumnName, IndexName, Qualified, TableName)
+import Orville.PostgreSQL.Expr.Name (ColumnName, IndexName, QualifiedOrUnqualified, TableName)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 {- |
@@ -53,7 +53,7 @@ unique, a table, and corresponding collection of 'ColumnName's.
 createIndexExpr ::
   IndexUniqueness ->
   Maybe ConcurrentlyExpr ->
-  Qualified TableName ->
+  QualifiedOrUnqualified TableName ->
   NonEmpty ColumnName ->
   CreateIndexExpr
 createIndexExpr uniqueness mbConcurrently tableName columns =
@@ -77,7 +77,7 @@ the index creation.
 createNamedIndexExpr ::
   IndexUniqueness ->
   Maybe ConcurrentlyExpr ->
-  Qualified TableName ->
+  QualifiedOrUnqualified TableName ->
   IndexName ->
   IndexBodyExpr ->
   CreateIndexExpr

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Insert.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Insert.hs
@@ -21,7 +21,7 @@ where
 
 import Data.Maybe (catMaybes)
 
-import Orville.PostgreSQL.Expr.Name (ColumnName, Qualified, TableName)
+import Orville.PostgreSQL.Expr.Name (ColumnName, QualifiedOrUnqualified, TableName)
 import Orville.PostgreSQL.Expr.OnConflict (OnConflictExpr)
 import Orville.PostgreSQL.Expr.ReturningExpr (ReturningExpr)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
@@ -53,7 +53,7 @@ itself.
 @since 1.0.0.0
 -}
 insertExpr ::
-  Qualified TableName ->
+  QualifiedOrUnqualified TableName ->
   Maybe InsertColumnList ->
   InsertSource ->
   Maybe OnConflictExpr ->
@@ -94,7 +94,7 @@ parens and commas are used to separate.
 
 @since 1.0.0.0
 -}
-insertColumnList :: [Qualified ColumnName] -> InsertColumnList
+insertColumnList :: [QualifiedOrUnqualified ColumnName] -> InsertColumnList
 insertColumnList columnNames =
   InsertColumnList $
     RawSql.leftParen

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/OnConflict.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/OnConflict.hs
@@ -26,7 +26,7 @@ import Data.List.NonEmpty (NonEmpty)
 
 import Orville.PostgreSQL.Expr.Index (IndexBodyExpr)
 import Orville.PostgreSQL.Expr.Internal.Name.ConstraintName (ConstraintName)
-import Orville.PostgreSQL.Expr.Name (ColumnName, Qualified)
+import Orville.PostgreSQL.Expr.Name (ColumnName, QualifiedOrUnqualified)
 import Orville.PostgreSQL.Expr.WhereClause (WhereClause)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
@@ -92,7 +92,7 @@ newtype ConflictTargetExpr
 
 @since 1.1.0.0
 -}
-conflictTargetForIndexColumn :: Qualified ColumnName -> Maybe WhereClause -> ConflictTargetExpr
+conflictTargetForIndexColumn :: QualifiedOrUnqualified ColumnName -> Maybe WhereClause -> ConflictTargetExpr
 conflictTargetForIndexColumn colName mbWhere =
   let
     parensCol = RawSql.parenthesized $ RawSql.toRawSql colName
@@ -180,7 +180,7 @@ the special pseudo-table 'EXCLUDED'.
 
 @since 1.1.0.0
 -}
-setColumnNameExcluded :: Qualified ColumnName -> ConflictSetItemExpr
+setColumnNameExcluded :: QualifiedOrUnqualified ColumnName -> ConflictSetItemExpr
 setColumnNameExcluded colName =
   let
     rawName = RawSql.toRawSql colName

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/OrderBy.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/OrderBy.hs
@@ -28,7 +28,7 @@ where
 
 import qualified Data.List.NonEmpty as NEL
 
-import Orville.PostgreSQL.Expr.Name (AliasExpr, ColumnName, Qualified)
+import Orville.PostgreSQL.Expr.Name (AliasExpr, ColumnName, QualifiedOrUnqualified)
 import qualified Orville.PostgreSQL.Expr.ValueExpression as ValueExpression
 import qualified Orville.PostgreSQL.Internal.Extra.NonEmpty as ExtraNonEmpty
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
@@ -96,7 +96,7 @@ appendOrderByExpr (OrderByExpr a) (OrderByExpr b) =
 
 @since 1.0.0.0
 -}
-orderByColumnsExpr :: NEL.NonEmpty (Qualified ColumnName, OrderByDirection) -> OrderByExpr
+orderByColumnsExpr :: NEL.NonEmpty (QualifiedOrUnqualified ColumnName, OrderByDirection) -> OrderByExpr
 orderByColumnsExpr = ExtraNonEmpty.foldMap1' (uncurry orderByColumnName)
 
 {- |
@@ -104,7 +104,7 @@ orderByColumnsExpr = ExtraNonEmpty.foldMap1' (uncurry orderByColumnName)
 
 @since 1.0.0.0
 -}
-orderByColumnName :: Qualified ColumnName -> OrderByDirection -> OrderByExpr
+orderByColumnName :: QualifiedOrUnqualified ColumnName -> OrderByDirection -> OrderByExpr
 orderByColumnName = orderByValueExpression . ValueExpression.columnReference
 
 {- | Create an 'OrderByExpr' for 'AliasExpr' and 'OrderByDirection' pairs, ensuring commas as needed. For basic queries involving columns on some table(s), use 'orderByColumnsExpr'.

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Query.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Query.hs
@@ -39,7 +39,7 @@ import Orville.PostgreSQL.Expr.FromItemExpr (FromItemExpr)
 import Orville.PostgreSQL.Expr.GroupBy (GroupByClause)
 import Orville.PostgreSQL.Expr.Join (JoinConstraint, JoinExpr, JoinType, joinExpr)
 import Orville.PostgreSQL.Expr.LimitExpr (LimitExpr)
-import Orville.PostgreSQL.Expr.Name (AliasExpr, ColumnName, Qualified)
+import Orville.PostgreSQL.Expr.Name (AliasExpr, ColumnName, QualifiedOrUnqualified)
 import Orville.PostgreSQL.Expr.OffsetExpr (OffsetExpr)
 import Orville.PostgreSQL.Expr.OrderBy (OrderByClause)
 import Orville.PostgreSQL.Expr.RowLocking (RowLockingClause)
@@ -243,9 +243,9 @@ selectStar =
 
   @since 1.0.0.0
 -}
-selectColumns :: [Qualified ColumnName] -> SelectList
+selectColumns :: [QualifiedOrUnqualified ColumnName] -> SelectList
 selectColumns =
-  selectDerivedColumns . map (deriveColumn . columnReference)
+  selectDerivedColumns . fmap (deriveColumn . columnReference)
 
 {- |
 Type to represent an individual item in a list of selected items. E.G.

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/SequenceDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/SequenceDefinition.hs
@@ -46,7 +46,7 @@ import Data.Int (Int64)
 import Data.Maybe (catMaybes)
 
 import Orville.PostgreSQL.Expr.IfExists (IfExists)
-import Orville.PostgreSQL.Expr.Name (FunctionName, Qualified, SequenceName, functionName)
+import Orville.PostgreSQL.Expr.Name (FunctionName, QualifiedOrUnqualified, SequenceName, functionName)
 import Orville.PostgreSQL.Expr.ValueExpression (ValueExpression, functionCall, valueExpression)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
@@ -89,7 +89,7 @@ newtype CreateSequenceExpr
 -}
 createSequenceExpr ::
   -- | The name to be used for the sequence.
-  Qualified SequenceName ->
+  QualifiedOrUnqualified SequenceName ->
   -- | An optional @INCREMENT@ expression.
   Maybe IncrementByExpr ->
   -- | An optional @MINVALUE@ expression.
@@ -161,7 +161,7 @@ newtype AlterSequenceExpr
 -}
 alterSequenceExpr ::
   -- | The name of the sequence to alter
-  Qualified SequenceName ->
+  QualifiedOrUnqualified SequenceName ->
   -- | An optional @INCREMENT@ expression
   Maybe IncrementByExpr ->
   -- | An optional @MINVALUE@ expression
@@ -434,7 +434,7 @@ newtype DropSequenceExpr
 
   @since 1.0.0.0
 -}
-dropSequenceExpr :: Maybe IfExists -> Qualified SequenceName -> DropSequenceExpr
+dropSequenceExpr :: Maybe IfExists -> QualifiedOrUnqualified SequenceName -> DropSequenceExpr
 dropSequenceExpr maybeIfExists sequenceName =
   DropSequenceExpr $
     RawSql.intercalate
@@ -455,7 +455,7 @@ dropSequenceExpr maybeIfExists sequenceName =
 
   @since 1.0.0.0
 -}
-nextVal :: Qualified SequenceName -> ValueExpression
+nextVal :: QualifiedOrUnqualified SequenceName -> ValueExpression
 nextVal sequenceName =
   functionCall
     nextValFunction
@@ -479,7 +479,7 @@ nextValFunction =
 
   @since 1.0.0.0
 -}
-currVal :: Qualified SequenceName -> ValueExpression
+currVal :: QualifiedOrUnqualified SequenceName -> ValueExpression
 currVal sequenceName =
   functionCall
     currValFunction
@@ -503,7 +503,7 @@ currValFunction =
 
   @since 1.0.0.0
 -}
-setVal :: Qualified SequenceName -> Int64 -> ValueExpression
+setVal :: QualifiedOrUnqualified SequenceName -> Int64 -> ValueExpression
 setVal sequenceName newValue =
   functionCall
     setValFunction

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/TableConstraint.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/TableConstraint.hs
@@ -25,7 +25,7 @@ where
 
 import Data.List.NonEmpty (NonEmpty)
 
-import Orville.PostgreSQL.Expr.Name (ColumnName, Qualified, TableName)
+import Orville.PostgreSQL.Expr.Name (ColumnName, QualifiedOrUnqualified, TableName)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 {- |
@@ -189,7 +189,7 @@ foreignKeyConstraint ::
   -- | The names of the columns in the source table that form the foreign key.
   NonEmpty ColumnName ->
   -- | The name of the table that the foreign key references.
-  Qualified TableName ->
+  QualifiedOrUnqualified TableName ->
   -- | The names of the columns in the foreign table that the foreign key references.
   NonEmpty ColumnName ->
   -- | An optional @ON UPDATE@ foreign key action to perform.

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/TableDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/TableDefinition.hs
@@ -42,7 +42,7 @@ import Data.Maybe (catMaybes, maybeToList)
 import Orville.PostgreSQL.Expr.ColumnDefinition (ColumnDefinition)
 import Orville.PostgreSQL.Expr.DataType (DataType)
 import Orville.PostgreSQL.Expr.IfExists (IfExists)
-import Orville.PostgreSQL.Expr.Name (ColumnName, ConstraintName, Qualified, TableName)
+import Orville.PostgreSQL.Expr.Name (ColumnName, ConstraintName, QualifiedOrUnqualified, TableName)
 import Orville.PostgreSQL.Expr.TableConstraint (TableConstraint)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
@@ -71,7 +71,7 @@ newtype CreateTableExpr
 -}
 createTableExpr ::
   -- | The name to be used for the table.
-  Qualified TableName ->
+  QualifiedOrUnqualified TableName ->
   -- | The columns to include in the table.
   [ColumnDefinition] ->
   -- | A primary key expression for the table.
@@ -160,7 +160,7 @@ newtype AlterTableExpr
 
   @since 1.0.0.0
 -}
-alterTableExpr :: Qualified TableName -> NonEmpty AlterTableAction -> AlterTableExpr
+alterTableExpr :: QualifiedOrUnqualified TableName -> NonEmpty AlterTableAction -> AlterTableExpr
 alterTableExpr tableName actions =
   AlterTableExpr $
     RawSql.fromString "ALTER TABLE "
@@ -173,7 +173,7 @@ alterTableExpr tableName actions =
 
   @since 1.1.0.0
 -}
-renameTableExpr :: Qualified TableName -> Qualified TableName -> AlterTableExpr
+renameTableExpr :: QualifiedOrUnqualified TableName -> QualifiedOrUnqualified TableName -> AlterTableExpr
 renameTableExpr existingTableName newTableName =
   alterTableExpr existingTableName . pure . AlterTableAction $ RawSql.fromString "RENAME TO " <> RawSql.toRawSql newTableName
 
@@ -409,7 +409,7 @@ newtype DropTableExpr
 
   @since 1.0.0.0
 -}
-dropTableExpr :: Maybe IfExists -> Qualified TableName -> DropTableExpr
+dropTableExpr :: Maybe IfExists -> QualifiedOrUnqualified TableName -> DropTableExpr
 dropTableExpr maybeIfExists tableName =
   DropTableExpr $
     RawSql.intercalate
@@ -444,7 +444,7 @@ newtype TruncateTableExpr
 
   @since 1.1.0.0
 -}
-truncateTablesExpr :: NonEmpty (Qualified TableName) -> TruncateTableExpr
+truncateTablesExpr :: NonEmpty (QualifiedOrUnqualified TableName) -> TruncateTableExpr
 truncateTablesExpr tableNames =
   TruncateTableExpr $
     RawSql.intercalate

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Trigger.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Trigger.hs
@@ -31,7 +31,7 @@ import qualified Data.List.NonEmpty as NEL
 import Data.Maybe (catMaybes)
 
 import Orville.PostgreSQL.Expr.IfExists (IfExists)
-import Orville.PostgreSQL.Expr.Name (ColumnName, FunctionName, Qualified, TableName, TriggerName)
+import Orville.PostgreSQL.Expr.Name (ColumnName, FunctionName, QualifiedOrUnqualified, TableName, TriggerName)
 import Orville.PostgreSQL.Expr.OrReplace (OrReplace)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
@@ -61,7 +61,7 @@ Constructs a SQL @DROP TRIGGER@ statement from the trigger name and table name
 dropTrigger ::
   Maybe IfExists ->
   TriggerName ->
-  Qualified TableName ->
+  QualifiedOrUnqualified TableName ->
   DropTriggerExpr
 dropTrigger maybeIfExists name tableName =
   DropTriggerExpr $
@@ -111,9 +111,9 @@ createTrigger ::
   TriggerName ->
   TriggerTiming ->
   NEL.NonEmpty TriggerEvent ->
-  Qualified TableName ->
+  QualifiedOrUnqualified TableName ->
   TriggerFireScope ->
-  Qualified FunctionName ->
+  QualifiedOrUnqualified FunctionName ->
   CreateTriggerExpr
 createTrigger maybeOrReplace name timing events tableName fireScope functionName =
   CreateTriggerExpr $

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Update.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Update.hs
@@ -20,7 +20,7 @@ where
 import Data.List.NonEmpty (NonEmpty)
 import Data.Maybe (catMaybes)
 
-import Orville.PostgreSQL.Expr.Name (ColumnName, Qualified, TableName)
+import Orville.PostgreSQL.Expr.Name (ColumnName, QualifiedOrUnqualified, TableName)
 import Orville.PostgreSQL.Expr.ReturningExpr (ReturningExpr)
 import Orville.PostgreSQL.Expr.WhereClause (WhereClause)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
@@ -53,7 +53,7 @@ newtype UpdateExpr
 -}
 updateExpr ::
   -- | The name of the table to be updated.
-  Qualified TableName ->
+  QualifiedOrUnqualified TableName ->
   -- | The updates to be made to the table.
   SetClauseList ->
   -- | An optional where clause to limit the rows updated.
@@ -125,7 +125,7 @@ newtype SetClause
 
   @since 1.0.0.0
 -}
-setColumn :: Qualified ColumnName -> SqlValue.SqlValue -> SetClause
+setColumn :: QualifiedOrUnqualified ColumnName -> SqlValue.SqlValue -> SetClause
 setColumn columnName value =
   SetClause $
     RawSql.toRawSql columnName

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Vacuum.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Vacuum.hs
@@ -20,7 +20,7 @@ where
 
 import Data.List.NonEmpty (NonEmpty)
 
-import Orville.PostgreSQL.Expr.Name (Qualified, TableName)
+import Orville.PostgreSQL.Expr.Name (QualifiedOrUnqualified, TableName)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 {- |
@@ -46,7 +46,7 @@ newtype VacuumExpr
 
   @since 1.1.0.0
 -}
-vacuumExpr :: [VacuumOption] -> NonEmpty (Qualified TableName) -> VacuumExpr
+vacuumExpr :: [VacuumOption] -> NonEmpty (QualifiedOrUnqualified TableName) -> VacuumExpr
 vacuumExpr vacuumOptions tables =
   let
     optionsWithSpaceRawSql =

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/ValueExpression.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/ValueExpression.hs
@@ -23,7 +23,7 @@ where
 import qualified Data.List.NonEmpty as NE
 
 import Orville.PostgreSQL.Expr.DataType (DataType)
-import Orville.PostgreSQL.Expr.Name (AliasExpr, ColumnName, FunctionName, Qualified)
+import Orville.PostgreSQL.Expr.Name (AliasExpr, ColumnName, FunctionName, QualifiedOrUnqualified)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import Orville.PostgreSQL.Raw.SqlValue (SqlValue)
 
@@ -69,7 +69,7 @@ is the equivalent of simply writing the column name as the expression. E.G.
 
 @since 1.0.0.0
 -}
-columnReference :: Qualified ColumnName -> ValueExpression
+columnReference :: QualifiedOrUnqualified ColumnName -> ValueExpression
 columnReference = ValueExpression . RawSql.toRawSql
 
 {- |

--- a/orville-postgresql/src/Orville/PostgreSQL/Extension/PgTrgm.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Extension/PgTrgm.hs
@@ -102,7 +102,7 @@ trigramSimilaritySyntheticField ::
   Marshall.SyntheticField Double
 trigramSimilaritySyntheticField colname compareVal fieldAlias =
   Marshall.syntheticField
-    (trigramSimilarity (Expr.columnReference $ Expr.aliasQualifyColumn Nothing colname) compareVal)
+    (trigramSimilarity (Expr.columnReference $ Expr.unqualified colname) compareVal)
     fieldAlias
     Marshall.double
 
@@ -121,7 +121,7 @@ trigramWordSimilaritySyntheticField ::
   Marshall.SyntheticField Double
 trigramWordSimilaritySyntheticField colname compareVal fieldAlias =
   Marshall.syntheticField
-    (trigramWordSimilarity (Expr.columnReference $ Expr.aliasQualifyColumn Nothing colname) compareVal)
+    (trigramWordSimilarity (Expr.columnReference $ Expr.unqualified colname) compareVal)
     fieldAlias
     Marshall.double
 
@@ -140,7 +140,7 @@ trigramStrictWordSimilaritySyntheticField ::
   Marshall.SyntheticField Double
 trigramStrictWordSimilaritySyntheticField colname compareVal fieldAlias =
   Marshall.syntheticField
-    (trigramStrictWordSimilarity (Expr.columnReference $ Expr.aliasQualifyColumn Nothing colname) compareVal)
+    (trigramStrictWordSimilarity (Expr.columnReference $ Expr.unqualified colname) compareVal)
     fieldAlias
     Marshall.double
 

--- a/orville-postgresql/src/Orville/PostgreSQL/Internal/IndexDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Internal/IndexDefinition.hs
@@ -42,7 +42,7 @@ import qualified Orville.PostgreSQL.Marshall.FieldDefinition as FieldDefinition
 data IndexDefinition = IndexDefinition
   { i_indexCreateExpr ::
       IndexCreationStrategy ->
-      Expr.Qualified Expr.TableName ->
+      Expr.QualifiedOrUnqualified Expr.TableName ->
       Expr.CreateIndexExpr
   , i_indexMigrationKey :: IndexMigrationKey
   , i_indexCreationStrategy :: IndexCreationStrategy
@@ -185,7 +185,7 @@ indexMigrationKey = i_indexMigrationKey
 
 @since 1.0.0.0
 -}
-indexCreateExpr :: IndexDefinition -> Expr.Qualified Expr.TableName -> Expr.CreateIndexExpr
+indexCreateExpr :: IndexDefinition -> Expr.QualifiedOrUnqualified Expr.TableName -> Expr.CreateIndexExpr
 indexCreateExpr indexDef =
   i_indexCreateExpr
     indexDef

--- a/orville-postgresql/src/Orville/PostgreSQL/Marshall/AliasName.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Marshall/AliasName.hs
@@ -45,7 +45,7 @@ newtype AliasName
 aliasNameAndFieldNameToColumnName :: AliasName -> FieldName -> Expr.Qualified Expr.ColumnName
 aliasNameAndFieldNameToColumnName aliasName =
   Expr.aliasQualifyColumn
-    (Just $ aliasNameToAliasExpr aliasName)
+    (aliasNameToAliasExpr aliasName)
     . fieldNameToColumnName
 
 {- |

--- a/orville-postgresql/src/Orville/PostgreSQL/Marshall/SyntheticField.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Marshall/SyntheticField.hs
@@ -157,4 +157,4 @@ prefixSyntheticField prefix synthField =
 -}
 orderBySyntheticField :: SyntheticField a -> Expr.OrderByDirection -> Expr.OrderByExpr
 orderBySyntheticField =
-  Expr.orderByColumnName . Expr.aliasQualifyColumn Nothing . Expr.fromIdentifier . Expr.identifierFromBytes . aliasNameToByteString . syntheticFieldAlias
+  Expr.orderByColumnName . Expr.unqualified . Expr.fromIdentifier . Expr.identifierFromBytes . aliasNameToByteString . syntheticFieldAlias

--- a/orville-postgresql/src/Orville/PostgreSQL/Raw/RawSql.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Raw/RawSql.hs
@@ -89,6 +89,7 @@ data RawSql
   | Append RawSql RawSql
   | Empty
 
+-- | @since 1.0.0.0
 instance Semigroup RawSql where
   (SqlSection builderA) <> (SqlSection builderB) =
     SqlSection (builderA <> builderB)
@@ -97,6 +98,7 @@ instance Semigroup RawSql where
   otherA <> otherB =
     Append otherA otherB
 
+-- | @since 1.0.0.0
 instance Monoid RawSql where
   mempty = Empty
 
@@ -130,6 +132,7 @@ class SqlExpression a where
   toRawSql :: a -> RawSql
   unsafeFromRawSql :: RawSql -> a
 
+-- | @since 1.0.0.0
 instance SqlExpression RawSql where
   toRawSql = id
   unsafeFromRawSql = id
@@ -485,38 +488,62 @@ execute connection sql = do
 @since 1.0.0.0
 -}
 executeVoid :: SqlExpression sql => Conn.Connection -> sql -> IO ()
-executeVoid connection sql = do
-  void $ execute connection sql
+executeVoid connection =
+  void . execute connection
 
--- | Just a plain old space, provided for convenience.
+{- | Just a plain old space, provided for convenience.
+
+@since 1.0.0.0
+-}
 space :: RawSql
 space = fromString " "
 
--- | Just a plain old comma, provided for convenience.
+{- | Just a plain old comma, provided for convenience.
+
+@since 1.0.0.0
+-}
 comma :: RawSql
 comma = fromString ","
 
--- | Comma space separator, provided for convenience.
+{- | Comma space separator, provided for convenience.
+
+@since 1.0.0.0
+-}
 commaSpace :: RawSql
 commaSpace = fromString ", "
 
--- | Just a plain old left paren, provided for convenience.
+{- | Just a plain old left paren, provided for convenience.
+
+@since 1.0.0.0
+-}
 leftParen :: RawSql
 leftParen = fromString "("
 
--- | Just a plain old right paren, provided for convenience.
+{- | Just a plain old right paren, provided for convenience.
+
+@since 1.0.0.0
+-}
 rightParen :: RawSql
 rightParen = fromString ")"
 
--- | Just a plain period, provided for convenience.
+{- | Just a plain period, provided for convenience.
+
+@since 1.0.0.0
+-}
 dot :: RawSql
 dot = fromString "."
 
--- | Just a plain double quote, provided for convenience.
+{- | Just a plain double quote, provided for convenience.
+
+@since 1.0.0.0
+-}
 doubleQuote :: RawSql
 doubleQuote = fromString "\""
 
--- | Just two colons, provided for convenience.
+{- | Just two colons, provided for convenience.
+
+@since 1.0.0.0
+-}
 doubleColon :: RawSql
 doubleColon = fromString "::"
 

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/FunctionDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/FunctionDefinition.hs
@@ -70,7 +70,7 @@ functionIdentifier =
 
 @since 1.1.0.0
 -}
-functionName :: FunctionDefinition -> Expr.Qualified Expr.FunctionName
+functionName :: FunctionDefinition -> Expr.QualifiedOrUnqualified Expr.FunctionName
 functionName =
   functionIdQualifiedName . i_functionIdentifier
 

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/FunctionIdentifier.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/FunctionIdentifier.hs
@@ -64,17 +64,21 @@ setFunctionIdSchema schema functionId =
     { i_functionIdSchema = Just schema
     }
 
-{- |
-  Returns the 'Expr.Qualified Expr.FunctionName' that should be used to refer to
-  the function in SQL queries.
+{- | Returns the 'Expr.QualifiedOrUnqualified Expr.FunctionName' that should be used to refer to the
+  function in SQL queries where a potentially qualified reference is appropriate.
 
 @since 1.1.0.0
 -}
-functionIdQualifiedName :: FunctionIdentifier -> Expr.Qualified Expr.FunctionName
+functionIdQualifiedName :: FunctionIdentifier -> Expr.QualifiedOrUnqualified Expr.FunctionName
 functionIdQualifiedName functionId =
-  Expr.qualifyFunction
-    (functionIdSchemaName functionId)
-    (functionIdUnqualifiedName functionId)
+  case functionIdSchemaName functionId of
+    Nothing ->
+      Expr.unqualified (functionIdUnqualifiedName functionId)
+    Just schemaName ->
+      Expr.untrackQualified $
+        Expr.qualifyFunction
+          schemaName
+          (functionIdUnqualifiedName functionId)
 
 {- |
   Returns the unqualified 'Expr.FunctionName' that should be used to refer to the

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/SequenceDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/SequenceDefinition.hs
@@ -109,7 +109,7 @@ sequenceIdentifier = i_sequenceIdentifier
 
 @since 1.0.0.0
 -}
-sequenceName :: SequenceDefinition -> Expr.Qualified Expr.SequenceName
+sequenceName :: SequenceDefinition -> Expr.QualifiedOrUnqualified Expr.SequenceName
 sequenceName =
   sequenceIdQualifiedName . i_sequenceIdentifier
 

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/SequenceIdentifier.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/SequenceIdentifier.hs
@@ -70,11 +70,16 @@ setSequenceIdSchema schema sequenceId =
 
 @since 1.0.0.0
 -}
-sequenceIdQualifiedName :: SequenceIdentifier -> Expr.Qualified Expr.SequenceName
+sequenceIdQualifiedName :: SequenceIdentifier -> Expr.QualifiedOrUnqualified Expr.SequenceName
 sequenceIdQualifiedName sequenceId =
-  Expr.qualifySequence
-    (sequenceIdSchemaName sequenceId)
-    (sequenceIdUnqualifiedName sequenceId)
+  case sequenceIdSchemaName sequenceId of
+    Nothing ->
+      Expr.unqualified (sequenceIdUnqualifiedName sequenceId)
+    Just schemaName ->
+      Expr.untrackQualified $
+        Expr.qualifySequence
+          schemaName
+          (sequenceIdUnqualifiedName sequenceId)
 
 {- |
   Returns the unqualified 'Expr.SequenceName' that should be used to refer to the

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/TableIdentifier.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/TableIdentifier.hs
@@ -70,11 +70,16 @@ setTableIdSchema schema tableId =
 
 @since 1.0.0.0
 -}
-tableIdQualifiedName :: TableIdentifier -> Expr.Qualified Expr.TableName
+tableIdQualifiedName :: TableIdentifier -> Expr.QualifiedOrUnqualified Expr.TableName
 tableIdQualifiedName tableId =
-  Expr.qualifyTable
-    (tableIdSchemaName tableId)
-    (tableIdUnqualifiedName tableId)
+  case tableIdSchemaName tableId of
+    Nothing ->
+      Expr.unqualified (tableIdUnqualifiedName tableId)
+    Just schemaName ->
+      Expr.untrackQualified $
+        Expr.qualifyTable
+          schemaName
+          (tableIdUnqualifiedName tableId)
 
 {- |
   Returns the unqualified 'Expr.TableName' that should be used to refer to the

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/TriggerDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/TriggerDefinition.hs
@@ -43,7 +43,7 @@ data TriggerDefinition = TriggerDefinition
   { i_triggerMigrationKey :: TriggerMigrationKey
   , i_triggerCreateExpr ::
       Maybe Expr.OrReplace ->
-      Expr.Qualified Expr.TableName ->
+      Expr.QualifiedOrUnqualified Expr.TableName ->
       Expr.CreateTriggerExpr
   }
 
@@ -79,7 +79,7 @@ triggerMigrationKey =
 
 @since 1.1.0.0
 -}
-beforeInsert :: String -> Expr.Qualified Expr.FunctionName -> TriggerDefinition
+beforeInsert :: String -> Expr.QualifiedOrUnqualified Expr.FunctionName -> TriggerDefinition
 beforeInsert name functionName =
   mkTriggerDefinition
     name
@@ -94,7 +94,7 @@ beforeInsert name functionName =
 
 @since 1.1.0.0
 -}
-afterInsert :: String -> Expr.Qualified Expr.FunctionName -> TriggerDefinition
+afterInsert :: String -> Expr.QualifiedOrUnqualified Expr.FunctionName -> TriggerDefinition
 afterInsert name functionName =
   mkTriggerDefinition
     name
@@ -109,7 +109,7 @@ afterInsert name functionName =
 
 @since 1.1.0.0
 -}
-beforeUpdate :: String -> Expr.Qualified Expr.FunctionName -> TriggerDefinition
+beforeUpdate :: String -> Expr.QualifiedOrUnqualified Expr.FunctionName -> TriggerDefinition
 beforeUpdate name functionName =
   mkTriggerDefinition
     name
@@ -124,7 +124,7 @@ beforeUpdate name functionName =
 
 @since 1.1.0.0
 -}
-afterUpdate :: String -> Expr.Qualified Expr.FunctionName -> TriggerDefinition
+afterUpdate :: String -> Expr.QualifiedOrUnqualified Expr.FunctionName -> TriggerDefinition
 afterUpdate name functionName =
   mkTriggerDefinition
     name
@@ -139,7 +139,7 @@ afterUpdate name functionName =
 
 @since 1.1.0.0
 -}
-beforeDelete :: String -> Expr.Qualified Expr.FunctionName -> TriggerDefinition
+beforeDelete :: String -> Expr.QualifiedOrUnqualified Expr.FunctionName -> TriggerDefinition
 beforeDelete name functionName =
   mkTriggerDefinition
     name
@@ -154,7 +154,7 @@ beforeDelete name functionName =
 
 @since 1.1.0.0
 -}
-afterDelete :: String -> Expr.Qualified Expr.FunctionName -> TriggerDefinition
+afterDelete :: String -> Expr.QualifiedOrUnqualified Expr.FunctionName -> TriggerDefinition
 afterDelete name functionName =
   mkTriggerDefinition
     name
@@ -177,7 +177,7 @@ mkTriggerDefinition ::
   Expr.TriggerTiming ->
   NonEmpty Expr.TriggerEvent ->
   Expr.TriggerFireScope ->
-  Expr.Qualified Expr.FunctionName ->
+  Expr.QualifiedOrUnqualified Expr.FunctionName ->
   TriggerDefinition
 mkTriggerDefinition name timing events fireScope functionName =
   TriggerDefinition
@@ -203,7 +203,7 @@ mkTriggerDefinition name timing events fireScope functionName =
 mkCreateTriggerExpr ::
   TriggerDefinition ->
   Maybe Expr.OrReplace ->
-  Expr.Qualified Expr.TableName ->
+  Expr.QualifiedOrUnqualified Expr.TableName ->
   Expr.CreateTriggerExpr
 mkCreateTriggerExpr =
   i_triggerCreateExpr

--- a/orville-postgresql/test/Test/Expr/Aggregate.hs
+++ b/orville-postgresql/test/Test/Expr/Aggregate.hs
@@ -145,13 +145,13 @@ mkAggregateTestExpectedRows test =
   in
     fmap mkRow (groupByExpectedQueryResults test)
 
-testTable :: Expr.Qualified Expr.TableName
+testTable :: Expr.QualifiedOrUnqualified Expr.TableName
 testTable =
-  Expr.qualifyTable Nothing (Expr.tableName "expr_test")
+  Expr.unqualified (Expr.tableName "expr_test")
 
-fooColumn :: Expr.Qualified Expr.ColumnName
+fooColumn :: Expr.QualifiedOrUnqualified Expr.ColumnName
 fooColumn =
-  Expr.aliasQualifyColumn Nothing (Expr.columnName "foo")
+  Expr.unqualified (Expr.columnName "foo")
 
 dropAndRecreateTestTable :: Orville.Connection -> IO ()
 dropAndRecreateTestTable connection = do

--- a/orville-postgresql/test/Test/Expr/Count.hs
+++ b/orville-postgresql/test/Test/Expr/Count.hs
@@ -57,7 +57,7 @@ prop_countColumn =
           (Expr.selectClause (Expr.selectExpr Nothing))
           ( Expr.selectDerivedColumns
               [ Expr.deriveColumnAs
-                  (Expr.countColumn (Orville.fieldColumnName Nothing Foo.fooIdField))
+                  (Expr.countColumn $ Orville.fieldColumnName Foo.fooIdField)
                   (Expr.columnName "count")
               ]
           )

--- a/orville-postgresql/test/Test/Expr/FromItemExpr.hs
+++ b/orville-postgresql/test/Test/Expr/FromItemExpr.hs
@@ -63,7 +63,7 @@ joinOnTrue =
   Expr.joinOnConstraint $ Expr.literalBooleanExpr True
 
 fooFromItem :: Expr.FromItemExpr
-fooFromItem = Expr.tableFromItem . Expr.qualifyTable Nothing $ Expr.tableName "foo"
+fooFromItem = Expr.tableFromItem . Expr.unqualified $ Expr.tableName "foo"
 
 barFromItem :: Expr.FromItemExpr
-barFromItem = Expr.tableFromItem . Expr.qualifyTable Nothing $ Expr.tableName "bar"
+barFromItem = Expr.tableFromItem . Expr.unqualified $ Expr.tableName "bar"

--- a/orville-postgresql/test/Test/Expr/GroupBy.hs
+++ b/orville-postgresql/test/Test/Expr/GroupBy.hs
@@ -103,17 +103,17 @@ groupByTest testName test =
 
     rows `assertEqualSqlRows` mkGroupByTestExpectedRows test
 
-testTable :: Expr.Qualified Expr.TableName
+testTable :: Expr.QualifiedOrUnqualified Expr.TableName
 testTable =
-  Expr.qualifyTable Nothing (Expr.tableName "expr_test")
+  Expr.unqualified (Expr.tableName "expr_test")
 
-fooColumn :: Expr.Qualified Expr.ColumnName
+fooColumn :: Expr.QualifiedOrUnqualified Expr.ColumnName
 fooColumn =
-  Expr.aliasQualifyColumn Nothing (Expr.columnName "foo")
+  Expr.unqualified (Expr.columnName "foo")
 
-barColumn :: Expr.Qualified Expr.ColumnName
+barColumn :: Expr.QualifiedOrUnqualified Expr.ColumnName
 barColumn =
-  Expr.aliasQualifyColumn Nothing (Expr.columnName "bar")
+  Expr.unqualified (Expr.columnName "bar")
 
 dropAndRecreateTestTable :: Orville.Connection -> IO ()
 dropAndRecreateTestTable connection = do

--- a/orville-postgresql/test/Test/Expr/GroupByOrderBy.hs
+++ b/orville-postgresql/test/Test/Expr/GroupByOrderBy.hs
@@ -93,17 +93,17 @@ groupByOrderByTest testName test =
 
     rows `assertEqualSqlRows` mkGroupByOrderByTestExpectedRows test
 
-testTable :: Expr.Qualified Expr.TableName
+testTable :: Expr.QualifiedOrUnqualified Expr.TableName
 testTable =
-  Expr.qualifyTable Nothing (Expr.tableName "expr_test")
+  Expr.unqualified (Expr.tableName "expr_test")
 
-fooColumn :: Expr.Qualified Expr.ColumnName
+fooColumn :: Expr.QualifiedOrUnqualified Expr.ColumnName
 fooColumn =
-  Expr.aliasQualifyColumn Nothing (Expr.columnName "foo")
+  Expr.unqualified (Expr.columnName "foo")
 
-barColumn :: Expr.Qualified Expr.ColumnName
+barColumn :: Expr.QualifiedOrUnqualified Expr.ColumnName
 barColumn =
-  Expr.aliasQualifyColumn Nothing (Expr.columnName "bar")
+  Expr.unqualified (Expr.columnName "bar")
 
 dropAndRecreateTestTable :: Orville.Connection -> IO ()
 dropAndRecreateTestTable connection = do

--- a/orville-postgresql/test/Test/Expr/InsertUpdateDelete.hs
+++ b/orville-postgresql/test/Test/Expr/InsertUpdateDelete.hs
@@ -86,8 +86,8 @@ prop_insertExprWithOnConflictDoUpdate =
       fooBars0 = [mkFooBar 1 "dog"]
       fooBars1 = [mkFooBar 1 "eagel"]
       addIndex = RawSql.fromString "CREATE UNIQUE INDEX ON " <> RawSql.toRawSql fooBarTable <> RawSql.fromString "( foo )"
-      fooColumnName = Expr.aliasQualifyColumn Nothing (Expr.columnName "foo")
-      barColumnName = Expr.aliasQualifyColumn Nothing (Expr.columnName "bar")
+      fooColumnName = Expr.unqualified (Expr.columnName "foo")
+      barColumnName = Expr.unqualified (Expr.columnName "bar")
       conflictTarget = Expr.conflictTargetForIndexColumn fooColumnName Nothing
       setExcludedColumn = Expr.setColumnNameExcluded barColumnName
       onConflictDoUpdate = Expr.onConflictDoUpdate (Just conflictTarget) (pure setExcludedColumn) Nothing
@@ -311,7 +311,7 @@ prop_truncateTablesExpr =
     let
       fooBars = [mkFooBar 1 "dog", mkFooBar 2 "cat"]
       fooBar2Table =
-        Expr.qualifyTable Nothing (Expr.tableName "foobar2")
+        Expr.unqualified (Expr.tableName "foobar2")
       dropAndRecreateSecondTable connection = do
         RawSql.executeVoid connection (RawSql.fromString "DROP TABLE IF EXISTS " <> RawSql.toRawSql fooBar2Table)
         RawSql.executeVoid connection (RawSql.fromString "CREATE TABLE " <> RawSql.toRawSql fooBar2Table <> RawSql.fromString "(foo INTEGER, bar TEXT)")

--- a/orville-postgresql/test/Test/Expr/Join.hs
+++ b/orville-postgresql/test/Test/Expr/Join.hs
@@ -36,4 +36,4 @@ joinOnTrue =
   Expr.joinOnConstraint $ Expr.literalBooleanExpr True
 
 fooFromItem :: Expr.FromItemExpr
-fooFromItem = Expr.tableFromItem . Expr.qualifyTable Nothing $ Expr.tableName "foo"
+fooFromItem = Expr.tableFromItem . Expr.unqualified $ Expr.tableName "foo"

--- a/orville-postgresql/test/Test/Expr/SequenceDefinition.hs
+++ b/orville-postgresql/test/Test/Expr/SequenceDefinition.hs
@@ -57,9 +57,9 @@ prop_createWithWithOptions =
     PgCatalog.pgSequenceCache pgSequence === 10
     PgCatalog.pgSequenceCycle pgSequence === True
 
-exprSequenceName :: Expr.Qualified Expr.SequenceName
+exprSequenceName :: Expr.QualifiedOrUnqualified Expr.SequenceName
 exprSequenceName =
-  Expr.qualifySequence Nothing (Expr.sequenceName sequenceNameString)
+  Expr.unqualified (Expr.sequenceName sequenceNameString)
 
 sequenceNameString :: String
 sequenceNameString =

--- a/orville-postgresql/test/Test/Expr/TableDefinition.hs
+++ b/orville-postgresql/test/Test/Expr/TableDefinition.hs
@@ -50,7 +50,7 @@ prop_renameTable =
   Property.singletonNamedDBProperty "Rename table results in the new name existing and the old name not" $ \pool -> do
     let
       newTableNameString = "renamed_" <> tableNameString
-      newTableName = Expr.qualifyTable Nothing $ Expr.tableName newTableNameString
+      newTableName = Expr.unqualified $ Expr.tableName newTableNameString
     MIO.liftIO $
       Orville.runOrville pool $ do
         Orville.executeVoid Orville.DDLQuery $ Expr.dropTableExpr (Just Expr.ifExists) exprTableName
@@ -86,9 +86,9 @@ prop_addMultipleColumns =
     tableDesc <- PgAssert.assertTableExists pool tableNameString
     PgAssert.assertColumnNamesEqual tableDesc [column1NameString, column2NameString]
 
-exprTableName :: Expr.Qualified Expr.TableName
+exprTableName :: Expr.QualifiedOrUnqualified Expr.TableName
 exprTableName =
-  Expr.qualifyTable Nothing (Expr.tableName tableNameString)
+  Expr.unqualified (Expr.tableName tableNameString)
 
 tableNameString :: String
 tableNameString =

--- a/orville-postgresql/test/Test/Expr/TestSchema.hs
+++ b/orville-postgresql/test/Test/Expr/TestSchema.hs
@@ -42,25 +42,25 @@ data FooBar = FooBar
 mkFooBar :: Int.Int32 -> String -> FooBar
 mkFooBar f b = FooBar (Just f) (Just b)
 
-fooBarTable :: Expr.Qualified Expr.TableName
+fooBarTable :: Expr.QualifiedOrUnqualified Expr.TableName
 fooBarTable =
-  Expr.qualifyTable Nothing (Expr.tableName "foobar")
+  Expr.unqualified (Expr.tableName "foobar")
 
-fooColumn :: Expr.Qualified Expr.ColumnName
+fooColumn :: Expr.QualifiedOrUnqualified Expr.ColumnName
 fooColumn =
-  Expr.aliasQualifyColumn Nothing $ Expr.columnName "foo"
+  Expr.unqualified $ Expr.columnName "foo"
 
 fooColumnRef :: Expr.ValueExpression
 fooColumnRef =
   Expr.columnReference fooColumn
 
-barColumn :: Expr.Qualified Expr.ColumnName
+barColumn :: Expr.QualifiedOrUnqualified Expr.ColumnName
 barColumn =
-  Expr.aliasQualifyColumn Nothing $ Expr.columnName "bar"
+  Expr.unqualified $ Expr.columnName "bar"
 
 barColumnAliased :: Expr.Qualified Expr.ColumnName
 barColumnAliased =
-  Expr.aliasQualifyColumn (Just $ Expr.stringToAliasExpr "b") $ Expr.columnName "bar"
+  Expr.aliasQualifyColumn (Expr.stringToAliasExpr "b") $ Expr.columnName "bar"
 
 barColumnRef :: Expr.ValueExpression
 barColumnRef =
@@ -75,14 +75,14 @@ findAllFooBars :: Expr.QueryExpr
 findAllFooBars =
   findAllFooBarsInTable fooBarTable
 
-findAllFooBarsInTable :: Expr.Qualified Expr.TableName -> Expr.QueryExpr
+findAllFooBarsInTable :: Expr.QualifiedOrUnqualified Expr.TableName -> Expr.QueryExpr
 findAllFooBarsInTable tableName =
   let
     tableRef = Expr.tableFromItemWithAlias (Expr.stringToAliasExpr "b") tableName
   in
     Expr.queryExpr
       (Expr.selectClause $ Expr.selectExpr Nothing)
-      (Expr.selectColumns [fooColumn, barColumnAliased])
+      (Expr.selectColumns [fooColumn, Expr.untrackQualified barColumnAliased])
       (Just $ Expr.tableExpr tableRef Nothing Nothing (Just orderByFoo) Nothing Nothing Nothing Nothing)
 
 encodeFooBar :: FooBar -> [(Maybe B8.ByteString, SqlValue.SqlValue)]

--- a/orville-postgresql/test/Test/Expr/Trigger.hs
+++ b/orville-postgresql/test/Test/Expr/Trigger.hs
@@ -38,7 +38,7 @@ prop_triggers =
         \END"
 
       triggerFunctionName =
-        Expr.qualifyFunction Nothing $ Expr.functionName "test_trigger_function"
+        Expr.unqualified $ Expr.functionName "test_trigger_function"
 
       createTriggerFunction =
         Expr.createFunction

--- a/orville-postgresql/test/Test/Expr/Vacuum.hs
+++ b/orville-postgresql/test/Test/Expr/Vacuum.hs
@@ -77,14 +77,14 @@ prop_vacuumTwoOptionsTwoTables =
       ]
       twoTables
 
-assertVacuumEquals :: (HH.MonadTest m, HasCallStack) => String -> [Expr.VacuumOption] -> NonEmpty (Expr.Qualified Expr.TableName) -> m ()
+assertVacuumEquals :: (HH.MonadTest m, HasCallStack) => String -> [Expr.VacuumOption] -> NonEmpty (Expr.QualifiedOrUnqualified Expr.TableName) -> m ()
 assertVacuumEquals mbVacuum vacuumOptions vacuumTables =
   withFrozenCallStack $
     RawSql.toExampleBytes (Expr.vacuumExpr vacuumOptions vacuumTables) HH.=== B8.pack mbVacuum
 
-singleTable :: NonEmpty (Expr.Qualified Expr.TableName)
-singleTable = pure . Expr.qualifyTable Nothing $ Expr.tableName "foo"
+singleTable :: NonEmpty (Expr.QualifiedOrUnqualified Expr.TableName)
+singleTable = pure . Expr.unqualified $ Expr.tableName "foo"
 
-twoTables :: NonEmpty (Expr.Qualified Expr.TableName)
+twoTables :: NonEmpty (Expr.QualifiedOrUnqualified Expr.TableName)
 twoTables =
-  (Expr.qualifyTable Nothing $ Expr.tableName "foo") :| [Expr.qualifyTable Nothing $ Expr.tableName "bar"]
+  (Expr.unqualified $ Expr.tableName "foo") :| [Expr.unqualified $ Expr.tableName "bar"]

--- a/orville-postgresql/test/Test/FieldDefinition.hs
+++ b/orville-postgresql/test/Test/FieldDefinition.hs
@@ -256,7 +256,7 @@ runRoundTripTest pool testCase = do
       RawSql.execute connection $
         Expr.queryExpr
           (Expr.selectClause $ Expr.selectExpr Nothing)
-          (Expr.selectColumns [Marshall.fieldColumnName Nothing fieldDef])
+          (Expr.selectColumns [Marshall.fieldColumnName fieldDef])
           (Just $ Expr.tableExpr (Expr.tableFromItem testTable) Nothing Nothing Nothing Nothing Nothing Nothing Nothing)
 
     Execution.readRows result
@@ -301,7 +301,7 @@ runNullableRoundTripTest pool testCase = do
       RawSql.execute connection $
         Expr.queryExpr
           (Expr.selectClause $ Expr.selectExpr Nothing)
-          (Expr.selectColumns [Marshall.fieldColumnName Nothing fieldDef])
+          (Expr.selectColumns [Marshall.fieldColumnName fieldDef])
           (Just $ Expr.tableExpr (Expr.tableFromItem testTable) Nothing Nothing Nothing Nothing Nothing Nothing Nothing)
 
     Execution.readRows result
@@ -371,7 +371,7 @@ runDefaultValueFieldDefinitionTest pool testCase mkDefaultValue = do
       RawSql.execute connection $
         Expr.queryExpr
           (Expr.selectClause $ Expr.selectExpr Nothing)
-          (Expr.selectColumns [Marshall.fieldColumnName Nothing fieldDef])
+          (Expr.selectColumns [Marshall.fieldColumnName fieldDef])
           (Just $ Expr.tableExpr (Expr.tableFromItem testTable) Nothing Nothing Nothing Nothing Nothing Nothing Nothing)
 
     Execution.readRows result
@@ -407,9 +407,9 @@ runDefaultValueInsertOnlyTest pool testCase defaultValue =
         Nothing
         Nothing
 
-testTable :: Expr.Qualified Expr.TableName
+testTable :: Expr.QualifiedOrUnqualified Expr.TableName
 testTable =
-  Expr.qualifyTable Nothing (Expr.tableName "field_definition_test")
+  Expr.unqualified (Expr.tableName "field_definition_test")
 
 dropAndRecreateTestTable :: Marshall.FieldDefinition nullability a -> Orville.Connection -> IO ()
 dropAndRecreateTestTable fieldDef connection = do

--- a/orville-postgresql/test/Test/PgCatalog.hs
+++ b/orville-postgresql/test/Test/PgCatalog.hs
@@ -137,7 +137,7 @@ prop_queryPgTrigger =
   Property.singletonNamedDBProperty "Can query the pg_trigger table to find out about a trigger" $ \pool -> do
     let
       triggerFunctionName =
-        Expr.qualifyFunction Nothing $ Expr.functionName "test_trigger_function"
+        Expr.unqualified $ Expr.functionName "test_trigger_function"
 
       createTriggerFunction =
         Expr.createFunction
@@ -185,7 +185,7 @@ prop_queryPgProc =
   Property.singletonNamedDBProperty "Can query the pg_proc table to find out about a proc" $ \pool -> do
     let
       procFunctionName =
-        Expr.qualifyFunction Nothing $ Expr.functionName "test_proc"
+        Expr.unqualified $ Expr.functionName "test_proc"
 
       procName =
         String.fromString "test_proc"

--- a/orville-postgresql/test/Test/SelectOptions.hs
+++ b/orville-postgresql/test/Test/SelectOptions.hs
@@ -319,7 +319,7 @@ prop_orderByAliased =
     assertOrderByClauseEquals
       (Just "ORDER BY \"f\".\"foo\" ASC, \"bar\" DESC")
       ( O.orderBy
-          ( O.orderByAliasedField (O.buildAliasedFieldDefinition fooField (Just $ Marshall.stringToAliasName "f")) Expr.ascendingOrder
+          ( O.orderByAliasedField (O.buildAliasedFieldDefinition fooField (Marshall.stringToAliasName "f")) Expr.ascendingOrder
               <> O.orderByField barField Expr.descendingOrder
           )
       )
@@ -329,7 +329,7 @@ prop_orderByCombined =
   Property.singletonNamedProperty "orderBy generates expected sql with multiple selectOptions" $
     assertOrderByClauseEquals
       (Just "ORDER BY \"foo\" ASC, \"bar\" DESC")
-      ( (O.orderBy $ O.orderByColumnName (Expr.aliasQualifyColumn Nothing (Expr.columnName "foo")) O.ascendingOrder)
+      ( (O.orderBy $ O.orderByColumnName (Expr.unqualified (Expr.columnName "foo")) O.ascendingOrder)
           <> (O.orderBy $ O.orderByField barField O.descendingOrder)
       )
 
@@ -339,7 +339,7 @@ prop_groupBy =
     assertGroupByClauseEquals
       (Just "GROUP BY \"foo\", \"bar\"")
       ( O.groupBy . Expr.groupByColumnsExpr $
-          FieldDef.fieldColumnName Nothing fooField :| [FieldDef.fieldColumnName Nothing barField]
+          FieldDef.fieldColumnName fooField :| [FieldDef.fieldColumnName barField]
       )
 
 prop_groupByCombined :: Property.NamedProperty
@@ -348,7 +348,7 @@ prop_groupByCombined =
     assertGroupByClauseEquals
       (Just "GROUP BY foo, \"bar\"")
       ( (O.groupBy . RawSql.unsafeSqlExpression $ "foo")
-          <> (O.groupBy . Expr.groupByColumnsExpr $ (FieldDef.fieldColumnName Nothing barField :| []))
+          <> (O.groupBy . Expr.groupByColumnsExpr $ ((FieldDef.fieldColumnName barField) :| []))
       )
 
 prop_forRowLock :: Property.NamedProperty

--- a/orville-postgresql/test/Test/SqlMarshaller.hs
+++ b/orville-postgresql/test/Test/SqlMarshaller.hs
@@ -320,9 +320,9 @@ prop_referenceValueExpression =
       expected =
         Expr.rowValueConstructor $
           NE.fromList
-            [ Expr.columnReference $ Marshall.fieldColumnName (Just alias) nameField
-            , Expr.columnReference $ Marshall.fieldColumnName (Just alias) sizeField
-            , Expr.columnReference $ Marshall.fieldColumnName (Just alias) optionField
+            [ Expr.columnReference . Expr.untrackQualified $ Marshall.fieldAliasQualifiedColumnName alias nameField
+            , Expr.columnReference . Expr.untrackQualified $ Marshall.fieldAliasQualifiedColumnName alias sizeField
+            , Expr.columnReference . Expr.untrackQualified $ Marshall.fieldAliasQualifiedColumnName alias optionField
             ]
       actual = Marshall.referenceValueExpression (Marshall.marshallAlias alias fooMarshaller)
 

--- a/orville-postgresql/test/Test/SqlType.hs
+++ b/orville-postgresql/test/Test/SqlType.hs
@@ -530,7 +530,7 @@ runDecodingTest pool test =
       dropAndRecreateTable connection "decoding_test" (sqlTypeDDL test)
 
       let
-        tableName = Expr.qualifyTable Nothing (Expr.tableName "decoding_test")
+        tableName = Expr.unqualified $ Expr.tableName "decoding_test"
 
       RawSql.executeVoid connection $
         Expr.insertExpr

--- a/orville-postgresql/test/Test/TestTable.hs
+++ b/orville-postgresql/test/Test/TestTable.hs
@@ -36,10 +36,10 @@ dropTableNameSql ::
   String ->
   RawSql.RawSql
 dropTableNameSql =
-  dropTableNameExprSql . Expr.qualifyTable Nothing . Expr.tableName
+  dropTableNameExprSql . Expr.unqualified . Expr.tableName
 
 dropTableNameExprSql ::
-  Expr.Qualified Expr.TableName ->
+  Expr.QualifiedOrUnqualified Expr.TableName ->
   RawSql.RawSql
 dropTableNameExprSql name =
   RawSql.fromString "DROP TABLE IF EXISTS " <> RawSql.toRawSql name


### PR DESCRIPTION
- Created a new 'QualifiedOrUnqualified' type to be precise in our meaning.

- Changed the 'Qualified' type to keep track of the qualification.

- Changed functions to handle or result in 'Qualified' when needed and 'QualifiedOrUnqualified' when not.

- Removed optionality of alias for qualification in a handful of places.