### PR TITLE
Rolls back transactions when begin fails in `withTransaction`

### DIFF
--- a/orville-postgresql/orville-postgresql.cabal
+++ b/orville-postgresql/orville-postgresql.cabal
@@ -262,7 +262,8 @@ test-suite spec
   hs-source-dirs:
       test
   build-depends:
-      attoparsec >=0.10 && <0.15
+      async >=2.0 && <2.3
+    , attoparsec >=0.10 && <0.15
     , base >=4.8 && <5
     , bytestring >=0.10 && <0.13
     , containers >=0.6 && <0.9
@@ -273,6 +274,8 @@ test-suite spec
     , safe-exceptions >=0.1.7 && <0.2
     , text >=1.2 && <1.3 || >=2.0 && <2.2
     , time >=1.9.1 && <1.15
+    , transformers >=0.5 && <0.7
+    , unliftio >=0.1 && <0.3
     , uuid >=1.3.15 && <1.4
   default-language: Haskell2010
   if flag(ci)

--- a/orville-postgresql/orville-postgresql.cabal
+++ b/orville-postgresql/orville-postgresql.cabal
@@ -262,8 +262,7 @@ test-suite spec
   hs-source-dirs:
       test
   build-depends:
-      async >=2.0 && <2.3
-    , attoparsec >=0.10 && <0.15
+      attoparsec >=0.10 && <0.15
     , base >=4.8 && <5
     , bytestring >=0.10 && <0.13
     , containers >=0.6 && <0.9

--- a/orville-postgresql/package.yaml
+++ b/orville-postgresql/package.yaml
@@ -193,6 +193,7 @@ tests:
     source-dirs: test
     main: Main.hs
     dependencies:
+      - async >=2.0 && <2.3
       - attoparsec >=0.10 && <0.15
       - base >=4.8 && <5
       - bytestring >=0.10 && <0.13
@@ -204,6 +205,8 @@ tests:
       - safe-exceptions >=0.1.7 && < 0.2
       - text (>= 1.2 && < 1.3) || (>=2.0 && <2.2)
       - time >=1.9.1 && < 1.15
+      - transformers >= 0.5 && < 0.7
+      - unliftio >= 0.1 && < 0.3
       - uuid >= 1.3.15 && <1.4
     when:
       - condition: flag(ci)

--- a/orville-postgresql/package.yaml
+++ b/orville-postgresql/package.yaml
@@ -193,7 +193,6 @@ tests:
     source-dirs: test
     main: Main.hs
     dependencies:
-      - async >=2.0 && <2.3
       - attoparsec >=0.10 && <0.15
       - base >=4.8 && <5
       - bytestring >=0.10 && <0.13

--- a/orville-postgresql/src/Orville/PostgreSQL/Internal/Bracket.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Internal/Bracket.hs
@@ -7,7 +7,6 @@ Stability : Stable
 -}
 module Orville.PostgreSQL.Internal.Bracket
   ( bracketWithResult
-  , handleAndRethrow
   , BracketResult (BracketSuccess, BracketError)
   ) where
 


### PR DESCRIPTION
Previously Orville could leak a connection with an open transaction if the `BeginTransaction` callback failed, e.g. due to throwing an exception or being interrupted by an async exception. We added exception handling around the begin action and added a test that will fail if the exception is not handled correctly.