### PR TITLE
Adds `ValuesExpr` for constructing `VALUES` SQL

### DIFF
--- a/orville-postgresql/orville-postgresql.cabal
+++ b/orville-postgresql/orville-postgresql.cabal
@@ -88,6 +88,7 @@ library
       Orville.PostgreSQL.Expr.Update
       Orville.PostgreSQL.Expr.Vacuum
       Orville.PostgreSQL.Expr.ValueExpression
+      Orville.PostgreSQL.Expr.Values
       Orville.PostgreSQL.Expr.WhereClause
       Orville.PostgreSQL.Expr.Window
       Orville.PostgreSQL.Expr.Window.WindowClause

--- a/orville-postgresql/package.yaml
+++ b/orville-postgresql/package.yaml
@@ -84,6 +84,7 @@ library:
     - Orville.PostgreSQL.Expr.Update
     - Orville.PostgreSQL.Expr.Vacuum
     - Orville.PostgreSQL.Expr.ValueExpression
+    - Orville.PostgreSQL.Expr.Values
     - Orville.PostgreSQL.Expr.WhereClause
     - Orville.PostgreSQL.Expr.Window
     - Orville.PostgreSQL.Expr.Window.WindowClause

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr.hs
@@ -77,6 +77,7 @@ module Orville.PostgreSQL.Expr
   , module Orville.PostgreSQL.Expr.Aggregate
   , module Orville.PostgreSQL.Expr.Filter
   , module Orville.PostgreSQL.Expr.FetchClause
+  , module Orville.PostgreSQL.Expr.Values
   )
 where
 
@@ -123,5 +124,6 @@ import Orville.PostgreSQL.Expr.Trigger
 import Orville.PostgreSQL.Expr.Update
 import Orville.PostgreSQL.Expr.Vacuum
 import Orville.PostgreSQL.Expr.ValueExpression
+import Orville.PostgreSQL.Expr.Values
 import Orville.PostgreSQL.Expr.WhereClause
 import Orville.PostgreSQL.Expr.Window

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Query.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Query.hs
@@ -174,7 +174,7 @@ queryExprWithAlias alias query =
       <> RawSql.fromString " AS "
       <> RawSql.toRawSql alias
 
-{- | Make a 'QueryExpr' into a 'FromItemExpr', aliased appropriately, so that it can be used to
+{- | Make a 'QueryExpr' into a 'FromItemExpr', aliased appropriately, so that it can be used
    as a subquery in @SELECT@ion.
 
 @since 1.1.0.0

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Values.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Values.hs
@@ -1,0 +1,146 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+{- |
+Copyright : Flipstone Technology Partners 2024
+License   : MIT
+Stability : Stable
+
+@since 1.1.0.0
+-}
+module Orville.PostgreSQL.Expr.Values
+  ( ValuesExpr
+  , valuesExpr
+  , valuesExprFromValueExpressions
+  , ValuesExprRow
+  , valuesExprRow
+  , ValuesExprValue
+  , valuesExprValue
+  , valuesExprDefaultValue
+  , valuesQueryExpr
+  ) where
+
+import Data.List.NonEmpty (NonEmpty)
+import Data.Maybe (catMaybes)
+
+import Orville.PostgreSQL.Expr.FetchClause (FetchClause)
+import Orville.PostgreSQL.Expr.LimitExpr (LimitExpr)
+import Orville.PostgreSQL.Expr.OffsetExpr (OffsetExpr)
+import Orville.PostgreSQL.Expr.OrderBy (OrderByExpr)
+import Orville.PostgreSQL.Expr.Query (QueryExpr)
+import Orville.PostgreSQL.Expr.ValueExpression (ValueExpression)
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+
+{- |
+Type to represent a @VALUES@ statement, e.g.
+
+> VALUES ('Bob',32),('Cindy',33)
+
+@since 1.1.0.0
+-}
+newtype ValuesExpr = ValuesExpr RawSql.RawSql
+  deriving
+    ( -- | @since 1.1.0.0
+      RawSql.SqlExpression
+    )
+
+{- |
+  Construct a 'ValuesExpr' for the given 'ValuesExprRow's, and any of the supported
+  optional clauses.
+
+@since 1.1.0.0
+-}
+valuesExpr ::
+  NonEmpty ValuesExprRow ->
+  Maybe OrderByExpr ->
+  Maybe LimitExpr ->
+  Maybe OffsetExpr ->
+  Maybe FetchClause ->
+  ValuesExpr
+valuesExpr vals mbOrderBy mbLimit mbOffset mbFetch =
+  let
+    opts =
+      RawSql.intercalate RawSql.space $
+        catMaybes
+          [ fmap RawSql.toRawSql mbOrderBy
+          , fmap RawSql.toRawSql mbLimit
+          , fmap RawSql.toRawSql mbOffset
+          , fmap RawSql.toRawSql mbFetch
+          ]
+  in
+    ValuesExpr $
+      RawSql.fromString "VALUES "
+        <> RawSql.intercalate RawSql.comma (fmap RawSql.toRawSql vals)
+        <> opts
+
+{- |
+  A helper function to construct a 'ValuesExpr' from a non-empty lists of 'ValueExpression's,
+  useful for conveinently constructing a 'ValuesExpr' in contexts where you don't need to use
+  @DEFAULT@ values or additional clauses.
+
+@since 1.1.0.0
+-}
+valuesExprFromValueExpressions :: NonEmpty (NonEmpty ValueExpression) -> ValuesExpr
+valuesExprFromValueExpressions valExprs =
+  let
+    rows =
+      fmap (valuesExprRow . fmap valuesExprValue) valExprs
+  in
+    valuesExpr rows Nothing Nothing Nothing Nothing
+
+{- |
+  A non-emtpy row of values or @DEFAULT@s used to construct the rows for a 'ValueExpr'.
+
+@since 1.1.0.0
+-}
+newtype ValuesExprRow = ValuesExprRow RawSql.RawSql
+  deriving
+    ( -- | @since 1.1.0.0
+      RawSql.SqlExpression
+    )
+
+{- |
+  Construct a 'ValuesExprRow' from a non-empty list of 'ValuesExprValue's.
+
+@since 1.1.0.0
+-}
+valuesExprRow :: NonEmpty ValuesExprValue -> ValuesExprRow
+valuesExprRow vals =
+  ValuesExprRow
+    . RawSql.parenthesized
+    $ RawSql.intercalate RawSql.comma (fmap RawSql.toRawSql vals)
+
+{- |
+  A value used to construct a 'ValuesExprRow'.
+
+@since 1.1.0.0
+-}
+newtype ValuesExprValue = ValuesExprValue RawSql.RawSql
+  deriving
+    ( -- | @since 1.1.0.0
+      RawSql.SqlExpression
+    )
+
+{- |
+  Construct a 'ValuesExprValue' from a 'ValueExpression'.
+
+@since 1.1.0.0
+-}
+valuesExprValue :: ValueExpression -> ValuesExprValue
+valuesExprValue = ValuesExprValue . RawSql.toRawSql
+
+{- |
+  Construct a @DEFAULT@ 'ValuesExprValue'. Only valid in the context of a 'ValuesExpr' used for an
+  @INSERT@ statement, where it indicates that the default value should be used for a column.
+
+@since 1.1.0.0
+-}
+valuesExprDefaultValue :: ValuesExprValue
+valuesExprDefaultValue = ValuesExprValue $ RawSql.fromString "DEFAULT"
+
+{- |
+  Use a 'ValuesExpr' as a 'QueryExpr'.
+
+@since 1.1.0.0
+-}
+valuesQueryExpr :: ValuesExpr -> QueryExpr
+valuesQueryExpr = RawSql.unsafeFromRawSql . RawSql.toRawSql

--- a/orville-postgresql/test/Test/Entities/Bar.hs
+++ b/orville-postgresql/test/Test/Entities/Bar.hs
@@ -1,5 +1,6 @@
 module Test.Entities.Bar
   ( Bar (..)
+  , BarId
   , table
   , generate
   , generateList
@@ -49,7 +50,8 @@ barIdField =
 
 barNameField :: Orville.FieldDefinition Orville.NotNull BarName
 barNameField =
-  Orville.unboundedTextField "name"
+  Orville.setDefaultValue (Orville.textDefault $ T.pack "default") $
+    Orville.unboundedTextField "name"
 
 generate :: HH.Gen BarWrite
 generate =

--- a/orville-postgresql/test/Test/Expr/OrderBy.hs
+++ b/orville-postgresql/test/Test/Expr/OrderBy.hs
@@ -32,7 +32,7 @@ prop_ascendingExpr :: Property.NamedDBProperty
 prop_ascendingExpr =
   orderByTest "ascendingExpr sorts a text column" $
     OrderByTest
-      { orderByValuesToInsert = [mkFooBar 1 "dog", mkFooBar 2 "dingo", mkFooBar 3 "dog"]
+      { orderByValuesToInsert = NE.fromList [mkFooBar 1 "dog", mkFooBar 2 "dingo", mkFooBar 3 "dog"]
       , orderByExpectedQueryResults = [mkFooBar 2 "dingo", mkFooBar 1 "dog", mkFooBar 3 "dog"]
       , orderByDistinctOn =
           Nothing
@@ -45,7 +45,7 @@ prop_descendingExpr :: Property.NamedDBProperty
 prop_descendingExpr =
   orderByTest "descendingExpr sorts a text column" $
     OrderByTest
-      { orderByValuesToInsert = [mkFooBar 1 "dog", mkFooBar 2 "dingo", mkFooBar 3 "dog"]
+      { orderByValuesToInsert = NE.fromList [mkFooBar 1 "dog", mkFooBar 2 "dingo", mkFooBar 3 "dog"]
       , orderByExpectedQueryResults = [mkFooBar 1 "dog", mkFooBar 3 "dog", mkFooBar 2 "dingo"]
       , orderByDistinctOn =
           Nothing
@@ -58,7 +58,7 @@ prop_appendOrderByExpr :: Property.NamedDBProperty
 prop_appendOrderByExpr =
   orderByTest "appendOrderByExpr causes ordering on both columns" $
     OrderByTest
-      { orderByValuesToInsert = [mkFooBar 1 "dog", mkFooBar 2 "dingo", mkFooBar 3 "dog"]
+      { orderByValuesToInsert = NE.fromList [mkFooBar 1 "dog", mkFooBar 2 "dingo", mkFooBar 3 "dog"]
       , orderByExpectedQueryResults = [mkFooBar 2 "dingo", mkFooBar 3 "dog", mkFooBar 1 "dog"]
       , orderByDistinctOn =
           Nothing
@@ -73,7 +73,7 @@ prop_orderByColumnsExpr :: Property.NamedDBProperty
 prop_orderByColumnsExpr =
   orderByTest "orderByColumnsExpr orders by columns" $
     OrderByTest
-      { orderByValuesToInsert = [mkFooBar 1 "dog", mkFooBar 2 "dingo", mkFooBar 3 "dog"]
+      { orderByValuesToInsert = NE.fromList [mkFooBar 1 "dog", mkFooBar 2 "dingo", mkFooBar 3 "dog"]
       , orderByExpectedQueryResults = [mkFooBar 2 "dingo", mkFooBar 3 "dog", mkFooBar 1 "dog"]
       , orderByDistinctOn =
           Nothing
@@ -89,7 +89,7 @@ prop_ascendingOrderWithExpr =
   orderByTest "ascendingOrderWith sorts columns with nulls first/last" $
     OrderByTest
       { orderByValuesToInsert =
-          [FooBar Nothing Nothing, FooBar (Just 1) Nothing, mkFooBar 2 "dog", FooBar Nothing (Just "dog")]
+          NE.fromList [FooBar Nothing Nothing, FooBar (Just 1) Nothing, mkFooBar 2 "dog", FooBar Nothing (Just "dog")]
       , orderByExpectedQueryResults =
           [FooBar Nothing (Just "dog"), FooBar Nothing Nothing, FooBar (Just 1) Nothing, mkFooBar 2 "dog"]
       , orderByDistinctOn =
@@ -106,7 +106,7 @@ prop_descendingOrderWithExpr =
   orderByTest "descendingOrderWith sorts columns with nulls first/last" $
     OrderByTest
       { orderByValuesToInsert =
-          [FooBar Nothing Nothing, FooBar (Just 1) Nothing, mkFooBar 2 "dog", FooBar Nothing (Just "dog")]
+          NE.fromList [FooBar Nothing Nothing, FooBar (Just 1) Nothing, mkFooBar 2 "dog", FooBar Nothing (Just "dog")]
       , orderByExpectedQueryResults =
           [FooBar Nothing (Just "dog"), FooBar Nothing Nothing, mkFooBar 2 "dog", FooBar (Just 1) Nothing]
       , orderByDistinctOn =
@@ -122,7 +122,7 @@ prop_distinctOnExpr :: Property.NamedDBProperty
 prop_distinctOnExpr =
   orderByTest "descendingExpr sorts a text column as expected with distinctOn" $
     OrderByTest
-      { orderByValuesToInsert = [mkFooBar 1 "dog", mkFooBar 2 "dingo", mkFooBar 3 "dog"]
+      { orderByValuesToInsert = NE.fromList [mkFooBar 1 "dog", mkFooBar 2 "dingo", mkFooBar 3 "dog"]
       , orderByExpectedQueryResults = [mkFooBar 2 "dingo", mkFooBar 1 "dog"]
       , orderByDistinctOn =
           Just . pure . RawSql.unsafeFromRawSql $ RawSql.toRawSql barColumn
@@ -134,7 +134,7 @@ prop_distinctOnExpr =
       }
 
 data OrderByTest = OrderByTest
-  { orderByValuesToInsert :: [FooBar]
+  { orderByValuesToInsert :: NE.NonEmpty FooBar
   , orderByClause :: Maybe Expr.OrderByClause
   , orderByDistinctOn :: Maybe (NE.NonEmpty Expr.DistinctOnExpr)
   , orderByExpectedQueryResults :: [FooBar]

--- a/orville-postgresql/test/Test/Expr/Trigger.hs
+++ b/orville-postgresql/test/Test/Expr/Trigger.hs
@@ -3,7 +3,6 @@ module Test.Expr.Trigger
   ) where
 
 import qualified Control.Monad.IO.Class as MIO
-import Data.List.NonEmpty (NonEmpty ((:|)))
 
 import qualified Orville.PostgreSQL as Orville
 import qualified Orville.PostgreSQL.Execution as Execution
@@ -26,7 +25,7 @@ prop_triggers =
   Property.singletonNamedDBProperty "creates a trigger on a table" $ \pool -> do
     let
       fooBars =
-        [mkFooBar 1 "dog"]
+        pure $ mkFooBar 1 "dog"
 
       expectedFooBars =
         [mkFooBar 1 "god"]
@@ -53,7 +52,7 @@ prop_triggers =
           Nothing
           (Expr.triggerName "test_trigger")
           Expr.triggerBefore
-          (Expr.triggerOnInsert :| [])
+          (pure Expr.triggerOnInsert)
           fooBarTable
           Expr.triggerForEachRow
           triggerFunctionName

--- a/orville-postgresql/test/Test/Expr/Where.hs
+++ b/orville-postgresql/test/Test/Expr/Where.hs
@@ -6,6 +6,7 @@ where
 import qualified Control.Monad.IO.Class as MIO
 import Data.Int (Int32)
 import Data.List.NonEmpty (NonEmpty ((:|)))
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
 
 import qualified Orville.PostgreSQL as Orville
@@ -42,7 +43,7 @@ prop_noWhereClauseSpecified :: Property.NamedDBProperty
 prop_noWhereClauseSpecified =
   whereConditionTest "Returns all rows when where clause is specified" $
     WhereConditionTest
-      { whereValuesToInsert = [mkFooBar 1 "ant", mkFooBar 2 "bee", mkFooBar 3 "chihuahua"]
+      { whereValuesToInsert = NE.fromList [mkFooBar 1 "ant", mkFooBar 2 "bee", mkFooBar 3 "chihuahua"]
       , whereExpectedQueryResults = [mkFooBar 1 "ant", mkFooBar 2 "bee", mkFooBar 3 "chihuahua"]
       , whereClause = Nothing
       }
@@ -51,7 +52,7 @@ prop_equalsOp :: Property.NamedDBProperty
 prop_equalsOp =
   whereConditionTest "equalsOp matches exact value" $
     WhereConditionTest
-      { whereValuesToInsert = [mkFooBar 1 "ant", mkFooBar 2 "bee", mkFooBar 3 "chihuahua"]
+      { whereValuesToInsert = NE.fromList [mkFooBar 1 "ant", mkFooBar 2 "bee", mkFooBar 3 "chihuahua"]
       , whereExpectedQueryResults = [mkFooBar 2 "bee"]
       , whereClause =
           Just . Expr.whereClause $
@@ -62,7 +63,7 @@ prop_isDistinctFromOp :: Property.NamedDBProperty
 prop_isDistinctFromOp =
   whereConditionTest "isDistinctFromOp matches on null correctly" $
     WhereConditionTest
-      { whereValuesToInsert = [FooBar Nothing (Just "ant"), mkFooBar 2 "bee", FooBar Nothing (Just "chihuahua")]
+      { whereValuesToInsert = NE.fromList [FooBar Nothing (Just "ant"), mkFooBar 2 "bee", FooBar Nothing (Just "chihuahua")]
       , whereExpectedQueryResults = [mkFooBar 2 "bee"]
       , whereClause =
           Just . Expr.whereClause $
@@ -76,7 +77,7 @@ prop_isNotDistinctFromOp =
       expectedResults = [FooBar Nothing (Just "ant"), FooBar Nothing (Just "chihuahua")]
     in
       WhereConditionTest
-        { whereValuesToInsert = [mkFooBar 2 "bee"] <> expectedResults
+        { whereValuesToInsert = mkFooBar 2 "bee" :| expectedResults
         , whereExpectedQueryResults = expectedResults
         , whereClause =
             Just . Expr.whereClause $
@@ -87,7 +88,7 @@ prop_greaterThanOp :: Property.NamedDBProperty
 prop_greaterThanOp =
   whereConditionTest "greaterThanOp matches greater values" $
     WhereConditionTest
-      { whereValuesToInsert = [mkFooBar 1 "ant", mkFooBar 2 "bee", mkFooBar 3 "chihuahua"]
+      { whereValuesToInsert = NE.fromList [mkFooBar 1 "ant", mkFooBar 2 "bee", mkFooBar 3 "chihuahua"]
       , whereExpectedQueryResults = [mkFooBar 3 "chihuahua"]
       , whereClause =
           Just . Expr.whereClause $
@@ -98,7 +99,7 @@ prop_greaterThanOrEqualsOp :: Property.NamedDBProperty
 prop_greaterThanOrEqualsOp =
   whereConditionTest "greaterThanOrEqualsOp matches greater or equal values" $
     WhereConditionTest
-      { whereValuesToInsert = [mkFooBar 1 "ant", mkFooBar 2 "bee", mkFooBar 3 "chihuahua"]
+      { whereValuesToInsert = NE.fromList [mkFooBar 1 "ant", mkFooBar 2 "bee", mkFooBar 3 "chihuahua"]
       , whereExpectedQueryResults = [mkFooBar 2 "bee", mkFooBar 3 "chihuahua"]
       , whereClause =
           Just . Expr.whereClause $
@@ -109,7 +110,7 @@ prop_lessThanOp :: Property.NamedDBProperty
 prop_lessThanOp =
   whereConditionTest "lessThanOp matches lesser values" $
     WhereConditionTest
-      { whereValuesToInsert = [mkFooBar 1 "ant", mkFooBar 2 "bee", mkFooBar 3 "chihuahua"]
+      { whereValuesToInsert = NE.fromList [mkFooBar 1 "ant", mkFooBar 2 "bee", mkFooBar 3 "chihuahua"]
       , whereExpectedQueryResults = [mkFooBar 1 "ant"]
       , whereClause =
           Just . Expr.whereClause $
@@ -120,7 +121,7 @@ prop_lessThanOrEqualsToOp :: Property.NamedDBProperty
 prop_lessThanOrEqualsToOp =
   whereConditionTest "lessThanOrEqualsOp matches lesser or equal values" $
     WhereConditionTest
-      { whereValuesToInsert = [mkFooBar 1 "ant", mkFooBar 2 "bee", mkFooBar 3 "chihuahua"]
+      { whereValuesToInsert = NE.fromList [mkFooBar 1 "ant", mkFooBar 2 "bee", mkFooBar 3 "chihuahua"]
       , whereExpectedQueryResults = [mkFooBar 1 "ant", mkFooBar 2 "bee"]
       , whereClause =
           Just . Expr.whereClause $
@@ -131,7 +132,7 @@ prop_andExpr :: Property.NamedDBProperty
 prop_andExpr =
   whereConditionTest "andExpr requires both conditions to be true" $
     WhereConditionTest
-      { whereValuesToInsert = [mkFooBar 1 "dog", mkFooBar 2 "dingo", mkFooBar 3 "dog"]
+      { whereValuesToInsert = NE.fromList [mkFooBar 1 "dog", mkFooBar 2 "dingo", mkFooBar 3 "dog"]
       , whereExpectedQueryResults = [mkFooBar 3 "dog"]
       , whereClause =
           Just . Expr.whereClause $
@@ -144,7 +145,7 @@ prop_orExpr :: Property.NamedDBProperty
 prop_orExpr =
   whereConditionTest "orExpr requires either conditions to be true" $
     WhereConditionTest
-      { whereValuesToInsert = [mkFooBar 1 "dog", mkFooBar 2 "dingo", mkFooBar 3 "dog"]
+      { whereValuesToInsert = NE.fromList [mkFooBar 1 "dog", mkFooBar 2 "dingo", mkFooBar 3 "dog"]
       , whereExpectedQueryResults = [mkFooBar 2 "dingo", mkFooBar 3 "dog"]
       , whereClause =
           Just . Expr.whereClause $
@@ -157,7 +158,7 @@ prop_notExpr :: Property.NamedDBProperty
 prop_notExpr =
   whereConditionTest "notExpr inverts condition" $
     WhereConditionTest
-      { whereValuesToInsert = [mkFooBar 1 "dog", mkFooBar 2 "dingo", mkFooBar 3 "dog"]
+      { whereValuesToInsert = NE.fromList [mkFooBar 1 "dog", mkFooBar 2 "dingo", mkFooBar 3 "dog"]
       , whereExpectedQueryResults = [mkFooBar 2 "dingo"]
       , whereClause =
           Just . Expr.whereClause . Expr.notExpr $
@@ -170,7 +171,7 @@ prop_valueIn :: Property.NamedDBProperty
 prop_valueIn =
   whereConditionTest "valueIn requires the column's value to be in the list" $
     WhereConditionTest
-      { whereValuesToInsert = [mkFooBar 1 "dog", mkFooBar 2 "dingo", mkFooBar 3 "dog"]
+      { whereValuesToInsert = NE.fromList [mkFooBar 1 "dog", mkFooBar 2 "dingo", mkFooBar 3 "dog"]
       , whereExpectedQueryResults = [mkFooBar 1 "dog", mkFooBar 3 "dog"]
       , whereClause =
           Just . Expr.whereClause $
@@ -183,7 +184,7 @@ prop_valueNotIn :: Property.NamedDBProperty
 prop_valueNotIn =
   whereConditionTest "valueNotIn requires the column's value to not be in the list" $
     WhereConditionTest
-      { whereValuesToInsert = [mkFooBar 1 "dog", mkFooBar 2 "dingo", mkFooBar 3 "dog"]
+      { whereValuesToInsert = NE.fromList [mkFooBar 1 "dog", mkFooBar 2 "dingo", mkFooBar 3 "dog"]
       , whereExpectedQueryResults = [mkFooBar 2 "dingo"]
       , whereClause =
           Just . Expr.whereClause $
@@ -196,7 +197,7 @@ prop_tupleIn :: Property.NamedDBProperty
 prop_tupleIn =
   whereConditionTest "tupleIn requires the column value combination to be in the list" $
     WhereConditionTest
-      { whereValuesToInsert = [mkFooBar 1 "dog", mkFooBar 2 "dingo", mkFooBar 3 "dog"]
+      { whereValuesToInsert = NE.fromList [mkFooBar 1 "dog", mkFooBar 2 "dingo", mkFooBar 3 "dog"]
       , whereExpectedQueryResults = [mkFooBar 1 "dog", mkFooBar 2 "dingo"]
       , whereClause =
           Just . Expr.whereClause $
@@ -211,7 +212,7 @@ prop_tupleNotIn :: Property.NamedDBProperty
 prop_tupleNotIn =
   whereConditionTest "tupleNotIn requires the column value combination to not be in the list" $
     WhereConditionTest
-      { whereValuesToInsert = [mkFooBar 1 "dog", mkFooBar 2 "dingo", mkFooBar 3 "dog"]
+      { whereValuesToInsert = NE.fromList [mkFooBar 1 "dog", mkFooBar 2 "dingo", mkFooBar 3 "dog"]
       , whereExpectedQueryResults = [mkFooBar 3 "dog"]
       , whereClause =
           Just . Expr.whereClause $
@@ -231,7 +232,7 @@ textValueExpr =
   Expr.valueExpression . SqlValue.fromText . T.pack
 
 data WhereConditionTest = WhereConditionTest
-  { whereValuesToInsert :: [FooBar]
+  { whereValuesToInsert :: NE.NonEmpty FooBar
   , whereClause :: Maybe Expr.WhereClause
   , whereExpectedQueryResults :: [FooBar]
   }

--- a/orville-postgresql/test/Test/FieldDefinition.hs
+++ b/orville-postgresql/test/Test/FieldDefinition.hs
@@ -248,7 +248,13 @@ runRoundTripTest pool testCase = do
       Expr.insertExpr
         testTable
         Nothing
-        (Expr.insertSqlValues [[Marshall.toComparableSqlValue fieldDef value]])
+        ( Expr.valuesExprInsertSource
+            . Expr.valuesExprFromValueExpressions
+            . pure
+            . pure
+            . Expr.valueExpression
+            $ Marshall.toComparableSqlValue fieldDef value
+        )
         Nothing
         Nothing
 
@@ -293,7 +299,13 @@ runNullableRoundTripTest pool testCase = do
       Expr.insertExpr
         testTable
         Nothing
-        (Expr.insertSqlValues [[Marshall.fieldValueToSqlValue fieldDef value]])
+        ( Expr.valuesExprInsertSource
+            . Expr.valuesExprFromValueExpressions
+            . pure
+            . pure
+            . Expr.valueExpression
+            $ Marshall.toComparableSqlValue fieldDef value
+        )
         Nothing
         Nothing
 
@@ -329,7 +341,12 @@ runNullCounterExampleTest pool testCase = do
         Expr.insertExpr
           testTable
           Nothing
-          (Expr.insertSqlValues [[SqlValue.sqlNull]])
+          ( Expr.valuesExprInsertSource
+              . Expr.valuesExprFromValueExpressions
+              . pure
+              . pure
+              $ Expr.valueExpression SqlValue.sqlNull
+          )
           Nothing
           Nothing
 

--- a/orville-postgresql/test/Test/SqlCommenter.hs
+++ b/orville-postgresql/test/Test/SqlCommenter.hs
@@ -6,6 +6,7 @@ where
 import qualified Control.Monad.IO.Class as MIO
 import qualified Data.ByteString.Char8 as B8
 import Data.Functor.Identity (runIdentity)
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import Hedgehog ((===))
@@ -62,7 +63,7 @@ prop_sqlCommenterInsertExpr :: Property.NamedDBProperty
 prop_sqlCommenterInsertExpr =
   Property.singletonNamedDBProperty "sqlcommenter support does not impact ability of insertExpr inserting values" $ \pool -> do
     let
-      fooBars = [mkFooBar 1 "dog", mkFooBar 2 "cat"]
+      fooBars = NE.fromList [mkFooBar 1 "dog", mkFooBar 2 "cat"]
 
     rows <-
       MIO.liftIO $
@@ -78,7 +79,7 @@ prop_sqlCommenterInsertExpr =
 
           Execution.readRows result
 
-    assertEqualFooBarRows rows fooBars
+    assertEqualFooBarRows rows (NE.toList fooBars)
 
 prop_sqlCommenterOrvilleState :: Property.NamedDBProperty
 prop_sqlCommenterOrvilleState =

--- a/orville-postgresql/test/Test/SqlType.hs
+++ b/orville-postgresql/test/Test/SqlType.hs
@@ -531,12 +531,20 @@ runDecodingTest pool test =
 
       let
         tableName = Expr.unqualified $ Expr.tableName "decoding_test"
+        insertSource =
+          Expr.valuesExprInsertSource
+            . Expr.valuesExprFromValueExpressions
+            . pure
+            . pure
+            . Expr.valueExpression
+            . SqlValue.fromRawBytesNullable
+            $ rawSqlValue test
 
       RawSql.executeVoid connection $
         Expr.insertExpr
           tableName
           Nothing
-          (Expr.insertSqlValues [[SqlValue.fromRawBytesNullable (rawSqlValue test)]])
+          insertSource
           Nothing
           Nothing
 


### PR DESCRIPTION
I added a new module for constructing `VALUES` statements and refactored `InsertSource` to use it. I deprecated the old `InsertSource` construction functions, which could be used to produce invalid SQL by passing empty lists of values.

This also had the effect of improving the behavior of `mkInsertSource` when called with a `SqlMarshaller` with no fields; it will now use `VALUES(DEFAULT)` for that case instead of generating invalid SQL.