### PR TITLE
Add initial support for identity columns

### DIFF
--- a/orville-postgresql/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL.hs
@@ -247,6 +247,8 @@ module Orville.PostgreSQL
   , FieldDefinition.getFieldDefinition
   , FieldDefinition.getAlias
   , FieldDefinition.buildAliasedFieldDefinition
+  , FieldDefinition.markAsIdentity
+  , FieldDefinition.unmarkIdentity
   , Marshall.AliasName
   , Marshall.stringToAliasName
   , Marshall.aliasNameToString

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/ConstraintDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/ConstraintDefinition.hs
@@ -103,8 +103,8 @@ tableConstraintDefinitions (TableConstraints constraints) =
 @since 1.0.0.0
 -}
 data ConstraintDefinition = ConstraintDefinition
-  { _constraintSqlExpr :: Expr.TableConstraint
-  , _constraintMigrationKey :: ConstraintMigrationKey
+  { i_constraintSqlExpr :: Expr.TableConstraint
+  , i_constraintMigrationKey :: ConstraintMigrationKey
   }
 
 {- | The key used by Orville to determine whether a constraint should be added to
@@ -153,14 +153,14 @@ data ConstraintKeyType
 @since 1.0.0.0
 -}
 constraintMigrationKey :: ConstraintDefinition -> ConstraintMigrationKey
-constraintMigrationKey = _constraintMigrationKey
+constraintMigrationKey = i_constraintMigrationKey
 
 {- | Gets the SQL expression that will be used to add the constraint to the table.
 
 @since 1.0.0.0
 -}
 constraintSqlExpr :: ConstraintDefinition -> Expr.TableConstraint
-constraintSqlExpr = _constraintSqlExpr
+constraintSqlExpr = i_constraintSqlExpr
 
 {- | Constructs a 'ConstraintDefinition' for a @UNIQUE@ constraint on the given
   columns.
@@ -184,8 +184,8 @@ uniqueConstraint fieldNames =
         }
   in
     ConstraintDefinition
-      { _constraintSqlExpr = expr
-      , _constraintMigrationKey = migrationKey
+      { i_constraintSqlExpr = expr
+      , i_constraintMigrationKey = migrationKey
       }
 
 {- | A 'ForeignReference' represents one part of a foreign key. The entire foreign
@@ -326,6 +326,6 @@ foreignKeyConstraintWithOptions foreignTableId foreignReferences options =
         }
   in
     ConstraintDefinition
-      { _constraintSqlExpr = expr
-      , _constraintMigrationKey = migrationKey
+      { i_constraintSqlExpr = expr
+      , i_constraintMigrationKey = migrationKey
       }

--- a/orville-postgresql/test/Test/Expr/TableDefinition.hs
+++ b/orville-postgresql/test/Test/Expr/TableDefinition.hs
@@ -99,7 +99,7 @@ column1Definition =
   Expr.columnDefinition
     (Expr.columnName column1NameString)
     Expr.text
-    Nothing
+    mempty
     Nothing
 
 column1NameString :: String
@@ -111,7 +111,7 @@ column2Definition =
   Expr.columnDefinition
     (Expr.columnName column2NameString)
     Expr.text
-    Nothing
+    mempty
     Nothing
 
 column2NameString :: String

--- a/orville-postgresql/test/Test/Orphans.hs
+++ b/orville-postgresql/test/Test/Orphans.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE StandaloneDeriving #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Orphans () where
@@ -6,6 +7,7 @@ import qualified Data.ByteString.Char8 as B8
 import qualified Data.List as List
 import qualified Data.List.NonEmpty as NE
 
+import qualified Orville.PostgreSQL.Marshall as Marshall
 import qualified Orville.PostgreSQL.Raw.PgTextFormatValue as PgTextFormatValue
 import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 
@@ -15,3 +17,7 @@ instance Show SqlValue.SqlValue where
       (B8.unpack . PgTextFormatValue.toByteString)
       (\vals -> "(" <> List.intercalate ", " (NE.toList vals) <> ")")
       "NULL"
+
+deriving instance Show Marshall.FieldIdentityGeneration
+deriving instance Enum Marshall.FieldIdentityGeneration
+deriving instance Bounded Marshall.FieldIdentityGeneration


### PR DESCRIPTION
- Expr support for column identity is added for columns that should be generated always or only by default

  - There is some oddity here. The specification for creating an identity column is to add a constraint. However when looking up in the catalog identity information is not held with other constraints.

- Field definitions can be marked as identity

- Support for identity at the field definition limits to non-nullable fields, as is the case in PostgreSQL.

- AutoMigration support for marking column identity

There is additional work needed for full support. This is left for the future. Particularly, identity columns can take options for the underlying sequence. However, supporting that will require being able to look up said sequence using a catalog table not currently supported: pg_depend.