### PR TITLE
Exposing functions from FieldDefinition module to Orville.PostgreSQL

### DIFF
--- a/orville-postgresql/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL.hs
@@ -224,6 +224,7 @@ module Orville.PostgreSQL
   , FieldDefinition.fieldOfType
   , FieldDefinition.fieldColumnName
   , FieldDefinition.fieldColumnReference
+  , FieldDefinition.fieldAliasQualifiedColumnName
   , FieldDefinition.fieldName
   , FieldDefinition.setFieldName
   , FieldDefinition.fieldDescription
@@ -288,6 +289,7 @@ module Orville.PostgreSQL
   , SelectOptions.appendSelectOptions
   , SelectOptions.forRowLock
   , SelectOptions.fetchRow
+  , SelectOptions.window
   , FieldDefinition.fieldEquals
   , (FieldDefinition..==)
   , FieldDefinition.fieldNotEquals


### PR DESCRIPTION
This PR exposes additional functions from the `FieldDefinition` module directly in `Orville.PostgreSQL`. Since these functions do not conflict with any existing names, exposing them should not cause any issues.