### PR TITLE
Adds `inWithTransaction` helper to get transaction status

### DIFF
--- a/orville-postgresql/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL.hs
@@ -70,6 +70,8 @@ module Orville.PostgreSQL
 
     -- * Opening transactions and savepoints
   , Transaction.withTransaction
+  , Transaction.inWithTransaction
+  , Transaction.InWithTransaction (InOutermostTransaction, InSavepointTransaction)
 
     -- * Types for incorporating Orville into other Monads
   , MonadOrville.MonadOrville


### PR DESCRIPTION
I added a function that will return a new type called `InWithTransaction` when called within the action passed to `withTransaction`. The value indicates whether the transaction is the outermost, or is within a savepoint.