### PR TITLE
Enable manually destroying connections

### DIFF
--- a/orville-postgresql/orville-postgresql.cabal
+++ b/orville-postgresql/orville-postgresql.cabal
@@ -184,7 +184,7 @@ library
     , network-uri ==2.6.*
     , postgresql-libpq >=0.9.4.2 && <0.12
     , random >=1.0 && <2
-    , resource-pool <0.3 || >=0.4 && <0.6
+    , resource-pool >=0.2.2.0 && <0.3 || >=0.4 && <0.6
     , safe-exceptions >=0.1.7 && <0.2
     , text >=1.2 && <1.3 || >=2.0 && <2.2
     , time >=1.9.1 && <1.16
@@ -267,7 +267,7 @@ test-suite spec
     , hedgehog >=1.0.5 && <1.7
     , orville-postgresql
     , postgresql-libpq >=0.9.4.2 && <0.12
-    , resource-pool <0.3 || >=0.4 && <0.6
+    , resource-pool >=0.2.2.0 && <0.3 || >=0.4 && <0.6
     , safe-exceptions >=0.1.7 && <0.2
     , text >=1.2 && <1.3 || >=2.0 && <2.2
     , time >=1.9.1 && <1.16

--- a/orville-postgresql/package.yaml
+++ b/orville-postgresql/package.yaml
@@ -175,7 +175,7 @@ library:
     - containers >= 0.6 && < 0.9
     - network-uri >= 2.6 && < 2.7
     - random >= 1.0 && <2
-    - resource-pool <0.3 || (>= 0.4  && <0.6)
+    - resource-pool (>= 0.2.2.0 && <0.3) || (>= 0.4  && <0.6)
     - safe-exceptions >=0.1.7 && < 0.2
     - text (>= 1.2 && < 1.3) || (>=2.0 && <2.2)
     - time >=1.9.1 && < 1.16
@@ -195,7 +195,7 @@ tests:
       - hedgehog >= 1.0.5 && <1.7
       - postgresql-libpq >= 0.9.4.2 && <0.12
       - orville-postgresql
-      - resource-pool <0.3 || (>= 0.4  && <0.6)
+      - resource-pool (>= 0.2.2.0 && <0.3) || (>= 0.4  && <0.6)
       - safe-exceptions >=0.1.7 && < 0.2
       - text (>= 1.2 && < 1.3) || (>=2.0 && <2.2)
       - time >=1.9.1 && < 1.16

--- a/orville-postgresql/src/Orville/PostgreSQL/Raw/Connection.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Raw/Connection.hs
@@ -22,7 +22,7 @@ module Orville.PostgreSQL.Raw.Connection
   , StripeOption (OneStripePerCapability, StripeCount)
   , ConnectionPool
   , createConnectionPool
-  , destroyAllConnections
+  , destroyIdleConnections
   , Connection
   , withPoolConnection
   , executeRaw
@@ -121,20 +121,20 @@ createConnectionPool options = do
       connPerStripe
 #endif
 
-{- | Destroy (close) all connections currently in the connection pool,
-proactively freeing the associated resources and returning the pool to an
-empty state. This can be useful when it is known that all connections have
-become invalid or are no longer needed.
+{- | Destroy (close) connections currently in the connection pool, proactively
+freeing the associated resources and returning the pool to an empty state. This
+can be useful when it is known that all connections have become invalid or are
+no longer needed.
 
 Connections in use, such as in 'withPoolConnection', are not considered /in/ the
-pool and will not be immediately affected by 'destroyAllConnections'.
+pool and will not be immediately affected by 'destroyIdleConnections'.
 
 Any exceptions thrown by the destroy function are ignored.
 
 @since 1.1.1.0
 -}
-destroyAllConnections :: ConnectionPool -> IO ()
-destroyAllConnections (ConnectionPool pool) =
+destroyIdleConnections :: ConnectionPool -> IO ()
+destroyIdleConnections (ConnectionPool pool) =
   destroyAllResources pool
 
 {- | Values for the 'connectionPoolStripes' field of 'ConnectionOptions'.

--- a/orville-postgresql/src/Orville/PostgreSQL/Raw/Connection.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Raw/Connection.hs
@@ -22,6 +22,7 @@ module Orville.PostgreSQL.Raw.Connection
   , StripeOption (OneStripePerCapability, StripeCount)
   , ConnectionPool
   , createConnectionPool
+  , destroyAllConnections
   , Connection
   , withPoolConnection
   , executeRaw
@@ -44,9 +45,9 @@ import qualified Data.ByteString.Char8 as B8
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import Data.Maybe (fromMaybe)
 #if MIN_VERSION_resource_pool(0,4,0)
-import Data.Pool (Pool, newPool, defaultPoolConfig, setNumStripes, withResource)
+import Data.Pool (Pool, newPool, defaultPoolConfig, setNumStripes, withResource, destroyAllResources)
 #else
-import Data.Pool (Pool, createPool, withResource)
+import Data.Pool (Pool, createPool, withResource, destroyAllResources)
 #endif
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as Enc
@@ -119,6 +120,22 @@ createConnectionPool options = do
       linger
       connPerStripe
 #endif
+
+{- | Destroy (close) all connections currently in the connection pool,
+proactively freeing the associated resources and returning the pool to an
+empty state. This can be useful when it is known that all connections have
+become invalid or are no longer needed.
+
+Connections in use, such as in 'withPoolConnection', are not considered /in/ the
+pool and will not be immediately affected by 'destroyAllConnections'.
+
+Any exceptions thrown by the destroy function are ignored.
+
+@since 1.1.1.0
+-}
+destroyAllConnections :: ConnectionPool -> IO ()
+destroyAllConnections (ConnectionPool pool) =
+  destroyAllResources pool
 
 {- | Values for the 'connectionPoolStripes' field of 'ConnectionOptions'.
 

--- a/orville-postgresql/test/Test/Connection.hs
+++ b/orville-postgresql/test/Test/Connection.hs
@@ -28,6 +28,8 @@ connectionTests pool =
     , prop_truncateValuesAtUnsafeNulByte pool
     , prop_errorOnInvalidSql pool
     , prop_returningAConnectionToPoolWithOpenTransactionCausesException pool
+    , prop_acquiredConnectionNotDestroyed pool
+    , prop_poolUsableAfterDestroyingConnections pool
     ]
 
 prop_safeOrUnsafeNonNullBytes :: Property.NamedDBProperty
@@ -137,7 +139,7 @@ prop_errorOnInvalidSql =
 
         Conn.sqlExecutionErrorSqlState err === Just syntaxErrorState
       Right _ -> do
-        HH.footnote "Expected 'executeRow' to return failure, but it did not"
+        HH.footnote "Expected 'executeRaw' to return failure, but it did not"
         HH.failure
 
 prop_returningAConnectionToPoolWithOpenTransactionCausesException :: Property.NamedDBProperty
@@ -156,3 +158,55 @@ prop_returningAConnectionToPoolWithOpenTransactionCausesException =
       Right _ -> do
         HH.footnote "Expected 'withPoolConnection' to return failure, but it did not"
         HH.failure
+
+prop_acquiredConnectionNotDestroyed :: Property.NamedDBProperty
+prop_acquiredConnectionNotDestroyed =
+  Property.namedDBProperty "destroying all connections in the pool does not affect connections already acquired" $ \pool -> do
+    textBytes <- fmap Enc.encodeUtf8 . HH.forAll $ PgGen.pgText (Range.linear 0 256)
+
+    value <-
+      MIO.liftIO . Conn.withPoolConnection pool $ \connection -> do
+        Conn.destroyAllConnections pool
+        result <-
+          Conn.executeRaw
+            connection
+            (B8.pack "SELECT $1::text")
+            [ Just $ PgTextFormatValue.fromByteString textBytes
+            ]
+
+        LibPQ.getvalue' result 0 0
+
+    value === Just textBytes
+
+prop_poolUsableAfterDestroyingConnections :: Property.NamedDBProperty
+prop_poolUsableAfterDestroyingConnections =
+  Property.namedDBProperty "the connection pool can be used after destroying all connections" $ \pool -> do
+    textBytes1 <- fmap Enc.encodeUtf8 . HH.forAll $ PgGen.pgText (Range.linear 0 256)
+    textBytes2 <- fmap Enc.encodeUtf8 . HH.forAll $ PgGen.pgText (Range.linear 0 256)
+
+    value1 <-
+      MIO.liftIO . Conn.withPoolConnection pool $ \connection -> do
+        result <-
+          Conn.executeRaw
+            connection
+            (B8.pack "SELECT $1::text")
+            [ Just $ PgTextFormatValue.fromByteString textBytes1
+            ]
+
+        LibPQ.getvalue' result 0 0
+
+    MIO.liftIO $ Conn.destroyAllConnections pool
+
+    value2 <-
+      MIO.liftIO . Conn.withPoolConnection pool $ \connection -> do
+        result <-
+          Conn.executeRaw
+            connection
+            (B8.pack "SELECT $1::text")
+            [ Just $ PgTextFormatValue.fromByteString textBytes2
+            ]
+
+        LibPQ.getvalue' result 0 0
+
+    value1 === Just textBytes1
+    value2 === Just textBytes2

--- a/orville-postgresql/test/Test/Connection.hs
+++ b/orville-postgresql/test/Test/Connection.hs
@@ -161,12 +161,12 @@ prop_returningAConnectionToPoolWithOpenTransactionCausesException =
 
 prop_acquiredConnectionNotDestroyed :: Property.NamedDBProperty
 prop_acquiredConnectionNotDestroyed =
-  Property.namedDBProperty "destroying all connections in the pool does not affect connections already acquired" $ \pool -> do
+  Property.namedDBProperty "destroying idle connections in the pool does not affect connections already acquired" $ \pool -> do
     textBytes <- fmap Enc.encodeUtf8 . HH.forAll $ PgGen.pgText (Range.linear 0 256)
 
     value <-
       MIO.liftIO . Conn.withPoolConnection pool $ \connection -> do
-        Conn.destroyAllConnections pool
+        Conn.destroyIdleConnections pool
         result <-
           Conn.executeRaw
             connection
@@ -180,7 +180,7 @@ prop_acquiredConnectionNotDestroyed =
 
 prop_poolUsableAfterDestroyingConnections :: Property.NamedDBProperty
 prop_poolUsableAfterDestroyingConnections =
-  Property.namedDBProperty "the connection pool can be used after destroying all connections" $ \pool -> do
+  Property.namedDBProperty "the connection pool can be used after destroying idle connections" $ \pool -> do
     textBytes1 <- fmap Enc.encodeUtf8 . HH.forAll $ PgGen.pgText (Range.linear 0 256)
     textBytes2 <- fmap Enc.encodeUtf8 . HH.forAll $ PgGen.pgText (Range.linear 0 256)
 
@@ -195,7 +195,7 @@ prop_poolUsableAfterDestroyingConnections =
 
         LibPQ.getvalue' result 0 0
 
-    MIO.liftIO $ Conn.destroyAllConnections pool
+    MIO.liftIO $ Conn.destroyIdleConnections pool
 
     value2 <-
       MIO.liftIO . Conn.withPoolConnection pool $ \connection -> do


### PR DESCRIPTION
Use `destroyAllResources` from `resource-pool`. Add the `resource-pool` package version where `destroyAllResources` was introduced as a minimum version constraint.

Fixes #425.