### PR TITLE
Removes extra parens in `conflictTargetForIndexExpr`

### DIFF
--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/OnConflict.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/OnConflict.hs
@@ -105,6 +105,7 @@ conflictTargetForIndexColumn colName mbWhere =
    for more than a single column. PostgreSQL will use the expression to infer which index to check for
    conflicts.
 
+   Note that this function assumes that the 'IndexBodyExpr' is parenthesized.
 @since 1.1.0.0
 -}
 conflictTargetForIndexExpr :: IndexBodyExpr -> Maybe WhereClause -> ConflictTargetExpr

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/OnConflict.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/OnConflict.hs
@@ -110,12 +110,12 @@ conflictTargetForIndexColumn colName mbWhere =
 conflictTargetForIndexExpr :: IndexBodyExpr -> Maybe WhereClause -> ConflictTargetExpr
 conflictTargetForIndexExpr idxBody mbWhere =
   let
-    parensBody = RawSql.parenthesized $ RawSql.toRawSql idxBody
+    rawIdxBody = RawSql.toRawSql idxBody
   in
     ConflictTargetExpr $
       case mbWhere of
-        Nothing -> parensBody
-        Just whereClause -> parensBody <> RawSql.space <> RawSql.toRawSql whereClause
+        Nothing -> rawIdxBody
+        Just whereClause -> rawIdxBody <> RawSql.space <> RawSql.toRawSql whereClause
 
 {- | Build a 'ConflictTargetExpr' for conflicting on the given 'ConstraintName'. For conflicing on an
    index, see 'conflictTargetForIndexColumn' or 'conflictTargetForIndexExpr' instead.


### PR DESCRIPTION
The `IndexBodyExpr` passed to `conflictTargetForIndexExpr` will already be parenthesized, and it is invalid PostgreSQL syntax to wrap it in an extra set of parens.