### PR TITLE
Add support for PostgreSQL 18

### DIFF
--- a/.github/workflows/orville-postgresql.yaml
+++ b/.github/workflows/orville-postgresql.yaml
@@ -30,17 +30,17 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        pg-version: ["pg13", "pg17"]
+        pg-version: ["pg14", "pg18"]
         stack-yaml: ${{ fromJson(needs.find-stack-yamls.outputs.stack-yamls) }}
 
         include:
           # Only test the default 'stack.yaml' for the "middle" postgresql versions to reduce the
           # load on CI
-          - pg-version: "pg14"
-            stack-yaml: "stack.yaml"
           - pg-version: "pg15"
             stack-yaml: "stack.yaml"
           - pg-version: "pg16"
+            stack-yaml: "stack.yaml"
+          - pg-version: "pg17"
             stack-yaml: "stack.yaml"
 
     permissions:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ may be the right choice for you.
 ## PostgreSQL Versions Supported
 
 Orville is tested against and supports major versions of PostgreSQL that are currently
-maintained. This is currently versions 13,14,15,16 and 17.
+maintained. This is currently versions 14,15,16,17, and 18.
 
 ## Tutorials
 

--- a/orville-postgresql/compose.yaml
+++ b/orville-postgresql/compose.yaml
@@ -7,9 +7,9 @@ services:
       - stack-root:/stack-root
     working_dir: /orville-postgresql
     depends_on:
-      - testdb-${PG_VERSION:-pg13}
+      - testdb-${PG_VERSION:-pg14}
     environment:
-      TEST_CONN_HOST: "host=testdb-${PG_VERSION:-pg13}"
+      TEST_CONN_HOST: "host=testdb-${PG_VERSION:-pg14}"
       STACK_ROOT: /stack-root
       IN_DEV_CONTAINER: "true"
 
@@ -20,12 +20,6 @@ services:
     working_dir: /orville-postgresql
     environment:
       IN_TOOLS_CONTAINER: "true"
-
-  testdb-pg13:
-    image: postgres:13.16-alpine
-    environment:
-      POSTGRES_USER: orville_test
-      POSTGRES_PASSWORD: orville
 
   testdb-pg14:
     image: postgres:14.13-alpine
@@ -47,6 +41,12 @@ services:
 
   testdb-pg17:
     image: postgres:17.0-alpine
+    environment:
+      POSTGRES_USER: orville_test
+      POSTGRES_PASSWORD: orville
+
+  testdb-pg18:
+    image: postgres:18.0-alpine
     environment:
       POSTGRES_USER: orville_test
       POSTGRES_PASSWORD: orville

--- a/orville-postgresql/orville-postgresql.cabal
+++ b/orville-postgresql/orville-postgresql.cabal
@@ -267,7 +267,7 @@ test-suite spec
     , base >=4.8 && <5
     , bytestring >=0.10 && <0.13
     , containers >=0.6 && <0.9
-    , hedgehog >=1.0.5 && <1.7
+    , hedgehog >=1.0.5 && <1.8
     , orville-postgresql
     , postgresql-libpq >=0.9.4.2 && <0.12
     , resource-pool <0.3 || >=0.4 && <0.6

--- a/orville-postgresql/package.yaml
+++ b/orville-postgresql/package.yaml
@@ -193,7 +193,7 @@ tests:
       - base >=4.8 && <5
       - bytestring >=0.10 && <0.13
       - containers >= 0.6 && < 0.9
-      - hedgehog >= 1.0.5 && <1.7
+      - hedgehog >= 1.0.5 && <1.8
       - postgresql-libpq >= 0.9.4.2 && <0.12
       - orville-postgresql
       - resource-pool <0.3 || (>= 0.4  && <0.6)

--- a/orville-postgresql/scripts/psql
+++ b/orville-postgresql/scripts/psql
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-docker compose exec testdb-pg13 psql -U orville_test
+docker compose exec testdb-pg14 psql -U orville_test

--- a/orville-postgresql/src/Orville/PostgreSQL/AutoMigration.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/AutoMigration.hs
@@ -1080,6 +1080,7 @@ mkDropConstraintActions constraintsToKeep constraint =
         PgCatalog.PrimaryKeyConstraint -> []
         PgCatalog.ConstraintTrigger -> []
         PgCatalog.ExclusionConstraint -> []
+        PgCatalog.NotNullConstraint -> []
 
 {- | Sets the schema name on a constraint to the given namespace when the
   constraint has no namespace explicitly given. This is important for Orville
@@ -1187,6 +1188,7 @@ pgConstraintMigrationKeys constraintDesc =
         PgCatalog.PrimaryKeyConstraint -> False
         PgCatalog.ConstraintTrigger -> False
         PgCatalog.ExclusionConstraint -> False
+        PgCatalog.NotNullConstraint -> False
   in
     if isMigratableConstraint
       then Schema.NamedBasedConstraint constraintIdentifier : Maybe.maybeToList attributeBasedConstraints
@@ -1380,6 +1382,8 @@ pgConstraintImpliedIndexOid pgConstraint =
     PgCatalog.ForeignKeyConstraint ->
       Nothing
     PgCatalog.ConstraintTrigger ->
+      Nothing
+    PgCatalog.NotNullConstraint ->
       Nothing
 
 {- | Builds the orville migration keys given a description of an existing index

--- a/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/PgConstraint.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/PgConstraint.hs
@@ -111,6 +111,7 @@ data ConstraintType
   | UniqueConstraint
   | ConstraintTrigger
   | ExclusionConstraint
+  | NotNullConstraint
   deriving
     ( -- | @since 1.0.0.0
       Show
@@ -135,6 +136,7 @@ constraintTypeToPgText conType =
       UniqueConstraint -> "u"
       ConstraintTrigger -> "t"
       ExclusionConstraint -> "x"
+      NotNullConstraint -> "n"
 
 {- | Attempts to parse a PostgreSQL single character textual value as a
   'ConstraintType'
@@ -152,6 +154,7 @@ pgTextToConstraintType text =
     "u" -> Right UniqueConstraint
     "t" -> Right ConstraintTrigger
     "x" -> Right ExclusionConstraint
+    "n" -> Right NotNullConstraint
     typ -> Left ("Unrecognized PostgreSQL constraint type: " <> typ)
 
 {- | Converts a 'Maybe Orville.ForeignKeyAction' to the corresponding single character

--- a/orville-postgresql/test/Test/AutoMigration.hs
+++ b/orville-postgresql/test/Test/AutoMigration.hs
@@ -724,7 +724,13 @@ prop_addAndRemovesUniqueConstraints =
     tableDesc <- PgAssert.assertTableExists pool "migration_test"
 
     Fold.traverse_ (PgAssert.assertUniqueConstraintExists tableDesc) newConstraintColumns
-    length (PgCatalog.relationConstraints tableDesc) === length (List.nub newConstraintColumns)
+    -- We ignore NotNullConstraint because it isn't supported on PostgreSQL versions < 18
+    length
+      ( filter
+          (\a -> PgCatalog.pgConstraintType (PgCatalog.constraintRecord a) /= PgCatalog.NotNullConstraint)
+          $ PgCatalog.relationConstraints tableDesc
+      )
+      === length (List.nub newConstraintColumns)
 
 prop_addAndRemovesForeignKeyConstraints :: Property.NamedDBProperty
 prop_addAndRemovesForeignKeyConstraints =
@@ -836,7 +842,13 @@ prop_addAndRemovesForeignKeyConstraints =
     migrationPlanStepStrings secondTimePlan === []
     tableDesc <- PgAssert.assertTableExists pool "migration_test"
     Fold.traverse_ (PgAssert.assertForeignKeyConstraintExists tableDesc) newForeignKeyInfos
-    length (PgCatalog.relationConstraints tableDesc) === length (List.nub newForeignKeyInfos)
+    -- We ignore NotNullConstraint because it isn't supported on PostgreSQL versions < 18
+    length
+      ( filter
+          (\a -> PgCatalog.pgConstraintType (PgCatalog.constraintRecord a) /= PgCatalog.NotNullConstraint)
+          $ PgCatalog.relationConstraints tableDesc
+      )
+      === length (List.nub newForeignKeyInfos)
 
 prop_addAndRemovesCheckConstraints :: Property.NamedDBProperty
 prop_addAndRemovesCheckConstraints =
@@ -884,7 +896,13 @@ prop_addAndRemovesCheckConstraints =
     tableDesc <- PgAssert.assertTableExists pool "migration_check_test"
 
     Fold.traverse_ (PgAssert.assertCheckConstraintExists tableDesc) newConstrs
-    length (PgCatalog.relationConstraints tableDesc) === length newConstraints
+    -- We ignore NotNullConstraint because it isn't supported on PostgreSQL versions < 18
+    length
+      ( filter
+          (\a -> PgCatalog.pgConstraintType (PgCatalog.constraintRecord a) /= PgCatalog.NotNullConstraint)
+          $ PgCatalog.relationConstraints tableDesc
+      )
+      === length newConstraints
 
 prop_addNamedUniqueConstraint :: Property.NamedDBProperty
 prop_addNamedUniqueConstraint =
@@ -946,7 +964,13 @@ prop_addNamedUniqueConstraint =
 
     -- We use originalConstraintColumns as we expect the constraint not to be migrated as the name is the same
     PgAssert.assertUniqueConstraintExists tableDesc originalConstraintColumns
-    length (PgCatalog.relationConstraints tableDesc) === 1
+    -- We ignore NotNullConstraint because it isn't supported on PostgreSQL versions < 18
+    length
+      ( filter
+          (\a -> PgCatalog.pgConstraintType (PgCatalog.constraintRecord a) /= PgCatalog.NotNullConstraint)
+          $ PgCatalog.relationConstraints tableDesc
+      )
+      === 1
 
 prop_addsAndRemovesMixedIndexes :: Property.NamedDBProperty
 prop_addsAndRemovesMixedIndexes =

--- a/orville-postgresql/test/Test/PgCatalog.hs
+++ b/orville-postgresql/test/Test/PgCatalog.hs
@@ -129,8 +129,11 @@ prop_queryPgConstraint =
         PgCatalog.pgConstraintTable
         (Orville.where_ $ Orville.fieldEquals PgCatalog.constraintRelationOidField pgClassOid)
 
-    map PgCatalog.pgConstraintType constraints === [PgCatalog.PrimaryKeyConstraint]
-    map PgCatalog.pgConstraintKey constraints === [Just [1]]
+    let
+      filterNotNulls =
+        filter (\a -> PgCatalog.pgConstraintType a /= PgCatalog.NotNullConstraint)
+    map PgCatalog.pgConstraintType (filterNotNulls constraints) === [PgCatalog.PrimaryKeyConstraint]
+    map PgCatalog.pgConstraintKey (filterNotNulls constraints) === [Just [1]]
 
 prop_queryPgTrigger :: Property.NamedDBProperty
 prop_queryPgTrigger =


### PR DESCRIPTION
Three main things here:

1. Adds PostgreSQL 18 to the support matrix, dropping the out of support version, 13. 
2. Ignores the new not-null constraint rows in the pg_catalog table, because they only exist starting in version 18. We still track not-null the same way as always which works across all the supported versions.
3. Bumps the version of hedgehog allowed in the cabal file. 