### PR TITLE
Transaction Enhancements

### DIFF
--- a/orville-postgresql/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL.hs
@@ -70,6 +70,8 @@ module Orville.PostgreSQL
 
     -- * Opening transactions and savepoints
   , Transaction.withTransaction
+  , Transaction.withTransactionInstruction
+  , Transaction.TransactionInstruction (Commit, Rollback)
   , Transaction.inWithTransaction
   , Transaction.InWithTransaction (InOutermostTransaction, InSavepointTransaction)
 

--- a/orville-postgresql/src/Orville/PostgreSQL/Execution/Transaction.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Execution/Transaction.hs
@@ -141,7 +141,7 @@ withTransactionInstruction action =
           LibPQ.TransUnknown ->
             throwIO transactionError
 
-      doAction () = do
+      doAction () =
         Monad.localOrvilleState
           (OrvilleState.connectState innerConnectedState)
           action

--- a/orville-postgresql/src/Orville/PostgreSQL/Internal/Bracket.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Internal/Bracket.hs
@@ -20,8 +20,8 @@ import Orville.PostgreSQL.Monad.MonadOrville (MonadOrvilleControl (liftCatch, li
 
 @since 1.0.0.0
 -}
-data BracketResult
-  = BracketSuccess
+data BracketResult a
+  = BracketSuccess a
   | BracketError
 
 {- | INTERNAL: A version of 'Control.Exception.bracket' that allows us to distinguish between
@@ -36,7 +36,7 @@ data BracketResult
 bracketWithResult ::
   (MonadIO m, MonadOrvilleControl m) =>
   m a ->
-  (a -> BracketResult -> m c) ->
+  (a -> BracketResult b -> m c) ->
   (a -> m b) ->
   m b
 bracketWithResult acquire release action = do
@@ -48,7 +48,7 @@ bracketWithResult acquire release action = do
         (restore (action resource))
         (handleAndRethrow (release resource BracketError))
 
-    _ <- release resource BracketSuccess
+    _ <- release resource (BracketSuccess result)
 
     pure result
 


### PR DESCRIPTION
This adds a new transaction function, `withTransactionInstruction` that allows the caller to explicitly specify whether the transaction should be committed or rolled back after executing their action inside it.

It also adds some connection transaction status checks to the connection pooling to ensure that open transactions cannot be leaked into the resource pool inadvertently.