### PR TITLE
Add initial support for check constraints

### DIFF
--- a/orville-postgresql/orville-postgresql.cabal
+++ b/orville-postgresql/orville-postgresql.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           orville-postgresql
-version:        1.1.0.0
+version:        1.1.0.0.1
 synopsis:       A Haskell library for PostgreSQL
 description:    Orville's goal is to provide a powerful API for applications to access PostgreSQL databases with minimal use of sophisticated language techniques or extensions. See https://github.com/flipstone/orville for more details.
 category:       database, library, postgresql
@@ -172,6 +172,7 @@ library
       Orville.PostgreSQL.PgCatalog.PgProc
       Orville.PostgreSQL.PgCatalog.PgSequence
       Orville.PostgreSQL.PgCatalog.PgTrigger
+      Orville.PostgreSQL.Schema.ConstraintIdentifier
       Paths_orville_postgresql
   hs-source-dirs:
       src

--- a/orville-postgresql/package.yaml
+++ b/orville-postgresql/package.yaml
@@ -1,6 +1,6 @@
 ---
 name: orville-postgresql
-version: '1.1.0.0'
+version: '1.1.0.0.1' # Development version, breaking changes included, release scheduled to be 1.2.0.0
 synopsis: A Haskell library for PostgreSQL
 description:
   Orville's goal is to provide a powerful API for applications to access

--- a/orville-postgresql/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL.hs
@@ -128,6 +128,7 @@ module Orville.PostgreSQL
   , TableIdentifier.tableIdSchemaNameString
   , TableIdentifier.tableIdToString
   , ConstraintDefinition.ConstraintDefinition
+  , ConstraintDefinition.checkConstraint
   , ConstraintDefinition.uniqueConstraint
   , ConstraintDefinition.foreignKeyConstraint
   , ConstraintDefinition.foreignKeyConstraintWithOptions
@@ -138,8 +139,8 @@ module Orville.PostgreSQL
   , ConstraintDefinition.ForeignKeyAction (..)
   , ConstraintDefinition.ForeignReference (ForeignReference, localFieldName, foreignFieldName)
   , ConstraintDefinition.foreignReference
-  , ConstraintDefinition.ConstraintMigrationKey (ConstraintMigrationKey, constraintKeyType, constraintKeyColumns, constraintKeyForeignTable, constraintKeyForeignColumns, constraintKeyForeignKeyOnUpdateAction, constraintKeyForeignKeyOnDeleteAction)
-  , ConstraintDefinition.ConstraintKeyType (UniqueConstraint, ForeignKeyConstraint)
+  , ConstraintDefinition.ConstraintMigrationKey (ConstraintMigrationKey, constraintKeyType, constraintKeyName, constraintKeyColumns, constraintKeyForeignTable, constraintKeyForeignColumns, constraintKeyForeignKeyOnUpdateAction, constraintKeyForeignKeyOnDeleteAction)
+  , ConstraintDefinition.ConstraintKeyType (UniqueConstraint, ForeignKeyConstraint, CheckConstraint)
   , ConstraintDefinition.constraintMigrationKey
   , ConstraintDefinition.constraintSqlExpr
   , IndexDefinition.IndexDefinition

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Internal/Name/Qualified.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Internal/Name/Qualified.hs
@@ -13,6 +13,7 @@ module Orville.PostgreSQL.Expr.Internal.Name.Qualified
   , qualifySequence
   , qualifyFunction
   , qualifyIndex
+  , qualifyConstraint
   , qualifyColumn
   , aliasQualifyColumn
   , QualifiedOrUnqualified
@@ -23,6 +24,7 @@ where
 
 import Orville.PostgreSQL.Expr.Internal.Name.Alias (AliasExpr)
 import Orville.PostgreSQL.Expr.Internal.Name.ColumnName (ColumnName)
+import Orville.PostgreSQL.Expr.Internal.Name.ConstraintName (ConstraintName)
 import Orville.PostgreSQL.Expr.Internal.Name.FunctionName (FunctionName)
 import Orville.PostgreSQL.Expr.Internal.Name.Identifier (IdentifierExpression (toIdentifier))
 import Orville.PostgreSQL.Expr.Internal.Name.IndexName (IndexName)
@@ -136,6 +138,19 @@ qualifyIndex ::
   IndexName ->
   Qualified IndexName
 qualifyIndex = unsafeSchemaQualify
+
+{- | Qualifies a 'ConstraintName' with a 'SchemaName'.
+
+Note: If you already have a 'Orville.PostgreSQL.Schema.ConstraintIdentifier' in
+hand you should probably use
+'Orville.PostgreSQL.Schema.constraintIdQualifiedName' instead.
+@since 1.2.0.0
+-}
+qualifyConstraint ::
+  SchemaName ->
+  ConstraintName ->
+  Qualified ConstraintName
+qualifyConstraint = unsafeSchemaQualify
 
 {- | Qualifies a 'ColumnName' with a 'TableName' and, optionally, a 'SchemaName'.
 This should be used to refer to the column in SQL queries where a qualified

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/TableConstraint.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/TableConstraint.hs
@@ -9,6 +9,7 @@ Stability : Stable
 -}
 module Orville.PostgreSQL.Expr.TableConstraint
   ( TableConstraint
+  , checkConstraint
   , uniqueConstraint
   , foreignKeyConstraint
   , ForeignKeyActionExpr
@@ -25,7 +26,7 @@ where
 
 import Data.List.NonEmpty (NonEmpty)
 
-import Orville.PostgreSQL.Expr.Name (ColumnName, QualifiedOrUnqualified, TableName)
+import Orville.PostgreSQL.Expr.Name (ColumnName, ConstraintName, QualifiedOrUnqualified, TableName)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 {- | Type to represent a table constraint that would be part of a @CREATE TABLE@ or
@@ -49,6 +50,21 @@ newtype TableConstraint
     ( -- | @since 1.0.0.0
       RawSql.SqlExpression
     )
+
+{- | Constructs a 'TableConstraint' that will create a named @CHECK@ constraint with the
+  given expression.
+
+  @since 1.2.0.0
+-}
+checkConstraint :: ConstraintName -> RawSql.RawSql -> TableConstraint
+checkConstraint constrName checkConstrExpr =
+  TableConstraint $
+    RawSql.fromString "CONSTRAINT "
+      <> RawSql.toRawSql constrName
+      <> RawSql.fromString " CHECK "
+      <> RawSql.leftParen
+      <> checkConstrExpr
+      <> RawSql.rightParen
 
 {- | Constructs a 'TableConstraint' will create a @UNIQUE@ constraint on the
   given columns.

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema.hs
@@ -1,7 +1,7 @@
 {-# OPTIONS_GHC -Wno-missing-import-lists #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2023-2024
+Copyright : Flipstone Technology Partners 2023-2025
 License   : MIT
 Stability : Stable
 
@@ -19,6 +19,7 @@ module Orville.PostgreSQL.Schema
   , module Orville.PostgreSQL.Schema.PrimaryKey
   , module Orville.PostgreSQL.Schema.IndexDefinition
   , module Orville.PostgreSQL.Schema.ConstraintDefinition
+  , module Orville.PostgreSQL.Schema.ConstraintIdentifier
   , module Orville.PostgreSQL.Schema.TriggerDefinition
 
     -- * Defining Sequences
@@ -38,6 +39,7 @@ where
 -- appear in the generated haddock documentation.
 
 import Orville.PostgreSQL.Schema.ConstraintDefinition
+import Orville.PostgreSQL.Schema.ConstraintIdentifier
 import Orville.PostgreSQL.Schema.ExtensionIdentifier
 import Orville.PostgreSQL.Schema.FunctionDefinition
 import Orville.PostgreSQL.Schema.FunctionIdentifier

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/ConstraintIdentifier.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/ConstraintIdentifier.hs
@@ -1,0 +1,128 @@
+{- |
+Copyright : Flipstone Technology Partners 2025
+License   : MIT
+Stability : Stable
+
+@since 1.2.0.0
+-}
+module Orville.PostgreSQL.Schema.ConstraintIdentifier
+  ( ConstraintIdentifier
+  , unqualifiedNameToConstraintId
+  , setConstraintIdSchema
+  , constraintIdQualifiedName
+  , constraintIdUnqualifiedName
+  , constraintIdSchemaName
+  , constraintIdToString
+  , constraintIdUnqualifiedNameString
+  , constraintIdSchemaNameString
+  )
+where
+
+import qualified Orville.PostgreSQL.Expr as Expr
+
+{- | An identifier used by Orville to identify a particular constraint in a particular
+  schema.
+
+@since 1.2.0.0
+-}
+data ConstraintIdentifier = ConstraintIdentifier
+  { i_constraintIdName :: String
+  , i_constraintIdSchema :: Maybe String
+  }
+  deriving
+    ( -- | @since 1.2.0.0
+      Eq
+    , -- | @since 1.2.0.0
+      Ord
+    , -- | @since 1.2.0.0
+      Show
+    )
+
+{- | Constructs a 'ConstraintIdentifier' where the constraint's name will not be qualified
+  by a particular schema.
+
+@since 1.2.0.0
+-}
+unqualifiedNameToConstraintId :: String -> ConstraintIdentifier
+unqualifiedNameToConstraintId name =
+  ConstraintIdentifier
+    { i_constraintIdName = name
+    , i_constraintIdSchema = Nothing
+    }
+
+{- | Sets the schema of the 'ConstraintIdentifier'. Wherever applicable, references to
+  the constraint will be qualified by the given schema name.
+
+@since 1.2.0.0
+-}
+setConstraintIdSchema :: String -> ConstraintIdentifier -> ConstraintIdentifier
+setConstraintIdSchema schema constraintId =
+  constraintId
+    { i_constraintIdSchema = Just schema
+    }
+
+{- | Returns the 'Expr.Qualified Expr.ConstraintName' that should be used to refer to
+  the constraint in SQL queries.
+
+@since 1.2.0.0
+-}
+constraintIdQualifiedName :: ConstraintIdentifier -> Expr.QualifiedOrUnqualified Expr.ConstraintName
+constraintIdQualifiedName constraintId =
+  case constraintIdSchemaName constraintId of
+    Nothing ->
+      Expr.unqualified (constraintIdUnqualifiedName constraintId)
+    Just schemaName ->
+      Expr.untrackQualified $
+        Expr.qualifyConstraint
+          schemaName
+          (constraintIdUnqualifiedName constraintId)
+
+{- | Returns the unqualified 'Expr.ConstraintName' that should be used to refer to the
+  constraint in SQL queries where an unqualified reference is appropriate.
+
+@since 1.2.0.0
+-}
+constraintIdUnqualifiedName :: ConstraintIdentifier -> Expr.ConstraintName
+constraintIdUnqualifiedName =
+  Expr.constraintName . i_constraintIdName
+
+{- | Returns the 'Expr.SchemaName' (if any) that should be used to qualify
+  references to the constraint in SQL queries.
+
+@since 1.2.0.0
+-}
+constraintIdSchemaName :: ConstraintIdentifier -> Maybe Expr.SchemaName
+constraintIdSchemaName =
+  fmap Expr.schemaName . i_constraintIdSchema
+
+{- | Retrieves the unqualified name of the constraint as a 'String'.
+
+@since 1.2.0.0
+-}
+constraintIdUnqualifiedNameString :: ConstraintIdentifier -> String
+constraintIdUnqualifiedNameString =
+  i_constraintIdName
+
+{- | Retrieves the schema name of the constraint as a 'String'.
+
+@since 1.2.0.0
+-}
+constraintIdSchemaNameString :: ConstraintIdentifier -> Maybe String
+constraintIdSchemaNameString =
+  i_constraintIdSchema
+
+{- | Converts a 'ConstraintIdentifier' to a 'String' for descriptive purposes. The
+  name will be qualified if a schema name has been set for the identifier.
+
+  Note: You should not use this function for building SQL expressions. Use
+  'constraintIdQualifiedName' instead for that.
+
+@since 1.2.0.0
+-}
+constraintIdToString :: ConstraintIdentifier -> String
+constraintIdToString constraintId =
+  case i_constraintIdSchema constraintId of
+    Nothing ->
+      i_constraintIdName constraintId
+    Just schema ->
+      schema <> "." <> i_constraintIdName constraintId

--- a/orville-postgresql/test/Test/PgAssert.hs
+++ b/orville-postgresql/test/Test/PgAssert.hs
@@ -13,6 +13,7 @@ module Test.PgAssert
   , assertColumnDefaultExists
   , assertColumnDefaultMatches
   , assertFieldIdentityGenerationMatches
+  , assertCheckConstraintExists
   , assertUniqueConstraintExists
   , assertForeignKeyConstraintExists
   , assertIndexExists
@@ -313,6 +314,22 @@ assertUniqueConstraintExists relationDesc columnNames = do
   Monad.when (not $ isMatchingConstraintPresent constraintMatches relationDesc) $
     withFrozenCallStack $ do
       HH.annotate $ "Unique constraint " <> show (NEL.toList columnNames) <> " not found"
+      HH.failure
+
+assertCheckConstraintExists ::
+  (HH.MonadTest m, HasCallStack) =>
+  PgCatalog.RelationDescription ->
+  String ->
+  m ()
+assertCheckConstraintExists relationDesc constrName = do
+  let
+    constraintMatches constraintDesc =
+      PgCatalog.pgConstraintType (PgCatalog.constraintRecord constraintDesc) == PgCatalog.CheckConstraint
+        && PgCatalog.constraintNameToString (PgCatalog.pgConstraintName $ PgCatalog.constraintRecord constraintDesc) == constrName
+
+  Monad.when (not $ isMatchingConstraintPresent constraintMatches relationDesc) $
+    withFrozenCallStack $ do
+      HH.annotate $ "Check constraint " <> constrName <> " not found"
       HH.failure
 
 data ForeignKeyInfo = ForeignKeyInfo


### PR DESCRIPTION
Current limitations:
  - Auto migration only refers to the name of check constraints
  - Check constraint conditional expressions are written directly with RawSql