### PR TITLE
Fix date generation range and haddock comments

### DIFF
--- a/orville-postgresql/src/Orville/PostgreSQL/Marshall/FieldDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Marshall/FieldDefinition.hs
@@ -670,7 +670,7 @@ jsonbField = fieldOfType SqlType.jsonb
   PostgreSQL "DATE" type.
 
   This field cannot represent the full range of 'Time.Day' values. PostgreSQL supports years
-  from -4731 to 5874897 inclusive for this field, and sending a 'Time.Day' with a year outside
+  from -4712 to 5874897 inclusive for this field, and sending a 'Time.Day' with a year outside
   of this range to the database will result in a PostgreSQL exception.
 
 @since 1.0.0.0
@@ -685,7 +685,7 @@ dateField = fieldOfType SqlType.date
   PostgreSQL "TIMESTAMP with time zone" type.
 
   This field cannot represent the full range of 'Time.UTCTime' values. PostgreSQL supports years
-  from -4731 to 294276 inclusive for this field, and sending a 'Time.UTCTime' with a year outside
+  from -4712 to 294276 inclusive for this field, and sending a 'Time.UTCTime' with a year outside
   of this range to the database will result in a PostgreSQL exception.
 
 @since 1.0.0.0
@@ -700,7 +700,7 @@ utcTimestampField = fieldOfType SqlType.timestamp
   PostgreSQL "TIMESTAMP without time zone" type.
 
   This field cannot represent the full range of 'Time.LocalTime' values. PostgreSQL supports years
-  from -4731 to 294276 inclusive for this field, and sending a 'Time.LocalTime' with a year outside
+  from -4712 to 294276 inclusive for this field, and sending a 'Time.LocalTime' with a year outside
   of this range to the database will result in a PostgreSQL exception.
 
 @since 1.0.0.0

--- a/orville-postgresql/src/Orville/PostgreSQL/Marshall/SqlType.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Marshall/SqlType.hs
@@ -331,7 +331,7 @@ uuid =
   to the "DATE" type in SQL.
 
   This type cannot represent the full range of 'Time.Day' values. PostgreSQL supports years
-  from -4731 to 5874897 inclusive for this type, and sending a 'Time.Day' with a year outside
+  from -4712 to 5874897 inclusive for this type, and sending a 'Time.Day' with a year outside
   of this range to the database will result in a PostgreSQL exception.
 
 @since 1.0.0.0
@@ -353,7 +353,7 @@ date =
   It corresponds to the "TIMESTAMP with time zone" type in SQL.
 
   This type cannot represent the full range of 'Time.UTCTime' values. PostgreSQL supports years
-  from -4731 to 294276 inclusive for this type, and sending a 'Time.UTCTime' with a year outside
+  from -4712 to 294276 inclusive for this type, and sending a 'Time.UTCTime' with a year outside
   of this range to the database will result in a PostgreSQL exception.
 
   Note: This is NOT a typo. The "TIMESTAMP with time zone" type in SQL does not include
@@ -379,7 +379,7 @@ timestamp =
   It corresponds to the "TIMESTAMP without time zone" type in SQL.
 
   This type cannot represent the full range of 'Time.LocalTime' values. PostgreSQL supports years
-  from -4731 to 294276 inclusive for this type, and sending a 'Time.LocalTime' with a year outside
+  from -4712 to 294276 inclusive for this type, and sending a 'Time.LocalTime' with a year outside
   of this range to the database will result in a PostgreSQL exception.
 
   http://blog.untrod.com/2016/08/actually-understanding-timezones-in-postgresql.html

--- a/orville-postgresql/test/Test/PgGen.hs
+++ b/orville-postgresql/test/Test/PgGen.hs
@@ -119,7 +119,7 @@ pgLocalTime =
 
 pgDay :: HH.Gen Time.Day
 pgDay = do
-  year <- Gen.integral (Range.constantFrom 2000 (-4713) 294276)
+  year <- Gen.integral (Range.constantFrom 2000 (-4712) 294276)
   month <- Gen.integral (Range.constant 1 12)
   day <- Gen.integral (Range.constant 1 (Time.gregorianMonthLength year month))
 
@@ -131,7 +131,7 @@ pgDay = do
 -- Edge case to help catch mistakes in date parsing/printing
 feb29thBCE :: HH.Gen Time.Day
 feb29thBCE = do
-  year <- Gen.filter Time.isLeapYear (Gen.integral (Range.linear (-4713) 0))
+  year <- Gen.filter Time.isLeapYear (Gen.integral (Range.linear (-4712) 0))
   pure (Time.fromGregorian year 2 29)
 
 pgTimeOfDay :: HH.Gen Time.TimeOfDay


### PR DESCRIPTION
Because the '0' turns into 1 BCE, as we correctly handle with a subtraction for negative numbers in our parser, and PostgreSQL having a lower bound for dates of 4713 BCE, there was an off by 1 error in our date generator for tests. Namely that '1 - (-4713)' is 4714, falling off the allowed minimum in PostgreSQL. This adjusts the generator to work with a lower bound of -4712.

While here, I noticed a typo in our haddocks that had -4731 instead of -4713, but that too would have resulted in the off by one so the comments have been adjusted.

I would think this has never been hit in practice as storing dates that far back is probably rare for users of Orville.