### PR TITLE
Add a 'FetchClause'

### DIFF
--- a/orville-postgresql/orville-postgresql.cabal
+++ b/orville-postgresql/orville-postgresql.cabal
@@ -58,6 +58,7 @@ library
       Orville.PostgreSQL.Expr.DataType
       Orville.PostgreSQL.Expr.Delete
       Orville.PostgreSQL.Expr.Extension
+      Orville.PostgreSQL.Expr.FetchClause
       Orville.PostgreSQL.Expr.Filter
       Orville.PostgreSQL.Expr.FromItemExpr
       Orville.PostgreSQL.Expr.Function

--- a/orville-postgresql/package.yaml
+++ b/orville-postgresql/package.yaml
@@ -54,6 +54,7 @@ library:
     - Orville.PostgreSQL.Expr.DataType
     - Orville.PostgreSQL.Expr.Delete
     - Orville.PostgreSQL.Expr.Extension
+    - Orville.PostgreSQL.Expr.FetchClause
     - Orville.PostgreSQL.Expr.Filter
     - Orville.PostgreSQL.Expr.FromItemExpr
     - Orville.PostgreSQL.Expr.Function

--- a/orville-postgresql/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL.hs
@@ -283,6 +283,7 @@ module Orville.PostgreSQL
   , SelectOptions.emptySelectOptions
   , SelectOptions.appendSelectOptions
   , SelectOptions.forRowLock
+  , SelectOptions.fetchRow
   , FieldDefinition.fieldEquals
   , (FieldDefinition..==)
   , FieldDefinition.fieldNotEquals
@@ -333,6 +334,7 @@ module Orville.PostgreSQL
   , SelectOptions.selectWhereClause
   , SelectOptions.selectDistinct
   , SelectOptions.selectRowLockingClause
+  , SelectOptions.selectFetchClause
 
     -- * Functions for defining and working with sequences
   , Sequence.sequenceNextValue

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr.hs
@@ -76,6 +76,7 @@ module Orville.PostgreSQL.Expr
   , module Orville.PostgreSQL.Expr.RowLocking
   , module Orville.PostgreSQL.Expr.Aggregate
   , module Orville.PostgreSQL.Expr.Filter
+  , module Orville.PostgreSQL.Expr.FetchClause
   )
 where
 
@@ -92,6 +93,7 @@ import Orville.PostgreSQL.Expr.Cursor
 import Orville.PostgreSQL.Expr.DataType
 import Orville.PostgreSQL.Expr.Delete
 import Orville.PostgreSQL.Expr.Extension
+import Orville.PostgreSQL.Expr.FetchClause
 import Orville.PostgreSQL.Expr.Filter
 import Orville.PostgreSQL.Expr.FromItemExpr
 import Orville.PostgreSQL.Expr.Function

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/FetchClause.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/FetchClause.hs
@@ -1,0 +1,102 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+{- |
+Copyright : Flipstone Technology Partners 2024
+License   : MIT
+Stability : Stable
+
+@since 1.1.0.0
+-}
+module Orville.PostgreSQL.Expr.FetchClause
+  ( FetchClause
+  , fetchClauseInt
+  , FetchClauseModifier
+  , withTiesFetchClauseModifier
+  , onlyFetchClauseModifier
+  )
+where
+
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
+
+{- |
+Type to represent a SQL FETCH clause. E.G.
+
+> FETCH FIRST 2 ROWS ONLY
+
+'FetchClause' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 1.1.0.0
+-}
+newtype FetchClause
+  = FetchClause RawSql.RawSql
+  deriving
+    ( -- | @since 1.1.0.0
+      RawSql.SqlExpression
+    )
+
+{- | Build a 'FETCH' for a given number of rows and with the given modifier.
+
+@since 1.1.0.0
+-}
+fetchClauseInt :: Int -> FetchClauseModifier -> FetchClause
+fetchClauseInt fetchNumber =
+  internal_fetchRaw (RawSql.parameter (SqlValue.fromInt fetchNumber))
+
+-- Internal helper for FETCH. Note this allows illegal expressions to be put together. However many
+-- potentially interesting expressions are valid. Such as:
+--
+-- `VALUES (1, 'o'), (2, 't'), (3, 'th') order by column2 fetch first (select 2) ROW with ties;`
+--
+-- How to best expose these is not clear at this moment as we do not generally allow any raw sql to
+-- be injected, but we do not have a good expression to capture the allowed values here. Finally, it
+-- would _appear_ that the same restrictions here would also apply to expressions allowed for
+-- LIMIT. Which as of this writing, we do not have a helper for creation.
+--
+-- Finally note that NEXT and ROW are as PostgreSQL docs call them, noise words, they do not impact
+-- the meaning. See https://www.postgresql.org/docs/13/sql-select.html. 'NEXT' and 'ROW' are chosen
+-- over 'FIRST' and 'ROWS' respecitvely because they are shorter and thus result in a smaller
+-- bytestring being sent over the wire.
+internal_fetchRaw :: RawSql.RawSql -> FetchClauseModifier -> FetchClause
+internal_fetchRaw countingRawSql modifier =
+  FetchClause $
+    RawSql.fromString "FETCH NEXT "
+      <> RawSql.parenthesized countingRawSql
+      <> RawSql.fromString " ROW "
+      <> RawSql.toRawSql modifier
+
+{- |
+Type to represent the treatment of ties in a SQL FETCH expression. E.G.
+
+> WITH TIES
+
+'FetchClauseModifier' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 1.1.0.0
+-}
+newtype FetchClauseModifier
+  = FetchClauseModifier RawSql.RawSql
+  deriving
+    ( -- | @since 1.1.0.0
+      RawSql.SqlExpression
+    )
+
+{- | Allow a FETCH clause to have ties.
+
+@since 1.1.0.0
+-}
+withTiesFetchClauseModifier :: FetchClauseModifier
+withTiesFetchClauseModifier =
+  FetchClauseModifier (RawSql.fromString "WITH TIES")
+
+{- | Disallow a FETCH clause to have ties.
+
+@since 1.1.0.0
+-}
+onlyFetchClauseModifier :: FetchClauseModifier
+onlyFetchClauseModifier =
+  FetchClauseModifier (RawSql.fromString "ONLY")

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Query.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Query.hs
@@ -35,6 +35,7 @@ where
 import Data.Maybe (catMaybes, fromMaybe)
 
 import Orville.PostgreSQL.Expr.BinaryOperator (BinaryOperator)
+import Orville.PostgreSQL.Expr.FetchClause (FetchClause)
 import Orville.PostgreSQL.Expr.FromItemExpr (FromItemExpr)
 import Orville.PostgreSQL.Expr.GroupBy (GroupByClause)
 import Orville.PostgreSQL.Expr.Join (JoinConstraint, JoinExpr, JoinType, joinExpr)
@@ -359,6 +360,8 @@ tableExpr ::
   Maybe RowLockingClause ->
   -- | An optional @WINDOW@ clause to apply to the result set.
   Maybe WindowClause ->
+  -- | An optional @FETCH@ clause to apply to the result set.
+  Maybe FetchClause ->
   TableExpr
 tableExpr
   tableReferenceList
@@ -368,7 +371,8 @@ tableExpr
   maybeLimitExpr
   maybeOffsetExpr
   maybeRowLockingClause
-  maybeWindowClause =
+  maybeWindowClause
+  maybeFetchClause =
     TableExpr
       . RawSql.intercalate RawSql.space
       $ RawSql.toRawSql tableReferenceList
@@ -379,5 +383,6 @@ tableExpr
           , RawSql.toRawSql <$> maybeOrderByClause
           , RawSql.toRawSql <$> maybeLimitExpr
           , RawSql.toRawSql <$> maybeOffsetExpr
+          , RawSql.toRawSql <$> maybeFetchClause
           , RawSql.toRawSql <$> maybeRowLockingClause
           ]

--- a/orville-postgresql/test/Test/Expr/Aggregate.hs
+++ b/orville-postgresql/test/Test/Expr/Aggregate.hs
@@ -120,7 +120,7 @@ aggregateFunctionTest testName test =
           Expr.queryExpr
             (Expr.selectClause $ Expr.selectExpr Nothing)
             (Expr.selectDerivedColumns . pure $ Expr.deriveColumnAsAlias (aggregateFunctionExpr test) (RawSql.unsafeFromRawSql $ RawSql.fromString "agg"))
-            (Just $ Expr.tableExpr (Expr.tableFromItem testTable) Nothing Nothing Nothing Nothing Nothing Nothing Nothing)
+            (Just $ Expr.tableExpr (Expr.tableFromItem testTable) Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing)
 
       Execution.readRows result
 

--- a/orville-postgresql/test/Test/Expr/Count.hs
+++ b/orville-postgresql/test/Test/Expr/Count.hs
@@ -61,7 +61,7 @@ prop_countColumn =
                   (Expr.columnName "count")
               ]
           )
-          (Just (Expr.tableExpr (Expr.tableFromItem $ Orville.tableName Foo.table) Nothing Nothing Nothing Nothing Nothing Nothing Nothing))
+          (Just (Expr.tableExpr (Expr.tableFromItem $ Orville.tableName Foo.table) Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing))
 
       marshaller =
         Orville.annotateSqlMarshallerEmptyAnnotation $

--- a/orville-postgresql/test/Test/Expr/GroupBy.hs
+++ b/orville-postgresql/test/Test/Expr/GroupBy.hs
@@ -97,7 +97,7 @@ groupByTest testName test =
           Expr.queryExpr
             (Expr.selectClause $ Expr.selectExpr Nothing)
             (Expr.selectColumns [fooColumn, barColumn])
-            (Just $ Expr.tableExpr (Expr.tableFromItem testTable) Nothing (groupByClause test) Nothing Nothing Nothing Nothing Nothing)
+            (Just $ Expr.tableExpr (Expr.tableFromItem testTable) Nothing (groupByClause test) Nothing Nothing Nothing Nothing Nothing Nothing)
 
       Execution.readRows result
 

--- a/orville-postgresql/test/Test/Expr/GroupByOrderBy.hs
+++ b/orville-postgresql/test/Test/Expr/GroupByOrderBy.hs
@@ -87,7 +87,7 @@ groupByOrderByTest testName test =
           Expr.queryExpr
             (Expr.selectClause $ Expr.selectExpr Nothing)
             (Expr.selectColumns [fooColumn, barColumn])
-            (Just $ Expr.tableExpr (Expr.tableFromItem testTable) Nothing (groupByClause test) (orderByClause test) Nothing Nothing Nothing Nothing)
+            (Just $ Expr.tableExpr (Expr.tableFromItem testTable) Nothing (groupByClause test) (orderByClause test) Nothing Nothing Nothing Nothing Nothing)
 
       Execution.readRows result
 

--- a/orville-postgresql/test/Test/Expr/OrderBy.hs
+++ b/orville-postgresql/test/Test/Expr/OrderBy.hs
@@ -156,7 +156,7 @@ orderByTest testName test =
               Expr.queryExpr
                 (Expr.selectClause . Expr.selectDistinctOnExpr $ orderByDistinctOn test)
                 (Expr.selectColumns [fooColumn, barColumn])
-                (Just $ Expr.tableExpr (Expr.tableFromItem fooBarTable) Nothing Nothing (orderByClause test) Nothing Nothing Nothing Nothing)
+                (Just $ Expr.tableExpr (Expr.tableFromItem fooBarTable) Nothing Nothing (orderByClause test) Nothing Nothing Nothing Nothing Nothing)
 
           Execution.readRows result
 

--- a/orville-postgresql/test/Test/Expr/TestSchema.hs
+++ b/orville-postgresql/test/Test/Expr/TestSchema.hs
@@ -83,7 +83,7 @@ findAllFooBarsInTable tableName =
     Expr.queryExpr
       (Expr.selectClause $ Expr.selectExpr Nothing)
       (Expr.selectColumns [fooColumn, Expr.untrackQualified barColumnAliased])
-      (Just $ Expr.tableExpr tableRef Nothing Nothing (Just orderByFoo) Nothing Nothing Nothing Nothing)
+      (Just $ Expr.tableExpr tableRef Nothing Nothing (Just orderByFoo) Nothing Nothing Nothing Nothing Nothing)
 
 encodeFooBar :: FooBar -> [(Maybe B8.ByteString, SqlValue.SqlValue)]
 encodeFooBar fooBar =

--- a/orville-postgresql/test/Test/Expr/Where.hs
+++ b/orville-postgresql/test/Test/Expr/Where.hs
@@ -252,7 +252,7 @@ whereConditionTest testName test =
               Expr.queryExpr
                 (Expr.selectClause $ Expr.selectExpr Nothing)
                 (Expr.selectColumns [fooColumn, barColumn])
-                (Just $ Expr.tableExpr (Expr.tableFromItem fooBarTable) (whereClause test) Nothing Nothing Nothing Nothing Nothing Nothing)
+                (Just $ Expr.tableExpr (Expr.tableFromItem fooBarTable) (whereClause test) Nothing Nothing Nothing Nothing Nothing Nothing Nothing)
 
           Execution.readRows result
 

--- a/orville-postgresql/test/Test/FieldDefinition.hs
+++ b/orville-postgresql/test/Test/FieldDefinition.hs
@@ -257,7 +257,7 @@ runRoundTripTest pool testCase = do
         Expr.queryExpr
           (Expr.selectClause $ Expr.selectExpr Nothing)
           (Expr.selectColumns [Marshall.fieldColumnName fieldDef])
-          (Just $ Expr.tableExpr (Expr.tableFromItem testTable) Nothing Nothing Nothing Nothing Nothing Nothing Nothing)
+          (Just $ Expr.tableExpr (Expr.tableFromItem testTable) Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing)
 
     Execution.readRows result
 
@@ -302,7 +302,7 @@ runNullableRoundTripTest pool testCase = do
         Expr.queryExpr
           (Expr.selectClause $ Expr.selectExpr Nothing)
           (Expr.selectColumns [Marshall.fieldColumnName fieldDef])
-          (Just $ Expr.tableExpr (Expr.tableFromItem testTable) Nothing Nothing Nothing Nothing Nothing Nothing Nothing)
+          (Just $ Expr.tableExpr (Expr.tableFromItem testTable) Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing)
 
     Execution.readRows result
 
@@ -372,7 +372,7 @@ runDefaultValueFieldDefinitionTest pool testCase mkDefaultValue = do
         Expr.queryExpr
           (Expr.selectClause $ Expr.selectExpr Nothing)
           (Expr.selectColumns [Marshall.fieldColumnName fieldDef])
-          (Just $ Expr.tableExpr (Expr.tableFromItem testTable) Nothing Nothing Nothing Nothing Nothing Nothing Nothing)
+          (Just $ Expr.tableExpr (Expr.tableFromItem testTable) Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing)
 
     Execution.readRows result
 

--- a/orville-postgresql/test/Test/SqlType.hs
+++ b/orville-postgresql/test/Test/SqlType.hs
@@ -545,7 +545,7 @@ runDecodingTest pool test =
           Expr.queryExpr
             (Expr.selectClause $ Expr.selectExpr Nothing)
             Expr.selectStar
-            (Just $ Expr.tableExpr (Expr.tableFromItem tableName) Nothing Nothing Nothing Nothing Nothing Nothing Nothing)
+            (Just $ Expr.tableExpr (Expr.tableFromItem tableName) Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing)
 
       Execution.readRows result
 


### PR DESCRIPTION
'FetchClause' is so named because it is not a top level item and to avoid the existing 'FetchExpr'.

Some of the function names have similar awkward naming conflicts with no obvious solution other than a big breaking change.

Extends 'SELECT' to support 'FETCH' using the new 'FetchClause'