### PR TITLE
Supports negative years for date and timestamp types

### DIFF
--- a/orville-postgresql/src/Orville/PostgreSQL/Marshall/FieldDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Marshall/FieldDefinition.hs
@@ -608,6 +608,10 @@ jsonbField = fieldOfType SqlType.jsonb
 {- | Builds a 'FieldDefinition' that stores Haskell 'Time.Day' values as the
   PostgreSQL "DATE" type.
 
+  This field cannot represent the full range of 'Time.Day' values. PostgreSQL supports years
+  from -4731 to 5874897 inclusive for this field, and sending a 'Time.Day' with a year outside
+  of this range to the database will result in a PostgreSQL exception.
+
 @since 1.0.0.0
 -}
 dateField ::
@@ -619,6 +623,10 @@ dateField = fieldOfType SqlType.date
 {- | Builds a 'FieldDefinition' that stores Haskell 'Time.UTCTime' values as the
   PostgreSQL "TIMESTAMP with time zone" type.
 
+  This field cannot represent the full range of 'Time.UTCTime' values. PostgreSQL supports years
+  from -4731 to 294276 inclusive for this field, and sending a 'Time.UTCTime' with a year outside
+  of this range to the database will result in a PostgreSQL exception.
+
 @since 1.0.0.0
 -}
 utcTimestampField ::
@@ -629,6 +637,10 @@ utcTimestampField = fieldOfType SqlType.timestamp
 
 {- | Builds a 'FieldDefinition' that stores Haskell 'Time.UTCTime' values as the
   PostgreSQL "TIMESTAMP without time zone" type.
+
+  This field cannot represent the full range of 'Time.LocalTime' values. PostgreSQL supports years
+  from -4731 to 294276 inclusive for this field, and sending a 'Time.LocalTime' with a year outside
+  of this range to the database will result in a PostgreSQL exception.
 
 @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Marshall/SqlType.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Marshall/SqlType.hs
@@ -309,6 +309,10 @@ uuid =
 {- | 'date' defines a type representing a calendar date (without time zone). It corresponds
   to the "DATE" type in SQL.
 
+  This type cannot represent the full range of 'Time.Day' values. PostgreSQL supports years
+  from -4731 to 5874897 inclusive for this type, and sending a 'Time.Day' with a year outside
+  of this range to the database will result in a PostgreSQL exception.
+
 @since 1.0.0.0
 -}
 date :: SqlType Time.Day
@@ -326,6 +330,10 @@ date =
 {- | 'timestamp' defines a type representing a particular point in time without time zone information,
   but can be constructed with a time zone offset.
   It corresponds to the "TIMESTAMP with time zone" type in SQL.
+
+  This type cannot represent the full range of 'Time.UTCTime' values. PostgreSQL supports years
+  from -4731 to 294276 inclusive for this type, and sending a 'Time.UTCTime' with a year outside
+  of this range to the database will result in a PostgreSQL exception.
 
   Note: This is NOT a typo. The "TIMESTAMP with time zone" type in SQL does not include
   any actual time zone information. For an excellent explanation of the complexities
@@ -348,6 +356,10 @@ timestamp =
 
 {- | 'timestampWithoutZone' defines a type representing a particular point in time (without time zone).
   It corresponds to the "TIMESTAMP without time zone" type in SQL.
+
+  This type cannot represent the full range of 'Time.LocalTime' values. PostgreSQL supports years
+  from -4731 to 294276 inclusive for this type, and sending a 'Time.LocalTime' with a year outside
+  of this range to the database will result in a PostgreSQL exception.
 
   http://blog.untrod.com/2016/08/actually-understanding-timezones-in-postgresql.html
 

--- a/orville-postgresql/test/Test/PgGen.hs
+++ b/orville-postgresql/test/Test/PgGen.hs
@@ -125,7 +125,7 @@ pgLocalTime =
 
 pgDay :: HH.Gen Time.Day
 pgDay = do
-  year <- Gen.integral (Range.linearFrom 2000 0 3000)
+  year <- Gen.integral (Range.constantFrom 2000 (-4713) 294276)
   month <- Gen.integral (Range.constant 1 12)
   day <- Gen.integral (Range.constant 1 (Time.gregorianMonthLength year month))
 


### PR DESCRIPTION
Previously we were ISO8601 encoding/decoding dates and timestamps with negative years, however PostgreSQL uses a "BC" suffix to indicate negative years. I added support for this syntax to the `Day`, `UTCTime`, and `LocalTime` `SqlType`s, and expanded the range of years generated in testing to ensure we're handling the negative years correctly.

Closes #380.