### PR TITLE
Adds upsert entity operations using `ON CONFLICT`

### DIFF
--- a/orville-postgresql/orville-postgresql.cabal
+++ b/orville-postgresql/orville-postgresql.cabal
@@ -215,6 +215,7 @@ test-suite spec
       Test.Entities.CompositeKeyEntity
       Test.Entities.Foo
       Test.Entities.FooChild
+      Test.Entities.UpsertEntity
       Test.Entities.User
       Test.EntityOperations
       Test.Execution

--- a/orville-postgresql/orville-postgresql.cabal
+++ b/orville-postgresql/orville-postgresql.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           orville-postgresql
-version:        1.1.1.0.0
+version:        1.1.1.0.1
 synopsis:       A Haskell library for PostgreSQL
 description:    Orville's goal is to provide a powerful API for applications to access PostgreSQL databases with minimal use of sophisticated language techniques or extensions. See https://github.com/flipstone/orville for more details.
 category:       database, library, postgresql

--- a/orville-postgresql/package.yaml
+++ b/orville-postgresql/package.yaml
@@ -1,6 +1,6 @@
 ---
 name: orville-postgresql
-version: '1.1.1.0.0' # Development version, breaking changes included, release scheduled to be 1.2.0.0
+version: '1.1.1.0.1' # Development version, breaking changes included, release scheduled to be 1.2.0.0
 synopsis: A Haskell library for PostgreSQL
 description:
   Orville's goal is to provide a powerful API for applications to access

--- a/orville-postgresql/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL.hs
@@ -30,6 +30,8 @@ module Orville.PostgreSQL
   , EntityOperations.insertEntities
   , EntityOperations.insertEntitiesAndReturnRowCount
   , EntityOperations.insertAndReturnEntities
+  , EntityOperations.ConflictTarget (..)
+  , EntityOperations.ConflictTargetError (..)
   , EntityOperations.upsertEntity
   , EntityOperations.upsertEntityAndReturnRowCount
   , EntityOperations.upsertAndReturnEntity

--- a/orville-postgresql/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL.hs
@@ -30,6 +30,12 @@ module Orville.PostgreSQL
   , EntityOperations.insertEntities
   , EntityOperations.insertEntitiesAndReturnRowCount
   , EntityOperations.insertAndReturnEntities
+  , EntityOperations.upsertEntity
+  , EntityOperations.upsertEntityAndReturnRowCount
+  , EntityOperations.upsertAndReturnEntity
+  , EntityOperations.upsertEntities
+  , EntityOperations.upsertEntitiesAndReturnRowCount
+  , EntityOperations.upsertAndReturnEntities
   , EntityOperations.updateEntity
   , EntityOperations.updateEntityAndReturnRowCount
   , EntityOperations.updateAndReturnEntity
@@ -263,6 +269,7 @@ module Orville.PostgreSQL
   , Marshall.aliasNameAndFieldNameToColumnName
   , Marshall.aliasNameToByteString
   , Marshall.byteStringToAliasName
+  , Marshall.marshallerConflictTargetExpr
   , DefaultValue.DefaultValue
   , DefaultValue.integerDefault
   , DefaultValue.smallIntegerDefault

--- a/orville-postgresql/src/Orville/PostgreSQL/Execution/EntityOperations.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Execution/EntityOperations.hs
@@ -22,6 +22,12 @@ module Orville.PostgreSQL.Execution.EntityOperations
   , updateFields
   , updateFieldsAndReturnEntities
   , updateFieldsAndReturnRowCount
+  , upsertEntity
+  , upsertEntityAndReturnRowCount
+  , upsertAndReturnEntity
+  , upsertEntities
+  , upsertEntitiesAndReturnRowCount
+  , upsertAndReturnEntities
   , deleteEntity
   , deleteEntityAndReturnRowCount
   , deleteAndReturnEntity
@@ -39,6 +45,7 @@ import Control.Exception (Exception, throwIO)
 import qualified Control.Monad as Monad
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import Data.List.NonEmpty (NonEmpty ((:|)))
+import qualified Data.List.NonEmpty as NEL
 import Data.Maybe (listToMaybe)
 
 import qualified Orville.PostgreSQL.Execution.Delete as Delete
@@ -419,3 +426,99 @@ instance Show EmptyUpdateError where
 
 -- | @since 1.0.0.0
 instance Exception EmptyUpdateError
+
+{- |
+  Similar to 'insertAndReturnEntity', but uses an @ON CONFLICT@ clause with an optional
+  'Expr.ConflictTargetExpr' to update the row if it conflicts due to a constraint violation.
+
+@since 1.1.1.0.1
+-}
+upsertAndReturnEntity ::
+  Monad.MonadOrville m =>
+  Schema.TableDefinition key writeEntity readEntity ->
+  Expr.ConflictTargetExpr ->
+  writeEntity ->
+  m readEntity
+upsertAndReturnEntity tableDef target entity = do
+  returnedEntities <- upsertAndReturnEntities tableDef target (entity :| [])
+
+  RowCountExpectation.expectExactlyOneRow
+    "upsertAndReturnEntity RETURNING clause"
+    returnedEntities
+
+{- |
+  Similar to 'insertEntity', but uses an @ON CONFLICT@ clause with an optional
+  'Expr.ConflictTargetExpr' to update the row if it conflicts due to a constraint violation.
+
+@since 1.1.1.0.1
+-}
+upsertEntity ::
+  Monad.MonadOrville m =>
+  Schema.TableDefinition key writeEntity readEntity ->
+  Expr.ConflictTargetExpr ->
+  writeEntity ->
+  m ()
+upsertEntity tableDef target =
+  Monad.void . upsertEntityAndReturnRowCount tableDef target
+
+{- |
+  Similar to 'insertEntity', but uses an @ON CONFLICT@ clause with an optional
+  'Expr.ConflictTargetExpr' to update the row if it conflicts due to a constraint violation.
+  Returns the count of the affected rows.
+
+@since 1.1.1.0.1
+-}
+upsertEntityAndReturnRowCount ::
+  Monad.MonadOrville m =>
+  Schema.TableDefinition key writeEntity readEntity ->
+  Expr.ConflictTargetExpr ->
+  writeEntity ->
+  m Int
+upsertEntityAndReturnRowCount tableDef target =
+  upsertEntitiesAndReturnRowCount tableDef target . pure
+
+{- |
+  Similar to 'insertAndReturnEntities', but uses an @ON CONFLICT@ clause with an optional
+  'Expr.ConflictTargetExpr' to update rows that conflict due to a constraint violation.
+
+@since 1.1.1.0.1
+-}
+upsertAndReturnEntities ::
+  Monad.MonadOrville m =>
+  Schema.TableDefinition key writeEntity readEntity ->
+  Expr.ConflictTargetExpr ->
+  NEL.NonEmpty writeEntity ->
+  m [readEntity]
+upsertAndReturnEntities tableDef target = do
+  Insert.executeInsertReturnEntities . Insert.upsertToTableReturning tableDef target
+
+{- |
+  Similar to 'insertEntities', but uses an @ON CONFLICT@ clause with an optional
+  'Expr.ConflictTargetExpr' to update rows that conflict due to a constraint violation.
+
+@since 1.1.1.0.1
+-}
+upsertEntities ::
+  Monad.MonadOrville m =>
+  Schema.TableDefinition key writeEntity readEntity ->
+  Expr.ConflictTargetExpr ->
+  NEL.NonEmpty writeEntity ->
+  m ()
+upsertEntities tableDef target =
+  Monad.void . upsertEntitiesAndReturnRowCount tableDef target
+
+{- |
+  Similar to 'insertEntitiesAndReturnRowCount', but uses an @ON CONFLICT@ clause with an optional
+  'Expr.ConflictTargetExpr' to update rows that conflict due to a constraint violation.
+  Returns the count of the affected rows.
+
+@since 1.1.1.0.1
+-}
+upsertEntitiesAndReturnRowCount ::
+  Monad.MonadOrville m =>
+  Schema.TableDefinition key writeEntity readEntity ->
+  Expr.ConflictTargetExpr ->
+  NEL.NonEmpty writeEntity ->
+  m Int
+upsertEntitiesAndReturnRowCount tableDef target =
+  Insert.executeInsert . Insert.upsertToTable tableDef target

--- a/orville-postgresql/src/Orville/PostgreSQL/Execution/EntityOperations.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Execution/EntityOperations.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE GADTs #-}
+
 {- |
 Copyright : Flipstone Technology Partners 2023
 License   : MIT
@@ -22,6 +24,8 @@ module Orville.PostgreSQL.Execution.EntityOperations
   , updateFields
   , updateFieldsAndReturnEntities
   , updateFieldsAndReturnRowCount
+  , ConflictTarget (..)
+  , ConflictTargetError (..)
   , upsertEntity
   , upsertEntityAndReturnRowCount
   , upsertAndReturnEntity
@@ -55,6 +59,7 @@ import qualified Orville.PostgreSQL.Execution.SelectOptions as SelectOptions
 import qualified Orville.PostgreSQL.Execution.Update as Update
 import qualified Orville.PostgreSQL.Expr as Expr
 import qualified Orville.PostgreSQL.Internal.RowCountExpectation as RowCountExpectation
+import qualified Orville.PostgreSQL.Marshall as Marshall
 import qualified Orville.PostgreSQL.Monad as Monad
 import qualified Orville.PostgreSQL.Schema as Schema
 
@@ -428,15 +433,125 @@ instance Show EmptyUpdateError where
 instance Exception EmptyUpdateError
 
 {- |
-  Similar to 'insertAndReturnEntity', but uses an @ON CONFLICT@ clause with an optional
-  'Expr.ConflictTargetExpr' to update the row if it conflicts due to a constraint violation.
+  Specifies the target for the @ON CONFLICT@ clause of an upsert function.
+  See the [PostgreSQL documentation](https://www.postgresql.org/docs/current/sql-insert.html#SQL-ON-CONFLICT) for more information.
+
+@since 1.1.1.0.1
+-}
+data ConflictTarget where
+  {- | Upsert by the primary key of the table. May only be used with tables that have a primary key.
+
+  @since 1.1.1.0.1
+  -}
+  ByPrimaryKey :: ConflictTarget
+  {- | Upsert by a field, assuming PostgreSQL can infer an arbiter constraint/index from the field.
+
+  @since 1.1.1.0.1
+  -}
+  ByField :: Marshall.FieldDefinition nullability a -> ConflictTarget
+  {- | Upsert by the writable fields in a marshaller, assuming PostgreSQL can infer an arbiter constraint/index from the fields.
+
+  @since 1.1.1.0.1
+  -}
+  ByMarshaller :: Marshall.SqlMarshaller writeEntity readEntity -> ConflictTarget
+  {- | Upsert by a unique constraint.
+
+  @since 1.1.1.0.1
+  -}
+  ByConstraint :: Schema.ConstraintDefinition -> ConflictTarget
+  {- | Upsert with a custom 'Expr.ConflictTargetExpr'. This allows usage of more complex arbiter indexes, such
+  as a partial unique index.
+
+  @since 1.1.1.0.1
+  -}
+  ByConflictTargetExpr :: Expr.ConflictTargetExpr -> ConflictTarget
+
+{- |
+  An error resulting from attempting to construct an invalid 'Expr.ConflictTargetExpr'.
+
+  Maybe be thrown as an exception by the upsert functions if a valid 'Expr.ConflictTargetExpr' could not
+  be constructed for the provided 'ConflictTarget'.
+
+@since 1.1.1.0.1
+-}
+data ConflictTargetError
+  = {- | The provided conflict target was empty.
+
+    @since 1.1.1.0.1
+    -}
+    EmptyConflictTarget
+  | {- | The provided constraint was not a unique constraint.
+
+    @since 1.1.1.0.1
+    -}
+    NonUniqueConstraintConflictTarget
+  | {- | 'ByPrimaryKey' was used with a table that has no primary key.
+
+    @since 1.1.1.0.1
+    -}
+    NoPrimaryKey
+
+-- | @since 1.1.1.0.1
+instance Show ConflictTargetError where
+  show EmptyConflictTarget =
+    "ConflictTargetError: the provided conflict target was empty."
+  show NonUniqueConstraintConflictTarget =
+    "ConflictTargetError: the provided constraint was not a unique constraint."
+  show NoPrimaryKey =
+    "ConflictTargetError: ByPrimaryKey was used with a table that has no primary key."
+
+-- | @since 1.1.1.0.1
+instance Exception ConflictTargetError
+
+conflictTargetToConflictTargetExpr ::
+  Schema.TableDefinition key writeEntity readEntity ->
+  ConflictTarget ->
+  Either ConflictTargetError Expr.ConflictTargetExpr
+conflictTargetToConflictTargetExpr tableDefinition conflictTarget = case conflictTarget of
+  ByPrimaryKey ->
+    case Schema.tablePrimaryKeyFieldNames tableDefinition of
+      Nothing -> Left NoPrimaryKey
+      Just fieldNames ->
+        Right
+          . Expr.conflictTargetForColumnNames
+          . fmap Marshall.fieldNameToColumnName
+          $ fieldNames
+  ByField fieldDefinition ->
+    Right
+      . Expr.conflictTargetForColumnNames
+      . pure
+      $ Marshall.fieldColumnName fieldDefinition
+  ByMarshaller marshaller ->
+    case Marshall.marshallerConflictTargetExpr marshaller of
+      Nothing -> Left EmptyConflictTarget
+      Just expr -> Right expr
+  ByConstraint constraintDef ->
+    case Schema.constraintDefinitionConflictTargetExpr constraintDef of
+      Nothing -> Left NonUniqueConstraintConflictTarget
+      Just expr -> Right expr
+  ByConflictTargetExpr expr ->
+    Right expr
+
+conflictTargetToConflictTargetExprOrThrow ::
+  MonadIO m =>
+  Schema.TableDefinition key writeEntity readEntity ->
+  ConflictTarget ->
+  m Expr.ConflictTargetExpr
+conflictTargetToConflictTargetExprOrThrow tableDef target =
+  case conflictTargetToConflictTargetExpr tableDef target of
+    Left err -> liftIO $ throwIO err
+    Right expr -> pure expr
+
+{- |
+  Similar to 'insertAndReturnEntity', but uses an @ON CONFLICT@ clause to update the row if it
+  conflicts with an arbiter constraint/index inferred from the provided 'ConflictTarget'.
 
 @since 1.1.1.0.1
 -}
 upsertAndReturnEntity ::
   Monad.MonadOrville m =>
   Schema.TableDefinition key writeEntity readEntity ->
-  Expr.ConflictTargetExpr ->
+  ConflictTarget ->
   writeEntity ->
   m readEntity
 upsertAndReturnEntity tableDef target entity = do
@@ -447,23 +562,23 @@ upsertAndReturnEntity tableDef target entity = do
     returnedEntities
 
 {- |
-  Similar to 'insertEntity', but uses an @ON CONFLICT@ clause with an optional
-  'Expr.ConflictTargetExpr' to update the row if it conflicts due to a constraint violation.
+  Similar to 'insertEntity', but uses an @ON CONFLICT@ clause to update the row if it
+  conflicts with an arbiter constraint/index inferred from the provided 'ConflictTarget'.
 
 @since 1.1.1.0.1
 -}
 upsertEntity ::
   Monad.MonadOrville m =>
   Schema.TableDefinition key writeEntity readEntity ->
-  Expr.ConflictTargetExpr ->
+  ConflictTarget ->
   writeEntity ->
   m ()
 upsertEntity tableDef target =
   Monad.void . upsertEntityAndReturnRowCount tableDef target
 
 {- |
-  Similar to 'insertEntity', but uses an @ON CONFLICT@ clause with an optional
-  'Expr.ConflictTargetExpr' to update the row if it conflicts due to a constraint violation.
+  Similar to 'insertEntity', but uses an @ON CONFLICT@ clause to update the row if it
+  conflicts with an arbiter constraint/index inferred from the provided 'ConflictTarget'.
   Returns the count of the affected rows.
 
 @since 1.1.1.0.1
@@ -471,45 +586,46 @@ upsertEntity tableDef target =
 upsertEntityAndReturnRowCount ::
   Monad.MonadOrville m =>
   Schema.TableDefinition key writeEntity readEntity ->
-  Expr.ConflictTargetExpr ->
+  ConflictTarget ->
   writeEntity ->
   m Int
 upsertEntityAndReturnRowCount tableDef target =
   upsertEntitiesAndReturnRowCount tableDef target . pure
 
 {- |
-  Similar to 'insertAndReturnEntities', but uses an @ON CONFLICT@ clause with an optional
-  'Expr.ConflictTargetExpr' to update rows that conflict due to a constraint violation.
+  Similar to 'insertAndReturnEntities', but uses an @ON CONFLICT@ clause to update the row if it
+  conflicts with an arbiter constraint/index inferred from the provided 'ConflictTarget'.
 
 @since 1.1.1.0.1
 -}
 upsertAndReturnEntities ::
   Monad.MonadOrville m =>
   Schema.TableDefinition key writeEntity readEntity ->
-  Expr.ConflictTargetExpr ->
+  ConflictTarget ->
   NEL.NonEmpty writeEntity ->
   m [readEntity]
-upsertAndReturnEntities tableDef target = do
-  Insert.executeInsertReturnEntities . Insert.upsertToTableReturning tableDef target
+upsertAndReturnEntities tableDef target entities = do
+  targetExpr <- conflictTargetToConflictTargetExprOrThrow tableDef target
+  Insert.executeInsertReturnEntities $ Insert.upsertToTableReturning tableDef targetExpr entities
 
 {- |
-  Similar to 'insertEntities', but uses an @ON CONFLICT@ clause with an optional
-  'Expr.ConflictTargetExpr' to update rows that conflict due to a constraint violation.
+  Similar to 'insertEntities', but uses an @ON CONFLICT@ clause to update the row if it
+  conflicts with an arbiter constraint/index inferred from the provided 'ConflictTarget'.
 
 @since 1.1.1.0.1
 -}
 upsertEntities ::
   Monad.MonadOrville m =>
   Schema.TableDefinition key writeEntity readEntity ->
-  Expr.ConflictTargetExpr ->
+  ConflictTarget ->
   NEL.NonEmpty writeEntity ->
   m ()
 upsertEntities tableDef target =
   Monad.void . upsertEntitiesAndReturnRowCount tableDef target
 
 {- |
-  Similar to 'insertEntitiesAndReturnRowCount', but uses an @ON CONFLICT@ clause with an optional
-  'Expr.ConflictTargetExpr' to update rows that conflict due to a constraint violation.
+  Similar to 'insertEntitiesAndReturnRowCount', but uses an @ON CONFLICT@ clause to update the row if it
+  conflicts with an arbiter constraint/index inferred from the provided 'ConflictTarget'.
   Returns the count of the affected rows.
 
 @since 1.1.1.0.1
@@ -517,8 +633,9 @@ upsertEntities tableDef target =
 upsertEntitiesAndReturnRowCount ::
   Monad.MonadOrville m =>
   Schema.TableDefinition key writeEntity readEntity ->
-  Expr.ConflictTargetExpr ->
+  ConflictTarget ->
   NEL.NonEmpty writeEntity ->
   m Int
-upsertEntitiesAndReturnRowCount tableDef target =
-  Insert.executeInsert . Insert.upsertToTable tableDef target
+upsertEntitiesAndReturnRowCount tableDef target entities = do
+  targetExpr <- conflictTargetToConflictTargetExprOrThrow tableDef target
+  Insert.executeInsert $ Insert.upsertToTable tableDef targetExpr entities

--- a/orville-postgresql/src/Orville/PostgreSQL/Execution/Insert.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Execution/Insert.hs
@@ -24,17 +24,20 @@ module Orville.PostgreSQL.Execution.Insert
   , executeInsertReturnEntities
   , insertToTableReturning
   , insertToTable
+  , upsertToTable
+  , upsertToTableReturning
   , rawInsertExpr
   )
 where
 
 import Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NE
 
 import qualified Orville.PostgreSQL.Execution.Execute as Execute
 import qualified Orville.PostgreSQL.Execution.QueryType as QueryType
 import Orville.PostgreSQL.Execution.ReturningOption (NoReturningClause, ReturningClause, ReturningOption (WithReturning, WithoutReturning))
 import qualified Orville.PostgreSQL.Expr as Expr
-import Orville.PostgreSQL.Marshall.SqlMarshaller (AnnotatedSqlMarshaller)
+import qualified Orville.PostgreSQL.Marshall as Marshall
 import qualified Orville.PostgreSQL.Monad as Monad
 import Orville.PostgreSQL.Schema (TableDefinition, mkInsertExpr, tableMarshaller)
 
@@ -47,10 +50,13 @@ result set when it is executed.
 -}
 data Insert readEntity returningClause where
   Insert ::
-    AnnotatedSqlMarshaller writeEntity readEntity ->
+    Marshall.AnnotatedSqlMarshaller writeEntity readEntity ->
     Expr.InsertExpr ->
     Insert readEntity NoReturningClause
-  InsertReturning :: AnnotatedSqlMarshaller writeEntity readEntity -> Expr.InsertExpr -> Insert readEntity ReturningClause
+  InsertReturning ::
+    Marshall.AnnotatedSqlMarshaller writeEntity readEntity ->
+    Expr.InsertExpr ->
+    Insert readEntity ReturningClause
 
 {- | Extracts the query that will be run when the insert is executed. Normally you
   don't want to extract the query and run it yourself, but this function is
@@ -112,6 +118,33 @@ insertToTableReturning ::
 insertToTableReturning =
   insertTable WithReturning
 
+{- | Builds an 'Insert' with an @ON CONFLICT@ clause that will insert new rows, or update conflicting rows
+  using a @SET@ clause derived from the writable columns of the table's @SqlMarshaller@.
+
+@since 1.1.1.0.1
+-}
+upsertToTable ::
+  TableDefinition key writeEntity readEntity ->
+  Expr.ConflictTargetExpr ->
+  NonEmpty writeEntity ->
+  Insert readEntity NoReturningClause
+upsertToTable =
+  upsertTable WithoutReturning
+
+{- | Builds an 'Insert' with an @ON CONFLICT@ clause that will insert new rows, or update conflicting rows
+  using a @SET@ clause derived from the writable columns of the table's @SqlMarshaller@. Returns the inserted
+  and updated rows.
+
+@since 1.1.1.0.1
+-}
+upsertToTableReturning ::
+  TableDefinition key writeEntity readEntity ->
+  Expr.ConflictTargetExpr ->
+  NonEmpty writeEntity ->
+  Insert readEntity ReturningClause
+upsertToTableReturning =
+  upsertTable WithReturning
+
 -- an internal helper function for creating an insert with a given `ReturningOption`
 insertTable ::
   ReturningOption returningClause ->
@@ -120,6 +153,40 @@ insertTable ::
   Insert readEntity returningClause
 insertTable returningOption tableDef entities =
   rawInsertExpr returningOption (tableMarshaller tableDef) (mkInsertExpr returningOption tableDef Nothing entities)
+
+-- an internal helper function for creating an @insert ... on conflict <target> do update set ...@ with a given `ReturningOption`
+upsertTable ::
+  ReturningOption returningClause ->
+  TableDefinition key writeEntity readEntity ->
+  Expr.ConflictTargetExpr ->
+  NE.NonEmpty writeEntity ->
+  Insert readEntity returningClause
+upsertTable returningOption tableDef target entities =
+  let
+    marshaller = tableMarshaller tableDef
+    unAnnTableMarshaller = Marshall.unannotatedSqlMarshaller marshaller
+
+    conflictSetItemExprs =
+      Marshall.foldMarshallerFields
+        unAnnTableMarshaller
+        []
+        ( Marshall.collectFromField
+            Marshall.ExcludeReadOnlyColumns
+            (const $ Expr.setColumnNameExcluded . Expr.unqualified . Marshall.fieldColumnName)
+        )
+
+    mkOnConflictExpr neSetItemExprs =
+      Expr.onConflictDoUpdate (Just target) neSetItemExprs Nothing
+  in
+    rawInsertExpr
+      returningOption
+      marshaller
+      ( mkInsertExpr
+          returningOption
+          tableDef
+          (fmap mkOnConflictExpr (NE.nonEmpty conflictSetItemExprs))
+          entities
+      )
 
 {- | Builds an 'Insert' that will execute the specified query and use the given
   'Orville.PostgreSQL.SqlMarshaller' to decode it. It is up to the caller to
@@ -135,6 +202,10 @@ insertTable returningOption tableDef entities =
 
 @since 1.0.0.0
 -}
-rawInsertExpr :: ReturningOption returningClause -> AnnotatedSqlMarshaller writeEntity readEntity -> Expr.InsertExpr -> Insert readEntity returningClause
+rawInsertExpr ::
+  ReturningOption returningClause ->
+  Marshall.AnnotatedSqlMarshaller writeEntity readEntity ->
+  Expr.InsertExpr ->
+  Insert readEntity returningClause
 rawInsertExpr WithReturning = InsertReturning
 rawInsertExpr WithoutReturning = Insert

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Internal/Name/Qualified.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Internal/Name/Qualified.hs
@@ -94,6 +94,7 @@ newtype Qualified name
 Note: If you already have a 'Orville.PostgreSQL.Schema.TableIdentifier' in
 hand you should probably use
 'Orville.PostgreSQL.Schema.tableIdQualifiedName' instead.
+
 @since 1.0.0.0
 -}
 qualifyTable ::
@@ -131,6 +132,7 @@ qualifyFunction ::
 qualifyFunction = unsafeSchemaQualify
 
 {- | Qualifies an 'IndexName' with a 'SchemaName'.
+
 @since 1.1.0.0
 -}
 qualifyIndex ::
@@ -144,6 +146,7 @@ qualifyIndex = unsafeSchemaQualify
 Note: If you already have a 'Orville.PostgreSQL.Schema.ConstraintIdentifier' in
 hand you should probably use
 'Orville.PostgreSQL.Schema.constraintIdQualifiedName' instead.
+
 @since 1.2.0.0
 -}
 qualifyConstraint ::

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/OnConflict.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/OnConflict.hs
@@ -107,6 +107,7 @@ conflictTargetForIndexColumn colName mbWhere =
    conflicts.
 
    Note that this function assumes that the 'IndexBodyExpr' is parenthesized.
+
 @since 1.1.0.0
 -}
 conflictTargetForIndexExpr :: IndexBodyExpr -> Maybe WhereClause -> ConflictTargetExpr

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/OnConflict.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/OnConflict.hs
@@ -16,6 +16,7 @@ module Orville.PostgreSQL.Expr.OnConflict
   , conflictTargetForIndexColumn
   , conflictTargetForIndexExpr
   , conflictTargetForConstraint
+  , conflictTargetForColumnNames
   , ConflictActionExpr
   , ConflictSetItemExpr
   , setColumnNameExcluded
@@ -126,6 +127,14 @@ conflictTargetForIndexExpr idxBody mbWhere =
 conflictTargetForConstraint :: ConstraintName -> ConflictTargetExpr
 conflictTargetForConstraint constraintName =
   ConflictTargetExpr $ RawSql.fromString "ON CONSTRAINT " <> RawSql.toRawSql constraintName
+
+{- | Build a 'ConflictTargetExpr' from a non-empty list of column names.
+
+@since 1.1.1.0.1
+-}
+conflictTargetForColumnNames :: NonEmpty ColumnName -> ConflictTargetExpr
+conflictTargetForColumnNames =
+  ConflictTargetExpr . RawSql.parenthesized . RawSql.intercalate RawSql.commaSpace
 
 {- | Type to represent the action portion of the SQL 'ON CONFLICT target action'
 

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Window/WindowClause.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Window/WindowClause.hs
@@ -48,7 +48,7 @@ appendNamedWindowDefinitionExpr (NamedWindowDefinitionExpr a) (NamedWindowDefini
   NamedWindowDefinitionExpr (a <> RawSql.commaSpace <> b)
 
 {- | Builds a 'NamedWindowDefinitionExpr' with the given name and 'WindowDefinitionExpr'.
-1
+
 @since 1.1.0.0
 -}
 namedWindowDefinition :: WindowName -> WindowDefinitionExpr -> NamedWindowDefinitionExpr
@@ -77,8 +77,8 @@ newtype WindowClause
       RawSql.SqlExpression
     )
 
-{- | Builds a full 'WindowClause' with the given windowing described in the 'NamedWindowDefinitionExpr'
-1
+{- | Builds a full 'WindowClause' with the given windowing described in the 'NamedWindowDefinitionExpr'.
+
 @since 1.1.0.0
 -}
 windowClause :: NamedWindowDefinitionExpr -> WindowClause

--- a/orville-postgresql/src/Orville/PostgreSQL/Marshall/SqlMarshaller.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Marshall/SqlMarshaller.hs
@@ -61,6 +61,7 @@ module Orville.PostgreSQL.Marshall.SqlMarshaller
   , marshallerGreaterThanOrEqualTo
   , marshallerIn
   , marshallerNotIn
+  , marshallerConflictTargetExpr
   )
 where
 
@@ -1114,3 +1115,22 @@ marshallerIn = SqlComparable.isIn
 -}
 marshallerNotIn :: SqlMarshaller writeEntity x -> NE.NonEmpty writeEntity -> Expr.BooleanExpr
 marshallerNotIn = SqlComparable.isNotIn
+
+{- | Builds a 'Expr.ConflictTargetExpr' using the writable columns in a 'SqlMarshaller'.
+  Returns 'Nothing' if the 'SqlMarshaller' has no writable columns.
+
+@since 1.1.1.0.1
+-}
+marshallerConflictTargetExpr :: SqlMarshaller writeEntity readEntity -> Maybe Expr.ConflictTargetExpr
+marshallerConflictTargetExpr marshaller =
+  let
+    colNames =
+      foldMarshallerFields
+        marshaller
+        []
+        ( collectFromField
+            ExcludeReadOnlyColumns
+            (const fieldColumnName)
+        )
+  in
+    fmap Expr.conflictTargetForColumnNames (NE.nonEmpty colNames)

--- a/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/PgTrigger.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/PgTrigger.hs
@@ -24,6 +24,7 @@ import Orville.PostgreSQL.PgCatalog.OidField (oidField, oidTypeField)
 
 {- | The Haskell representation of data read from the @pg_catalog.pg_trigger@
   table. Rows in this table correspond to triggers created on tables and views.
+
 @since 1.1.0.0
 -}
 data PgTrigger = PgTrigger

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/ConstraintDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/ConstraintDefinition.hs
@@ -30,6 +30,7 @@ module Orville.PostgreSQL.Schema.ConstraintDefinition
   , addConstraint
   , tableConstraintDefinitions
   , tableConstraintKeys
+  , constraintDefinitionConflictTargetExpr
   )
 where
 
@@ -391,3 +392,22 @@ foreignKeyConstraintWithOptions foreignTableId foreignReferences options =
       { i_constraintSqlExpr = expr
       , i_constraintMigrationKey = migrationKey
       }
+
+{- | Attempt to build a 'Expr.ConflictTargetExpr' for a 'ConstraintDefinition'. Will return
+  'Nothing' if the provided constraint is not a unique constraint.
+
+@since 1.1.1.0.1
+-}
+constraintDefinitionConflictTargetExpr :: ConstraintDefinition -> Maybe Expr.ConflictTargetExpr
+constraintDefinitionConflictTargetExpr constraintDef = case constraintMigrationKey constraintDef of
+  NamedBasedConstraint constraintIdentifier ->
+    Just
+      . Expr.conflictTargetForConstraint
+      $ ConstraintIdentifier.constraintIdUnqualifiedName constraintIdentifier
+  AttributeBasedConstraint attributeBasedKey -> case attributeBasedKey of
+    ForeignKeyConstraint _ ->
+      Nothing
+    UniqueConstraint fieldNames ->
+      fmap
+        (Expr.conflictTargetForColumnNames . fmap FieldName.fieldNameToColumnName)
+        (NEL.nonEmpty fieldNames)

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/FunctionDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/FunctionDefinition.hs
@@ -74,6 +74,7 @@ setFunctionSchema schemaName functionDef =
 {- | Retrieves the 'FunctionIdentifier' for this function, which is set by the
   name provided to 'mkTriggerFunction' or 'mkFunction' and any calls made to
   'setFunctionSchema' thereafter.
+
 @since 1.1.0.0
 -}
 functionIdentifier :: FunctionDefinition -> FunctionIdentifier
@@ -110,6 +111,7 @@ functionAutoMigrationStep =
 {- | Constructs a 'FunctionDefinition' that will create a PostgreSQL function
   with a return type of @trigger@ using the specified lanugage and function
   body.
+
 @since 1.1.0.0
 -}
 mkTriggerFunction ::
@@ -128,6 +130,7 @@ mkTriggerFunction name language source =
 
 {- | Constructs a 'FunctionDefinition' that will create a PostgreSQL function
   using the specified lanugage, return type and function body.
+
 @since 1.2.0.0
 -}
 mkFunction ::

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/TableDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/TableDefinition.hs
@@ -34,6 +34,7 @@ module Orville.PostgreSQL.Schema.TableDefinition
   , mkCreateTableExpr
   , mkTableColumnDefinitions
   , mkTablePrimaryKeyExpr
+  , tablePrimaryKeyFieldNames
   , mkInsertColumnList
   , mkInsertSource
   , mkTableReturningClause
@@ -48,7 +49,7 @@ import qualified Data.Text as T
 import Orville.PostgreSQL.Execution.ReturningOption (ReturningOption (WithReturning, WithoutReturning))
 import qualified Orville.PostgreSQL.Expr as Expr
 import Orville.PostgreSQL.Internal.IndexDefinition (IndexDefinition, IndexMigrationKey, indexMigrationKey)
-import Orville.PostgreSQL.Marshall.FieldDefinition (fieldColumnDefinition, fieldColumnName, fieldValueToSqlValue, qualifiedFieldColumnName, qualifyField)
+import Orville.PostgreSQL.Marshall.FieldDefinition (FieldName, fieldColumnDefinition, fieldColumnName, fieldValueToSqlValue, qualifiedFieldColumnName, qualifyField)
 import Orville.PostgreSQL.Marshall.SqlMarshaller (AnnotatedSqlMarshaller, MarshallerField (Natural, Synthetic), ReadOnlyColumnOption (ExcludeReadOnlyColumns, IncludeReadOnlyColumns), SqlMarshaller, annotateSqlMarshaller, annotateSqlMarshallerEmptyAnnotation, collectFromField, foldMarshallerFields, mapSqlMarshaller, marshallerDerivedColumns, marshallerTableConstraints, unannotatedSqlMarshaller)
 import Orville.PostgreSQL.Schema.ConstraintDefinition (ConstraintDefinition, TableConstraints, addConstraint, constraintSqlExpr, emptyTableConstraints, tableConstraintDefinitions)
 import Orville.PostgreSQL.Schema.PrimaryKey (PrimaryKey, mkPrimaryKeyExpr, primaryKeyFieldNames)
@@ -455,6 +456,21 @@ mkTablePrimaryKeyExpr tableDef =
   case i_tablePrimaryKey tableDef of
     TableHasKey primaryKey ->
       Just $ mkPrimaryKeyExpr primaryKey
+    TableHasNoKey ->
+      Nothing
+
+{- | Returns the field names of the primary key columns for this table, or 'Nothing' if the
+  table has no primary key.
+
+@since 1.1.1.0.1
+-}
+tablePrimaryKeyFieldNames ::
+  TableDefinition key writeEntity readEntity ->
+  Maybe (NE.NonEmpty FieldName)
+tablePrimaryKeyFieldNames tableDef =
+  case i_tablePrimaryKey tableDef of
+    TableHasKey primaryKey ->
+      Just $ primaryKeyFieldNames primaryKey
     TableHasNoKey ->
       Nothing
 

--- a/orville-postgresql/test/Test/Entities/CompositeKeyEntity.hs
+++ b/orville-postgresql/test/Test/Entities/CompositeKeyEntity.hs
@@ -14,7 +14,6 @@ module Test.Entities.CompositeKeyEntity
   , compositeKeyEntityIdField
   , compositeKeyEntityNameField
   , compositeKeyEntityAgeField
-  , compositeKeyConflictTarget
   )
 where
 
@@ -23,14 +22,12 @@ import Data.Function (on)
 import Data.Int (Int32)
 import qualified Data.List as List
 import qualified Data.List.NonEmpty as NEL
-import Data.Maybe (fromJust)
 import qualified Data.Text as T
 import qualified Hedgehog as HH
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 import qualified Orville.PostgreSQL as Orville
-import qualified Orville.PostgreSQL.Expr as Expr
 import qualified Orville.PostgreSQL.Raw.Connection as Conn
 
 import qualified Test.PgGen as PgGen
@@ -131,7 +128,3 @@ withTable pool operation =
     Conn.withPoolConnection pool $ \connection ->
       TestTable.dropAndRecreateTableDef connection table
     Orville.runOrville pool operation
-
-compositeKeyConflictTarget :: Expr.ConflictTargetExpr
-compositeKeyConflictTarget =
-  fromJust $ Orville.marshallerConflictTargetExpr compositeKeyMap

--- a/orville-postgresql/test/Test/Entities/CompositeKeyEntity.hs
+++ b/orville-postgresql/test/Test/Entities/CompositeKeyEntity.hs
@@ -7,24 +7,30 @@ module Test.Entities.CompositeKeyEntity
   , generate
   , generateCompositeKeyEntityId
   , generateCompositeKeyEntityName
+  , generateCompositeKeyEntityAge
   , generateNonEmpty
+  , generateList
   , withTable
   , compositeKeyEntityIdField
   , compositeKeyEntityNameField
   , compositeKeyEntityAgeField
+  , compositeKeyConflictTarget
   )
 where
 
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import Data.Function (on)
 import Data.Int (Int32)
+import qualified Data.List as List
 import qualified Data.List.NonEmpty as NEL
+import Data.Maybe (fromJust)
 import qualified Data.Text as T
 import qualified Hedgehog as HH
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 import qualified Orville.PostgreSQL as Orville
+import qualified Orville.PostgreSQL.Expr as Expr
 import qualified Orville.PostgreSQL.Raw.Connection as Conn
 
 import qualified Test.PgGen as PgGen
@@ -113,9 +119,19 @@ generateNonEmpty range =
     (NEL.nubBy ((==) `on` compositeKey))
     (Gen.nonEmpty range generate)
 
+generateList :: HH.Range Int -> HH.Gen [CompositeKeyEntity]
+generateList range =
+  fmap
+    (List.nubBy ((==) `on` compositeKey))
+    (Gen.list range generate)
+
 withTable :: MonadIO m => Orville.ConnectionPool -> Orville.Orville a -> m a
 withTable pool operation =
   liftIO $ do
     Conn.withPoolConnection pool $ \connection ->
       TestTable.dropAndRecreateTableDef connection table
     Orville.runOrville pool operation
+
+compositeKeyConflictTarget :: Expr.ConflictTargetExpr
+compositeKeyConflictTarget =
+  fromJust $ Orville.marshallerConflictTargetExpr compositeKeyMap

--- a/orville-postgresql/test/Test/Entities/Foo.hs
+++ b/orville-postgresql/test/Test/Entities/Foo.hs
@@ -24,6 +24,7 @@ module Test.Entities.Foo
   , hasAge
   , averageFooAge
   , nameAndAgeMarshaller
+  , idConflictTarget
   )
 where
 
@@ -42,6 +43,7 @@ import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 import qualified Orville.PostgreSQL as Orville
+import qualified Orville.PostgreSQL.Expr as Expr
 import qualified Orville.PostgreSQL.Raw.Connection as Conn
 
 import qualified Test.PgGen as PgGen
@@ -167,3 +169,7 @@ nameAndAgeMarshaller =
     (,)
     (Orville.marshallField fst fooNameField)
     (Orville.marshallField snd fooAgeField)
+
+idConflictTarget :: Expr.ConflictTargetExpr
+idConflictTarget =
+  Expr.conflictTargetForColumnNames . pure $ Orville.fieldColumnName fooIdField

--- a/orville-postgresql/test/Test/Entities/Foo.hs
+++ b/orville-postgresql/test/Test/Entities/Foo.hs
@@ -24,7 +24,6 @@ module Test.Entities.Foo
   , hasAge
   , averageFooAge
   , nameAndAgeMarshaller
-  , idConflictTarget
   )
 where
 
@@ -43,7 +42,6 @@ import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 import qualified Orville.PostgreSQL as Orville
-import qualified Orville.PostgreSQL.Expr as Expr
 import qualified Orville.PostgreSQL.Raw.Connection as Conn
 
 import qualified Test.PgGen as PgGen
@@ -169,7 +167,3 @@ nameAndAgeMarshaller =
     (,)
     (Orville.marshallField fst fooNameField)
     (Orville.marshallField snd fooAgeField)
-
-idConflictTarget :: Expr.ConflictTargetExpr
-idConflictTarget =
-  Expr.conflictTargetForColumnNames . pure $ Orville.fieldColumnName fooIdField

--- a/orville-postgresql/test/Test/Entities/UpsertEntity.hs
+++ b/orville-postgresql/test/Test/Entities/UpsertEntity.hs
@@ -1,0 +1,168 @@
+module Test.Entities.UpsertEntity
+  ( UpsertEntity (..)
+  , UpsertEntityId
+  , UpsertEntityCode
+  , UpsertEntityValue
+  , table
+  , generate
+  , generateUpsertEntityId
+  , generateUpsertEntityCode
+  , generateUpsertEntityValue
+  , generateList
+  , generateNonEmpty
+  , withTable
+  , upsertEntityIdField
+  , upsertEntityCodeField
+  , upsertEntityGroupAField
+  , upsertEntityGroupBField
+  , upsertEntityValueField
+  , codeUniqueConstraint
+  , groupUniqueConstraint
+  , groupMarshaller
+  )
+where
+
+import Control.Monad.IO.Class (MonadIO (liftIO))
+import Data.Int (Int32)
+import Data.List.NonEmpty (NonEmpty ((:|)))
+import qualified Data.List.NonEmpty as NEL
+import qualified Data.Set as Set
+import qualified Data.Text as T
+import qualified Hedgehog as HH
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+import qualified Orville.PostgreSQL as Orville
+import qualified Orville.PostgreSQL.Raw.Connection as Conn
+
+import qualified Test.PgGen as PgGen
+import qualified Test.TestTable as TestTable
+
+type UpsertEntityId = Int32
+type UpsertEntityCode = T.Text
+type UpsertEntityValue = Int32
+
+data UpsertEntity = UpsertEntity
+  { upsertEntityId :: UpsertEntityId
+  , upsertEntityCode :: UpsertEntityCode
+  , upsertEntityGroupA :: T.Text
+  , upsertEntityGroupB :: T.Text
+  , upsertEntityValue :: UpsertEntityValue
+  }
+  deriving (Eq, Show)
+
+-- Wrapper with special Eq and Ord instances so we can more easily generate unique UpsertEntities
+newtype UniqueUpsertEntity = UniqueUpsertEntity {toUpsertEntity :: UpsertEntity}
+
+instance Eq UniqueUpsertEntity where
+  (UniqueUpsertEntity a) == (UniqueUpsertEntity b) =
+    upsertEntityId a == upsertEntityId b
+      || upsertEntityCode a == upsertEntityCode b
+      || upsertEntityGroup a == upsertEntityGroup b
+
+instance Ord UniqueUpsertEntity where
+  compare ua@(UniqueUpsertEntity a) ub@(UniqueUpsertEntity b)
+    | ua == ub = EQ
+    | otherwise =
+        compare (upsertEntityId a) (upsertEntityId b)
+          <> compare (upsertEntityCode a) (upsertEntityCode b)
+          <> compare (upsertEntityGroup a) (upsertEntityGroup b)
+
+upsertEntityGroup :: UpsertEntity -> (T.Text, T.Text)
+upsertEntityGroup e = (upsertEntityGroupA e, upsertEntityGroupB e)
+
+table :: Orville.TableDefinition (Orville.HasKey UpsertEntityId) UpsertEntity UpsertEntity
+table =
+  Orville.addTableConstraints
+    [codeUniqueConstraint, groupUniqueConstraint]
+    $ Orville.mkTableDefinition "upsert_entity" (Orville.primaryKey upsertEntityIdField) upsertEntityMarshaller
+
+upsertEntityMarshaller :: Orville.SqlMarshaller UpsertEntity UpsertEntity
+upsertEntityMarshaller =
+  UpsertEntity
+    <$> Orville.marshallField upsertEntityId upsertEntityIdField
+    <*> Orville.marshallField upsertEntityCode upsertEntityCodeField
+    <*> Orville.marshallField upsertEntityGroupA upsertEntityGroupAField
+    <*> Orville.marshallField upsertEntityGroupB upsertEntityGroupBField
+    <*> Orville.marshallField upsertEntityValue upsertEntityValueField
+
+upsertEntityIdField :: Orville.FieldDefinition Orville.NotNull UpsertEntityId
+upsertEntityIdField =
+  Orville.integerField "id"
+
+upsertEntityCodeField :: Orville.FieldDefinition Orville.NotNull UpsertEntityCode
+upsertEntityCodeField =
+  Orville.unboundedTextField "code"
+
+upsertEntityGroupAField :: Orville.FieldDefinition Orville.NotNull T.Text
+upsertEntityGroupAField =
+  Orville.unboundedTextField "group_a"
+
+upsertEntityGroupBField :: Orville.FieldDefinition Orville.NotNull T.Text
+upsertEntityGroupBField =
+  Orville.unboundedTextField "group_b"
+
+upsertEntityValueField :: Orville.FieldDefinition Orville.NotNull UpsertEntityValue
+upsertEntityValueField =
+  Orville.integerField "value"
+
+codeUniqueConstraint :: Orville.ConstraintDefinition
+codeUniqueConstraint =
+  Orville.uniqueConstraint (Orville.fieldName upsertEntityCodeField :| [])
+
+groupUniqueConstraint :: Orville.ConstraintDefinition
+groupUniqueConstraint =
+  Orville.uniqueConstraint (Orville.fieldName upsertEntityGroupAField :| [Orville.fieldName upsertEntityGroupBField])
+
+groupMarshaller :: Orville.SqlMarshaller (T.Text, T.Text) (T.Text, T.Text)
+groupMarshaller =
+  (,)
+    <$> Orville.marshallField fst upsertEntityGroupAField
+    <*> Orville.marshallField snd upsertEntityGroupBField
+
+generate :: HH.Gen UpsertEntity
+generate =
+  UpsertEntity
+    <$> generateUpsertEntityId
+    <*> generateUpsertEntityCode
+    <*> generateGroupA
+    <*> generateGroupB
+    <*> generateUpsertEntityValue
+
+generateUpsertEntityId :: HH.Gen UpsertEntityId
+generateUpsertEntityId =
+  PgGen.pgInt32
+
+generateUpsertEntityCode :: HH.Gen UpsertEntityCode
+generateUpsertEntityCode =
+  PgGen.pgText (Range.constant 1 10)
+
+generateGroupA :: HH.Gen T.Text
+generateGroupA =
+  PgGen.pgText (Range.constant 1 10)
+
+generateGroupB :: HH.Gen T.Text
+generateGroupB =
+  PgGen.pgText (Range.constant 1 10)
+
+generateUpsertEntityValue :: HH.Gen UpsertEntityValue
+generateUpsertEntityValue =
+  Gen.integral (Range.constant 0 100)
+
+generateList :: HH.Range Int -> HH.Gen [UpsertEntity]
+generateList range =
+  fmap (fmap toUpsertEntity . Set.toList) (Gen.set range (fmap UniqueUpsertEntity generate))
+
+generateNonEmpty :: HH.Range Int -> HH.Gen (NEL.NonEmpty UpsertEntity)
+generateNonEmpty range = do
+  set <- Gen.set range (fmap UniqueUpsertEntity generate)
+  case fmap toUpsertEntity (Set.toList set) of
+    (x : xs) -> pure (x :| xs)
+    [] -> fmap (:| []) generate
+
+withTable :: MonadIO m => Orville.ConnectionPool -> Orville.Orville a -> m a
+withTable pool operation =
+  liftIO $ do
+    Conn.withPoolConnection pool $ \connection ->
+      TestTable.dropAndRecreateTableDef connection table
+    Orville.runOrville pool operation

--- a/orville-postgresql/test/Test/EntityOperations.hs
+++ b/orville-postgresql/test/Test/EntityOperations.hs
@@ -3,7 +3,6 @@ module Test.EntityOperations
   )
 where
 
-import Data.Foldable (traverse_)
 import qualified Data.List as List
 import Data.List.NonEmpty (NonEmpty ((:|)))
 import qualified Data.List.NonEmpty as NEL
@@ -16,9 +15,11 @@ import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 import qualified Orville.PostgreSQL as Orville
+import qualified Orville.PostgreSQL.Expr as Expr
 
 import qualified Test.Entities.CompositeKeyEntity as CompositeKeyEntity
 import qualified Test.Entities.Foo as Foo
+import qualified Test.Entities.UpsertEntity as UpsertEntity
 import qualified Test.Property as Property
 
 entityOperationsTests :: Orville.ConnectionPool -> Property.Group
@@ -52,13 +53,16 @@ entityOperationsTests pool =
     , prop_updateFieldsAffectedRows pool
     , prop_updateFieldsAndReturnEntities pool
     , prop_updateFieldsAndReturnEntities_NoMatch pool
-    , prop_upsertEntitiesFindEntitiesByRoundTrip pool
-    , prop_upsertEntitiesAffectedRows pool
-    , prop_upsertEntitiesFindFirstEntityByRoundTrip pool
-    , prop_upsertEntityFindEntityRoundTrip pool
-    , prop_upsertEntityFindEntitiesRoundTrip pool
-    , prop_upsertEntityFindEntitiesCompositeKeyRoundTrip pool
+    , prop_upsertByPrimaryKeyRoundTrip pool
+    , prop_upsertByPrimaryKeyUpdatesExistingRow pool
+    , prop_upsertByFieldRoundTrip pool
+    , prop_upsertByConstraintRoundTrip pool
+    , prop_upsertByMarshallerRoundTrip pool
+    , prop_upsertByConflictTargetExprRoundTrip pool
     , prop_upsertAndReturnEntity pool
+    , prop_upsertEntitiesAffectedRows pool
+    , prop_upsertEntitiesFindEntitiesRoundTrip pool
+    , prop_upsertEntitiesMixedInsertsAndUpdates pool
     ]
 
 prop_insertEntitiesFindEntitiesByRoundTrip :: Property.NamedDBProperty
@@ -505,157 +509,183 @@ prop_updateFieldsAndReturnEntities_NoMatch =
 
     updatedFoos === []
 
-prop_upsertEntitiesFindEntitiesByRoundTrip :: Property.NamedDBProperty
-prop_upsertEntitiesFindEntitiesByRoundTrip =
-  Property.namedDBProperty "upsertEntity/findEntitiesBy forms a round trip" $ \pool -> do
-    originalFoo <- HH.forAll Foo.generate
+prop_upsertByPrimaryKeyRoundTrip :: Property.NamedDBProperty
+prop_upsertByPrimaryKeyRoundTrip =
+  Property.namedDBProperty "upsertEntity ByPrimaryKey inserts entity" $ \pool -> do
+    entity <- HH.forAll UpsertEntity.generate
 
-    retrievedFoos <-
-      Foo.withTable pool $ do
-        Orville.upsertEntity Foo.table Foo.idConflictTarget originalFoo
-        Orville.findEntitiesBy Foo.table mempty
+    retrieved <-
+      UpsertEntity.withTable pool $ do
+        Orville.upsertEntity UpsertEntity.table Orville.ByPrimaryKey entity
+        Orville.findEntitiesBy UpsertEntity.table mempty
 
-    retrievedFoos === [originalFoo]
+    retrieved === [entity]
 
-prop_upsertEntitiesFindFirstEntityByRoundTrip :: Property.NamedDBProperty
-prop_upsertEntitiesFindFirstEntityByRoundTrip =
-  Property.namedDBProperty "upsertEntities/findFirstEntityBy only return 1" $ \pool -> do
-    originalFoos <- HH.forAll $ Foo.generateList (Range.linear 0 10)
-
-    HH.cover 1 (String.fromString "empty list") (null originalFoos)
-    HH.cover 20 (String.fromString "non-empty list") (not (null originalFoos))
-
-    mbRetrievedFoo <-
-      Foo.withTable pool $ do
-        mapM_ (Orville.upsertEntities Foo.table Foo.idConflictTarget) (NEL.nonEmpty originalFoos)
-        Orville.findFirstEntityBy Foo.table mempty
-
+prop_upsertByPrimaryKeyUpdatesExistingRow :: Property.NamedDBProperty
+prop_upsertByPrimaryKeyUpdatesExistingRow =
+  Property.namedDBProperty "upsertEntity ByPrimaryKey updates existing row" $ \pool -> do
+    entity <- HH.forAll UpsertEntity.generate
+    newValue <- HH.forAll UpsertEntity.generateUpsertEntityValue
     let
-      expectedLength =
-        case originalFoos of
-          [] -> 0
-          _ -> 1
+      updated = entity {UpsertEntity.upsertEntityValue = newValue}
 
-    -- Once we add order by to 'SelectOptions' we can order by something here
-    -- and assert which item is returned.
-    length (Maybe.maybeToList mbRetrievedFoo) === expectedLength
+    (mbOriginal, mbUpdated) <-
+      UpsertEntity.withTable pool $ do
+        Orville.upsertEntity UpsertEntity.table Orville.ByPrimaryKey entity
+        mbOrig <- Orville.findEntity UpsertEntity.table (UpsertEntity.upsertEntityId entity)
+        Orville.upsertEntity UpsertEntity.table Orville.ByPrimaryKey updated
+        mbUpd <- Orville.findEntity UpsertEntity.table (UpsertEntity.upsertEntityId entity)
+        pure (mbOrig, mbUpd)
 
-prop_upsertEntitiesAffectedRows :: Property.NamedDBProperty
-prop_upsertEntitiesAffectedRows =
-  Property.namedDBProperty "upsertEntities returns the number of affected rows" $ \pool -> do
-    originalFoos <- HH.forAll $ Foo.generateList (Range.linear 0 10)
-    additionalFoos <- HH.forAll $ Foo.generateList (Range.linear 0 10)
-    toDrop <- HH.forAll . Gen.int $ Range.constant 0 (length originalFoos)
-    updatedFoos <-
-      HH.forAll $
-        traverse
-          (\foo -> fmap (\newAge -> foo {Foo.fooAge = newAge}) Foo.generateFooAge)
-          (drop toDrop originalFoos <> additionalFoos)
+    mbOriginal === Just entity
+    mbUpdated === Just updated
 
-    HH.cover 1 (String.fromString "empty list") (null originalFoos)
-    HH.cover 20 (String.fromString "non-empty list") (not (null originalFoos))
-
-    (affectedOriginalRows, affectedUpdatedRows) <-
-      Foo.withTable pool $ do
-        affectedOriginal <- case NEL.nonEmpty originalFoos of
-          Nothing -> pure 0
-          Just nonEmptyFoos -> do
-            Orville.upsertEntitiesAndReturnRowCount Foo.table Foo.idConflictTarget nonEmptyFoos
-        affectedUpdated <- case NEL.nonEmpty updatedFoos of
-          Nothing -> pure 0
-          Just nonEmptyUpdatedFoos -> do
-            Orville.upsertEntitiesAndReturnRowCount Foo.table Foo.idConflictTarget nonEmptyUpdatedFoos
-        pure (affectedOriginal, affectedUpdated)
-
-    affectedOriginalRows === length originalFoos
-    affectedUpdatedRows === length updatedFoos
-
-prop_upsertEntityFindEntityRoundTrip :: Property.NamedDBProperty
-prop_upsertEntityFindEntityRoundTrip =
-  Property.namedDBProperty "upsertEntity/findEntity forms a round trip" $ \pool -> do
-    originalFoo <- HH.forAll Foo.generate
-    updatedAge <- HH.forAll Foo.generateFooAge
+prop_upsertByFieldRoundTrip :: Property.NamedDBProperty
+prop_upsertByFieldRoundTrip =
+  Property.namedDBProperty "upsertEntity ByField updates existing row" $ \pool -> do
+    entity <- HH.forAll UpsertEntity.generate
+    newValue <- HH.forAll UpsertEntity.generateUpsertEntityValue
+    newId <- HH.forAll UpsertEntity.generateUpsertEntityId
     let
-      updatedFoo = originalFoo {Foo.fooAge = updatedAge}
+      conflicting =
+        entity
+          { UpsertEntity.upsertEntityId = newId
+          , UpsertEntity.upsertEntityValue = newValue
+          }
 
-    (mbOriginalFoo, mbUpdatedFoo) <-
-      Foo.withTable pool $ do
-        Orville.upsertEntity Foo.table Foo.idConflictTarget originalFoo
-        mbOriginal <- Orville.findEntity Foo.table (Foo.fooId originalFoo)
-        Orville.upsertEntity Foo.table Foo.idConflictTarget updatedFoo
-        mbUpdated <- Orville.findEntity Foo.table (Foo.fooId originalFoo)
-        pure (mbOriginal, mbUpdated)
+    retrieved <-
+      UpsertEntity.withTable pool $ do
+        Orville.upsertEntity UpsertEntity.table (Orville.ByField UpsertEntity.upsertEntityCodeField) entity
+        Orville.upsertEntity UpsertEntity.table (Orville.ByField UpsertEntity.upsertEntityCodeField) conflicting
+        Orville.findEntitiesBy UpsertEntity.table mempty
 
-    mbOriginalFoo === Just originalFoo
-    mbUpdatedFoo === Just updatedFoo
+    retrieved === [conflicting]
 
-prop_upsertEntityFindEntitiesRoundTrip :: Property.NamedDBProperty
-prop_upsertEntityFindEntitiesRoundTrip =
-  Property.namedDBProperty "upsertEntity/findEntities form a round trip" $ \pool -> do
-    foos <- HH.forAll $ Foo.generateNonEmpty (Range.linear 1 5)
-    additionalFoos <- HH.forAll $ Foo.generateList (Range.linear 0 5)
-    toDrop <- HH.forAll . Gen.int $ Range.constant 0 (length foos)
-    updatedFoos <-
-      HH.forAll $
-        traverse
-          (\foo -> fmap (\newAge -> foo {Foo.fooAge = newAge}) Foo.generateFooAge)
-          (NEL.drop toDrop foos <> additionalFoos)
+prop_upsertByConstraintRoundTrip :: Property.NamedDBProperty
+prop_upsertByConstraintRoundTrip =
+  Property.namedDBProperty "upsertEntity ByConstraint updates existing row" $ \pool -> do
+    entity <- HH.forAll UpsertEntity.generate
+    newValue <- HH.forAll UpsertEntity.generateUpsertEntityValue
+    newId <- HH.forAll UpsertEntity.generateUpsertEntityId
+    let
+      conflicting =
+        entity
+          { UpsertEntity.upsertEntityId = newId
+          , UpsertEntity.upsertEntityValue = newValue
+          }
 
-    (originalRetrievedFoos, updatedRetrievedFoos) <-
-      Foo.withTable pool $ do
-        Orville.upsertEntities Foo.table Foo.idConflictTarget foos
-        original <- Orville.findEntities Foo.table (Foo.fooId <$> foos)
-        let
-          neUpdated = NEL.nonEmpty updatedFoos
-        traverse_ (Orville.upsertEntities Foo.table Foo.idConflictTarget) neUpdated
-        mbUpdated <- traverse (Orville.findEntities Foo.table . fmap Foo.fooId) neUpdated
-        pure (original, Maybe.fromMaybe [] mbUpdated)
+    retrieved <-
+      UpsertEntity.withTable pool $ do
+        Orville.upsertEntity UpsertEntity.table (Orville.ByConstraint UpsertEntity.codeUniqueConstraint) entity
+        Orville.upsertEntity UpsertEntity.table (Orville.ByConstraint UpsertEntity.codeUniqueConstraint) conflicting
+        Orville.findEntitiesBy UpsertEntity.table mempty
 
-    List.sortOn Foo.fooId originalRetrievedFoos === List.sortOn Foo.fooId (NEL.toList foos)
-    List.sortOn Foo.fooId updatedRetrievedFoos === List.sortOn Foo.fooId updatedFoos
+    retrieved === [conflicting]
 
-prop_upsertEntityFindEntitiesCompositeKeyRoundTrip :: Property.NamedDBProperty
-prop_upsertEntityFindEntitiesCompositeKeyRoundTrip =
-  Property.namedDBProperty "upsertEntity/findEntities form a round trip (composite primary key)" $ \pool -> do
-    compositeKeyEntities <- HH.forAll $ CompositeKeyEntity.generateNonEmpty (Range.linear 1 5)
-    additionalEntities <- HH.forAll $ CompositeKeyEntity.generateList (Range.linear 0 5)
-    toDrop <- HH.forAll . Gen.int $ Range.constant 0 (length compositeKeyEntities)
-    updatedEntities <-
-      HH.forAll $
-        traverse
-          ( \entity ->
-              fmap
-                (\newAge -> entity {CompositeKeyEntity.compositeKeyEntityAge = newAge})
-                CompositeKeyEntity.generateCompositeKeyEntityAge
-          )
-          (NEL.drop toDrop compositeKeyEntities <> additionalEntities)
+prop_upsertByMarshallerRoundTrip :: Property.NamedDBProperty
+prop_upsertByMarshallerRoundTrip =
+  Property.namedDBProperty "upsertEntity ByMarshaller updates existing row" $ \pool -> do
+    entity <- HH.forAll UpsertEntity.generate
+    newValue <- HH.forAll UpsertEntity.generateUpsertEntityValue
+    newId <- HH.forAll UpsertEntity.generateUpsertEntityId
+    newCode <- HH.forAll UpsertEntity.generateUpsertEntityCode
+    let
+      conflicting =
+        entity
+          { UpsertEntity.upsertEntityId = newId
+          , UpsertEntity.upsertEntityCode = newCode
+          , UpsertEntity.upsertEntityValue = newValue
+          }
 
-    (originalRetrievedCompositeKeyEntities, updatedRetrievedCompositeKeyEntities) <-
-      CompositeKeyEntity.withTable pool $ do
-        Orville.upsertEntities CompositeKeyEntity.table CompositeKeyEntity.compositeKeyConflictTarget compositeKeyEntities
-        original <- Orville.findEntities CompositeKeyEntity.table (CompositeKeyEntity.compositeKey <$> compositeKeyEntities)
-        let
-          neUpdated = NEL.nonEmpty updatedEntities
-        traverse_ (Orville.upsertEntities CompositeKeyEntity.table CompositeKeyEntity.compositeKeyConflictTarget) neUpdated
-        updated <- traverse (Orville.findEntities CompositeKeyEntity.table . fmap CompositeKeyEntity.compositeKey) (NEL.nonEmpty updatedEntities)
-        pure (original, Maybe.fromMaybe [] updated)
+    retrieved <-
+      UpsertEntity.withTable pool $ do
+        Orville.upsertEntity UpsertEntity.table (Orville.ByMarshaller UpsertEntity.groupMarshaller) entity
+        Orville.upsertEntity UpsertEntity.table (Orville.ByMarshaller UpsertEntity.groupMarshaller) conflicting
+        Orville.findEntitiesBy UpsertEntity.table mempty
 
-    List.sortOn CompositeKeyEntity.compositeKey originalRetrievedCompositeKeyEntities === List.sortOn CompositeKeyEntity.compositeKey (NEL.toList compositeKeyEntities)
-    List.sortOn CompositeKeyEntity.compositeKey updatedRetrievedCompositeKeyEntities === List.sortOn CompositeKeyEntity.compositeKey updatedEntities
+    retrieved === [conflicting]
+
+prop_upsertByConflictTargetExprRoundTrip :: Property.NamedDBProperty
+prop_upsertByConflictTargetExprRoundTrip =
+  Property.namedDBProperty "upsertEntity ByConflictTargetExpr updates existing row" $ \pool -> do
+    entity <- HH.forAll UpsertEntity.generate
+    newValue <- HH.forAll UpsertEntity.generateUpsertEntityValue
+    let
+      updated = entity {UpsertEntity.upsertEntityValue = newValue}
+      target :: Orville.ConflictTarget
+      target =
+        Orville.ByConflictTargetExpr
+          . Expr.conflictTargetForColumnNames
+          . pure
+          $ Orville.fieldColumnName UpsertEntity.upsertEntityIdField
+
+    (mbOriginal, mbUpdated) <-
+      UpsertEntity.withTable pool $ do
+        Orville.upsertEntity UpsertEntity.table target entity
+        mbOrig <- Orville.findEntity UpsertEntity.table (UpsertEntity.upsertEntityId entity)
+        Orville.upsertEntity UpsertEntity.table target updated
+        mbUpd <- Orville.findEntity UpsertEntity.table (UpsertEntity.upsertEntityId entity)
+        pure (mbOrig, mbUpd)
+
+    mbOriginal === Just entity
+    mbUpdated === Just updated
 
 prop_upsertAndReturnEntity :: Property.NamedDBProperty
 prop_upsertAndReturnEntity =
   Property.namedDBProperty "upsertAndReturnEntity returns the upserted entity" $ \pool -> do
-    originalFoo <- HH.forAll Foo.generate
-    updatedAge <- HH.forAll Foo.generateFooAge
+    entity <- HH.forAll UpsertEntity.generate
+    newValue <- HH.forAll UpsertEntity.generateUpsertEntityValue
     let
-      updatedFoo = originalFoo {Foo.fooAge = updatedAge}
+      updated = entity {UpsertEntity.upsertEntityValue = newValue}
 
-    (originalRetrievedFoo, updatedRetrievedFoo) <-
-      Foo.withTable pool $ do
-        original <- Orville.upsertAndReturnEntity Foo.table Foo.idConflictTarget originalFoo
-        updated <- Orville.upsertAndReturnEntity Foo.table Foo.idConflictTarget updatedFoo
-        pure (original, updated)
+    (originalReturned, updatedReturned) <-
+      UpsertEntity.withTable pool $ do
+        original <- Orville.upsertAndReturnEntity UpsertEntity.table Orville.ByPrimaryKey entity
+        upd <- Orville.upsertAndReturnEntity UpsertEntity.table Orville.ByPrimaryKey updated
+        pure (original, upd)
 
-    originalRetrievedFoo === originalFoo
-    updatedRetrievedFoo === updatedFoo
+    originalReturned === entity
+    updatedReturned === updated
+
+prop_upsertEntitiesAffectedRows :: Property.NamedDBProperty
+prop_upsertEntitiesAffectedRows =
+  Property.namedDBProperty "upsertEntitiesAndReturnRowCount returns the number of affected rows" $ \pool -> do
+    entities <- HH.forAll $ UpsertEntity.generateList (Range.linear 0 10)
+
+    affectedRows <-
+      UpsertEntity.withTable pool $ do
+        case NEL.nonEmpty entities of
+          Nothing -> pure 0
+          Just nonEmpty ->
+            Orville.upsertEntitiesAndReturnRowCount UpsertEntity.table Orville.ByPrimaryKey nonEmpty
+
+    affectedRows === length entities
+
+prop_upsertEntitiesFindEntitiesRoundTrip :: Property.NamedDBProperty
+prop_upsertEntitiesFindEntitiesRoundTrip =
+  Property.namedDBProperty "upsertEntities/findEntities form a round trip" $ \pool -> do
+    entities <- HH.forAll $ UpsertEntity.generateNonEmpty (Range.linear 1 5)
+
+    retrievedEntities <-
+      UpsertEntity.withTable pool $ do
+        Orville.upsertEntities UpsertEntity.table Orville.ByPrimaryKey entities
+        Orville.findEntities UpsertEntity.table (UpsertEntity.upsertEntityId <$> entities)
+
+    List.sortOn UpsertEntity.upsertEntityId retrievedEntities === List.sortOn UpsertEntity.upsertEntityId (NEL.toList entities)
+
+prop_upsertEntitiesMixedInsertsAndUpdates :: Property.NamedDBProperty
+prop_upsertEntitiesMixedInsertsAndUpdates =
+  Property.singletonNamedDBProperty "upsertEntities handles a batch with both inserts and updates" $ \pool -> do
+    existing <- HH.forAll UpsertEntity.generate
+    new <- HH.forAll $ Gen.filter (\e -> UpsertEntity.upsertEntityId e /= UpsertEntity.upsertEntityId existing) UpsertEntity.generate
+    newValue <- HH.forAll UpsertEntity.generateUpsertEntityValue
+    let
+      updated = existing {UpsertEntity.upsertEntityValue = newValue}
+
+    retrievedEntities <-
+      UpsertEntity.withTable pool $ do
+        Orville.upsertEntity UpsertEntity.table Orville.ByPrimaryKey existing
+        Orville.upsertEntities UpsertEntity.table Orville.ByPrimaryKey (updated :| [new])
+        Orville.findEntitiesBy UpsertEntity.table mempty
+
+    List.sortOn UpsertEntity.upsertEntityId retrievedEntities === List.sortOn UpsertEntity.upsertEntityId [updated, new]

--- a/orville-postgresql/test/Test/EntityOperations.hs
+++ b/orville-postgresql/test/Test/EntityOperations.hs
@@ -3,6 +3,7 @@ module Test.EntityOperations
   )
 where
 
+import Data.Foldable (traverse_)
 import qualified Data.List as List
 import Data.List.NonEmpty (NonEmpty ((:|)))
 import qualified Data.List.NonEmpty as NEL
@@ -22,7 +23,8 @@ import qualified Test.Property as Property
 
 entityOperationsTests :: Orville.ConnectionPool -> Property.Group
 entityOperationsTests pool =
-  Property.group "EntityOperations" $
+  Property.group
+    "EntityOperations"
     [ prop_insertEntitiesFindEntitiesByRoundTrip pool
     , prop_insertEntitiesAffectedRows pool
     , prop_insertEntitiesFindFirstEntityByRoundTrip pool
@@ -50,6 +52,13 @@ entityOperationsTests pool =
     , prop_updateFieldsAffectedRows pool
     , prop_updateFieldsAndReturnEntities pool
     , prop_updateFieldsAndReturnEntities_NoMatch pool
+    , prop_upsertEntitiesFindEntitiesByRoundTrip pool
+    , prop_upsertEntitiesAffectedRows pool
+    , prop_upsertEntitiesFindFirstEntityByRoundTrip pool
+    , prop_upsertEntityFindEntityRoundTrip pool
+    , prop_upsertEntityFindEntitiesRoundTrip pool
+    , prop_upsertEntityFindEntitiesCompositeKeyRoundTrip pool
+    , prop_upsertAndReturnEntity pool
     ]
 
 prop_insertEntitiesFindEntitiesByRoundTrip :: Property.NamedDBProperty
@@ -495,3 +504,158 @@ prop_updateFieldsAndReturnEntities_NoMatch =
           (Just (Orville.fieldEquals Foo.fooIdField mismatchedId))
 
     updatedFoos === []
+
+prop_upsertEntitiesFindEntitiesByRoundTrip :: Property.NamedDBProperty
+prop_upsertEntitiesFindEntitiesByRoundTrip =
+  Property.namedDBProperty "upsertEntity/findEntitiesBy forms a round trip" $ \pool -> do
+    originalFoo <- HH.forAll Foo.generate
+
+    retrievedFoos <-
+      Foo.withTable pool $ do
+        Orville.upsertEntity Foo.table Foo.idConflictTarget originalFoo
+        Orville.findEntitiesBy Foo.table mempty
+
+    retrievedFoos === [originalFoo]
+
+prop_upsertEntitiesFindFirstEntityByRoundTrip :: Property.NamedDBProperty
+prop_upsertEntitiesFindFirstEntityByRoundTrip =
+  Property.namedDBProperty "upsertEntities/findFirstEntityBy only return 1" $ \pool -> do
+    originalFoos <- HH.forAll $ Foo.generateList (Range.linear 0 10)
+
+    HH.cover 1 (String.fromString "empty list") (null originalFoos)
+    HH.cover 20 (String.fromString "non-empty list") (not (null originalFoos))
+
+    mbRetrievedFoo <-
+      Foo.withTable pool $ do
+        mapM_ (Orville.upsertEntities Foo.table Foo.idConflictTarget) (NEL.nonEmpty originalFoos)
+        Orville.findFirstEntityBy Foo.table mempty
+
+    let
+      expectedLength =
+        case originalFoos of
+          [] -> 0
+          _ -> 1
+
+    -- Once we add order by to 'SelectOptions' we can order by something here
+    -- and assert which item is returned.
+    length (Maybe.maybeToList mbRetrievedFoo) === expectedLength
+
+prop_upsertEntitiesAffectedRows :: Property.NamedDBProperty
+prop_upsertEntitiesAffectedRows =
+  Property.namedDBProperty "upsertEntities returns the number of affected rows" $ \pool -> do
+    originalFoos <- HH.forAll $ Foo.generateList (Range.linear 0 10)
+    additionalFoos <- HH.forAll $ Foo.generateList (Range.linear 0 10)
+    toDrop <- HH.forAll . Gen.int $ Range.constant 0 (length originalFoos)
+    updatedFoos <-
+      HH.forAll $
+        traverse
+          (\foo -> fmap (\newAge -> foo {Foo.fooAge = newAge}) Foo.generateFooAge)
+          (drop toDrop originalFoos <> additionalFoos)
+
+    HH.cover 1 (String.fromString "empty list") (null originalFoos)
+    HH.cover 20 (String.fromString "non-empty list") (not (null originalFoos))
+
+    (affectedOriginalRows, affectedUpdatedRows) <-
+      Foo.withTable pool $ do
+        affectedOriginal <- case NEL.nonEmpty originalFoos of
+          Nothing -> pure 0
+          Just nonEmptyFoos -> do
+            Orville.upsertEntitiesAndReturnRowCount Foo.table Foo.idConflictTarget nonEmptyFoos
+        affectedUpdated <- case NEL.nonEmpty updatedFoos of
+          Nothing -> pure 0
+          Just nonEmptyUpdatedFoos -> do
+            Orville.upsertEntitiesAndReturnRowCount Foo.table Foo.idConflictTarget nonEmptyUpdatedFoos
+        pure (affectedOriginal, affectedUpdated)
+
+    affectedOriginalRows === length originalFoos
+    affectedUpdatedRows === length updatedFoos
+
+prop_upsertEntityFindEntityRoundTrip :: Property.NamedDBProperty
+prop_upsertEntityFindEntityRoundTrip =
+  Property.namedDBProperty "upsertEntity/findEntity forms a round trip" $ \pool -> do
+    originalFoo <- HH.forAll Foo.generate
+    updatedAge <- HH.forAll Foo.generateFooAge
+    let
+      updatedFoo = originalFoo {Foo.fooAge = updatedAge}
+
+    (mbOriginalFoo, mbUpdatedFoo) <-
+      Foo.withTable pool $ do
+        Orville.upsertEntity Foo.table Foo.idConflictTarget originalFoo
+        mbOriginal <- Orville.findEntity Foo.table (Foo.fooId originalFoo)
+        Orville.upsertEntity Foo.table Foo.idConflictTarget updatedFoo
+        mbUpdated <- Orville.findEntity Foo.table (Foo.fooId originalFoo)
+        pure (mbOriginal, mbUpdated)
+
+    mbOriginalFoo === Just originalFoo
+    mbUpdatedFoo === Just updatedFoo
+
+prop_upsertEntityFindEntitiesRoundTrip :: Property.NamedDBProperty
+prop_upsertEntityFindEntitiesRoundTrip =
+  Property.namedDBProperty "upsertEntity/findEntities form a round trip" $ \pool -> do
+    foos <- HH.forAll $ Foo.generateNonEmpty (Range.linear 1 5)
+    additionalFoos <- HH.forAll $ Foo.generateList (Range.linear 0 5)
+    toDrop <- HH.forAll . Gen.int $ Range.constant 0 (length foos)
+    updatedFoos <-
+      HH.forAll $
+        traverse
+          (\foo -> fmap (\newAge -> foo {Foo.fooAge = newAge}) Foo.generateFooAge)
+          (NEL.drop toDrop foos <> additionalFoos)
+
+    (originalRetrievedFoos, updatedRetrievedFoos) <-
+      Foo.withTable pool $ do
+        Orville.upsertEntities Foo.table Foo.idConflictTarget foos
+        original <- Orville.findEntities Foo.table (Foo.fooId <$> foos)
+        let
+          neUpdated = NEL.nonEmpty updatedFoos
+        traverse_ (Orville.upsertEntities Foo.table Foo.idConflictTarget) neUpdated
+        mbUpdated <- traverse (Orville.findEntities Foo.table . fmap Foo.fooId) neUpdated
+        pure (original, Maybe.fromMaybe [] mbUpdated)
+
+    List.sortOn Foo.fooId originalRetrievedFoos === List.sortOn Foo.fooId (NEL.toList foos)
+    List.sortOn Foo.fooId updatedRetrievedFoos === List.sortOn Foo.fooId updatedFoos
+
+prop_upsertEntityFindEntitiesCompositeKeyRoundTrip :: Property.NamedDBProperty
+prop_upsertEntityFindEntitiesCompositeKeyRoundTrip =
+  Property.namedDBProperty "upsertEntity/findEntities form a round trip (composite primary key)" $ \pool -> do
+    compositeKeyEntities <- HH.forAll $ CompositeKeyEntity.generateNonEmpty (Range.linear 1 5)
+    additionalEntities <- HH.forAll $ CompositeKeyEntity.generateList (Range.linear 0 5)
+    toDrop <- HH.forAll . Gen.int $ Range.constant 0 (length compositeKeyEntities)
+    updatedEntities <-
+      HH.forAll $
+        traverse
+          ( \entity ->
+              fmap
+                (\newAge -> entity {CompositeKeyEntity.compositeKeyEntityAge = newAge})
+                CompositeKeyEntity.generateCompositeKeyEntityAge
+          )
+          (NEL.drop toDrop compositeKeyEntities <> additionalEntities)
+
+    (originalRetrievedCompositeKeyEntities, updatedRetrievedCompositeKeyEntities) <-
+      CompositeKeyEntity.withTable pool $ do
+        Orville.upsertEntities CompositeKeyEntity.table CompositeKeyEntity.compositeKeyConflictTarget compositeKeyEntities
+        original <- Orville.findEntities CompositeKeyEntity.table (CompositeKeyEntity.compositeKey <$> compositeKeyEntities)
+        let
+          neUpdated = NEL.nonEmpty updatedEntities
+        traverse_ (Orville.upsertEntities CompositeKeyEntity.table CompositeKeyEntity.compositeKeyConflictTarget) neUpdated
+        updated <- traverse (Orville.findEntities CompositeKeyEntity.table . fmap CompositeKeyEntity.compositeKey) (NEL.nonEmpty updatedEntities)
+        pure (original, Maybe.fromMaybe [] updated)
+
+    List.sortOn CompositeKeyEntity.compositeKey originalRetrievedCompositeKeyEntities === List.sortOn CompositeKeyEntity.compositeKey (NEL.toList compositeKeyEntities)
+    List.sortOn CompositeKeyEntity.compositeKey updatedRetrievedCompositeKeyEntities === List.sortOn CompositeKeyEntity.compositeKey updatedEntities
+
+prop_upsertAndReturnEntity :: Property.NamedDBProperty
+prop_upsertAndReturnEntity =
+  Property.namedDBProperty "upsertAndReturnEntity returns the upserted entity" $ \pool -> do
+    originalFoo <- HH.forAll Foo.generate
+    updatedAge <- HH.forAll Foo.generateFooAge
+    let
+      updatedFoo = originalFoo {Foo.fooAge = updatedAge}
+
+    (originalRetrievedFoo, updatedRetrievedFoo) <-
+      Foo.withTable pool $ do
+        original <- Orville.upsertAndReturnEntity Foo.table Foo.idConflictTarget originalFoo
+        updated <- Orville.upsertAndReturnEntity Foo.table Foo.idConflictTarget updatedFoo
+        pure (original, updated)
+
+    originalRetrievedFoo === originalFoo
+    updatedRetrievedFoo === updatedFoo


### PR DESCRIPTION
Added variations of the `insert*` entity operations that use `ON CONFLICT <target> DO UPDATE` clauses to update values that conflict due to a constraint violation.