### PR TITLE
[Bugfix] Qualify IndexName for dropIndexExpr to fix automigration

### DIFF
--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Index.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Index.hs
@@ -195,7 +195,7 @@ newtype DropIndexExpr
 
 @since 1.0.0.0
 -}
-dropIndexExpr :: IndexName -> DropIndexExpr
+dropIndexExpr :: QualifiedOrUnqualified IndexName -> DropIndexExpr
 dropIndexExpr indexName =
   DropIndexExpr $
     RawSql.fromString "DROP INDEX " <> RawSql.toRawSql indexName

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Internal/Name/Qualified.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Internal/Name/Qualified.hs
@@ -12,6 +12,7 @@ module Orville.PostgreSQL.Expr.Internal.Name.Qualified
   , qualifyTable
   , qualifySequence
   , qualifyFunction
+  , qualifyIndex
   , qualifyColumn
   , aliasQualifyColumn
   , QualifiedOrUnqualified
@@ -24,6 +25,7 @@ import Orville.PostgreSQL.Expr.Internal.Name.Alias (AliasExpr)
 import Orville.PostgreSQL.Expr.Internal.Name.ColumnName (ColumnName)
 import Orville.PostgreSQL.Expr.Internal.Name.FunctionName (FunctionName)
 import Orville.PostgreSQL.Expr.Internal.Name.Identifier (IdentifierExpression (toIdentifier))
+import Orville.PostgreSQL.Expr.Internal.Name.IndexName (IndexName)
 import Orville.PostgreSQL.Expr.Internal.Name.SchemaName (SchemaName)
 import Orville.PostgreSQL.Expr.Internal.Name.SequenceName (SequenceName)
 import Orville.PostgreSQL.Expr.Internal.Name.TableName (TableName)
@@ -125,6 +127,15 @@ qualifyFunction ::
   FunctionName ->
   Qualified FunctionName
 qualifyFunction = unsafeSchemaQualify
+
+{- | Qualifies an 'IndexName' with a 'SchemaName'.
+@since 1.1.0.0
+-}
+qualifyIndex ::
+  SchemaName ->
+  IndexName ->
+  Qualified IndexName
+qualifyIndex = unsafeSchemaQualify
 
 {- | Qualifies a 'ColumnName' with a 'TableName' and, optionally, a 'SchemaName'.
 This should be used to refer to the column in SQL queries where a qualified

--- a/orville-postgresql/test/Test/AutoMigration.hs
+++ b/orville-postgresql/test/Test/AutoMigration.hs
@@ -30,6 +30,7 @@ import qualified Orville.PostgreSQL.PgCatalog as PgCatalog
 import qualified Orville.PostgreSQL.Raw.Connection as Conn
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import qualified Orville.PostgreSQL.Schema as Schema
+import qualified Orville.PostgreSQL.Schema.TableDefinition as TableDefinition
 
 import qualified Test.Entities.Foo as Foo
 import Test.Orphans ()
@@ -862,10 +863,21 @@ prop_addsAndRemovesMixedIndexes =
         Orville.addTableIndexes originalIndexes $
           mkIntListTable "migration_test" originalColumns
 
+      originalTableDefWithSchema =
+        TableDefinition.setTableSchema "orville_migration_schema" $
+          Orville.addTableIndexes originalIndexes $
+            mkIntListTable "migration_test" originalColumns
+
       newTableDef =
         Orville.addTableIndexes newIndexes $
           Orville.dropColumns columnsToDrop $
             mkIntListTable "migration_test" newColumns
+
+      newTableDefWithSchema =
+        TableDefinition.setTableSchema "orville_migration_schema" $
+          Orville.addTableIndexes newIndexes $
+            Orville.dropColumns columnsToDrop $
+              mkIntListTable "migration_test" newColumns
 
     HH.cover 5 (String.fromString "Adding Indexes") (not $ null (newTestIndexes \\ originalTestIndexes))
     HH.cover 5 (String.fromString "Dropping Indexes") (not $ null (originalTestIndexes \\ newTestIndexes))
@@ -880,9 +892,11 @@ prop_addsAndRemovesMixedIndexes =
     firstTimePlan <-
       HH.evalIO $
         Orville.runOrville pool $ do
+          Orville.executeVoid Orville.DDLQuery $ RawSql.fromString "DROP SCHEMA IF EXISTS orville_migration_schema CASCADE"
+          Orville.executeVoid Orville.DDLQuery $ RawSql.fromString "CREATE SCHEMA orville_migration_schema"
           Orville.executeVoid Orville.DDLQuery $ TestTable.dropTableDefSql originalTableDef
-          AutoMigration.autoMigrateSchema AutoMigration.defaultOptions [AutoMigration.SchemaTable originalTableDef]
-          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable newTableDef]
+          AutoMigration.autoMigrateSchema AutoMigration.defaultOptions [AutoMigration.SchemaTable originalTableDef, AutoMigration.SchemaTable originalTableDefWithSchema]
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable newTableDef, AutoMigration.SchemaTable newTableDefWithSchema]
 
     HH.annotate ("First time migration steps: " <> show (migrationPlanStepStrings firstTimePlan))
 
@@ -891,19 +905,33 @@ prop_addsAndRemovesMixedIndexes =
       (PgAssert.assertIndexExists originalTableDesc <$> testIndexUniqueness <*> testIndexColumns)
       originalTestIndexes
 
+    originalTableWithSchemaDesc <- PgAssert.assertTableExistsInSchema pool "orville_migration_schema" "migration_test"
+    Fold.traverse_
+      (PgAssert.assertIndexExists originalTableWithSchemaDesc <$> testIndexUniqueness <*> testIndexColumns)
+      originalTestIndexes
+
     secondTimePlan <-
       HH.evalIO $
         Orville.runOrville pool $ do
           AutoMigration.executeMigrationPlan AutoMigration.defaultOptions firstTimePlan
-          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable newTableDef]
+          AutoMigration.generateMigrationPlan
+            AutoMigration.defaultOptions
+            [AutoMigration.SchemaTable newTableDef, AutoMigration.SchemaTable newTableDefWithSchema]
 
     migrationPlanStepStrings secondTimePlan === []
+
     newTableDesc <- PgAssert.assertTableExists pool "migration_test"
+    newTableWithSchemaDesc <- PgAssert.assertTableExistsInSchema pool "orville_migration_schema" "migration_test"
 
     Fold.traverse_
       (PgAssert.assertIndexExists newTableDesc <$> testIndexUniqueness <*> testIndexColumns)
       newTestIndexes
     length (PgCatalog.relationIndexes newTableDesc) === length (List.nub newTestIndexes)
+
+    Fold.traverse_
+      (PgAssert.assertIndexExists newTableWithSchemaDesc <$> testIndexUniqueness <*> testIndexColumns)
+      newTestIndexes
+    length (PgCatalog.relationIndexes newTableWithSchemaDesc) === length (List.nub newTestIndexes)
 
 prop_createsMissingSequences :: Property.NamedDBProperty
 prop_createsMissingSequences =


### PR DESCRIPTION
- Ran into an issue where automigration would attemnt to drop an index that belonged to a schema without qualifying it resulting in a SqlError
- `qualifyIndex` wrapper added
- `dropIndexExpr` api changed to take `QualifiedOrUnqualified IndexName`