### PR TITLE
Use oldest release from each PostgreSQL major series

### DIFF
--- a/orville-postgresql-typeid/compose.yaml
+++ b/orville-postgresql-typeid/compose.yaml
@@ -23,31 +23,31 @@ services:
       IN_TOOLS_CONTAINER: "true"
 
   testdb-pg13:
-    image: postgres:13.23-alpine
+    image: postgres:13.0-alpine
     environment:
       POSTGRES_USER: orville_test
       POSTGRES_PASSWORD: orville
 
   testdb-pg14:
-    image: postgres:14.21-alpine
+    image: postgres:14.0-alpine
     environment:
       POSTGRES_USER: orville_test
       POSTGRES_PASSWORD: orville
 
   testdb-pg15:
-    image: postgres:15.16-alpine
+    image: postgres:15.0-alpine
     environment:
       POSTGRES_USER: orville_test
       POSTGRES_PASSWORD: orville
 
   testdb-pg16:
-    image: postgres:16.12-alpine
+    image: postgres:16.0-alpine
     environment:
       POSTGRES_USER: orville_test
       POSTGRES_PASSWORD: orville
 
   testdb-pg17:
-    image: postgres:17.8-alpine
+    image: postgres:17.0-alpine
     environment:
       POSTGRES_USER: orville_test
       POSTGRES_PASSWORD: orville

--- a/orville-postgresql-typeid/compose.yaml
+++ b/orville-postgresql-typeid/compose.yaml
@@ -23,31 +23,31 @@ services:
       IN_TOOLS_CONTAINER: "true"
 
   testdb-pg13:
-    image: postgres:13.16-alpine
+    image: postgres:13.23-alpine
     environment:
       POSTGRES_USER: orville_test
       POSTGRES_PASSWORD: orville
 
   testdb-pg14:
-    image: postgres:14.13-alpine
+    image: postgres:14.21-alpine
     environment:
       POSTGRES_USER: orville_test
       POSTGRES_PASSWORD: orville
 
   testdb-pg15:
-    image: postgres:15.8-alpine
+    image: postgres:15.16-alpine
     environment:
       POSTGRES_USER: orville_test
       POSTGRES_PASSWORD: orville
 
   testdb-pg16:
-    image: postgres:16.4-alpine
+    image: postgres:16.12-alpine
     environment:
       POSTGRES_USER: orville_test
       POSTGRES_PASSWORD: orville
 
   testdb-pg17:
-    image: postgres:17.0-alpine
+    image: postgres:17.8-alpine
     environment:
       POSTGRES_USER: orville_test
       POSTGRES_PASSWORD: orville

--- a/orville-postgresql/compose.yaml
+++ b/orville-postgresql/compose.yaml
@@ -22,31 +22,31 @@ services:
       IN_TOOLS_CONTAINER: "true"
 
   testdb-pg14:
-    image: postgres:14.21-alpine
+    image: postgres:14.0-alpine
     environment:
       POSTGRES_USER: orville_test
       POSTGRES_PASSWORD: orville
 
   testdb-pg15:
-    image: postgres:15.16-alpine
+    image: postgres:15.0-alpine
     environment:
       POSTGRES_USER: orville_test
       POSTGRES_PASSWORD: orville
 
   testdb-pg16:
-    image: postgres:16.12-alpine
+    image: postgres:16.0-alpine
     environment:
       POSTGRES_USER: orville_test
       POSTGRES_PASSWORD: orville
 
   testdb-pg17:
-    image: postgres:17.8-alpine
+    image: postgres:17.0-alpine
     environment:
       POSTGRES_USER: orville_test
       POSTGRES_PASSWORD: orville
 
   testdb-pg18:
-    image: postgres:18.2-alpine
+    image: postgres:18.0-alpine
     environment:
       POSTGRES_USER: orville_test
       POSTGRES_PASSWORD: orville

--- a/orville-postgresql/compose.yaml
+++ b/orville-postgresql/compose.yaml
@@ -22,31 +22,31 @@ services:
       IN_TOOLS_CONTAINER: "true"
 
   testdb-pg14:
-    image: postgres:14.13-alpine
+    image: postgres:14.21-alpine
     environment:
       POSTGRES_USER: orville_test
       POSTGRES_PASSWORD: orville
 
   testdb-pg15:
-    image: postgres:15.8-alpine
+    image: postgres:15.16-alpine
     environment:
       POSTGRES_USER: orville_test
       POSTGRES_PASSWORD: orville
 
   testdb-pg16:
-    image: postgres:16.4-alpine
+    image: postgres:16.12-alpine
     environment:
       POSTGRES_USER: orville_test
       POSTGRES_PASSWORD: orville
 
   testdb-pg17:
-    image: postgres:17.0-alpine
+    image: postgres:17.8-alpine
     environment:
       POSTGRES_USER: orville_test
       POSTGRES_PASSWORD: orville
 
   testdb-pg18:
-    image: postgres:18.0-alpine
+    image: postgres:18.2-alpine
     environment:
       POSTGRES_USER: orville_test
       POSTGRES_PASSWORD: orville


### PR DESCRIPTION
Since it is more likely that users use the latest minor release, than a previous one, we should test Orville on the latest minor release from each major release series.