### PR TITLE
Adds support for batched insert/upsert of multiple entities

### DIFF
--- a/orville-postgresql/orville-postgresql.cabal
+++ b/orville-postgresql/orville-postgresql.cabal
@@ -32,6 +32,7 @@ library
   exposed-modules:
       Orville.PostgreSQL
       Orville.PostgreSQL.AutoMigration
+      Orville.PostgreSQL.Batchable
       Orville.PostgreSQL.ErrorDetailLevel
       Orville.PostgreSQL.Execution
       Orville.PostgreSQL.Execution.Cursor
@@ -209,6 +210,7 @@ test-suite spec
   main-is: Main.hs
   other-modules:
       Test.AutoMigration
+      Test.Batchable
       Test.Connection
       Test.Cursor
       Test.Entities.Bar

--- a/orville-postgresql/package.yaml
+++ b/orville-postgresql/package.yaml
@@ -28,6 +28,7 @@ library:
   exposed-modules:
     - Orville.PostgreSQL
     - Orville.PostgreSQL.AutoMigration
+    - Orville.PostgreSQL.Batchable
     - Orville.PostgreSQL.ErrorDetailLevel
     - Orville.PostgreSQL.Execution
     - Orville.PostgreSQL.Execution.Cursor

--- a/orville-postgresql/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL.hs
@@ -38,6 +38,10 @@ module Orville.PostgreSQL
   , EntityOperations.upsertEntities
   , EntityOperations.upsertEntitiesAndReturnRowCount
   , EntityOperations.upsertAndReturnEntities
+  , EntityOperations.BatchInsertOption (InOneStatement, InBatches)
+  , EntityOperations.BatchInsertTransactionality (WithNewTransaction, WithoutNewTransaction)
+  , Batchable.BatchSize (BatchSize, BatchSizeAuto)
+  , Batchable.Batchable
   , EntityOperations.updateEntity
   , EntityOperations.updateEntityAndReturnRowCount
   , EntityOperations.updateAndReturnEntity
@@ -458,6 +462,7 @@ module Orville.PostgreSQL
   )
 where
 
+import qualified Orville.PostgreSQL.Batchable as Batchable
 import qualified Orville.PostgreSQL.ErrorDetailLevel as ErrorDetailLevel
 import qualified Orville.PostgreSQL.Execution.EntityOperations as EntityOperations
 import qualified Orville.PostgreSQL.Execution.Execute as Execute

--- a/orville-postgresql/src/Orville/PostgreSQL/Batchable.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Batchable.hs
@@ -1,0 +1,136 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE RankNTypes #-}
+
+{- |
+Copyright : Flipstone Technology Partners 2026
+License   : MIT
+Stability : Stable
+
+@since 1.2.0.0
+-}
+module Orville.PostgreSQL.Batchable
+  ( Batchable
+  , BatchSize (..)
+  , batchNonEmpty
+  , mapBatchable
+  , toBatched
+  , toUnbatched
+  ) where
+
+import Data.Functor.Identity (Identity (Identity, runIdentity))
+import Data.Kind (Type)
+import qualified Data.List as List
+import qualified Data.List.NonEmpty as NE
+
+{- | 'BatchSize' controls how many items are included in each batch when a
+  'Batchable' is resolved via 'toBatched'.
+
+  * 'BatchSizeAuto' uses the automatic batch size that was determined when
+    the 'Batchable' was created (e.g. based on PostgreSQL's parameter limit).
+  * @'BatchSize' n@ uses an explicit batch size of @n@ items per batch.
+
+@since 1.2.0.0
+-}
+data BatchSize
+  = BatchSizeAuto
+  | BatchSize Int
+  deriving (Show)
+
+{- | A 'Batchable' represents a value that can either be used as a single
+  unit or split into multiple batches. This is used to support executing
+  large insert operations in batches that stay within PostgreSQL's parameter
+  limit, while also allowing the same operation to be executed as a single
+  statement when batching is not needed.
+
+  This type is designed to allow batching to be provided as an option while
+  incurring no actual batching overhead when it's not actually desired.
+
+@since 1.2.0.0
+-}
+newtype Batchable a
+  = Batchable (forall f. Batching f -> f a)
+
+instance Functor Batchable where
+  fmap = mapBatchable
+
+data Batching (f :: Type -> Type) where
+  Unbatched :: Batching Identity
+  Batched :: BatchSize -> Batching []
+
+{- | Maps a function over both the batched and unbatched representations of a
+  'Batchable'.
+
+@since 1.2.0.0
+-}
+{-# INLINEABLE mapBatchable #-}
+mapBatchable :: (a -> b) -> Batchable a -> Batchable b
+mapBatchable f (Batchable g) =
+  Batchable (\batching -> mapBatching batching f (g batching))
+
+-- This uses multiple function branches rather than a
+-- case statement to help GHC fully inline and specialize
+-- this in the hopes that 'Identity' will be completely
+-- erased at runtime
+mapBatching :: Batching f -> (a -> b) -> f a -> f b
+mapBatching Unbatched = fmap
+mapBatching (Batched _) = fmap
+
+{- | Resolves a 'Batchable' as a single unbatched value. No batching logic is
+  applied; the original value is returned directly.
+
+@since 1.2.0.0
+-}
+{-# INLINEABLE toUnbatched #-}
+toUnbatched :: Batchable a -> a
+toUnbatched (Batchable f) =
+  runIdentity (f Unbatched)
+
+{- | Resolves a 'Batchable' into a list of batched values according to the
+  given 'BatchSize'.
+
+@since 1.2.0.0
+-}
+{-# INLINEABLE toBatched #-}
+toBatched :: BatchSize -> Batchable a -> [a]
+toBatched batchSize (Batchable f) =
+  f (Batched batchSize)
+
+{- | Creates a 'Batchable' from a 'NE.NonEmpty' list. When resolved via
+  'toUnbatched', the original list is returned unchanged. When resolved via
+  'toBatched', the list is split into chunks of the appropriate size.
+
+  Note: The @autoBatchSize@ parameter is lazy — it will only be evaluated if
+  the 'Batchable' is later resolved via 'toBatched' with 'BatchSizeAuto'. This
+  means callers can provide a potentially expensive batch size calculation
+  without paying the cost of the calculation when the 'Batchable' is resolved
+  via 'toUnbatched'.
+
+@since 1.2.0.0
+-}
+batchNonEmpty ::
+  Int ->
+  NE.NonEmpty a ->
+  Batchable (NE.NonEmpty a)
+batchNonEmpty autoBatchSize source =
+  Batchable $ \batching ->
+    case batching of
+      Unbatched -> Identity source
+      Batched batchSize ->
+        let
+          itemsPerBatch =
+            case batchSize of
+              BatchSizeAuto -> autoBatchSize
+              BatchSize n -> n
+
+          go rest =
+            case rest of
+              [] -> []
+              _ ->
+                let
+                  (batch, remaining) =
+                    List.splitAt itemsPerBatch rest
+                in
+                  maybe [] (: go remaining) (NE.nonEmpty batch)
+        in
+          go (NE.toList source)

--- a/orville-postgresql/src/Orville/PostgreSQL/Execution/EntityOperations.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Execution/EntityOperations.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE GADTs #-}
 
 {- |
@@ -18,6 +19,8 @@ module Orville.PostgreSQL.Execution.EntityOperations
   , insertEntities
   , insertAndReturnEntities
   , insertEntitiesAndReturnRowCount
+  , BatchInsertOption (InOneStatement, InBatches)
+  , BatchInsertTransactionality (WithNewTransaction, WithoutNewTransaction)
   , updateEntity
   , updateEntityAndReturnRowCount
   , updateAndReturnEntity
@@ -48,14 +51,18 @@ where
 import Control.Exception (Exception, throwIO)
 import qualified Control.Monad as Monad
 import Control.Monad.IO.Class (MonadIO (liftIO))
+import qualified Data.DList as DList
+import Data.Foldable (traverse_)
 import Data.List.NonEmpty (NonEmpty ((:|)))
 import qualified Data.List.NonEmpty as NEL
 import Data.Maybe (listToMaybe)
 
+import Orville.PostgreSQL.Batchable (BatchSize, Batchable, toBatched, toUnbatched)
 import qualified Orville.PostgreSQL.Execution.Delete as Delete
 import qualified Orville.PostgreSQL.Execution.Insert as Insert
 import qualified Orville.PostgreSQL.Execution.Select as Select
 import qualified Orville.PostgreSQL.Execution.SelectOptions as SelectOptions
+import qualified Orville.PostgreSQL.Execution.Transaction as Transaction
 import qualified Orville.PostgreSQL.Execution.Update as Update
 import qualified Orville.PostgreSQL.Expr as Expr
 import qualified Orville.PostgreSQL.Internal.RowCountExpectation as RowCountExpectation
@@ -86,7 +93,7 @@ insertEntityAndReturnRowCount ::
   writeEntity ->
   m Int
 insertEntityAndReturnRowCount entityTable entity =
-  insertEntitiesAndReturnRowCount entityTable (entity :| [])
+  insertEntitiesAndReturnRowCount InOneStatement entityTable (entity :| [])
 
 {- | Inserts an entity into the specified table, returning the data inserted into
   the database.
@@ -102,7 +109,7 @@ insertAndReturnEntity ::
   writeEntity ->
   m readEntity
 insertAndReturnEntity entityTable entity = do
-  returnedEntities <- insertAndReturnEntities entityTable (entity :| [])
+  returnedEntities <- insertAndReturnEntities InOneStatement entityTable (entity :| [])
 
   RowCountExpectation.expectExactlyOneRow
     "insertAndReturnEntity RETURNING clause"
@@ -114,11 +121,15 @@ insertAndReturnEntity entityTable entity = do
 -}
 insertEntities ::
   Monad.MonadOrville m =>
+  BatchInsertOption ->
   Schema.TableDefinition key writeEntity readEntity ->
   NonEmpty writeEntity ->
   m ()
-insertEntities tableDef =
-  Monad.void . insertEntitiesAndReturnRowCount tableDef
+insertEntities batchOption tableDef =
+  executeBatchOption_
+    batchOption
+    Insert.executeInsert
+    . Insert.insertToTable tableDef
 
 {- | Inserts a non-empty list of entities into the specified table. Returns the
   number of rows affected by the query.
@@ -127,11 +138,17 @@ insertEntities tableDef =
 -}
 insertEntitiesAndReturnRowCount ::
   Monad.MonadOrville m =>
+  BatchInsertOption ->
   Schema.TableDefinition key writeEntity readEntity ->
   NonEmpty writeEntity ->
   m Int
-insertEntitiesAndReturnRowCount tableDef =
-  Insert.executeInsert . Insert.insertToTable tableDef
+insertEntitiesAndReturnRowCount batchOption tableDef =
+  executeBatchOption
+    batchOption
+    Insert.executeInsert
+    0
+    (+)
+    . Insert.insertToTable tableDef
 
 {- | Inserts a non-empty list of entities into the specified table, returning the data that
   was inserted into the database.
@@ -143,11 +160,99 @@ insertEntitiesAndReturnRowCount tableDef =
 -}
 insertAndReturnEntities ::
   Monad.MonadOrville m =>
+  BatchInsertOption ->
   Schema.TableDefinition key writeEntity readEntity ->
   NonEmpty writeEntity ->
   m [readEntity]
-insertAndReturnEntities tableDef =
-  Insert.executeInsertReturnEntities . Insert.insertToTableReturning tableDef
+insertAndReturnEntities batchOption tableDef =
+  fmap DList.toList
+    . executeBatchOption
+      batchOption
+      (fmap DList.fromList . Insert.executeInsertReturnEntities)
+      DList.empty
+      (<>)
+    . Insert.insertToTableReturning tableDef
+
+executeBatchOption ::
+  Monad.MonadOrville m =>
+  BatchInsertOption ->
+  (batch -> m batchResult) ->
+  fullResult ->
+  (fullResult -> batchResult -> fullResult) ->
+  Batchable batch ->
+  m fullResult
+executeBatchOption batchOption runBatch initialAcc combine batchable =
+  case batchOption of
+    InOneStatement ->
+      combine initialAcc <$> runBatch (toUnbatched batchable)
+    InBatches batchSize transactionality ->
+      let
+        -- make sure to force the accumulator to WHNF at each batch
+        foldBatch !acc =
+          fmap (combine acc) . runBatch
+      in
+        withBatchInsertTransactionality
+          transactionality
+          (Monad.foldM foldBatch initialAcc . toBatched batchSize $ batchable)
+
+executeBatchOption_ ::
+  Monad.MonadOrville m =>
+  BatchInsertOption ->
+  (batch -> m result) ->
+  Batchable batch ->
+  m ()
+executeBatchOption_ batchOption runBatch batchable =
+  case batchOption of
+    InOneStatement ->
+      Monad.void . runBatch . toUnbatched $ batchable
+    InBatches batchSize transactionality ->
+      withBatchInsertTransactionality
+        transactionality
+        (traverse_ runBatch . toBatched batchSize $ batchable)
+
+{- | Controls whether a multi-entity insert is executed as a single SQL
+  statement or in multiple batches.
+
+  * 'InOneStatement' sends all entities in a single @INSERT@ statement. This
+    is the simplest option but may exceed PostgreSQL's parameter limit for very
+    large inserts.
+
+  * @'InBatches' batchSize transactionality@ splits the entities into batches
+    and executes a separate @INSERT@ for each batch. The 'BatchSize' controls
+    how many entities are included per batch, and the
+    'BatchInsertTransactionality' controls whether the batches are wrapped in
+    a transaction.
+
+@since 1.2.0.0
+-}
+data BatchInsertOption
+  = InOneStatement
+  | InBatches BatchSize BatchInsertTransactionality
+
+{- | Controls whether batched inserts are wrapped in a new transaction.
+
+  * 'WithNewTransaction' wraps all batches in a single transaction, ensuring
+    atomicity — either all batches succeed or none do.
+
+  * 'WithoutNewTransaction' does not start a new transaction. Use this when
+    you are already inside a transaction or when you do not need atomicity
+    across batches.
+
+@since 1.2.0.0
+-}
+data BatchInsertTransactionality
+  = WithNewTransaction
+  | WithoutNewTransaction
+
+withBatchInsertTransactionality ::
+  Monad.MonadOrville m =>
+  BatchInsertTransactionality ->
+  m a ->
+  m a
+withBatchInsertTransactionality transactionality =
+  case transactionality of
+    WithNewTransaction -> Transaction.withTransaction
+    WithoutNewTransaction -> id
 
 {- | Updates the row with the given key with the data given by @writeEntity@.
 
@@ -555,7 +660,7 @@ upsertAndReturnEntity ::
   writeEntity ->
   m readEntity
 upsertAndReturnEntity tableDef target entity = do
-  returnedEntities <- upsertAndReturnEntities tableDef target (entity :| [])
+  returnedEntities <- upsertAndReturnEntities InOneStatement tableDef target (entity :| [])
 
   RowCountExpectation.expectExactlyOneRow
     "upsertAndReturnEntity RETURNING clause"
@@ -590,7 +695,7 @@ upsertEntityAndReturnRowCount ::
   writeEntity ->
   m Int
 upsertEntityAndReturnRowCount tableDef target =
-  upsertEntitiesAndReturnRowCount tableDef target . pure
+  upsertEntitiesAndReturnRowCount InOneStatement tableDef target . pure
 
 {- |
   Similar to 'insertAndReturnEntities', but uses an @ON CONFLICT@ clause to update the row if it
@@ -600,13 +705,20 @@ upsertEntityAndReturnRowCount tableDef target =
 -}
 upsertAndReturnEntities ::
   Monad.MonadOrville m =>
+  BatchInsertOption ->
   Schema.TableDefinition key writeEntity readEntity ->
   ConflictTarget ->
   NEL.NonEmpty writeEntity ->
   m [readEntity]
-upsertAndReturnEntities tableDef target entities = do
+upsertAndReturnEntities batchOption tableDef target entities = do
   targetExpr <- conflictTargetToConflictTargetExprOrThrow tableDef target
-  Insert.executeInsertReturnEntities $ Insert.upsertToTableReturning tableDef targetExpr entities
+  fmap DList.toList
+    . executeBatchOption
+      batchOption
+      (fmap DList.fromList . Insert.executeInsertReturnEntities)
+      DList.empty
+      (<>)
+    $ Insert.upsertToTableReturning tableDef targetExpr entities
 
 {- |
   Similar to 'insertEntities', but uses an @ON CONFLICT@ clause to update the row if it
@@ -616,12 +728,17 @@ upsertAndReturnEntities tableDef target entities = do
 -}
 upsertEntities ::
   Monad.MonadOrville m =>
+  BatchInsertOption ->
   Schema.TableDefinition key writeEntity readEntity ->
   ConflictTarget ->
   NEL.NonEmpty writeEntity ->
   m ()
-upsertEntities tableDef target =
-  Monad.void . upsertEntitiesAndReturnRowCount tableDef target
+upsertEntities batchOption tableDef target entities = do
+  targetExpr <- conflictTargetToConflictTargetExprOrThrow tableDef target
+  executeBatchOption_
+    batchOption
+    Insert.executeInsert
+    $ Insert.upsertToTable tableDef targetExpr entities
 
 {- |
   Similar to 'insertEntitiesAndReturnRowCount', but uses an @ON CONFLICT@ clause to update the row if it
@@ -632,10 +749,16 @@ upsertEntities tableDef target =
 -}
 upsertEntitiesAndReturnRowCount ::
   Monad.MonadOrville m =>
+  BatchInsertOption ->
   Schema.TableDefinition key writeEntity readEntity ->
   ConflictTarget ->
   NEL.NonEmpty writeEntity ->
   m Int
-upsertEntitiesAndReturnRowCount tableDef target entities = do
+upsertEntitiesAndReturnRowCount batchOption tableDef target entities = do
   targetExpr <- conflictTargetToConflictTargetExprOrThrow tableDef target
-  Insert.executeInsert $ Insert.upsertToTable tableDef targetExpr entities
+  executeBatchOption
+    batchOption
+    Insert.executeInsert
+    0
+    (+)
+    $ Insert.upsertToTable tableDef targetExpr entities

--- a/orville-postgresql/src/Orville/PostgreSQL/Execution/EntityOperations.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Execution/EntityOperations.hs
@@ -173,6 +173,9 @@ insertAndReturnEntities batchOption tableDef =
       (<>)
     . Insert.insertToTableReturning tableDef
 
+-- This is intentionally written in a form where the 'Batchable' argument is not
+-- listed syntatically as an argument to make it possible for GHC inline when
+-- only 4 arguments are passed
 executeBatchOption ::
   Monad.MonadOrville m =>
   BatchInsertOption ->
@@ -181,10 +184,10 @@ executeBatchOption ::
   (fullResult -> batchResult -> fullResult) ->
   Batchable batch ->
   m fullResult
-executeBatchOption batchOption runBatch initialAcc combine batchable =
+executeBatchOption batchOption runBatch initialAcc combine =
   case batchOption of
     InOneStatement ->
-      combine initialAcc <$> runBatch (toUnbatched batchable)
+      fmap (combine initialAcc) . runBatch . toUnbatched
     InBatches batchSize transactionality ->
       let
         -- make sure to force the accumulator to WHNF at each batch
@@ -193,22 +196,27 @@ executeBatchOption batchOption runBatch initialAcc combine batchable =
       in
         withBatchInsertTransactionality
           transactionality
-          (Monad.foldM foldBatch initialAcc . toBatched batchSize $ batchable)
+          . Monad.foldM foldBatch initialAcc
+          . toBatched batchSize
 
+-- This is intentionally written in a form where the 'Batchable' argument is not
+-- listed syntatically as an argument to make it possible for GHC inline when
+-- only 2 arguments are passed
 executeBatchOption_ ::
   Monad.MonadOrville m =>
   BatchInsertOption ->
   (batch -> m result) ->
   Batchable batch ->
   m ()
-executeBatchOption_ batchOption runBatch batchable =
+executeBatchOption_ batchOption runBatch =
   case batchOption of
     InOneStatement ->
-      Monad.void . runBatch . toUnbatched $ batchable
+      Monad.void . runBatch . toUnbatched
     InBatches batchSize transactionality ->
       withBatchInsertTransactionality
         transactionality
-        (traverse_ runBatch . toBatched batchSize $ batchable)
+        . traverse_ runBatch
+        . toBatched batchSize
 
 {- | Controls whether a multi-entity insert is executed as a single SQL
   statement or in multiple batches.

--- a/orville-postgresql/src/Orville/PostgreSQL/Execution/Insert.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Execution/Insert.hs
@@ -33,6 +33,7 @@ where
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
 
+import Orville.PostgreSQL.Batchable (Batchable)
 import qualified Orville.PostgreSQL.Execution.Execute as Execute
 import qualified Orville.PostgreSQL.Execution.QueryType as QueryType
 import Orville.PostgreSQL.Execution.ReturningOption (NoReturningClause, ReturningClause, ReturningOption (WithReturning, WithoutReturning))
@@ -101,7 +102,7 @@ executeInsertReturnEntities (InsertReturning marshaller expr) =
 insertToTable ::
   TableDefinition key writeEntity readEntity ->
   NonEmpty writeEntity ->
-  Insert readEntity NoReturningClause
+  Batchable (Insert readEntity NoReturningClause)
 insertToTable =
   insertTable WithoutReturning
 
@@ -114,7 +115,7 @@ insertToTable =
 insertToTableReturning ::
   TableDefinition key writeEntity readEntity ->
   NonEmpty writeEntity ->
-  Insert readEntity ReturningClause
+  Batchable (Insert readEntity ReturningClause)
 insertToTableReturning =
   insertTable WithReturning
 
@@ -127,7 +128,7 @@ upsertToTable ::
   TableDefinition key writeEntity readEntity ->
   Expr.ConflictTargetExpr ->
   NonEmpty writeEntity ->
-  Insert readEntity NoReturningClause
+  Batchable (Insert readEntity NoReturningClause)
 upsertToTable =
   upsertTable WithoutReturning
 
@@ -141,7 +142,7 @@ upsertToTableReturning ::
   TableDefinition key writeEntity readEntity ->
   Expr.ConflictTargetExpr ->
   NonEmpty writeEntity ->
-  Insert readEntity ReturningClause
+  Batchable (Insert readEntity ReturningClause)
 upsertToTableReturning =
   upsertTable WithReturning
 
@@ -150,9 +151,11 @@ insertTable ::
   ReturningOption returningClause ->
   TableDefinition key writeEntity readEntity ->
   NonEmpty writeEntity ->
-  Insert readEntity returningClause
+  Batchable (Insert readEntity returningClause)
 insertTable returningOption tableDef entities =
-  rawInsertExpr returningOption (tableMarshaller tableDef) (mkInsertExpr returningOption tableDef Nothing entities)
+  fmap
+    (rawInsertExpr returningOption (tableMarshaller tableDef))
+    (mkInsertExpr returningOption tableDef Nothing entities)
 
 -- an internal helper function for creating an @insert ... on conflict <target> do update set ...@ with a given `ReturningOption`
 upsertTable ::
@@ -160,7 +163,7 @@ upsertTable ::
   TableDefinition key writeEntity readEntity ->
   Expr.ConflictTargetExpr ->
   NE.NonEmpty writeEntity ->
-  Insert readEntity returningClause
+  Batchable (Insert readEntity returningClause)
 upsertTable returningOption tableDef target entities =
   let
     marshaller = tableMarshaller tableDef
@@ -178,9 +181,8 @@ upsertTable returningOption tableDef target entities =
     mkOnConflictExpr neSetItemExprs =
       Expr.onConflictDoUpdate (Just target) neSetItemExprs Nothing
   in
-    rawInsertExpr
-      returningOption
-      marshaller
+    fmap
+      (rawInsertExpr returningOption marshaller)
       ( mkInsertExpr
           returningOption
           tableDef

--- a/orville-postgresql/src/Orville/PostgreSQL/Raw/RawSql.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Raw/RawSql.hs
@@ -47,6 +47,7 @@ module Orville.PostgreSQL.Raw.RawSql
   , unsafeSqlExpression
   , toBytesAndParams
   , toExampleBytes
+  , toParamCount
   , Quoting (Quoting, quoteStringLiteral, quoteIdentifier)
   , exampleQuoting
   )
@@ -247,6 +248,21 @@ toBytesAndParams quoting sql = do
 toExampleBytes :: SqlExpression sql => sql -> BS.ByteString
 toExampleBytes =
   fst . runIdentity . toBytesAndParams exampleQuoting
+
+{- |
+  Counts the number of parameters contained in the SQL expression.
+
+@since 1.2.0.0
+-}
+toParamCount :: SqlExpression sql => sql -> Int
+toParamCount sql =
+  case toRawSql sql of
+    SqlSection _ -> 0
+    Parameter _ -> 1
+    StringLiteral _ -> 0
+    Identifier _ -> 0
+    Append left right -> toParamCount left + toParamCount right
+    Empty -> 0
 
 {- | This is an internal datatype used during the SQL building process to track
   how many params have been seen so that placeholder indices (e.g. '$1', etc)

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/TableDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/TableDefinition.hs
@@ -46,11 +46,13 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import qualified Data.Text as T
 
+import Orville.PostgreSQL.Batchable (Batchable, batchNonEmpty)
 import Orville.PostgreSQL.Execution.ReturningOption (ReturningOption (WithReturning, WithoutReturning))
 import qualified Orville.PostgreSQL.Expr as Expr
 import Orville.PostgreSQL.Internal.IndexDefinition (IndexDefinition, IndexMigrationKey, indexMigrationKey)
 import Orville.PostgreSQL.Marshall.FieldDefinition (FieldName, fieldColumnDefinition, fieldColumnName, fieldValueToSqlValue, qualifiedFieldColumnName, qualifyField)
 import Orville.PostgreSQL.Marshall.SqlMarshaller (AnnotatedSqlMarshaller, MarshallerField (Natural, Synthetic), ReadOnlyColumnOption (ExcludeReadOnlyColumns, IncludeReadOnlyColumns), SqlMarshaller, annotateSqlMarshaller, annotateSqlMarshallerEmptyAnnotation, collectFromField, foldMarshallerFields, mapSqlMarshaller, marshallerDerivedColumns, marshallerTableConstraints, unannotatedSqlMarshaller)
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import Orville.PostgreSQL.Schema.ConstraintDefinition (ConstraintDefinition, TableConstraints, addConstraint, constraintSqlExpr, emptyTableConstraints, tableConstraintDefinitions)
 import Orville.PostgreSQL.Schema.PrimaryKey (PrimaryKey, mkPrimaryKeyExpr, primaryKeyFieldNames)
 import Orville.PostgreSQL.Schema.TableIdentifier (TableIdentifier, setTableIdSchema, tableIdQualifiedName, unqualifiedNameToTableId)
@@ -496,6 +498,14 @@ mkTableReturningClause returningOption tableDef =
         . tableMarshaller
         $ tableDef
 
+{- | The maximum number of parameters that can be sent in a single PostgreSQL
+query. PostgreSQL uses a 16-bit integer to identify parameter placeholders,
+so the maximum is 65535.
+-}
+postgresqlMaxParams :: Int
+postgresqlMaxParams =
+  65535
+
 {- | Builds an 'Expr.InsertExpr' that will insert the given entities into the SQL
   table when it is executed. A @RETURNING@ clause will either be included to
   return the inserted rows or not, depending on the 'ReturningOption' given.
@@ -507,7 +517,7 @@ mkInsertExpr ::
   TableDefinition key writeEntity readEntity ->
   Maybe Expr.OnConflictExpr ->
   NE.NonEmpty writeEntity ->
-  Expr.InsertExpr
+  Batchable Expr.InsertExpr
 mkInsertExpr returningOption tableDef maybeOnConflict entities =
   let
     marshaller =
@@ -516,15 +526,40 @@ mkInsertExpr returningOption tableDef maybeOnConflict entities =
     insertColumnList =
       mkInsertColumnList marshaller
 
-    insertSource =
-      mkInsertSource marshaller entities
+    countInsertField :: MarshallerField writeEntity -> Int -> Int
+    countInsertField field =
+      case field of
+        Natural _qualfier _fieldDef (Just _writeAccessor) -> (+ 1)
+        Natural _qualfier _fieldDef Nothing -> id
+        Synthetic _syntheticField -> id
+
+    insertColumnCount =
+      foldMarshallerFields
+        marshaller
+        0
+        countInsertField
+
+    availableParams =
+      postgresqlMaxParams
+        - maybe 0 RawSql.toParamCount maybeOnConflict
+
+    autoBatchSize =
+      if insertColumnCount > 0
+        then availableParams `div` insertColumnCount
+        else maxBound
+
+    batches =
+      batchNonEmpty autoBatchSize entities
+
+    mkExprForBatch batch =
+      Expr.insertExpr
+        (tableName tableDef)
+        (Just insertColumnList)
+        (mkInsertSource marshaller batch)
+        maybeOnConflict
+        (mkTableReturningClause returningOption tableDef)
   in
-    Expr.insertExpr
-      (tableName tableDef)
-      (Just insertColumnList)
-      insertSource
-      maybeOnConflict
-      (mkTableReturningClause returningOption tableDef)
+    fmap mkExprForBatch batches
 
 {- | Builds an 'Expr.InsertColumnList' that specifies the columns for an
   insert statement in the order that they appear in the given 'SqlMarshaller'.

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/TableDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/TableDefinition.hs
@@ -518,7 +518,7 @@ mkInsertExpr ::
   Maybe Expr.OnConflictExpr ->
   NE.NonEmpty writeEntity ->
   Batchable Expr.InsertExpr
-mkInsertExpr returningOption tableDef maybeOnConflict entities =
+mkInsertExpr returningOption tableDef maybeOnConflict =
   let
     marshaller =
       unannotatedSqlMarshaller $ tableMarshaller tableDef
@@ -548,9 +548,6 @@ mkInsertExpr returningOption tableDef maybeOnConflict entities =
         then availableParams `div` insertColumnCount
         else maxBound
 
-    batches =
-      batchNonEmpty autoBatchSize entities
-
     mkExprForBatch batch =
       Expr.insertExpr
         (tableName tableDef)
@@ -559,7 +556,7 @@ mkInsertExpr returningOption tableDef maybeOnConflict entities =
         maybeOnConflict
         (mkTableReturningClause returningOption tableDef)
   in
-    fmap mkExprForBatch batches
+    fmap mkExprForBatch . batchNonEmpty autoBatchSize
 
 {- | Builds an 'Expr.InsertColumnList' that specifies the columns for an
   insert statement in the order that they appear in the given 'SqlMarshaller'.

--- a/orville-postgresql/test/Main.hs
+++ b/orville-postgresql/test/Main.hs
@@ -12,6 +12,7 @@ import qualified System.Exit as SE
 import qualified Orville.PostgreSQL as Orville
 
 import qualified Test.AutoMigration as AutoMigration
+import qualified Test.Batchable as Batchable
 import qualified Test.Connection as Connection
 import qualified Test.Cursor as Cursor
 import qualified Test.EntityOperations as EntityOperations
@@ -83,6 +84,7 @@ main = do
       , ExprConditional.conditionalTests
       , ExprWindow.windowTests
       , ExprTextSearch.textSearchTests pool
+      , Batchable.batchableTests
       , FieldDefinition.fieldDefinitionTests pool
       , SqlMarshaller.sqlMarshallerTests
       , MarshallError.marshallErrorTests pool

--- a/orville-postgresql/test/Test/Batchable.hs
+++ b/orville-postgresql/test/Test/Batchable.hs
@@ -1,0 +1,95 @@
+module Test.Batchable
+  ( batchableTests
+  ) where
+
+import qualified Data.List.NonEmpty as NE
+import Hedgehog ((===))
+import qualified Hedgehog as HH
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+import qualified Orville.PostgreSQL.Batchable as Batchable
+
+import qualified Test.Property as Property
+
+batchableTests :: Property.Group
+batchableTests =
+  Property.group
+    "Batchable"
+    [ prop_nonEmptyToUnbatched
+    , prop_nonEmptyToBatchedReturnsAllItems
+    , prop_nonEmptyToBatchedSizesBatchesCorrectly
+    ]
+
+prop_nonEmptyToUnbatched :: Property.NamedProperty
+prop_nonEmptyToUnbatched =
+  Property.namedProperty "(toUnbatched . batchNonEmpty) returns the original list" $ do
+    autoSize <- HH.forAll (Gen.int (Range.linear 1 10))
+    list <- HH.forAll $ Gen.nonEmpty (Range.linear 1 100) (Gen.int (Range.linear 10 99))
+    (Batchable.toUnbatched . Batchable.batchNonEmpty autoSize $ list) === list
+
+prop_nonEmptyToBatchedReturnsAllItems :: Property.NamedProperty
+prop_nonEmptyToBatchedReturnsAllItems =
+  Property.namedProperty "(toBatched . batchNonEmpty) returns all items in the original list, in order" $ do
+    autoSize <- HH.forAll (Gen.int (Range.linear 1 10))
+    list <- HH.forAll $ Gen.nonEmpty (Range.linear 1 100) (Gen.int (Range.linear 10 99))
+    batchSize <-
+      HH.forAll $
+        Gen.frequency
+          [ (1, pure Batchable.BatchSizeAuto)
+          , (5, Batchable.BatchSize <$> Gen.int (Range.linear 1 10))
+          ]
+
+    let
+      allBatchedItems =
+        concat
+          . map NE.toList
+          . Batchable.toBatched batchSize
+          . Batchable.batchNonEmpty autoSize
+          $ list
+
+    allBatchedItems === NE.toList list
+
+prop_nonEmptyToBatchedSizesBatchesCorrectly :: Property.NamedProperty
+prop_nonEmptyToBatchedSizesBatchesCorrectly =
+  Property.namedProperty "(toBatched . batchNonEmpty) sizes batches correctly" $ do
+    autoSize <- HH.forAll (Gen.int (Range.linear 1 10))
+    list <- HH.forAll $ Gen.nonEmpty (Range.linear 1 100) (Gen.int (Range.linear 10 99))
+    batchSize <-
+      HH.forAll $
+        Gen.frequency
+          [ (1, pure Batchable.BatchSizeAuto)
+          , (5, Batchable.BatchSize <$> Gen.int (Range.linear 1 10))
+          ]
+
+    let
+      itemCount =
+        NE.length list
+
+      expectedBatchSize =
+        case batchSize of
+          Batchable.BatchSizeAuto -> autoSize
+          Batchable.BatchSize size -> size
+
+      expectedBatchCount =
+        itemCount `div` expectedBatchSize
+
+      leftoverCount =
+        itemCount - (expectedBatchCount * expectedBatchSize)
+
+      expectedLeftovers =
+        if leftoverCount > 0
+          then [leftoverCount]
+          else []
+
+      expectedBatchSizes =
+        replicate expectedBatchCount expectedBatchSize
+          <> expectedLeftovers
+
+      actualBatchSizes =
+        map NE.length
+          . Batchable.toBatched batchSize
+          . Batchable.batchNonEmpty autoSize
+          $ list
+
+    actualBatchSizes === expectedBatchSizes

--- a/orville-postgresql/test/Test/Cursor.hs
+++ b/orville-postgresql/test/Test/Cursor.hs
@@ -42,7 +42,7 @@ prop_withCursorFetch =
     actualRows <-
       Foo.withTable pool $ do
         Orville.withTransaction $ do
-          _ <- Orville.insertEntities Foo.table foos
+          _ <- Orville.insertEntities Orville.InOneStatement Foo.table foos
           Exec.withCursor Nothing Nothing selectAllFoosOrderedById $ \cursor ->
             Exec.fetch (Just $ Exec.forwardCount numToFetch) cursor
 
@@ -69,7 +69,7 @@ prop_withCursorMove =
     actualRows <-
       Foo.withTable pool $ do
         Orville.withTransaction $ do
-          _ <- Orville.insertEntities Foo.table foos
+          _ <- Orville.insertEntities Orville.InOneStatement Foo.table foos
           Exec.withCursor Nothing Nothing selectAllFoosOrderedById $ \cursor -> do
             Exec.move (Just $ Exec.forwardCount numToSkip) cursor
             Exec.fetch (Just $ Exec.forwardCount numToFetch) cursor

--- a/orville-postgresql/test/Test/Entities/Foo.hs
+++ b/orville-postgresql/test/Test/Entities/Foo.hs
@@ -23,6 +23,7 @@ module Test.Entities.Foo
   , hasName
   , hasAge
   , averageFooAge
+  , fooMarshaller
   , nameAndAgeMarshaller
   )
 where

--- a/orville-postgresql/test/Test/EntityOperations.hs
+++ b/orville-postgresql/test/Test/EntityOperations.hs
@@ -27,30 +27,33 @@ entityOperationsTests pool =
   Property.group
     "EntityOperations"
     [ prop_insertEntitiesFindEntitiesByRoundTrip pool
-    , prop_insertEntitiesAffectedRows pool
+    , prop_insertEntitiesAndReturnRowCount pool
+    , prop_insertEntitiesAndReturnRowCountBatched pool
+    , prop_insertAndReturnEntitiesBatched pool
     , prop_insertEntitiesFindFirstEntityByRoundTrip pool
     , prop_insertEntityFindEntityRoundTrip pool
     , prop_insertEntityFindEntitiesRoundTrip pool
+    , prop_insertEntityFindEntitiesRoundTripBatched pool
     , prop_insertEntityFindEntitiesCompositeKeyRoundTrip pool
     , prop_insertAndReturnEntity pool
     , prop_updateEntity pool
-    , prop_updateEntityAffectedRows pool
+    , prop_updateEntityAndReturnRowCount pool
     , prop_updateAndReturnEntity pool
     , prop_updateEntity_NoMatch pool
     , prop_updateAndReturnEntity_NoMatch pool
     , prop_deleteEntity pool
-    , prop_deleteEntityAffectedRows pool
+    , prop_deleteEntityAndReturnRowCount pool
     , prop_deleteAndReturnEntity pool
     , prop_deleteEntity_NoMatch pool
     , prop_deleteAndReturnEntity_NoMatch pool
     , prop_deleteEntities pool
-    , prop_deleteEntitiesAffectedRows pool
+    , prop_deleteEntitiesAndReturnRowCount pool
     , prop_deleteEntities_NoMatch pool
     , prop_deleteAndReturnEntities pool
     , prop_deleteAndReturnEntities_NoMatch pool
     , prop_updateFields pool
     , prop_updateFields_NoMatch pool
-    , prop_updateFieldsAffectedRows pool
+    , prop_updateFieldsAndReturnRowCount pool
     , prop_updateFieldsAndReturnEntities pool
     , prop_updateFieldsAndReturnEntities_NoMatch pool
     , prop_upsertByPrimaryKeyRoundTrip pool
@@ -60,9 +63,13 @@ entityOperationsTests pool =
     , prop_upsertByMarshallerRoundTrip pool
     , prop_upsertByConflictTargetExprRoundTrip pool
     , prop_upsertAndReturnEntity pool
-    , prop_upsertEntitiesAffectedRows pool
+    , prop_upsertEntitiesAndReturnRowCount pool
+    , prop_upsertEntitiesAndReturnRowCountBatched pool
     , prop_upsertEntitiesFindEntitiesRoundTrip pool
+    , prop_upsertEntitiesFindEntitiesRoundTripBatched pool
+    , prop_upsertAndReturnEntitiesBatched pool
     , prop_upsertEntitiesMixedInsertsAndUpdates pool
+    , prop_upsertEntitiesMixedInsertsAndUpdatesBatched pool
     ]
 
 prop_insertEntitiesFindEntitiesByRoundTrip :: Property.NamedDBProperty
@@ -87,7 +94,7 @@ prop_insertEntitiesFindFirstEntityByRoundTrip =
 
     mbRetrievedFoo <-
       Foo.withTable pool $ do
-        mapM_ (Orville.insertEntities Foo.table) (NEL.nonEmpty originalFoos)
+        mapM_ (Orville.insertEntities Orville.InOneStatement Foo.table) (NEL.nonEmpty originalFoos)
         Orville.findFirstEntityBy Foo.table mempty
 
     let
@@ -100,21 +107,49 @@ prop_insertEntitiesFindFirstEntityByRoundTrip =
     -- and assert which item is returned.
     length (Maybe.maybeToList mbRetrievedFoo) === expectedLength
 
-prop_insertEntitiesAffectedRows :: Property.NamedDBProperty
-prop_insertEntitiesAffectedRows =
-  Property.namedDBProperty "insertEntities returns the number of affected rows" $ \pool -> do
-    originalFoos <- HH.forAll $ Foo.generateList (Range.linear 0 10)
-
-    HH.cover 1 (String.fromString "empty list") (null originalFoos)
-    HH.cover 20 (String.fromString "non-empty list") (not (null originalFoos))
+prop_insertEntitiesAndReturnRowCount :: Property.NamedDBProperty
+prop_insertEntitiesAndReturnRowCount =
+  Property.namedDBProperty "insertEntitiesAndReturnRowCount returns the number of affected rows" $ \pool -> do
+    foos <- HH.forAll $ Foo.generateNonEmpty (Range.linear 1 10)
 
     affectedRows <-
       Foo.withTable pool $ do
-        case NEL.nonEmpty originalFoos of
-          Nothing -> pure 0
-          Just nonEmptyFoos -> Orville.insertEntitiesAndReturnRowCount Foo.table nonEmptyFoos
+        Orville.insertEntitiesAndReturnRowCount
+          Orville.InOneStatement
+          Foo.table
+          foos
 
-    affectedRows === length originalFoos
+    affectedRows === length foos
+
+prop_insertEntitiesAndReturnRowCountBatched :: Property.NamedDBProperty
+prop_insertEntitiesAndReturnRowCountBatched =
+  Property.namedDBProperty "insertEntitiesAndReturnRowCount returns the number of affected rows (batched)" $ \pool -> do
+    foos <- HH.forAll $ Foo.generateNonEmpty (Range.linear 1 10)
+    batchSize <- HH.forAll $ Gen.int (Range.linear 1 5)
+
+    affectedRows <-
+      Foo.withTable pool $ do
+        Orville.insertEntitiesAndReturnRowCount
+          (Orville.InBatches (Orville.BatchSize batchSize) Orville.WithNewTransaction)
+          Foo.table
+          foos
+
+    affectedRows === length foos
+
+prop_insertAndReturnEntitiesBatched :: Property.NamedDBProperty
+prop_insertAndReturnEntitiesBatched =
+  Property.singletonNamedDBProperty "insertAndReturnEntities returns the inserted entities (batched)" $ \pool -> do
+    foos <- HH.forAll $ Foo.generateNonEmpty (Range.linear 1 10)
+    batchSize <- HH.forAll $ Gen.int (Range.linear 1 5)
+
+    returnedFoos <-
+      Foo.withTable pool $ do
+        Orville.insertAndReturnEntities
+          (Orville.InBatches (Orville.BatchSize batchSize) Orville.WithNewTransaction)
+          Foo.table
+          foos
+
+    returnedFoos === NEL.toList foos
 
 prop_insertEntityFindEntityRoundTrip :: Property.NamedDBProperty
 prop_insertEntityFindEntityRoundTrip =
@@ -135,7 +170,23 @@ prop_insertEntityFindEntitiesRoundTrip =
 
     retrievedFoos <-
       Foo.withTable pool $ do
-        Orville.insertEntities Foo.table foos
+        Orville.insertEntities Orville.InOneStatement Foo.table foos
+        Orville.findEntities Foo.table (Foo.fooId <$> foos)
+
+    List.sortOn Foo.fooId retrievedFoos === List.sortOn Foo.fooId (NEL.toList foos)
+
+prop_insertEntityFindEntitiesRoundTripBatched :: Property.NamedDBProperty
+prop_insertEntityFindEntitiesRoundTripBatched =
+  Property.singletonNamedDBProperty "insertEntity/findEntities form a round trip (batched)" $ \pool -> do
+    foos <- HH.forAll $ Foo.generateNonEmpty (Range.linear 1 10)
+    batchSize <- HH.forAll $ Gen.int (Range.linear 1 5)
+
+    retrievedFoos <-
+      Foo.withTable pool $ do
+        Orville.insertEntities
+          (Orville.InBatches (Orville.BatchSize batchSize) Orville.WithNewTransaction)
+          Foo.table
+          foos
         Orville.findEntities Foo.table (Foo.fooId <$> foos)
 
     List.sortOn Foo.fooId retrievedFoos === List.sortOn Foo.fooId (NEL.toList foos)
@@ -147,7 +198,7 @@ prop_insertEntityFindEntitiesCompositeKeyRoundTrip =
 
     retrievedCompositeKeyEntities <-
       CompositeKeyEntity.withTable pool $ do
-        Orville.insertEntities CompositeKeyEntity.table compositeKeyEntities
+        Orville.insertEntities Orville.InOneStatement CompositeKeyEntity.table compositeKeyEntities
         Orville.findEntities CompositeKeyEntity.table (CompositeKeyEntity.compositeKey <$> compositeKeyEntities)
 
     List.sortOn CompositeKeyEntity.compositeKey retrievedCompositeKeyEntities === List.sortOn CompositeKeyEntity.compositeKey (NEL.toList compositeKeyEntities)
@@ -177,9 +228,9 @@ prop_updateEntity =
 
     returnedFoo === [newFoo]
 
-prop_updateEntityAffectedRows :: Property.NamedDBProperty
-prop_updateEntityAffectedRows =
-  Property.singletonNamedDBProperty "updateEntity returns the number of affected rows" $ \pool -> do
+prop_updateEntityAndReturnRowCount :: Property.NamedDBProperty
+prop_updateEntityAndReturnRowCount =
+  Property.singletonNamedDBProperty "updateEntityAndReturnRowCount returns the number of affected rows" $ \pool -> do
     originalFoo <- HH.forAll Foo.generate
     newFoo <- HH.forAll Foo.generate
 
@@ -255,9 +306,9 @@ prop_deleteEntity =
 
     retrievedFoos === [anotherFoo]
 
-prop_deleteEntityAffectedRows :: Property.NamedDBProperty
-prop_deleteEntityAffectedRows =
-  Property.singletonNamedDBProperty "deleteEntity returns the number of affected rows" $ \pool -> do
+prop_deleteEntityAndReturnRowCount :: Property.NamedDBProperty
+prop_deleteEntityAndReturnRowCount =
+  Property.singletonNamedDBProperty "deleteEntityAndReturnRowCount returns the number of affected rows" $ \pool -> do
     originalFoo <- HH.forAll Foo.generate
     let
       withDifferentKey = Gen.filter $ (Foo.fooId originalFoo /=) . Foo.fooId
@@ -325,7 +376,7 @@ prop_deleteEntities =
 
     remainingFoos <-
       Foo.withTable pool $ do
-        Orville.insertEntities Foo.table foos
+        Orville.insertEntities Orville.InOneStatement Foo.table foos
         Orville.deleteEntities
           Foo.table
           (Just (Orville.fieldIn Foo.fooIdField fooIds))
@@ -335,9 +386,9 @@ prop_deleteEntities =
 
     fmap Foo.fooId remainingFoos === []
 
-prop_deleteEntitiesAffectedRows :: Property.NamedDBProperty
-prop_deleteEntitiesAffectedRows =
-  Property.singletonNamedDBProperty "deleteEntities returns the number of affected rows" $ \pool -> do
+prop_deleteEntitiesAndReturnRowCount :: Property.NamedDBProperty
+prop_deleteEntitiesAndReturnRowCount =
+  Property.singletonNamedDBProperty "deleteEntitiesAndReturnRowCount returns the number of affected rows" $ \pool -> do
     foos <- HH.forAll $ Foo.generateNonEmpty (Range.linear 1 5)
 
     let
@@ -345,7 +396,7 @@ prop_deleteEntitiesAffectedRows =
 
     affectedRows <-
       Foo.withTable pool $ do
-        Orville.insertEntities Foo.table foos
+        Orville.insertEntities Orville.InOneStatement Foo.table foos
         Orville.deleteEntitiesAndReturnRowCount
           Foo.table
           (Just (Orville.fieldIn Foo.fooIdField fooIds))
@@ -363,7 +414,7 @@ prop_deleteEntities_NoMatch =
 
     remainingFoos <-
       Foo.withTable pool $ do
-        Orville.insertEntities Foo.table foos
+        Orville.insertEntities Orville.InOneStatement Foo.table foos
         Orville.deleteEntities
           Foo.table
           (Just (Orville.fieldEquals Foo.fooIdField mismatchedId))
@@ -383,7 +434,7 @@ prop_deleteAndReturnEntities =
 
     deletedFoos <-
       Foo.withTable pool $ do
-        Orville.insertEntities Foo.table foos
+        Orville.insertEntities Orville.InOneStatement Foo.table foos
         Orville.deleteAndReturnEntities
           Foo.table
           (Just (Orville.fieldIn Foo.fooIdField fooIds))
@@ -401,7 +452,7 @@ prop_deleteAndReturnEntities_NoMatch =
 
     deletedFoos <-
       Foo.withTable pool $ do
-        Orville.insertEntities Foo.table foos
+        Orville.insertEntities Orville.InOneStatement Foo.table foos
         Orville.deleteAndReturnEntities
           Foo.table
           (Just (Orville.fieldEquals Foo.fooIdField mismatchedId))
@@ -419,7 +470,7 @@ prop_updateFields =
 
     updatedFoos <-
       Foo.withTable pool $ do
-        Orville.insertEntities Foo.table foos
+        Orville.insertEntities Orville.InOneStatement Foo.table foos
         Orville.updateFields
           Foo.table
           (Orville.setField Foo.fooNameField updatedName :| [])
@@ -442,7 +493,7 @@ prop_updateFields_NoMatch =
 
     foosAfterUpdate <-
       Foo.withTable pool $ do
-        Orville.insertEntities Foo.table foos
+        Orville.insertEntities Orville.InOneStatement Foo.table foos
         Orville.updateFields
           Foo.table
           (Orville.setField Foo.fooNameField updatedName :| [])
@@ -451,9 +502,9 @@ prop_updateFields_NoMatch =
 
     List.sortOn Foo.fooId foosAfterUpdate === List.sortOn Foo.fooId (NEL.toList foos)
 
-prop_updateFieldsAffectedRows :: Property.NamedDBProperty
-prop_updateFieldsAffectedRows =
-  Property.singletonNamedDBProperty "updateFields returns the number of affeted rows" $ \pool -> do
+prop_updateFieldsAndReturnRowCount :: Property.NamedDBProperty
+prop_updateFieldsAndReturnRowCount =
+  Property.singletonNamedDBProperty "updateFieldsAndReturnRowCount returns the number of affeted rows" $ \pool -> do
     foos <- HH.forAll $ Foo.generateNonEmpty (Range.linear 1 5)
 
     let
@@ -462,7 +513,7 @@ prop_updateFieldsAffectedRows =
 
     affectedRows <-
       Foo.withTable pool $ do
-        Orville.insertEntities Foo.table foos
+        Orville.insertEntities Orville.InOneStatement Foo.table foos
         Orville.updateFieldsAndReturnRowCount
           Foo.table
           (Orville.setField Foo.fooNameField updatedName :| [])
@@ -481,7 +532,7 @@ prop_updateFieldsAndReturnEntities =
 
     updatedFoos <-
       Foo.withTable pool $ do
-        Orville.insertEntities Foo.table foos
+        Orville.insertEntities Orville.InOneStatement Foo.table foos
         Orville.updateFieldsAndReturnEntities
           Foo.table
           (Orville.setField Foo.fooNameField updatedName :| [])
@@ -501,7 +552,7 @@ prop_updateFieldsAndReturnEntities_NoMatch =
 
     updatedFoos <-
       Foo.withTable pool $ do
-        Orville.insertEntities Foo.table foos
+        Orville.insertEntities Orville.InOneStatement Foo.table foos
         Orville.updateFieldsAndReturnEntities
           Foo.table
           (Orville.setField Foo.fooNameField updatedName :| [])
@@ -647,17 +698,34 @@ prop_upsertAndReturnEntity =
     originalReturned === entity
     updatedReturned === updated
 
-prop_upsertEntitiesAffectedRows :: Property.NamedDBProperty
-prop_upsertEntitiesAffectedRows =
+prop_upsertEntitiesAndReturnRowCount :: Property.NamedDBProperty
+prop_upsertEntitiesAndReturnRowCount =
   Property.namedDBProperty "upsertEntitiesAndReturnRowCount returns the number of affected rows" $ \pool -> do
-    entities <- HH.forAll $ UpsertEntity.generateList (Range.linear 0 10)
+    entities <- HH.forAll $ UpsertEntity.generateNonEmpty (Range.linear 1 10)
 
     affectedRows <-
       UpsertEntity.withTable pool $ do
-        case NEL.nonEmpty entities of
-          Nothing -> pure 0
-          Just nonEmpty ->
-            Orville.upsertEntitiesAndReturnRowCount UpsertEntity.table Orville.ByPrimaryKey nonEmpty
+        Orville.upsertEntitiesAndReturnRowCount
+          Orville.InOneStatement
+          UpsertEntity.table
+          Orville.ByPrimaryKey
+          entities
+
+    affectedRows === length entities
+
+prop_upsertEntitiesAndReturnRowCountBatched :: Property.NamedDBProperty
+prop_upsertEntitiesAndReturnRowCountBatched =
+  Property.namedDBProperty "upsertEntitiesAndReturnRowCount returns the number of affected rows (batched)" $ \pool -> do
+    entities <- HH.forAll $ UpsertEntity.generateNonEmpty (Range.linear 1 10)
+    batchSize <- HH.forAll $ Gen.int (Range.linear 1 5)
+
+    affectedRows <-
+      UpsertEntity.withTable pool $ do
+        Orville.upsertEntitiesAndReturnRowCount
+          (Orville.InBatches (Orville.BatchSize batchSize) Orville.WithNewTransaction)
+          UpsertEntity.table
+          Orville.ByPrimaryKey
+          entities
 
     affectedRows === length entities
 
@@ -668,10 +736,43 @@ prop_upsertEntitiesFindEntitiesRoundTrip =
 
     retrievedEntities <-
       UpsertEntity.withTable pool $ do
-        Orville.upsertEntities UpsertEntity.table Orville.ByPrimaryKey entities
+        Orville.upsertEntities Orville.InOneStatement UpsertEntity.table Orville.ByPrimaryKey entities
         Orville.findEntities UpsertEntity.table (UpsertEntity.upsertEntityId <$> entities)
 
     List.sortOn UpsertEntity.upsertEntityId retrievedEntities === List.sortOn UpsertEntity.upsertEntityId (NEL.toList entities)
+
+prop_upsertEntitiesFindEntitiesRoundTripBatched :: Property.NamedDBProperty
+prop_upsertEntitiesFindEntitiesRoundTripBatched =
+  Property.singletonNamedDBProperty "upsertEntities/findEntities form a round trip (batched)" $ \pool -> do
+    entities <- HH.forAll $ UpsertEntity.generateNonEmpty (Range.linear 1 5)
+    batchSize <- HH.forAll $ Gen.int (Range.linear 1 5)
+
+    retrievedEntities <-
+      UpsertEntity.withTable pool $ do
+        Orville.upsertEntities
+          (Orville.InBatches (Orville.BatchSize batchSize) Orville.WithNewTransaction)
+          UpsertEntity.table
+          Orville.ByPrimaryKey
+          entities
+        Orville.findEntities UpsertEntity.table (UpsertEntity.upsertEntityId <$> entities)
+
+    List.sortOn UpsertEntity.upsertEntityId retrievedEntities === List.sortOn UpsertEntity.upsertEntityId (NEL.toList entities)
+
+prop_upsertAndReturnEntitiesBatched :: Property.NamedDBProperty
+prop_upsertAndReturnEntitiesBatched =
+  Property.singletonNamedDBProperty "upsertAndReturnEntities returns the upserted entities (batched)" $ \pool -> do
+    entities <- HH.forAll $ UpsertEntity.generateNonEmpty (Range.linear 1 10)
+    batchSize <- HH.forAll $ Gen.int (Range.linear 1 5)
+
+    returnedEntities <-
+      UpsertEntity.withTable pool $ do
+        Orville.upsertAndReturnEntities
+          (Orville.InBatches (Orville.BatchSize batchSize) Orville.WithNewTransaction)
+          UpsertEntity.table
+          Orville.ByPrimaryKey
+          entities
+
+    List.sortOn UpsertEntity.upsertEntityId returnedEntities === List.sortOn UpsertEntity.upsertEntityId (NEL.toList entities)
 
 prop_upsertEntitiesMixedInsertsAndUpdates :: Property.NamedDBProperty
 prop_upsertEntitiesMixedInsertsAndUpdates =
@@ -685,7 +786,28 @@ prop_upsertEntitiesMixedInsertsAndUpdates =
     retrievedEntities <-
       UpsertEntity.withTable pool $ do
         Orville.upsertEntity UpsertEntity.table Orville.ByPrimaryKey existing
-        Orville.upsertEntities UpsertEntity.table Orville.ByPrimaryKey (updated :| [new])
+        Orville.upsertEntities Orville.InOneStatement UpsertEntity.table Orville.ByPrimaryKey (updated :| [new])
+        Orville.findEntitiesBy UpsertEntity.table mempty
+
+    List.sortOn UpsertEntity.upsertEntityId retrievedEntities === List.sortOn UpsertEntity.upsertEntityId [updated, new]
+
+prop_upsertEntitiesMixedInsertsAndUpdatesBatched :: Property.NamedDBProperty
+prop_upsertEntitiesMixedInsertsAndUpdatesBatched =
+  Property.singletonNamedDBProperty "upsertEntities handles a batch with both inserts and updates (batched)" $ \pool -> do
+    existing <- HH.forAll UpsertEntity.generate
+    new <- HH.forAll $ Gen.filter (\e -> UpsertEntity.upsertEntityId e /= UpsertEntity.upsertEntityId existing) UpsertEntity.generate
+    newValue <- HH.forAll UpsertEntity.generateUpsertEntityValue
+    let
+      updated = existing {UpsertEntity.upsertEntityValue = newValue}
+
+    retrievedEntities <-
+      UpsertEntity.withTable pool $ do
+        Orville.upsertEntity UpsertEntity.table Orville.ByPrimaryKey existing
+        Orville.upsertEntities
+          (Orville.InBatches (Orville.BatchSize 1) Orville.WithNewTransaction)
+          UpsertEntity.table
+          Orville.ByPrimaryKey
+          (updated :| [new])
         Orville.findEntitiesBy UpsertEntity.table mempty
 
     List.sortOn UpsertEntity.upsertEntityId retrievedEntities === List.sortOn UpsertEntity.upsertEntityId [updated, new]

--- a/orville-postgresql/test/Test/Expr/Count.hs
+++ b/orville-postgresql/test/Test/Expr/Count.hs
@@ -83,7 +83,7 @@ prop_countColumn =
 
     result <-
       Foo.withTable pool $ do
-        Fold.traverse_ (Orville.insertEntities Foo.table) (NEL.nonEmpty foos)
+        Fold.traverse_ (Orville.insertEntities Orville.InOneStatement Foo.table) (NEL.nonEmpty foos)
         Orville.executeAndDecode Orville.SelectQuery sql marshaller
 
     result === [List.genericLength foos]

--- a/orville-postgresql/test/Test/Plan.hs
+++ b/orville-postgresql/test/Test/Plan.hs
@@ -98,7 +98,7 @@ prop_findMaybeOne =
     (targetName, _, foos) <- HH.forAll generateSearchTargetAndSubjects
     maybeResult <-
       Foo.withTable pool $ do
-        traverse_ (Orville.insertEntities Foo.table) (NEL.nonEmpty foos)
+        traverse_ (Orville.insertEntities Orville.InOneStatement Foo.table) (NEL.nonEmpty foos)
         Plan.execute plan targetName
 
     let
@@ -117,7 +117,7 @@ prop_findMaybeOneByMarshaller =
     (targetName, targetAge, foos) <- HH.forAll generateSearchTargetAndSubjects
     maybeResult <-
       Foo.withTable pool $ do
-        traverse_ (Orville.insertEntities Foo.table) (NEL.nonEmpty foos)
+        traverse_ (Orville.insertEntities Orville.InOneStatement Foo.table) (NEL.nonEmpty foos)
         Plan.execute plan (targetName, targetAge)
 
     let
@@ -136,7 +136,7 @@ prop_planMany_findMaybeOne =
     (targetNames, _, foos) <- HH.forAll generateSearchTargetListAndSubjects
     results <-
       Foo.withTable pool $ do
-        traverse_ (Orville.insertEntities Foo.table) (NEL.nonEmpty foos)
+        traverse_ (Orville.insertEntities Orville.InOneStatement Foo.table) (NEL.nonEmpty foos)
         Plan.execute plan targetNames
 
     let
@@ -162,7 +162,7 @@ prop_planMany_findMaybeOneByMarshaller =
       target = zip targetNames targetAges
     results <-
       Foo.withTable pool $ do
-        traverse_ (Orville.insertEntities Foo.table) (NEL.nonEmpty foos)
+        traverse_ (Orville.insertEntities Orville.InOneStatement Foo.table) (NEL.nonEmpty foos)
         Plan.execute plan target
 
     let
@@ -190,7 +190,7 @@ prop_findMaybeOneWhere =
     (targetName, _, foos) <- HH.forAll generateSearchTargetAndSubjects
     maybeResult <-
       Foo.withTable pool $ do
-        traverse_ (Orville.insertEntities Foo.table) (NEL.nonEmpty foos)
+        traverse_ (Orville.insertEntities Orville.InOneStatement Foo.table) (NEL.nonEmpty foos)
         Plan.execute plan targetName
 
     let
@@ -213,7 +213,7 @@ prop_findMaybeOneWhereByMarshaller =
     (targetName, targetAge, foos) <- HH.forAll generateSearchTargetAndSubjects
     maybeResult <-
       Foo.withTable pool $ do
-        traverse_ (Orville.insertEntities Foo.table) (NEL.nonEmpty foos)
+        traverse_ (Orville.insertEntities Orville.InOneStatement Foo.table) (NEL.nonEmpty foos)
         Plan.execute plan (targetName, targetAge)
 
     let
@@ -237,7 +237,7 @@ prop_planMany_findMaybeOneWhere =
     (targetNames, _, foos) <- HH.forAll generateSearchTargetListAndSubjects
     results <-
       Foo.withTable pool $ do
-        traverse_ (Orville.insertEntities Foo.table) (NEL.nonEmpty foos)
+        traverse_ (Orville.insertEntities Orville.InOneStatement Foo.table) (NEL.nonEmpty foos)
         Plan.execute plan targetNames
 
     let
@@ -272,7 +272,7 @@ prop_planMany_findMaybeOneWhereByMarshaller =
 
     results <-
       Foo.withTable pool $ do
-        traverse_ (Orville.insertEntities Foo.table) (NEL.nonEmpty foos)
+        traverse_ (Orville.insertEntities Orville.InOneStatement Foo.table) (NEL.nonEmpty foos)
         Plan.execute plan target
 
     let
@@ -298,7 +298,7 @@ prop_findAll =
     (targetName, _, foos) <- HH.forAll generateSearchTargetAndSubjects
     results <-
       Foo.withTable pool $ do
-        traverse_ (Orville.insertEntities Foo.table) (NEL.nonEmpty foos)
+        traverse_ (Orville.insertEntities Orville.InOneStatement Foo.table) (NEL.nonEmpty foos)
         Plan.execute plan targetName
 
     let
@@ -317,7 +317,7 @@ prop_findAllByMarshaller =
     (targetName, targetAge, foos) <- HH.forAll generateSearchTargetAndSubjects
     results <-
       Foo.withTable pool $ do
-        traverse_ (Orville.insertEntities Foo.table) (NEL.nonEmpty foos)
+        traverse_ (Orville.insertEntities Orville.InOneStatement Foo.table) (NEL.nonEmpty foos)
         Plan.execute plan (targetName, targetAge)
 
     let
@@ -336,7 +336,7 @@ prop_planMany_findAll =
     (targetNames, _, foos) <- HH.forAll generateSearchTargetListAndSubjects
     results <-
       Foo.withTable pool $ do
-        traverse_ (Orville.insertEntities Foo.table) (NEL.nonEmpty foos)
+        traverse_ (Orville.insertEntities Orville.InOneStatement Foo.table) (NEL.nonEmpty foos)
         Plan.execute plan targetNames
 
     let
@@ -358,7 +358,7 @@ prop_planTraversable_Map_findAll =
       targetNamesMap = Map.fromList $ Monad.join zip targetNames
     results <-
       Foo.withTable pool $ do
-        traverse_ (Orville.insertEntities Foo.table) (NEL.nonEmpty foos)
+        traverse_ (Orville.insertEntities Orville.InOneStatement Foo.table) (NEL.nonEmpty foos)
         Plan.execute plan targetNamesMap
 
     let
@@ -385,7 +385,7 @@ prop_planMany_findAllByMarshaller =
       target = zip targetNames targetAges
     results <-
       Foo.withTable pool $ do
-        traverse_ (Orville.insertEntities Foo.table) (NEL.nonEmpty foos)
+        traverse_ (Orville.insertEntities Orville.InOneStatement Foo.table) (NEL.nonEmpty foos)
         Plan.execute plan target
 
     let
@@ -409,7 +409,7 @@ prop_findAllWhere =
     (targetName, _, foos) <- HH.forAll generateSearchTargetAndSubjects
     results <-
       Foo.withTable pool $ do
-        traverse_ (Orville.insertEntities Foo.table) (NEL.nonEmpty foos)
+        traverse_ (Orville.insertEntities Orville.InOneStatement Foo.table) (NEL.nonEmpty foos)
         Plan.execute plan targetName
 
     let
@@ -432,7 +432,7 @@ prop_findAllWhereByMarshaller =
     (targetName, targetAge, foos) <- HH.forAll generateSearchTargetAndSubjects
     results <-
       Foo.withTable pool $ do
-        traverse_ (Orville.insertEntities Foo.table) (NEL.nonEmpty foos)
+        traverse_ (Orville.insertEntities Orville.InOneStatement Foo.table) (NEL.nonEmpty foos)
         Plan.execute plan (targetName, targetAge)
 
     let
@@ -456,7 +456,7 @@ prop_planMany_findAllWhere =
     (targetNames, _, foos) <- HH.forAll generateSearchTargetListAndSubjects
     results <-
       Foo.withTable pool $ do
-        traverse_ (Orville.insertEntities Foo.table) (NEL.nonEmpty foos)
+        traverse_ (Orville.insertEntities Orville.InOneStatement Foo.table) (NEL.nonEmpty foos)
         Plan.execute plan targetNames
 
     let
@@ -483,7 +483,7 @@ prop_planMany_findAllWhereByMarshaller =
       target = zip targetNames targetAges
     results <-
       Foo.withTable pool $ do
-        traverse_ (Orville.insertEntities Foo.table) (NEL.nonEmpty foos)
+        traverse_ (Orville.insertEntities Orville.InOneStatement Foo.table) (NEL.nonEmpty foos)
         Plan.execute plan target
 
     let
@@ -544,7 +544,7 @@ prop_planMany_planEither =
 
     foundFoos <-
       Foo.withTable pool $ do
-        traverse_ (Orville.insertEntities Foo.table) (NEL.nonEmpty foos)
+        traverse_ (Orville.insertEntities Orville.InOneStatement Foo.table) (NEL.nonEmpty foos)
         Plan.execute plan params
 
     assertEachManyResult params foundFoos $ \input foo ->
@@ -602,8 +602,8 @@ prop_planMany_bindAndUse =
 
     results <-
       FooChild.withTables pool $ do
-        traverse_ (Orville.insertEntities Foo.table) (NEL.nonEmpty allFoos)
-        traverse_ (Orville.insertEntities FooChild.table) (NEL.nonEmpty allChildren)
+        traverse_ (Orville.insertEntities Orville.InOneStatement Foo.table) (NEL.nonEmpty allFoos)
+        traverse_ (Orville.insertEntities Orville.InOneStatement FooChild.table) (NEL.nonEmpty allChildren)
         Plan.execute plan allFooNames
 
     assertEachManyResult allFooNames results $ \fooName (foo, children) -> do
@@ -686,8 +686,8 @@ prop_planMany_bindAndUse_qualifiedDo =
 
     results <-
       FooChild.withTables pool $ do
-        traverse_ (Orville.insertEntities Foo.table) (NEL.nonEmpty allFoos)
-        traverse_ (Orville.insertEntities FooChild.table) (NEL.nonEmpty allChildren)
+        traverse_ (Orville.insertEntities Orville.InOneStatement Foo.table) (NEL.nonEmpty allFoos)
+        traverse_ (Orville.insertEntities Orville.InOneStatement FooChild.table) (NEL.nonEmpty allChildren)
         Plan.execute plan allFooNames
 
     assertEachManyResult allFooNames results $ \fooName (foo, children) -> do

--- a/orville-postgresql/test/Test/RawSql.hs
+++ b/orville-postgresql/test/Test/RawSql.hs
@@ -9,6 +9,7 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
 import Hedgehog ((===))
 import qualified Hedgehog as HH
+import qualified Hedgehog.Gen as Gen
 
 import qualified Orville.PostgreSQL as Orville
 import qualified Orville.PostgreSQL.Raw.Connection as Conn
@@ -28,6 +29,7 @@ rawSqlTests pool =
     , prop_escapesIdentifiersForExamples
     , prop_escapesStringLiteralsForConnections pool
     , prop_escapesIdentifiersForConnections pool
+    , prop_toParamCountIsAccurate
     ]
 
 prop_concatenatesSQLStrings :: Property.NamedProperty
@@ -157,3 +159,25 @@ prop_escapesIdentifiersForConnections =
           RawSql.toBytesAndParams (RawSql.connectionQuoting conn) rawSql
 
     actualBytes === expectedBytes
+
+prop_toParamCountIsAccurate :: Property.NamedProperty
+prop_toParamCountIsAccurate =
+  Property.singletonNamedProperty "toParamCount is accurate" $ do
+    let
+      genSqlAndParams =
+        Gen.choice
+          [ pure (RawSql.fromString "Foo", [0])
+          , pure (RawSql.parameter (SqlValue.fromInt8 0), [1])
+          , pure (RawSql.identifier (B8.pack "Bar"), [0])
+          , pure (RawSql.stringLiteral (B8.pack "Baz"), [0])
+          , pure (mempty, [0])
+          , (<>) <$> Gen.small genSqlAndParams <*> Gen.small genSqlAndParams
+          ]
+
+      showSqlAndParams :: (RawSql.RawSql, [Int]) -> String
+      showSqlAndParams (rawSql, params) =
+        show (RawSql.toExampleBytes rawSql, params)
+
+    (rawSql, params) <- HH.forAllWith showSqlAndParams genSqlAndParams
+
+    RawSql.toParamCount rawSql === sum params

--- a/orville-postgresql/test/Test/TableDefinition.hs
+++ b/orville-postgresql/test/Test/TableDefinition.hs
@@ -345,7 +345,7 @@ prop_autoSizedBatchedInsertCountsOnConflictParams =
       onConflictExpr :: Expr.OnConflictExpr
       onConflictExpr =
         RawSql.unsafeFromRawSql
-          ( RawSql.fromString "ON CONFLICT DO NOTHING "
+          ( RawSql.toRawSql Expr.onConflictDoNothing
               <> onConflictWithParams
           )
 

--- a/orville-postgresql/test/Test/TableDefinition.hs
+++ b/orville-postgresql/test/Test/TableDefinition.hs
@@ -6,6 +6,7 @@ where
 import qualified Control.Exception as E
 import qualified Control.Monad.IO.Class as MIO
 import qualified Data.ByteString.Char8 as B8
+import Data.Foldable (traverse_)
 import Data.List.NonEmpty (NonEmpty ((:|)))
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Set as Set
@@ -14,10 +15,13 @@ import Hedgehog ((===))
 import qualified Hedgehog as HH
 
 import qualified Orville.PostgreSQL as Orville
+import qualified Orville.PostgreSQL.Batchable as Batchable
 import qualified Orville.PostgreSQL.Execution.ReturningOption as ReturningOption
 import qualified Orville.PostgreSQL.Execution.Select as Select
+import qualified Orville.PostgreSQL.Expr as Expr
 import qualified Orville.PostgreSQL.Raw.Connection as Conn
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+import qualified Orville.PostgreSQL.Raw.SqlValue as SqlValue
 import qualified Orville.PostgreSQL.Schema as Schema
 import qualified Orville.PostgreSQL.Schema.ConstraintDefinition as ConstraintDefinition
 import qualified Orville.PostgreSQL.Schema.TableDefinition as TableDefinition
@@ -38,6 +42,8 @@ tableDefinitionTests pool =
     , prop_uniqueConstraint pool
     , prop_fieldConstraints
     , prop_insertDefaultValuesWithEmptyMarshaller pool
+    , prop_autoSizedBatchedInsert pool
+    , prop_autoSizedBatchedInsertCountsOnConflictParams
     ]
 
 prop_roundTrip :: Property.NamedDBProperty
@@ -47,11 +53,12 @@ prop_roundTrip =
 
     let
       insertFoo =
-        TableDefinition.mkInsertExpr
-          ReturningOption.WithoutReturning
-          Foo.table
-          Nothing
-          (originalFoo NE.:| [])
+        Batchable.toUnbatched $
+          TableDefinition.mkInsertExpr
+            ReturningOption.WithoutReturning
+            Foo.table
+            Nothing
+            (originalFoo NE.:| [])
 
       selectFoos =
         Select.selectTable Foo.table mempty
@@ -72,7 +79,12 @@ prop_readOnlyFields =
 
     let
       insertBar =
-        TableDefinition.mkInsertExpr ReturningOption.WithoutReturning Bar.table Nothing (originalBar :| [])
+        Batchable.toUnbatched $
+          TableDefinition.mkInsertExpr
+            ReturningOption.WithoutReturning
+            Bar.table
+            Nothing
+            (originalBar :| [])
 
       selectBars =
         Select.selectTable Bar.table mempty
@@ -96,11 +108,12 @@ prop_primaryKey =
         originalFoo {Foo.fooName = T.reverse $ Foo.fooName originalFoo}
 
       insertFoos =
-        TableDefinition.mkInsertExpr
-          ReturningOption.WithoutReturning
-          Foo.table
-          Nothing
-          (originalFoo :| [conflictingFoo])
+        Batchable.toUnbatched $
+          TableDefinition.mkInsertExpr
+            ReturningOption.WithoutReturning
+            Foo.table
+            Nothing
+            (originalFoo :| [conflictingFoo])
 
     result <- MIO.liftIO . E.try . Conn.withPoolConnection pool $ \connection -> do
       TestTable.dropAndRecreateTableDef connection Foo.table
@@ -128,11 +141,12 @@ prop_uniqueConstraint =
         originalFoo {Foo.fooId = 1 + Foo.fooId originalFoo}
 
       insertFoos =
-        TableDefinition.mkInsertExpr
-          ReturningOption.WithoutReturning
-          Foo.table
-          Nothing
-          (originalFoo :| [conflictingFoo])
+        Batchable.toUnbatched $
+          TableDefinition.mkInsertExpr
+            ReturningOption.WithoutReturning
+            Foo.table
+            Nothing
+            (originalFoo :| [conflictingFoo])
 
     result <- MIO.liftIO . E.try . Conn.withPoolConnection pool $ \connection -> do
       TestTable.dropAndRecreateTableDef connection fooTableWithUniqueNameConstraint
@@ -157,11 +171,12 @@ prop_checkConstraint =
           Foo.table
 
       insertFoo foo =
-        TableDefinition.mkInsertExpr
-          ReturningOption.WithoutReturning
-          Foo.table
-          Nothing
-          (pure foo)
+        Batchable.toUnbatched $
+          TableDefinition.mkInsertExpr
+            ReturningOption.WithoutReturning
+            Foo.table
+            Nothing
+            (pure foo)
 
       validFoo =
         originalFoo {Foo.fooAge = 6}
@@ -246,11 +261,12 @@ prop_insertDefaultValuesWithEmptyMarshaller =
         ]
 
       insertExpr =
-        TableDefinition.mkInsertExpr
-          ReturningOption.WithoutReturning
-          table
-          Nothing
-          entities
+        Batchable.toUnbatched $
+          TableDefinition.mkInsertExpr
+            ReturningOption.WithoutReturning
+            table
+            Nothing
+            entities
 
     result <- MIO.liftIO . Orville.runOrville pool $ do
       MIO.liftIO . Conn.withPoolConnection pool $ \connection -> do
@@ -259,3 +275,99 @@ prop_insertDefaultValuesWithEmptyMarshaller =
       Select.executeSelect $ Select.selectTable Bar.table mempty
 
     result === expectedResult
+
+prop_autoSizedBatchedInsert :: Property.NamedDBProperty
+prop_autoSizedBatchedInsert =
+  Property.singletonNamedDBProperty "Auto-sized batched insert keeps parameter count below postgresql max" $ \pool -> do
+    let
+      columnCount =
+        Orville.foldMarshallerFields
+          Foo.fooMarshaller
+          0
+          (const (+ 1))
+
+      entityCount =
+        -- postgresql allows 65535 params and we will include one param per column
+        70000 `div` columnCount
+
+      mkFoo n =
+        Foo.Foo n (T.pack ("Foo " <> show n)) n
+
+      entities =
+        mkFoo <$> (1 :| [2 .. entityCount])
+
+      insertExprs =
+        Batchable.toBatched Batchable.BatchSizeAuto $
+          TableDefinition.mkInsertExpr
+            ReturningOption.WithoutReturning
+            Foo.table
+            Nothing
+            entities
+
+    MIO.liftIO . Conn.withPoolConnection pool $ \connection -> do
+      TestTable.dropAndRecreateTableDef connection Foo.table
+      traverse_ (RawSql.executeVoid connection) insertExprs
+
+prop_autoSizedBatchedInsertCountsOnConflictParams :: Property.NamedProperty
+prop_autoSizedBatchedInsertCountsOnConflictParams =
+  Property.singletonNamedProperty "Auto-sized batched insert accounts for on conflict params" $ do
+    let
+      columnCount =
+        Orville.foldMarshallerFields
+          Foo.fooMarshaller
+          0
+          (const (+ 1))
+
+      entityCount =
+        -- Use enough entities that the on conflict params will push us past a
+        -- batch boundary. Without on conflict: 65535/3 = 21845 per batch.
+        -- With 10000 on conflict params: (65535-10000)/3 = 18511 per batch.
+        -- 40000 entities = 2 batches without, 3 batches with.
+        120000 `div` columnCount
+
+      mkFoo n =
+        Foo.Foo n (T.pack ("Foo " <> show n)) n
+
+      entities =
+        mkFoo <$> (1 :| [2 .. entityCount])
+
+      -- Build an OnConflictExpr that contains parameters. The exact SQL
+      -- doesn't need to be valid for this table — we just need it to have
+      -- a known parameter count so we can verify the batching accounts for it.
+      onConflictParamCount =
+        10000
+
+      onConflictWithParams =
+        mconcat
+          . replicate onConflictParamCount
+          $ RawSql.parameter (SqlValue.fromInt32 0)
+
+      onConflictExpr :: Expr.OnConflictExpr
+      onConflictExpr =
+        RawSql.unsafeFromRawSql
+          ( RawSql.fromString "ON CONFLICT DO NOTHING "
+              <> onConflictWithParams
+          )
+
+      batchesWithoutOnConflict =
+        Batchable.toBatched Batchable.BatchSizeAuto $
+          TableDefinition.mkInsertExpr
+            ReturningOption.WithoutReturning
+            Foo.table
+            Nothing
+            entities
+
+      batchesWithOnConflict =
+        Batchable.toBatched Batchable.BatchSizeAuto $
+          TableDefinition.mkInsertExpr
+            ReturningOption.WithoutReturning
+            Foo.table
+            (Just onConflictExpr)
+            entities
+
+    HH.footnote $ "Batches without OnConflict: " <> show (length batchesWithoutOnConflict)
+    HH.footnote $ "Batches with OnConflict: " <> show (length batchesWithOnConflict)
+
+    -- With the OnConflict params consuming available parameter slots, there
+    -- should be more batches needed.
+    HH.assert (length batchesWithOnConflict > length batchesWithoutOnConflict)


### PR DESCRIPTION
This changes the signature of the entity operations that insert multiple
entities to allow callers to request batching be performed to insert
the values in multiple statements.

The most common use case is to insert many entities with many columns
that would exceed the postgresql parameter limit. This is supported
via auto batch sizing. Explicit batch sizing is support also.

The caller must also specify if Orville should do its inserts in a new
transaction or not, either because they do not want any transaction at
all or because the caller knows a transaction is already open and
does not want to incur the cost of an extra savepoint being created.
