### PR TITLE
Supports negative years in ISO style date/time format

### DIFF
--- a/orville-postgresql/src/Orville/PostgreSQL/Marshall/FieldDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Marshall/FieldDefinition.hs
@@ -617,6 +617,10 @@ jsonbField = fieldOfType SqlType.jsonb
 {- | Builds a 'FieldDefinition' that stores Haskell 'Time.Day' values as the
   PostgreSQL "DATE" type.
 
+  This field cannot represent the full range of 'Time.Day' values. PostgreSQL supports years
+  from -4731 to 5874897 inclusive for this field, and sending a 'Time.Day' with a year outside
+  of this range to the database will result in a PostgreSQL exception.
+
 @since 1.0.0.0
 -}
 dateField ::
@@ -628,6 +632,10 @@ dateField = fieldOfType SqlType.date
 {- | Builds a 'FieldDefinition' that stores Haskell 'Time.UTCTime' values as the
   PostgreSQL "TIMESTAMP with time zone" type.
 
+  This field cannot represent the full range of 'Time.UTCTime' values. PostgreSQL supports years
+  from -4731 to 294276 inclusive for this field, and sending a 'Time.UTCTime' with a year outside
+  of this range to the database will result in a PostgreSQL exception.
+
 @since 1.0.0.0
 -}
 utcTimestampField ::
@@ -638,6 +646,10 @@ utcTimestampField = fieldOfType SqlType.timestamp
 
 {- | Builds a 'FieldDefinition' that stores Haskell 'Time.UTCTime' values as the
   PostgreSQL "TIMESTAMP without time zone" type.
+
+  This field cannot represent the full range of 'Time.LocalTime' values. PostgreSQL supports years
+  from -4731 to 294276 inclusive for this field, and sending a 'Time.LocalTime' with a year outside
+  of this range to the database will result in a PostgreSQL exception.
 
 @since 1.0.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Marshall/SqlType.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Marshall/SqlType.hs
@@ -323,6 +323,10 @@ uuid =
 {- | 'date' defines a type representing a calendar date (without time zone). It corresponds
   to the "DATE" type in SQL.
 
+  This type cannot represent the full range of 'Time.Day' values. PostgreSQL supports years
+  from -4731 to 5874897 inclusive for this type, and sending a 'Time.Day' with a year outside
+  of this range to the database will result in a PostgreSQL exception.
+
 @since 1.0.0.0
 -}
 date :: SqlType Time.Day
@@ -340,6 +344,10 @@ date =
 {- | 'timestamp' defines a type representing a particular point in time without time zone information,
   but can be constructed with a time zone offset.
   It corresponds to the "TIMESTAMP with time zone" type in SQL.
+
+  This type cannot represent the full range of 'Time.UTCTime' values. PostgreSQL supports years
+  from -4731 to 294276 inclusive for this type, and sending a 'Time.UTCTime' with a year outside
+  of this range to the database will result in a PostgreSQL exception.
 
   Note: This is NOT a typo. The "TIMESTAMP with time zone" type in SQL does not include
   any actual time zone information. For an excellent explanation of the complexities
@@ -362,6 +370,10 @@ timestamp =
 
 {- | 'timestampWithoutZone' defines a type representing a particular point in time (without time zone).
   It corresponds to the "TIMESTAMP without time zone" type in SQL.
+
+  This type cannot represent the full range of 'Time.LocalTime' values. PostgreSQL supports years
+  from -4731 to 294276 inclusive for this type, and sending a 'Time.LocalTime' with a year outside
+  of this range to the database will result in a PostgreSQL exception.
 
   http://blog.untrod.com/2016/08/actually-understanding-timezones-in-postgresql.html
 

--- a/orville-postgresql/test/Main.hs
+++ b/orville-postgresql/test/Main.hs
@@ -61,6 +61,7 @@ main = do
       [ Connection.connectionTests pool
       , RawSql.rawSqlTests pool
       , Execution.executionTests pool
+      , PgTime.pgTimeTests pool
       , SqlType.sqlTypeTests pool
       , PostgreSQLAxioms.postgreSQLAxiomTests pool
       , ExprAggregate.aggregateTests pool
@@ -96,7 +97,6 @@ main = do
       , AutoMigration.autoMigrationTests pool
       , Cursor.cursorTests pool
       , SqlCommenter.sqlCommenterTests pool
-      , PgTime.pgTimeTests pool
       ]
 
   Monad.unless (Property.allPassed summary) SE.exitFailure

--- a/orville-postgresql/test/Test/PgGen.hs
+++ b/orville-postgresql/test/Test/PgGen.hs
@@ -125,11 +125,20 @@ pgLocalTime =
 
 pgDay :: HH.Gen Time.Day
 pgDay = do
-  year <- Gen.integral (Range.linearFrom 2000 0 3000)
+  year <- Gen.integral (Range.constantFrom 2000 (-4713) 294276)
   month <- Gen.integral (Range.constant 1 12)
   day <- Gen.integral (Range.constant 1 (Time.gregorianMonthLength year month))
 
-  pure (Time.fromGregorian year month day)
+  Gen.frequency
+    [ (1, feb29thBCE)
+    , (49, pure (Time.fromGregorian year month day))
+    ]
+
+-- Edge case to help catch mistakes in date parsing/printing
+feb29thBCE :: HH.Gen Time.Day
+feb29thBCE = do
+  year <- Gen.filter Time.isLeapYear (Gen.integral (Range.linear (-4713) 0))
+  pure (Time.fromGregorian year 2 29)
 
 pgTimeOfDay :: HH.Gen Time.TimeOfDay
 pgTimeOfDay = fmap Time.timeToTimeOfDay pgDiffTime

--- a/orville-postgresql/test/Test/SqlType.hs
+++ b/orville-postgresql/test/Test/SqlType.hs
@@ -370,6 +370,26 @@ dateTests pool =
           , expectedValue = Time.fromGregorian 10000 12 21
           }
     )
+  ,
+    ( String.fromString "Testing the decode of DATE with value 0001-12-21 BC"
+    , runDecodingTest pool $
+        DecodingTest
+          { sqlTypeDDL = "DATE"
+          , rawSqlValue = Just $ B8.pack "'0001-12-21 BC'"
+          , sqlType = SqlType.date
+          , expectedValue = Time.fromGregorian 0 12 21
+          }
+    )
+  ,
+    ( String.fromString "Testing the decode of DATE with value 0041-02-29 BC"
+    , runDecodingTest pool $
+        DecodingTest
+          { sqlTypeDDL = "DATE"
+          , rawSqlValue = Just $ B8.pack "'0041-02-29 BC'"
+          , sqlType = SqlType.date
+          , expectedValue = Time.fromGregorian (-40) 2 29
+          }
+    )
   ]
 
 timestampTests :: Orville.ConnectionPool -> [(HH.PropertyName, HH.Property)]
@@ -445,6 +465,26 @@ timestampTests pool =
           }
     )
   ,
+    ( String.fromString "Testing the decode of TIMESTAMP WITH TIME ZONE with value '0001-12-21 00:00:32.000+00 BC'"
+    , runDecodingTest pool $
+        DecodingTest
+          { sqlTypeDDL = "TIMESTAMP WITH TIME ZONE"
+          , rawSqlValue = Just $ B8.pack "'0001-12-21 00:00:32.000+00 BC'"
+          , sqlType = SqlType.timestamp
+          , expectedValue = Time.UTCTime (Time.fromGregorian 0 12 21) (Time.secondsToDiffTime 32)
+          }
+    )
+  ,
+    ( String.fromString "Testing the decode of TIMESTAMP WITH TIME ZONE with value '0041-02-29 00:00:32.000+00 BC'"
+    , runDecodingTest pool $
+        DecodingTest
+          { sqlTypeDDL = "TIMESTAMP WITH TIME ZONE"
+          , rawSqlValue = Just $ B8.pack "'0041-02-29 00:00:32.000+00 BC'"
+          , sqlType = SqlType.timestamp
+          , expectedValue = Time.UTCTime (Time.fromGregorian (-40) 2 29) (Time.secondsToDiffTime 32)
+          }
+    )
+  ,
     ( String.fromString "Testing the decode of TIMESTAMP WITHOUT TIME ZONE with value '2020-12-21 00:00:32'"
     , runDecodingTest pool $
         DecodingTest
@@ -512,6 +552,26 @@ timestampTests pool =
           , rawSqlValue = Just $ B8.pack "'0001-12-21 00:00:32'"
           , sqlType = SqlType.timestampWithoutZone
           , expectedValue = Time.LocalTime (Time.fromGregorian 1 12 21) (Time.timeToTimeOfDay $ Time.secondsToDiffTime 32)
+          }
+    )
+  ,
+    ( String.fromString "Testing the decode of TIMESTAMP WITHOUT TIME ZONE with value '0001-12-21 00:00:32 BC'"
+    , runDecodingTest pool $
+        DecodingTest
+          { sqlTypeDDL = "TIMESTAMP WITHOUT TIME ZONE"
+          , rawSqlValue = Just $ B8.pack "'0001-12-21 00:00:32 BC'"
+          , sqlType = SqlType.timestampWithoutZone
+          , expectedValue = Time.LocalTime (Time.fromGregorian 0 12 21) (Time.timeToTimeOfDay $ Time.secondsToDiffTime 32)
+          }
+    )
+  ,
+    ( String.fromString "Testing the decode of TIMESTAMP WITHOUT TIME ZONE with value '0041-02-29 00:00:32 BC'"
+    , runDecodingTest pool $
+        DecodingTest
+          { sqlTypeDDL = "TIMESTAMP WITHOUT TIME ZONE"
+          , rawSqlValue = Just $ B8.pack "'0041-02-29 00:00:32 BC'"
+          , sqlType = SqlType.timestampWithoutZone
+          , expectedValue = Time.LocalTime (Time.fromGregorian (-40) 2 29) (Time.timeToTimeOfDay $ Time.secondsToDiffTime 32)
           }
     )
   ]


### PR DESCRIPTION
Previously the `PgTime` module supported a hybrid between ISO-8601 format date/times and PostgreSQL's ISO text format and would not parse or print negative years correctly.

I changed the module to handle negative `Day`, `LocalTime`, and `UTCTime`s by converting the years to and from the common era scheme and parsing or appending the string " BC" as necessary.

I also added documentation to the relevant `SqlType`s and `FieldDefinition`s describing PostgreSQL's bounds on years, and several tests that cover edge cases like BCE leap years.

Closes #380.