### PR TITLE
Adds custom user data tracking for `FieldDefinition`

### DIFF
--- a/orville-postgresql/orville-postgresql.cabal
+++ b/orville-postgresql/orville-postgresql.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           orville-postgresql
-version:        1.1.0.0.3
+version:        1.1.0.0.4
 synopsis:       A Haskell library for PostgreSQL
 description:    Orville's goal is to provide a powerful API for applications to access PostgreSQL databases with minimal use of sophisticated language techniques or extensions. See https://github.com/flipstone/orville for more details.
 category:       database, library, postgresql
@@ -159,6 +159,7 @@ library
       Orville.PostgreSQL.Internal.MonadOrville
       Orville.PostgreSQL.Internal.OrvilleState
       Orville.PostgreSQL.Internal.RowCountExpectation
+      Orville.PostgreSQL.Internal.TypeMap
       Orville.PostgreSQL.PgCatalog.DatabaseDescription
       Orville.PostgreSQL.PgCatalog.OidField
       Orville.PostgreSQL.PgCatalog.PgAttribute

--- a/orville-postgresql/package.yaml
+++ b/orville-postgresql/package.yaml
@@ -1,6 +1,6 @@
 ---
 name: orville-postgresql
-version: '1.1.0.0.3' # Development version, breaking changes included, release scheduled to be 1.2.0.0
+version: '1.1.0.0.4' # Development version, breaking changes included, release scheduled to be 1.2.0.0
 synopsis: A Haskell library for PostgreSQL
 description:
   Orville's goal is to provide a powerful API for applications to access

--- a/orville-postgresql/src/Orville/PostgreSQL/Internal/TypeMap.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Internal/TypeMap.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Orville.PostgreSQL.Internal.TypeMap
+  ( TypeMap
+  , empty
+  , insert
+  , lookup
+  ) where
+
+import Prelude (Maybe, fmap)
+
+import qualified Data.Map.Strict as Map
+import Data.Proxy (Proxy (Proxy))
+import GHC.Base (Any)
+import Type.Reflection (SomeTypeRep, Typeable, someTypeRep)
+import qualified Unsafe.Coerce as UnsafeCoerce
+
+{- |
+  A type map can be used to store dynamic values keyed by their
+  type. Orville uses this internally to store custome user data to allow
+  extensibility without needing to track all user data in every function's
+  type signature that deals with the type the user data is attached to
+  (e.g. FieldDefinition)
+-}
+newtype TypeMap = TypeMap (Map.Map SomeTypeRep Any)
+
+{- |
+  An empty 'TypeMap' with no values.
+-}
+empty :: TypeMap
+empty = TypeMap Map.empty
+
+{- |
+  Inserts a value into the 'TypeMap'. Any existing value of the same type
+  will be overwritten.
+-}
+insert :: forall a. Typeable a => a -> TypeMap -> TypeMap
+insert a (TypeMap m) =
+  let
+    typeRep =
+      someTypeRep (Proxy :: Proxy a)
+  in
+    TypeMap (Map.insert typeRep (UnsafeCoerce.unsafeCoerce a) m)
+
+{- |
+  Looks up a value from the 'TypeMap'. The value retrieved is based on the
+  type of the return value based. Type applications can be used, if desired,
+  to determine the return type directly.
+-}
+lookup :: forall a. Typeable a => TypeMap -> Maybe a
+lookup (TypeMap m) =
+  let
+    typeRep =
+      someTypeRep (Proxy :: Proxy a)
+  in
+    fmap UnsafeCoerce.unsafeCoerce (Map.lookup typeRep m)

--- a/orville-postgresql/src/Orville/PostgreSQL/Internal/TypeMap.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Internal/TypeMap.hs
@@ -17,15 +17,19 @@ import qualified Unsafe.Coerce as UnsafeCoerce
 
 {- |
   A type map can be used to store dynamic values keyed by their
-  type. Orville uses this internally to store custome user data to allow
+  type. Orville uses this internally to store custom user data to allow
   extensibility without needing to track all user data in every function's
   type signature that deals with the type the user data is attached to
   (e.g. FieldDefinition)
+
+  @since 1.2.0.0
 -}
 newtype TypeMap = TypeMap (Map.Map SomeTypeRep Any)
 
 {- |
   An empty 'TypeMap' with no values.
+
+  @since 1.2.0.0
 -}
 empty :: TypeMap
 empty = TypeMap Map.empty
@@ -33,6 +37,8 @@ empty = TypeMap Map.empty
 {- |
   Inserts a value into the 'TypeMap'. Any existing value of the same type
   will be overwritten.
+
+  @since 1.2.0.0
 -}
 insert :: forall a. Typeable a => a -> TypeMap -> TypeMap
 insert a (TypeMap m) =
@@ -44,8 +50,10 @@ insert a (TypeMap m) =
 
 {- |
   Looks up a value from the 'TypeMap'. The value retrieved is based on the
-  type of the return value based. Type applications can be used, if desired,
+  type of the return value. Type applications can be used, if desired,
   to determine the return type directly.
+
+  @since 1.2.0.0
 -}
 lookup :: forall a. Typeable a => TypeMap -> Maybe a
 lookup (TypeMap m) =

--- a/orville-postgresql/src/Orville/PostgreSQL/Marshall/FieldDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Marshall/FieldDefinition.hs
@@ -357,12 +357,12 @@ addUniqueConstraint fieldDef =
 
 {- |
 Adds some custom user data to a 'FieldDefinition'. The data can then be
-retrieved later via 'lookupFieldUseData'. If there is already user data
+retrieved later via 'lookupFieldUserData'. If there is already user data
 present of the same type, it will be replaced with the new value. User
 data of other types will not be changed or removed however. If desired,
 the type can be made explicit via use of @TypeApplications@. This is
 usually not required, however, since the type is inferred from the value
-being passed. For example, the following are equivalent
+being passed. For example, the following are equivalent:
 
 @@
   data Foo = Bar
@@ -391,10 +391,10 @@ addFieldUserData a field =
     }
 
 {- |
-Retrieves customer user data that was added via 'addFieldUserdata'. The
+Retrieves customer user data that was added via 'addFieldUserData'. The
 type of data retrieved is inferred based on the type of @a@ required by
 the caller. If required, this can be made explicit via an appropriate
-type signature or @TypeApplications@ as desired. For example
+type signature or @TypeApplications@ as desired. For example:
 
 @@
   data Foo = Bar
@@ -403,6 +403,8 @@ type signature or @TypeApplications@ as desired. For example
   lookupFieldUserData (textField "baz") :: Maybe Foo
   lookupFieldUserData @Foo (textField "baz")
 @@
+
+@since 1.2.0.0
 -}
 lookupFieldUserData ::
   Typeable a =>
@@ -671,7 +673,7 @@ jsonbField = fieldOfType SqlType.jsonb
   from -4731 to 5874897 inclusive for this field, and sending a 'Time.Day' with a year outside
   of this range to the database will result in a PostgreSQL exception.
 
-/@since 1.0.0.0
+@since 1.0.0.0
 -}
 dateField ::
   -- | Name of the field in the database.

--- a/orville-postgresql/src/Orville/PostgreSQL/Marshall/FieldDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Marshall/FieldDefinition.hs
@@ -31,6 +31,8 @@ module Orville.PostgreSQL.Marshall.FieldDefinition
   , addForeignKeyConstraint
   , addForeignKeyConstraintWithOptions
   , addUniqueConstraint
+  , addFieldUserData
+  , lookupFieldUserData
   , fieldEquals
   , (.==)
   , fieldNotEquals
@@ -115,10 +117,12 @@ import Data.Int (Int16, Int32, Int64)
 import Data.List.NonEmpty (NonEmpty ((:|)))
 import qualified Data.Text as T
 import qualified Data.Time as Time
+import Data.Typeable (Typeable)
 import qualified Data.UUID as UUID
 
 import qualified Orville.PostgreSQL.Expr as Expr
 import Orville.PostgreSQL.Internal.FieldName (FieldName, byteStringToFieldName, fieldNameToByteString, fieldNameToColumnName, fieldNameToString, stringToFieldName)
+import qualified Orville.PostgreSQL.Internal.TypeMap as TypeMap
 import qualified Orville.PostgreSQL.Marshall.AliasName as AliasName
 import qualified Orville.PostgreSQL.Marshall.DefaultValue as DefaultValue
 import Orville.PostgreSQL.Marshall.SqlComparable (SqlComparable (referenceValueExpression, toComparableSqlValue))
@@ -144,6 +148,7 @@ data FieldDefinition nullability a = FieldDefinition
   , i_fieldDescription :: Maybe String
   , i_fieldTableConstraints :: [FieldName -> ConstraintDefinition.ConstraintDefinition]
   , i_fieldIdentity :: IdentityGADT nullability
+  , i_userData :: TypeMap.TypeMap
   }
 
 {- | Constructs the 'Expr.ValueExpression' for a field for use in SQL expressions
@@ -349,6 +354,62 @@ addUniqueConstraint fieldDef =
       ConstraintDefinition.uniqueConstraint (name :| [])
   in
     addFieldTableConstraints [constraintToAdd] fieldDef
+
+{- |
+Adds some custom user data to a 'FieldDefinition'. The data can then be
+retrieved later via 'lookupFieldUseData'. If there is already user data
+present of the same type, it will be replaced with the new value. User
+data of other types will not be changed or removed however. If desired,
+the type can be made explicit via use of @TypeApplications@. This is
+usually not required, however, since the type is inferred from the value
+being passed. For example, the following are equivalent
+
+@@
+  data Foo = Bar
+
+  addFieldUserData Bar (textField "baz")
+  addFieldUserData @Foo Bar (textField "baz")
+@@
+
+@since 1.2.0.0
+-}
+addFieldUserData ::
+  Typeable a =>
+  a ->
+  FieldDefinition nullability b ->
+  FieldDefinition nullability b
+addFieldUserData a field =
+  FieldDefinition
+    { i_fieldName = i_fieldName field
+    , i_fieldType = i_fieldType field
+    , i_fieldNullability = i_fieldNullability field
+    , i_fieldDefaultValue = i_fieldDefaultValue field
+    , i_fieldDescription = i_fieldDescription field
+    , i_fieldTableConstraints = i_fieldTableConstraints field
+    , i_fieldIdentity = i_fieldIdentity field
+    , i_userData = TypeMap.insert a (i_userData field)
+    }
+
+{- |
+Retrieves customer user data that was added via 'addFieldUserdata'. The
+type of data retrieved is inferred based on the type of @a@ required by
+the caller. If required, this can be made explicit via an appropriate
+type signature or @TypeApplications@ as desired. For example
+
+@@
+  data Foo = Bar
+
+  lookupFieldUserData (textField "baz") -- when Foo can be inferred based on the usage
+  lookupFieldUserData (textField "baz") :: Maybe Foo
+  lookupFieldUserData @Foo (textField "baz")
+@@
+-}
+lookupFieldUserData ::
+  Typeable a =>
+  FieldDefinition nullability b ->
+  Maybe a
+lookupFieldUserData =
+  TypeMap.lookup . i_userData
 
 {- | Marshalls a Haskell value to be stored in the field to its 'SqlValue.SqlValue'
   representation and packages the result as a 'Expr.ValueExpression' so that
@@ -610,7 +671,7 @@ jsonbField = fieldOfType SqlType.jsonb
   from -4731 to 5874897 inclusive for this field, and sending a 'Time.Day' with a year outside
   of this range to the database will result in a PostgreSQL exception.
 
-@since 1.0.0.0
+/@since 1.0.0.0
 -}
 dateField ::
   -- | Name of the field in the database.
@@ -682,6 +743,7 @@ fieldOfType sqlType name =
     , i_fieldDescription = Nothing
     , i_fieldTableConstraints = mempty
     , i_fieldIdentity = AllowedIdentityButNotSetGADT
+    , i_userData = TypeMap.empty
     }
 
 {- | Makes a 'NotNull' field 'Nullable' by wrapping the Haskell type of the field in 'Maybe'. The
@@ -713,6 +775,7 @@ nullableField field =
       , i_fieldDescription = fieldDescription field
       , i_fieldTableConstraints = i_fieldTableConstraints field
       , i_fieldIdentity = NotIdentityGADT
+      , i_userData = i_userData field
       }
 
 {- | Adds a 'Maybe' wrapper to a field that is already nullable. (If your field is
@@ -747,6 +810,7 @@ asymmetricNullableField field =
       , i_fieldDescription = fieldDescription field
       , i_fieldTableConstraints = i_fieldTableConstraints field
       , i_fieldIdentity = i_fieldIdentity field
+      , i_userData = i_userData field
       }
 
 {- | Applies a 'SqlType.SqlType' conversion to a 'FieldDefinition'. You can

--- a/orville-postgresql/test/Test/FieldDefinition.hs
+++ b/orville-postgresql/test/Test/FieldDefinition.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TypeApplications #-}
+
 module Test.FieldDefinition
   ( fieldDefinitionTests
   )
@@ -29,7 +31,8 @@ import qualified Test.Property as Property
 fieldDefinitionTests :: Orville.ConnectionPool -> Property.Group
 fieldDefinitionTests pool =
   Property.group "FieldDefinition" $
-    integerField pool
+    [prop_userData]
+      <> integerField pool
       <> bigIntegerField pool
       <> doubleField pool
       <> booleanField pool
@@ -42,6 +45,20 @@ fieldDefinitionTests pool =
       <> utcTimestampField pool
       <> localTimestampField pool
       <> jsonbField pool
+
+prop_userData :: Property.NamedProperty
+prop_userData =
+  Property.singletonNamedProperty "User data can be stored on FieldDefinition" $ do
+    let
+      fieldDef =
+        Marshall.addFieldUserData @Int 42
+          . Marshall.addFieldUserData "Life the universe and everything"
+          . Marshall.integerField
+          $ "foo"
+
+    Marshall.lookupFieldUserData @Double fieldDef === Nothing
+    Marshall.lookupFieldUserData @Int fieldDef === Just 42
+    Marshall.lookupFieldUserData fieldDef === Just "Life the universe and everything"
 
 integerField :: Orville.ConnectionPool -> [(HH.PropertyName, HH.Property)]
 integerField pool =


### PR DESCRIPTION
This adds `addFieldUserData` and `lookupFieldUserData` to be an
interface for other libraries to associate their own data with
fields without needing to track them at the type level.
