### PR TITLE
Updates haskell-tools image

### DIFF
--- a/orville-docsite/Dockerfile
+++ b/orville-docsite/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/flipstone/haskell-tools:debian-stable-ghc-9.6.6-2024-10-23-eb5da39
+FROM ghcr.io/flipstone/haskell-tools:debian-stable-ghc-9.6.6-2025-08-12-593a4ee
 
 ADD samples/install-packages.sh /install-packages.sh
 RUN sh /install-packages.sh

--- a/orville-postgresql/Dockerfile
+++ b/orville-postgresql/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/flipstone/haskell-tools:debian-stable-ghc-9.6.6-2024-10-23-eb5da39
+FROM ghcr.io/flipstone/haskell-tools:debian-stable-ghc-9.6.6-2025-08-12-593a4ee
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update &&\


### PR DESCRIPTION
This updates haskell-tools image, which uses a fixed debian base, i.e. `trixie`, instead of the moving `stable` tag.