### PR TITLE
Add table policy support

### DIFF
--- a/orville-postgresql/CHANGELOG.md
+++ b/orville-postgresql/CHANGELOG.md
@@ -7,11 +7,43 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- Support for PostgreSQL row-level security policies: `mkPolicyDefinition` /
+  `addTablePolicies` / `dropPolicies` on table definitions, with permissive or
+  restrictive policies (`PolicyPermission`), command targeting
+  (`PolicyCommand`), role targets including `PUBLIC`, `CURRENT_ROLE`,
+  `CURRENT_USER` and `SESSION_USER` (`PolicyRole`), and `USING` / `WITH CHECK`
+  expressions. Auto-migration creates, recreates and drops policies by
+  comparing definitions against the `pg_policies` catalog view. Corresponding
+  SQL builders are available in `Orville.PostgreSQL.Expr`.
+- `setRowLevelSecurityEnabled` on table definitions. Auto-migration keeps the
+  table's row-level security setting in sync with the definition (see the
+  Security section below).
+- Auto-migration rejects invalid policy definitions when generating a plan
+  (throwing `MigrationDataError`) rather than failing mid-migration: policies
+  both defined and marked for dropping, `USING` on `INSERT` policies,
+  `WITH CHECK` on `SELECT`/`DELETE` policies, policy names over PostgreSQL's
+  63-byte identifier limit, and policy expressions containing bind parameters.
+
 ### Changed
+- Changed policies are always dropped and recreated rather than altered, since
+  `ALTER POLICY` cannot change a policy's permissive/restrictive setting or
+  command, nor remove a `USING`/`WITH CHECK` clause, and recreation orders
+  correctly around column additions and drops.
 ### Deprecated
 ### Removed
 ### Fixed
+- `addTableConstraints`, `addTableIndexes` and `addTableTriggers` now keep the
+  last item when a single call passes multiple items with the same migration
+  key, as documented. Previously the first item in the list won.
 ### Security
+- **Auto-migration now manages row-level security on migrated tables.** A
+  table definition that does not call `setRowLevelSecurityEnabled` declares
+  row-level security disabled, and auto-migration will actively run
+  `ALTER TABLE ... DISABLE ROW LEVEL SECURITY` on such a table if RLS is
+  currently enabled on it — including RLS that was enabled outside of Orville.
+  If you rely on manually-enabled RLS on Orville-managed tables, add
+  `setRowLevelSecurityEnabled` to those table definitions before upgrading.
+  Tables that already have RLS disabled are untouched.
 
 ## [v1.0.0.0] - 2023-10-30
 

--- a/orville-postgresql/orville-postgresql.cabal
+++ b/orville-postgresql/orville-postgresql.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.38.1.
+-- This file has been generated from package.yaml by hpack version 0.39.6.
 --
 -- see: https://github.com/sol/hpack
 
 name:           orville-postgresql
-version:        1.1.1.0.1
+version:        1.1.1.0.2
 synopsis:       A Haskell library for PostgreSQL
 description:    Orville's goal is to provide a powerful API for applications to access PostgreSQL databases with minimal use of sophisticated language techniques or extensions. See https://github.com/flipstone/orville for more details.
 category:       database, library, postgresql
@@ -146,6 +146,7 @@ library
       Orville.PostgreSQL.Expr.Internal.Name.FunctionName
       Orville.PostgreSQL.Expr.Internal.Name.Identifier
       Orville.PostgreSQL.Expr.Internal.Name.IndexName
+      Orville.PostgreSQL.Expr.Internal.Name.PolicyName
       Orville.PostgreSQL.Expr.Internal.Name.Qualified
       Orville.PostgreSQL.Expr.Internal.Name.SavepointName
       Orville.PostgreSQL.Expr.Internal.Name.SchemaName
@@ -153,6 +154,10 @@ library
       Orville.PostgreSQL.Expr.Internal.Name.TableName
       Orville.PostgreSQL.Expr.Internal.Name.TriggerName
       Orville.PostgreSQL.Expr.Internal.Name.WindowName
+      Orville.PostgreSQL.Expr.PolicyExpr
+      Orville.PostgreSQL.Expr.PolicyExpr.CreatePolicyExpr
+      Orville.PostgreSQL.Expr.PolicyExpr.DropPolicyExpr
+      Orville.PostgreSQL.Expr.PolicyExpr.PolicyRole
       Orville.PostgreSQL.Internal.Bracket
       Orville.PostgreSQL.Internal.Extra.NonEmpty
       Orville.PostgreSQL.Internal.FieldName
@@ -176,6 +181,7 @@ library
       Orville.PostgreSQL.PgCatalog.PgSequence
       Orville.PostgreSQL.PgCatalog.PgTrigger
       Orville.PostgreSQL.Schema.ConstraintIdentifier
+      Orville.PostgreSQL.Schema.PolicyDefinition
       Paths_orville_postgresql
   hs-source-dirs:
       src

--- a/orville-postgresql/orville-postgresql.cabal
+++ b/orville-postgresql/orville-postgresql.cabal
@@ -76,6 +76,7 @@ library
       Orville.PostgreSQL.Expr.OnConflict
       Orville.PostgreSQL.Expr.OrReplace
       Orville.PostgreSQL.Expr.OrderBy
+      Orville.PostgreSQL.Expr.PolicyExpr
       Orville.PostgreSQL.Expr.Query
       Orville.PostgreSQL.Expr.ReturningExpr
       Orville.PostgreSQL.Expr.RowLocking
@@ -130,6 +131,7 @@ library
       Orville.PostgreSQL.Schema.FunctionDefinition
       Orville.PostgreSQL.Schema.FunctionIdentifier
       Orville.PostgreSQL.Schema.IndexDefinition
+      Orville.PostgreSQL.Schema.PolicyDefinition
       Orville.PostgreSQL.Schema.PrimaryKey
       Orville.PostgreSQL.Schema.SequenceDefinition
       Orville.PostgreSQL.Schema.SequenceIdentifier
@@ -154,7 +156,6 @@ library
       Orville.PostgreSQL.Expr.Internal.Name.TableName
       Orville.PostgreSQL.Expr.Internal.Name.TriggerName
       Orville.PostgreSQL.Expr.Internal.Name.WindowName
-      Orville.PostgreSQL.Expr.PolicyExpr
       Orville.PostgreSQL.Expr.PolicyExpr.CreatePolicyExpr
       Orville.PostgreSQL.Expr.PolicyExpr.DropPolicyExpr
       Orville.PostgreSQL.Expr.PolicyExpr.PolicyRole
@@ -181,7 +182,6 @@ library
       Orville.PostgreSQL.PgCatalog.PgSequence
       Orville.PostgreSQL.PgCatalog.PgTrigger
       Orville.PostgreSQL.Schema.ConstraintIdentifier
-      Orville.PostgreSQL.Schema.PolicyDefinition
       Paths_orville_postgresql
   hs-source-dirs:
       src

--- a/orville-postgresql/orville-postgresql.cabal
+++ b/orville-postgresql/orville-postgresql.cabal
@@ -166,6 +166,7 @@ library
       Orville.PostgreSQL.Internal.MigrationLock
       Orville.PostgreSQL.Internal.MonadOrville
       Orville.PostgreSQL.Internal.OrvilleState
+      Orville.PostgreSQL.Internal.PgArrayText
       Orville.PostgreSQL.Internal.RowCountExpectation
       Orville.PostgreSQL.Internal.TypeMap
       Orville.PostgreSQL.PgCatalog.DatabaseDescription
@@ -178,6 +179,7 @@ library
       Orville.PostgreSQL.PgCatalog.PgExtension
       Orville.PostgreSQL.PgCatalog.PgIndex
       Orville.PostgreSQL.PgCatalog.PgNamespace
+      Orville.PostgreSQL.PgCatalog.PgPolicy
       Orville.PostgreSQL.PgCatalog.PgProc
       Orville.PostgreSQL.PgCatalog.PgSequence
       Orville.PostgreSQL.PgCatalog.PgTrigger

--- a/orville-postgresql/orville-postgresql.cabal
+++ b/orville-postgresql/orville-postgresql.cabal
@@ -237,6 +237,7 @@ test-suite spec
       Test.Expr.Join
       Test.Expr.Math
       Test.Expr.OrderBy
+      Test.Expr.Policy
       Test.Expr.SequenceDefinition
       Test.Expr.TableDefinition
       Test.Expr.TableReferenceList

--- a/orville-postgresql/orville-postgresql.cabal
+++ b/orville-postgresql/orville-postgresql.cabal
@@ -77,6 +77,9 @@ library
       Orville.PostgreSQL.Expr.OrReplace
       Orville.PostgreSQL.Expr.OrderBy
       Orville.PostgreSQL.Expr.PolicyExpr
+      Orville.PostgreSQL.Expr.PolicyExpr.CreatePolicyExpr
+      Orville.PostgreSQL.Expr.PolicyExpr.DropPolicyExpr
+      Orville.PostgreSQL.Expr.PolicyExpr.PolicyRole
       Orville.PostgreSQL.Expr.Query
       Orville.PostgreSQL.Expr.ReturningExpr
       Orville.PostgreSQL.Expr.RowLocking
@@ -156,9 +159,6 @@ library
       Orville.PostgreSQL.Expr.Internal.Name.TableName
       Orville.PostgreSQL.Expr.Internal.Name.TriggerName
       Orville.PostgreSQL.Expr.Internal.Name.WindowName
-      Orville.PostgreSQL.Expr.PolicyExpr.CreatePolicyExpr
-      Orville.PostgreSQL.Expr.PolicyExpr.DropPolicyExpr
-      Orville.PostgreSQL.Expr.PolicyExpr.PolicyRole
       Orville.PostgreSQL.Internal.Bracket
       Orville.PostgreSQL.Internal.Extra.NonEmpty
       Orville.PostgreSQL.Internal.FieldName

--- a/orville-postgresql/package.yaml
+++ b/orville-postgresql/package.yaml
@@ -1,6 +1,6 @@
 ---
 name: orville-postgresql
-version: '1.1.1.0.1' # Development version, breaking changes included, release scheduled to be 1.2.0.0
+version: '1.1.1.0.2' # Development version, breaking changes included, release scheduled to be 1.2.0.0
 synopsis: A Haskell library for PostgreSQL
 description:
   Orville's goal is to provide a powerful API for applications to access

--- a/orville-postgresql/package.yaml
+++ b/orville-postgresql/package.yaml
@@ -72,6 +72,7 @@ library:
     - Orville.PostgreSQL.Expr.OnConflict
     - Orville.PostgreSQL.Expr.OrReplace
     - Orville.PostgreSQL.Expr.OrderBy
+    - Orville.PostgreSQL.Expr.PolicyExpr
     - Orville.PostgreSQL.Expr.Query
     - Orville.PostgreSQL.Expr.ReturningExpr
     - Orville.PostgreSQL.Expr.RowLocking
@@ -126,6 +127,7 @@ library:
     - Orville.PostgreSQL.Schema.FunctionDefinition
     - Orville.PostgreSQL.Schema.FunctionIdentifier
     - Orville.PostgreSQL.Schema.IndexDefinition
+    - Orville.PostgreSQL.Schema.PolicyDefinition
     - Orville.PostgreSQL.Schema.PrimaryKey
     - Orville.PostgreSQL.Schema.SequenceDefinition
     - Orville.PostgreSQL.Schema.SequenceIdentifier

--- a/orville-postgresql/package.yaml
+++ b/orville-postgresql/package.yaml
@@ -73,6 +73,9 @@ library:
     - Orville.PostgreSQL.Expr.OrReplace
     - Orville.PostgreSQL.Expr.OrderBy
     - Orville.PostgreSQL.Expr.PolicyExpr
+    - Orville.PostgreSQL.Expr.PolicyExpr.CreatePolicyExpr
+    - Orville.PostgreSQL.Expr.PolicyExpr.DropPolicyExpr
+    - Orville.PostgreSQL.Expr.PolicyExpr.PolicyRole
     - Orville.PostgreSQL.Expr.Query
     - Orville.PostgreSQL.Expr.ReturningExpr
     - Orville.PostgreSQL.Expr.RowLocking

--- a/orville-postgresql/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL.hs
@@ -1,5 +1,5 @@
 {- |
-Copyright : Flipstone Technology Partners 2023-2025
+Copyright : Flipstone Technology Partners 2023-2026
 License   : MIT
 Stability : Stable
 
@@ -121,6 +121,12 @@ module Orville.PostgreSQL
   , TableDefinition.addTableIndexes
   , TableDefinition.tableTriggers
   , TableDefinition.addTableTriggers
+  , TableDefinition.tablePolicies
+  , TableDefinition.addTablePolicies
+  , TableDefinition.dropPolicies
+  , TableDefinition.policiesToDrop
+  , TableDefinition.tableRowLevelSecurity
+  , TableDefinition.setRowLevelSecurityEnabled
   , TableDefinition.dropColumns
   , TableDefinition.columnsToDrop
   , TableDefinition.tableIdentifier
@@ -391,6 +397,14 @@ module Orville.PostgreSQL
   , SequenceIdentifier.sequenceIdSchemaNameString
   , SequenceIdentifier.sequenceIdToString
 
+    -- * Functions for defining and working with policies
+  , PolicyDefinition.PolicyDefinition
+  , PolicyDefinition.mkPolicyDefinition
+  , PolicyDefinition.policyDefinitionPolicyName
+  , PolicyDefinition.policyDefinitionPolicyRoles
+  , PolicyDefinition.policyDefinitionUsingExpr
+  , PolicyDefinition.policyDefinitionCheckExpr
+
     -- * Functions for defining and working with PostgreSQL functions
   , FunctionDefinition.FunctionDefinition
   , FunctionDefinition.setFunctionSchema
@@ -488,6 +502,7 @@ import qualified Orville.PostgreSQL.Schema.ExtensionIdentifier as ExtensionIdent
 import qualified Orville.PostgreSQL.Schema.FunctionDefinition as FunctionDefinition
 import qualified Orville.PostgreSQL.Schema.FunctionIdentifier as FunctionIdentifier
 import qualified Orville.PostgreSQL.Schema.IndexDefinition as IndexDefinition
+import qualified Orville.PostgreSQL.Schema.PolicyDefinition as PolicyDefinition
 import qualified Orville.PostgreSQL.Schema.PrimaryKey as PrimaryKey
 import qualified Orville.PostgreSQL.Schema.SequenceDefinition as SequenceDefinition
 import qualified Orville.PostgreSQL.Schema.SequenceIdentifier as SequenceIdentifier

--- a/orville-postgresql/src/Orville/PostgreSQL.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL.hs
@@ -399,8 +399,13 @@ module Orville.PostgreSQL
 
     -- * Functions for defining and working with policies
   , PolicyDefinition.PolicyDefinition
+  , PolicyDefinition.PolicyPermission (PolicyPermissive, PolicyRestrictive)
+  , PolicyDefinition.PolicyCommand (PolicyCommandAll, PolicyCommandSelect, PolicyCommandInsert, PolicyCommandUpdate, PolicyCommandDelete)
+  , PolicyDefinition.PolicyRole (PolicyRolePublic, PolicyRoleCurrentRole, PolicyRoleCurrentUser, PolicyRoleSessionUser, PolicyRoleNamed)
   , PolicyDefinition.mkPolicyDefinition
   , PolicyDefinition.policyDefinitionPolicyName
+  , PolicyDefinition.policyDefinitionPermission
+  , PolicyDefinition.policyDefinitionCommand
   , PolicyDefinition.policyDefinitionPolicyRoles
   , PolicyDefinition.policyDefinitionUsingExpr
   , PolicyDefinition.policyDefinitionCheckExpr

--- a/orville-postgresql/src/Orville/PostgreSQL/AutoMigration.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/AutoMigration.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE RankNTypes #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2023-2025
+Copyright : Flipstone Technology Partners 2023-2026
 License   : MIT
 Stability : Stable
 
@@ -241,6 +241,7 @@ mkMigrationStepWithType stepType sql =
 isMigrationStepTransactional :: MigrationStepWithType -> Bool
 isMigrationStepTransactional stepWithType =
   case migrationStepType stepWithType of
+    DropPolicyDefinitions -> True
     DropForeignKeys -> True
     DropConstraints -> True
     DropIndexes -> True
@@ -257,6 +258,7 @@ isMigrationStepTransactional stepWithType =
     AddForeignKeys -> True
     AddIndexesConcurrently -> False
     SetComments -> True
+    AddPolicyDefinitions -> True
 
 {- | Indicates the kind of operation being performed by a 'MigrationStep' so
   that the steps can be ordered in a sequence that is guaranteed to succeed.
@@ -266,7 +268,9 @@ isMigrationStepTransactional stepWithType =
 @since 1.0.0.0
 -}
 data StepType
-  = -- | @since 1.1.0.0.3
+  = -- | @since 1.2.0.0
+    DropPolicyDefinitions
+  | -- | @since 1.1.0.0.3
     DropForeignKeys -- Foreign key constraints must be dropped before unique constraints
   | -- | @since 1.1.0.0.3
     DropConstraints
@@ -298,6 +302,8 @@ data StepType
     AddIndexesConcurrently
   | -- | @since 1.1.0.0
     SetComments
+  | -- | @since 1.2.0.0
+    AddPolicyDefinitions
   deriving
     ( -- | @since 1.0.0.0
       Eq
@@ -439,8 +445,9 @@ generateMigrationPlanWithoutLock schemaItems =
         Maybe.mapMaybe schemaItemPgCatalogExtension schemaItems
 
     dbDesc <- PgCatalog.describeDatabase pgCatalogRelations pgCatalogFunctions pgCatalogExtensions
+    existingPolicies <- queryExistingPolicies currentNamespace schemaItems
 
-    case traverse (calculateMigrationSteps currentNamespace dbDesc) schemaItems of
+    case traverse (calculateMigrationSteps currentNamespace dbDesc existingPolicies) schemaItems of
       Left err ->
         liftIO . throwIO $ err
       Right migrationSteps ->
@@ -496,9 +503,10 @@ executeMigrationStepsWithoutTransaction =
 calculateMigrationSteps ::
   PgCatalog.NamespaceName ->
   PgCatalog.DatabaseDescription ->
+  Map.Map Orville.TableIdentifier (Set.Set Schema.PolicyDefinition) ->
   SchemaItem ->
   Either MigrationDataError [MigrationStepWithType]
-calculateMigrationSteps currentNamespace dbDesc schemaItem =
+calculateMigrationSteps currentNamespace dbDesc existingPolicies schemaItem =
   case schemaItem of
     SchemaTable tableDef ->
       Right $
@@ -512,12 +520,20 @@ calculateMigrationSteps currentNamespace dbDesc schemaItem =
             Nothing ->
               mkCreateTableSteps currentNamespace tableDef
             Just relationDesc ->
-              mkAlterTableSteps currentNamespace relationDesc tableDef
+              mkAlterTableSteps currentNamespace existingPolicies relationDesc tableDef
     SchemaDropTable tableId ->
       Right $
         let
           (schemaName, tableName) =
             tableIdToPgCatalogNames currentNamespace tableId
+
+          qualifiedTableId = setSchemaNameOnTableId currentNamespace tableId
+          existing = Maybe.fromMaybe Set.empty $ Map.lookup qualifiedTableId existingPolicies
+
+          dropPolicySteps =
+            [ mkMigrationStepWithType DropPolicyDefinitions (Schema.mkDropPolicyExpr qualifiedTableId pd)
+            | pd <- Set.toList existing
+            ]
         in
           case PgCatalog.lookupRelation (schemaName, tableName) dbDesc of
             Nothing ->
@@ -529,7 +545,7 @@ calculateMigrationSteps currentNamespace dbDesc schemaItem =
                     Nothing
                     (Orville.tableIdQualifiedName tableId)
               in
-                [mkMigrationStepWithType AddRemoveTablesAndColumns dropTableExpr]
+                dropPolicySteps <> [mkMigrationStepWithType AddRemoveTablesAndColumns dropTableExpr]
     SchemaSequence sequenceDef ->
       let
         (schemaName, sequenceName) =
@@ -651,6 +667,9 @@ mkCreateTableSteps currentNamespace tableDef =
     tableName =
       Orville.tableName tableDef
 
+    tableId =
+      setSchemaNameOnTableId currentNamespace (Orville.tableIdentifier tableDef)
+
     -- constraints are not included in the create table expression because
     -- they are added in a separate migration step to avoid ordering problems
     -- when creating multiple tables with interrelated foreign keys.
@@ -677,12 +696,27 @@ mkCreateTableSteps currentNamespace tableDef =
       concatMap
         (mkAddTriggerSteps Set.empty tableName)
         (Orville.tableTriggers tableDef)
+
+    desiredPolicies = Orville.tablePolicies tableDef
+    wantsRLS = Orville.tableRowLevelSecurity tableDef
+
+    enableRLSSteps =
+      if wantsRLS && not (Set.null desiredPolicies)
+        then [mkMigrationStepWithType AddPolicyDefinitions (Expr.enableRowLevelSecurityExpr tableName)]
+        else []
+
+    addPolicySteps =
+      [ mkMigrationStepWithType AddPolicyDefinitions (Schema.mkCreatePolicyExpr tableId pd)
+      | pd <- Set.toList desiredPolicies
+      ]
   in
     mkMigrationStepWithType AddRemoveTablesAndColumns createTableExpr
       : mkConstraintSteps tableName addConstraintActions
         <> addIndexSteps
         <> addTriggerSteps
         <> commentSteps
+        <> enableRLSSteps
+        <> addPolicySteps
 
 mkCreateTableCommentSteps ::
   Orville.TableDefinition key writeEntity readEntity ->
@@ -738,10 +772,11 @@ mkCreateTableCommentSteps tableDef =
 -}
 mkAlterTableSteps ::
   PgCatalog.NamespaceName ->
+  Map.Map Orville.TableIdentifier (Set.Set Schema.PolicyDefinition) ->
   PgCatalog.RelationDescription ->
   Orville.TableDefinition key writeEntity readEntity ->
   [MigrationStepWithType]
-mkAlterTableSteps currentNamespace relationDesc tableDef =
+mkAlterTableSteps currentNamespace existingPolicies relationDesc tableDef =
   let
     addAlterColumnActions =
       concat $
@@ -833,6 +868,43 @@ mkAlterTableSteps currentNamespace relationDesc tableDef =
 
     commentSteps = mkCommentSteps relationDesc tableDef
 
+    tableId =
+      setSchemaNameOnTableId currentNamespace (Orville.tableIdentifier tableDef)
+
+    desiredPolicies = Orville.tablePolicies tableDef
+    polsToDrop = Orville.policiesToDrop tableDef
+    existing = Maybe.fromMaybe Set.empty $ Map.lookup tableId existingPolicies
+    existingByName = Map.fromList [(Schema.policyDefinitionPolicyName pd, pd) | pd <- Set.toList existing]
+    wantsRLS = Orville.tableRowLevelSecurity tableDef
+
+    -- Create policies that don't exist yet
+    createPolicySteps =
+      [ mkMigrationStepWithType AddPolicyDefinitions (Schema.mkCreatePolicyExpr tableId pd)
+      | pd <- Set.toList desiredPolicies
+      , not $ Map.member (Schema.policyDefinitionPolicyName pd) existingByName
+      ]
+
+    -- Alter policies that exist but have changed
+    alterPolicySteps =
+      [ mkMigrationStepWithType AddPolicyDefinitions (Schema.mkAlterPolicyExpr tableId desiredPd)
+      | desiredPd <- Set.toList desiredPolicies
+      , Just existingPd <- [Map.lookup (Schema.policyDefinitionPolicyName desiredPd) existingByName]
+      , existingPd /= desiredPd
+      ]
+
+    -- Drop policies that are explicitly marked for dropping
+    dropPolicySteps =
+      [ mkMigrationStepWithType DropPolicyDefinitions (Schema.mkDropPolicyExpr tableId existingPd)
+      | existingPd <- Set.toList existing
+      , Set.member (Schema.policyDefinitionPolicyName existingPd) polsToDrop
+      ]
+
+    -- Enable RLS if the table should have it and we're adding new policies
+    enableRLSSteps =
+      if wantsRLS && not (null createPolicySteps)
+        then [mkMigrationStepWithType AddPolicyDefinitions (Expr.enableRowLevelSecurityExpr tableName)]
+        else []
+
     tableName =
       Orville.tableName tableDef
   in
@@ -843,10 +915,14 @@ mkAlterTableSteps currentNamespace relationDesc tableDef =
       <> addTriggerSteps
       <> dropTriggerSteps
       <> commentSteps
+      <> dropPolicySteps
+      <> enableRLSSteps
+      <> createPolicySteps
+      <> alterPolicySteps
 
 {- | Consolidates alter table actions (which should all be related to adding and
   dropping constraints) into migration steps based on their 'StepType'. Actions
-  with the same 'StepType' will be performed togethir in a single @ALTER TABLE@
+  with the same 'StepType' will be performed together in a single @ALTER TABLE@
   statement.
 
 @since 1.0.0.0
@@ -1673,3 +1749,128 @@ findCurrentNamespace = do
         throwIO $ UnableToDiscoverCurrentSchema "No results returned by current_schema query"
       _ ->
         throwIO $ UnableToDiscoverCurrentSchema "Multiple results returned by current_schema query"
+
+-- Policy migration support
+
+-- | Represents a policy as discovered from the pg_policies catalog view
+data PgPolicyRow = PgPolicyRow
+  { pgPolicySchemaName :: T.Text
+  , pgPolicyTableName :: T.Text
+  , pgPolicyPolicyName :: T.Text
+  , pgPolicyRoles :: T.Text
+  , pgPolicyQual :: Maybe T.Text
+  , pgPolicyWithCheck :: Maybe T.Text
+  }
+
+pgPolicyMarshaller :: Orville.SqlMarshaller w PgPolicyRow
+pgPolicyMarshaller =
+  PgPolicyRow
+    <$> Orville.marshallReadOnlyField pgPolicySchemaNameField
+    <*> Orville.marshallReadOnlyField pgPolicyTableNameField
+    <*> Orville.marshallReadOnlyField pgPolicyPolicyNameField
+    <*> Orville.marshallReadOnlyField pgPolicyRolesField
+    <*> Orville.marshallReadOnlyField pgPolicyQualField
+    <*> Orville.marshallReadOnlyField pgPolicyWithCheckField
+
+pgPolicySchemaNameField :: Orville.FieldDefinition Orville.NotNull T.Text
+pgPolicySchemaNameField = Orville.unboundedTextField "schemaname"
+
+pgPolicyTableNameField :: Orville.FieldDefinition Orville.NotNull T.Text
+pgPolicyTableNameField = Orville.unboundedTextField "tablename"
+
+pgPolicyPolicyNameField :: Orville.FieldDefinition Orville.NotNull T.Text
+pgPolicyPolicyNameField = Orville.unboundedTextField "policyname"
+
+pgPolicyRolesField :: Orville.FieldDefinition Orville.NotNull T.Text
+pgPolicyRolesField = Orville.unboundedTextField "roles"
+
+pgPolicyQualField :: Orville.FieldDefinition Orville.Nullable (Maybe T.Text)
+pgPolicyQualField = Orville.nullableField $ Orville.unboundedTextField "qual"
+
+pgPolicyWithCheckField :: Orville.FieldDefinition Orville.Nullable (Maybe T.Text)
+pgPolicyWithCheckField = Orville.nullableField $ Orville.unboundedTextField "with_check"
+
+pgPoliciesTable :: Orville.TableDefinition Orville.NoKey PgPolicyRow PgPolicyRow
+pgPoliciesTable =
+  Orville.setTableSchema "pg_catalog" $
+    Orville.mkTableDefinitionWithoutKey "pg_policies" pgPolicyMarshaller
+
+pgPolicyToDefinition :: PgPolicyRow -> Schema.PolicyDefinition
+pgPolicyToDefinition row =
+  let
+    -- pg_policies.roles is a name[] column represented as text like "{role1,role2}"
+    rawRoles = pgPolicyRoles row
+    strippedRoles = T.dropWhile (== '{') . T.dropWhileEnd (== '}') $ rawRoles
+    rolesList = T.splitOn (T.pack ",") strippedRoles
+    roles = Set.fromList . fmap T.unpack $ rolesList
+
+    -- If the only role is "public", this means no specific roles were set
+    mbRoles =
+      if roles == Set.singleton "public"
+        then Nothing
+        else Just roles
+
+    mbUsing =
+      fmap (RawSql.unsafeSqlExpression . (\s -> "(" <> s <> ")") . T.unpack) $ pgPolicyQual row
+
+    mbCheck =
+      fmap (RawSql.unsafeSqlExpression . (\s -> "(" <> s <> ")") . T.unpack) $ pgPolicyWithCheck row
+  in
+    Schema.mkPolicyDefinition
+      (T.unpack $ pgPolicyPolicyName row)
+      mbRoles
+      mbUsing
+      mbCheck
+
+-- | Query existing policies for all tables mentioned in the schema items
+queryExistingPolicies ::
+  Orville.MonadOrville m =>
+  PgCatalog.NamespaceName ->
+  [SchemaItem] ->
+  m (Map.Map Orville.TableIdentifier (Set.Set Schema.PolicyDefinition))
+queryExistingPolicies currentNamespace schemaItems =
+  let
+    getTableName item =
+      case item of
+        SchemaTable tableDef ->
+          Just . T.pack . Orville.tableIdUnqualifiedNameString . Orville.tableIdentifier $ tableDef
+        SchemaDropTable tableId ->
+          Just . T.pack . Orville.tableIdUnqualifiedNameString $ tableId
+        _ -> Nothing
+
+    tableNames = Maybe.mapMaybe getTableName schemaItems
+  in
+    case tableNames of
+      [] -> pure Map.empty
+      (firstName : restNames) -> do
+        let
+          nonEmptyTableNames = firstName :| restNames
+          schemaNameStr = PgCatalog.namespaceNameToString currentNamespace
+          whereCondition =
+            Orville.fieldIn pgPolicyTableNameField nonEmptyTableNames
+              `Orville.andExpr` Orville.fieldEquals pgPolicySchemaNameField (T.pack schemaNameStr)
+
+        pgPolicies <- Orville.findEntitiesBy pgPoliciesTable (Orville.where_ whereCondition)
+        pure $
+          foldl
+            ( \acc row ->
+                let
+                  tableId =
+                    Orville.setTableIdSchema (T.unpack $ pgPolicySchemaName row) $
+                      Orville.unqualifiedNameToTableId (T.unpack $ pgPolicyTableName row)
+                in
+                  Map.insertWith
+                    (<>)
+                    tableId
+                    (Set.singleton $ pgPolicyToDefinition row)
+                    acc
+            )
+            Map.empty
+            pgPolicies
+
+-- | Sets the schema name on a table identifier if it doesn't already have one
+setSchemaNameOnTableId :: PgCatalog.NamespaceName -> Orville.TableIdentifier -> Orville.TableIdentifier
+setSchemaNameOnTableId currentNamespace tableId =
+  case Orville.tableIdSchemaNameString tableId of
+    Just _ -> tableId
+    Nothing -> Orville.setTableIdSchema (PgCatalog.namespaceNameToString currentNamespace) tableId

--- a/orville-postgresql/src/Orville/PostgreSQL/AutoMigration.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/AutoMigration.hs
@@ -533,8 +533,8 @@ calculateMigrationSteps currentNamespace dbDesc existingPolicies schemaItem =
           qualifiedTableId = setSchemaNameOnTableId currentNamespace tableId
           existing = Map.findWithDefault Map.empty qualifiedTableId existingPolicies
 
-          dropPolicySteps = fmap mkStep $ Map.elems existing
-          mkStep pd = mkMigrationStepWithType DropPolicyDefinitions (Schema.mkDropPolicyExpr qualifiedTableId pd)
+          dropPolicySteps = fmap mkDropPolicyStep $ Map.elems existing
+          mkDropPolicyStep pd = mkMigrationStepWithType DropPolicyDefinitions (Schema.mkDropPolicyExpr qualifiedTableId pd)
         in
           case PgCatalog.lookupRelation (schemaName, tableName) dbDesc of
             Nothing ->
@@ -709,8 +709,8 @@ mkCreateTableSteps currentNamespace tableDef =
         then [mkMigrationStepWithType AddPolicyDefinitions (Expr.enableRowLevelSecurityExpr tableName)]
         else []
 
-    addPolicySteps = fmap mkStep $ Map.elems desiredPolicies
-    mkStep pd = mkMigrationStepWithType AddPolicyDefinitions (Schema.mkCreatePolicyExpr tableId pd)
+    addPolicySteps = fmap mkAddPolicyStep $ Map.elems desiredPolicies
+    mkAddPolicyStep pd = mkMigrationStepWithType AddPolicyDefinitions (Schema.mkCreatePolicyExpr tableId pd)
   in
     mkMigrationStepWithType AddRemoveTablesAndColumns createTableExpr
       : mkConstraintSteps tableName addConstraintActions

--- a/orville-postgresql/src/Orville/PostgreSQL/AutoMigration.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/AutoMigration.hs
@@ -315,13 +315,16 @@ data StepType
     )
 
 {- | A 'MigrationDataError' will be thrown from the migration functions if data
-  necessary for migration cannot be found.
+  necessary for migration cannot be found or if the schema items given are
+  invalid.
 
 @since 1.0.0.0
 -}
 data MigrationDataError
   = UnableToDiscoverCurrentSchema String
   | PgCatalogInvariantViolated String
+  | -- | @since 1.2.0.0
+    ConflictingPolicyDefinitions Orville.TableIdentifier (Set.Set String)
   deriving
     ( -- | @since 1.0.0.0
       Show
@@ -512,18 +515,30 @@ calculateMigrationSteps ::
 calculateMigrationSteps currentNamespace dbDesc existingPolicies schemaItem =
   case schemaItem of
     SchemaTable tableDef ->
-      Right $
-        let
-          (schemaName, tableName) =
-            tableIdToPgCatalogNames
-              currentNamespace
-              (Orville.tableIdentifier tableDef)
-        in
-          case PgCatalog.lookupRelationOfKind PgCatalog.OrdinaryTable (schemaName, tableName) dbDesc of
-            Nothing ->
-              mkCreateTableSteps currentNamespace tableDef
-            Just relationDesc ->
-              mkAlterTableSteps currentNamespace existingPolicies relationDesc tableDef
+      let
+        (schemaName, tableName) =
+          tableIdToPgCatalogNames
+            currentNamespace
+            (Orville.tableIdentifier tableDef)
+
+        -- A policy cannot be both defined via 'Orville.addTablePolicies' and
+        -- marked for dropping via 'Orville.dropPolicies'
+        conflictingPolicyNames =
+          Map.keysSet (Orville.tablePolicies tableDef)
+            `Set.intersection` Orville.policiesToDrop tableDef
+      in
+        if not (Set.null conflictingPolicyNames)
+          then
+            Left $
+              ConflictingPolicyDefinitions
+                (setSchemaNameOnTableId currentNamespace (Orville.tableIdentifier tableDef))
+                conflictingPolicyNames
+          else Right $
+            case PgCatalog.lookupRelationOfKind PgCatalog.OrdinaryTable (schemaName, tableName) dbDesc of
+              Nothing ->
+                mkCreateTableSteps currentNamespace tableDef
+              Just relationDesc ->
+                mkAlterTableSteps currentNamespace existingPolicies relationDesc tableDef
     SchemaDropTable tableId ->
       Right $
         let

--- a/orville-postgresql/src/Orville/PostgreSQL/AutoMigration.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/AutoMigration.hs
@@ -54,6 +54,7 @@ import qualified Database.PostgreSQL.LibPQ as LibPQ
 
 import qualified Orville.PostgreSQL as Orville
 import qualified Orville.PostgreSQL.Expr as Expr
+import qualified Orville.PostgreSQL.Internal.Extra.NonEmpty as ExtraNonEmpty
 import qualified Orville.PostgreSQL.Internal.IndexDefinition as IndexDefinition
 import qualified Orville.PostgreSQL.Internal.MigrationLock as MigrationLock
 import qualified Orville.PostgreSQL.Marshall as Marshall
@@ -503,7 +504,7 @@ executeMigrationStepsWithoutTransaction =
 calculateMigrationSteps ::
   PgCatalog.NamespaceName ->
   PgCatalog.DatabaseDescription ->
-  Map.Map Orville.TableIdentifier (Set.Set Schema.PolicyDefinition) ->
+  Map.Map Orville.TableIdentifier (Map.Map String Schema.PolicyDefinition) ->
   SchemaItem ->
   Either MigrationDataError [MigrationStepWithType]
 calculateMigrationSteps currentNamespace dbDesc existingPolicies schemaItem =
@@ -528,12 +529,10 @@ calculateMigrationSteps currentNamespace dbDesc existingPolicies schemaItem =
             tableIdToPgCatalogNames currentNamespace tableId
 
           qualifiedTableId = setSchemaNameOnTableId currentNamespace tableId
-          existing = Maybe.fromMaybe Set.empty $ Map.lookup qualifiedTableId existingPolicies
+          existing = Map.findWithDefault Map.empty qualifiedTableId existingPolicies
 
-          dropPolicySteps =
-            [ mkMigrationStepWithType DropPolicyDefinitions (Schema.mkDropPolicyExpr qualifiedTableId pd)
-            | pd <- Set.toList existing
-            ]
+          dropPolicySteps = fmap mkStep $ Map.elems existing
+          mkStep pd = mkMigrationStepWithType DropPolicyDefinitions (Schema.mkDropPolicyExpr qualifiedTableId pd)
         in
           case PgCatalog.lookupRelation (schemaName, tableName) dbDesc of
             Nothing ->
@@ -700,15 +699,16 @@ mkCreateTableSteps currentNamespace tableDef =
     desiredPolicies = Orville.tablePolicies tableDef
     wantsRLS = Orville.tableRowLevelSecurity tableDef
 
+    -- Enable RLS whenever the table definition asks for it, regardless of
+    -- whether any policies are defined. A freshly created table always
+    -- starts with RLS disabled, so no disable step is ever needed here.
     enableRLSSteps =
-      if wantsRLS && not (Set.null desiredPolicies)
+      if wantsRLS
         then [mkMigrationStepWithType AddPolicyDefinitions (Expr.enableRowLevelSecurityExpr tableName)]
         else []
 
-    addPolicySteps =
-      [ mkMigrationStepWithType AddPolicyDefinitions (Schema.mkCreatePolicyExpr tableId pd)
-      | pd <- Set.toList desiredPolicies
-      ]
+    addPolicySteps = fmap mkStep $ Map.elems desiredPolicies
+    mkStep pd = mkMigrationStepWithType AddPolicyDefinitions (Schema.mkCreatePolicyExpr tableId pd)
   in
     mkMigrationStepWithType AddRemoveTablesAndColumns createTableExpr
       : mkConstraintSteps tableName addConstraintActions
@@ -772,7 +772,7 @@ mkCreateTableCommentSteps tableDef =
 -}
 mkAlterTableSteps ::
   PgCatalog.NamespaceName ->
-  Map.Map Orville.TableIdentifier (Set.Set Schema.PolicyDefinition) ->
+  Map.Map Orville.TableIdentifier (Map.Map String Schema.PolicyDefinition) ->
   PgCatalog.RelationDescription ->
   Orville.TableDefinition key writeEntity readEntity ->
   [MigrationStepWithType]
@@ -873,37 +873,67 @@ mkAlterTableSteps currentNamespace existingPolicies relationDesc tableDef =
 
     desiredPolicies = Orville.tablePolicies tableDef
     polsToDrop = Orville.policiesToDrop tableDef
-    existing = Maybe.fromMaybe Set.empty $ Map.lookup tableId existingPolicies
-    existingByName = Map.fromList [(Schema.policyDefinitionPolicyName pd, pd) | pd <- Set.toList existing]
+    existing = Map.findWithDefault Map.empty tableId existingPolicies
     wantsRLS = Orville.tableRowLevelSecurity tableDef
+
+    -- Policies that exist under both names, paired for comparison
+    matchedPolicies = Map.elems $ Map.intersectionWith (,) existing desiredPolicies
 
     -- Create policies that don't exist yet
     createPolicySteps =
-      [ mkMigrationStepWithType AddPolicyDefinitions (Schema.mkCreatePolicyExpr tableId pd)
-      | pd <- Set.toList desiredPolicies
-      , not $ Map.member (Schema.policyDefinitionPolicyName pd) existingByName
-      ]
+      fmap
+        (mkMigrationStepWithType AddPolicyDefinitions . Schema.mkCreatePolicyExpr tableId)
+        (Map.elems $ Map.difference desiredPolicies existing)
+
+    -- ALTER POLICY cannot change whether a policy is permissive or
+    -- restrictive, nor the command it applies to, so policies where either
+    -- changed must be dropped and recreated instead of altered
+    requiresRecreate existingPd desiredPd =
+      Schema.policyDefinitionPermission existingPd /= Schema.policyDefinitionPermission desiredPd
+        || Schema.policyDefinitionCommand existingPd /= Schema.policyDefinitionCommand desiredPd
 
     -- Alter policies that exist but have changed
     alterPolicySteps =
       [ mkMigrationStepWithType AddPolicyDefinitions (Schema.mkAlterPolicyExpr tableId desiredPd)
-      | desiredPd <- Set.toList desiredPolicies
-      , Just existingPd <- [Map.lookup (Schema.policyDefinitionPolicyName desiredPd) existingByName]
+      | (existingPd, desiredPd) <- matchedPolicies
       , existingPd /= desiredPd
+      , not (requiresRecreate existingPd desiredPd)
       ]
+
+    -- Recreate policies whose permissive/restrictive setting or command has
+    -- changed
+    recreatePolicySteps =
+      concat
+        [ [ mkMigrationStepWithType DropPolicyDefinitions (Schema.mkDropPolicyExpr tableId existingPd)
+          , mkMigrationStepWithType AddPolicyDefinitions (Schema.mkCreatePolicyExpr tableId desiredPd)
+          ]
+        | (existingPd, desiredPd) <- matchedPolicies
+        , requiresRecreate existingPd desiredPd
+        ]
 
     -- Drop policies that are explicitly marked for dropping
     dropPolicySteps =
       [ mkMigrationStepWithType DropPolicyDefinitions (Schema.mkDropPolicyExpr tableId existingPd)
-      | existingPd <- Set.toList existing
+      | existingPd <- Map.elems existing
       , Set.member (Schema.policyDefinitionPolicyName existingPd) polsToDrop
       ]
 
-    -- Enable RLS if the table should have it and we're adding new policies
-    enableRLSSteps =
-      if wantsRLS && not (null createPolicySteps)
-        then [mkMigrationStepWithType AddPolicyDefinitions (Expr.enableRowLevelSecurityExpr tableName)]
-        else []
+    -- Enable or disable RLS so that the table matches the table definition,
+    -- regardless of whether any policies are being created, altered or
+    -- dropped. When the table's current setting already matches, no step is
+    -- emitted; in particular no DISABLE statement is issued for tables that
+    -- already have RLS disabled.
+    rlsCurrentlyEnabled =
+      PgCatalog.pgClassRowSecurity (PgCatalog.relationRecord relationDesc)
+
+    rowLevelSecuritySteps =
+      case (wantsRLS, rlsCurrentlyEnabled) of
+        (True, False) ->
+          [mkMigrationStepWithType AddPolicyDefinitions (Expr.enableRowLevelSecurityExpr tableName)]
+        (False, True) ->
+          [mkMigrationStepWithType DropPolicyDefinitions (Expr.disableRowLevelSecurityExpr tableName)]
+        _ ->
+          []
 
     tableName =
       Orville.tableName tableDef
@@ -916,9 +946,10 @@ mkAlterTableSteps currentNamespace existingPolicies relationDesc tableDef =
       <> dropTriggerSteps
       <> commentSteps
       <> dropPolicySteps
-      <> enableRLSSteps
+      <> rowLevelSecuritySteps
       <> createPolicySteps
       <> alterPolicySteps
+      <> recreatePolicySteps
 
 {- | Consolidates alter table actions (which should all be related to adding and
   dropping constraints) into migration steps based on their 'StepType'. Actions
@@ -1757,6 +1788,8 @@ data PgPolicyRow = PgPolicyRow
   { pgPolicySchemaName :: T.Text
   , pgPolicyTableName :: T.Text
   , pgPolicyPolicyName :: T.Text
+  , pgPolicyPermissive :: T.Text
+  , pgPolicyCmd :: T.Text
   , pgPolicyRoles :: T.Text
   , pgPolicyQual :: Maybe T.Text
   , pgPolicyWithCheck :: Maybe T.Text
@@ -1768,6 +1801,8 @@ pgPolicyMarshaller =
     <$> Orville.marshallReadOnlyField pgPolicySchemaNameField
     <*> Orville.marshallReadOnlyField pgPolicyTableNameField
     <*> Orville.marshallReadOnlyField pgPolicyPolicyNameField
+    <*> Orville.marshallReadOnlyField pgPolicyPermissiveField
+    <*> Orville.marshallReadOnlyField pgPolicyCmdField
     <*> Orville.marshallReadOnlyField pgPolicyRolesField
     <*> Orville.marshallReadOnlyField pgPolicyQualField
     <*> Orville.marshallReadOnlyField pgPolicyWithCheckField
@@ -1780,6 +1815,12 @@ pgPolicyTableNameField = Orville.unboundedTextField "tablename"
 
 pgPolicyPolicyNameField :: Orville.FieldDefinition Orville.NotNull T.Text
 pgPolicyPolicyNameField = Orville.unboundedTextField "policyname"
+
+pgPolicyPermissiveField :: Orville.FieldDefinition Orville.NotNull T.Text
+pgPolicyPermissiveField = Orville.unboundedTextField "permissive"
+
+pgPolicyCmdField :: Orville.FieldDefinition Orville.NotNull T.Text
+pgPolicyCmdField = Orville.unboundedTextField "cmd"
 
 pgPolicyRolesField :: Orville.FieldDefinition Orville.NotNull T.Text
 pgPolicyRolesField = Orville.unboundedTextField "roles"
@@ -1802,71 +1843,91 @@ pgPolicyToDefinition row =
     rawRoles = pgPolicyRoles row
     strippedRoles = T.dropWhile (== '{') . T.dropWhileEnd (== '}') $ rawRoles
     rolesList = T.splitOn (T.pack ",") strippedRoles
-    roles = Set.fromList . fmap T.unpack $ rolesList
 
-    -- If the only role is "public", this means no specific roles were set
-    mbRoles =
-      if roles == Set.singleton "public"
-        then Nothing
-        else Just roles
+    -- PostgreSQL reports policies with no specific roles as applying to
+    -- "public". CURRENT_ROLE, CURRENT_USER and SESSION_USER never appear
+    -- here because PostgreSQL resolves them to concrete roles when the
+    -- policy is created.
+    parseRole roleText =
+      if roleText == T.pack "public"
+        then Schema.PolicyRolePublic
+        else Schema.PolicyRoleNamed (T.unpack roleText)
 
+    roles = Set.fromList . fmap parseRole $ rolesList
+
+    -- The parenthesization matches what 'Expr.policyUsingExpr' and
+    -- 'Expr.policyCheckExpr' produce so the expressions compare consistently
     mbUsing =
-      fmap (RawSql.unsafeSqlExpression . (\s -> "(" <> s <> ")") . T.unpack) $ pgPolicyQual row
+      fmap (RawSql.unsafeFromRawSql . RawSql.parenthesized . RawSql.fromText) $ pgPolicyQual row
 
     mbCheck =
-      fmap (RawSql.unsafeSqlExpression . (\s -> "(" <> s <> ")") . T.unpack) $ pgPolicyWithCheck row
+      fmap (RawSql.unsafeFromRawSql . RawSql.parenthesized . RawSql.fromText) $ pgPolicyWithCheck row
+
+    -- pg_policies.permissive contains either 'PERMISSIVE' or 'RESTRICTIVE'
+    permission =
+      if T.toUpper (pgPolicyPermissive row) == T.pack "RESTRICTIVE"
+        then Schema.PolicyRestrictive
+        else Schema.PolicyPermissive
+
+    -- pg_policies.cmd contains 'ALL', 'SELECT', 'INSERT', 'UPDATE' or 'DELETE'
+    command =
+      case T.unpack (T.toUpper (pgPolicyCmd row)) of
+        "SELECT" -> Schema.PolicyCommandSelect
+        "INSERT" -> Schema.PolicyCommandInsert
+        "UPDATE" -> Schema.PolicyCommandUpdate
+        "DELETE" -> Schema.PolicyCommandDelete
+        _ -> Schema.PolicyCommandAll
   in
     Schema.mkPolicyDefinition
       (T.unpack $ pgPolicyPolicyName row)
-      mbRoles
+      (Just permission)
+      (Just command)
+      (Just roles)
       mbUsing
       mbCheck
 
--- | Query existing policies for all tables mentioned in the schema items
+{- | Query existing policies for all tables mentioned in the schema items,
+matching each table in the schema it belongs to (either the schema
+explicitly set on the table or the current namespace)
+-}
 queryExistingPolicies ::
   Orville.MonadOrville m =>
   PgCatalog.NamespaceName ->
   [SchemaItem] ->
-  m (Map.Map Orville.TableIdentifier (Set.Set Schema.PolicyDefinition))
+  m (Map.Map Orville.TableIdentifier (Map.Map String Schema.PolicyDefinition))
 queryExistingPolicies currentNamespace schemaItems =
   let
-    getTableName item =
+    getPgCatalogNames item =
       case item of
         SchemaTable tableDef ->
-          Just . T.pack . Orville.tableIdUnqualifiedNameString . Orville.tableIdentifier $ tableDef
+          Just . tableIdToPgCatalogNames currentNamespace . Orville.tableIdentifier $ tableDef
         SchemaDropTable tableId ->
-          Just . T.pack . Orville.tableIdUnqualifiedNameString $ tableId
+          Just $ tableIdToPgCatalogNames currentNamespace tableId
         _ -> Nothing
 
-    tableNames = Maybe.mapMaybe getTableName schemaItems
+    tableCondition (schemaName, tableName) =
+      Orville.fieldEquals pgPolicySchemaNameField (T.pack $ PgCatalog.namespaceNameToString schemaName)
+        `Orville.andExpr` Orville.fieldEquals pgPolicyTableNameField (T.pack $ PgCatalog.relationNameToString tableName)
+
+    policyMapEntry row =
+      let
+        policyDef = pgPolicyToDefinition row
+      in
+        ( Orville.setTableIdSchema (T.unpack $ pgPolicySchemaName row) $
+            Orville.unqualifiedNameToTableId (T.unpack $ pgPolicyTableName row)
+        , Map.singleton (Schema.policyDefinitionPolicyName policyDef) policyDef
+        )
   in
-    case tableNames of
-      [] -> pure Map.empty
-      (firstName : restNames) -> do
+    case nonEmpty (Maybe.mapMaybe getPgCatalogNames schemaItems) of
+      Nothing -> pure Map.empty
+      Just tableCatalogNames -> do
         let
-          nonEmptyTableNames = firstName :| restNames
-          schemaNameStr = PgCatalog.namespaceNameToString currentNamespace
           whereCondition =
-            Orville.fieldIn pgPolicyTableNameField nonEmptyTableNames
-              `Orville.andExpr` Orville.fieldEquals pgPolicySchemaNameField (T.pack schemaNameStr)
+            ExtraNonEmpty.foldl1' Orville.orExpr $
+              fmap tableCondition tableCatalogNames
 
         pgPolicies <- Orville.findEntitiesBy pgPoliciesTable (Orville.where_ whereCondition)
-        pure $
-          foldl
-            ( \acc row ->
-                let
-                  tableId =
-                    Orville.setTableIdSchema (T.unpack $ pgPolicySchemaName row) $
-                      Orville.unqualifiedNameToTableId (T.unpack $ pgPolicyTableName row)
-                in
-                  Map.insertWith
-                    (<>)
-                    tableId
-                    (Set.singleton $ pgPolicyToDefinition row)
-                    acc
-            )
-            Map.empty
-            pgPolicies
+        pure . Map.fromListWith (<>) . fmap policyMapEntry $ pgPolicies
 
 -- | Sets the schema name on a table identifier if it doesn't already have one
 setSchemaNameOnTableId :: PgCatalog.NamespaceName -> Orville.TableIdentifier -> Orville.TableIdentifier

--- a/orville-postgresql/src/Orville/PostgreSQL/AutoMigration.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/AutoMigration.hs
@@ -1863,26 +1863,11 @@ pgPolicyToDefinition row =
 
     mbCheck =
       fmap (RawSql.unsafeFromRawSql . RawSql.parenthesized . RawSql.fromText) $ PgCatalog.pgPolicyWithCheck row
-
-    -- pg_policies.permissive contains either 'PERMISSIVE' or 'RESTRICTIVE'
-    permission =
-      if T.toUpper (PgCatalog.pgPolicyPermissive row) == T.pack "RESTRICTIVE"
-        then Schema.PolicyRestrictive
-        else Schema.PolicyPermissive
-
-    -- pg_policies.cmd contains 'ALL', 'SELECT', 'INSERT', 'UPDATE' or 'DELETE'
-    command =
-      case T.unpack (T.toUpper (PgCatalog.pgPolicyCmd row)) of
-        "SELECT" -> Schema.PolicyCommandSelect
-        "INSERT" -> Schema.PolicyCommandInsert
-        "UPDATE" -> Schema.PolicyCommandUpdate
-        "DELETE" -> Schema.PolicyCommandDelete
-        _ -> Schema.PolicyCommandAll
   in
     Schema.mkPolicyDefinition
       (T.unpack $ PgCatalog.pgPolicyPolicyName row)
-      (Just permission)
-      (Just command)
+      (Just $ PgCatalog.pgPolicyPermissive row)
+      (Just $ PgCatalog.pgPolicyCmd row)
       (Just roles)
       mbUsing
       mbCheck

--- a/orville-postgresql/src/Orville/PostgreSQL/AutoMigration.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/AutoMigration.hs
@@ -38,9 +38,11 @@ module Orville.PostgreSQL.AutoMigration
   )
 where
 
+import Control.Applicative ((<|>))
 import Control.Exception.Safe (Exception, throwIO)
 import Control.Monad (guard, when)
 import Control.Monad.IO.Class (liftIO)
+import qualified Data.Attoparsec.Text as AttoText
 import Data.Foldable (traverse_)
 import qualified Data.List as List
 import Data.List.NonEmpty (NonEmpty ((:|)), nonEmpty)
@@ -1790,7 +1792,7 @@ data PgPolicyRow = PgPolicyRow
   , pgPolicyPolicyName :: T.Text
   , pgPolicyPermissive :: T.Text
   , pgPolicyCmd :: T.Text
-  , pgPolicyRoles :: T.Text
+  , pgPolicyRoles :: [T.Text]
   , pgPolicyQual :: Maybe T.Text
   , pgPolicyWithCheck :: Maybe T.Text
   }
@@ -1822,8 +1824,67 @@ pgPolicyPermissiveField = Orville.unboundedTextField "permissive"
 pgPolicyCmdField :: Orville.FieldDefinition Orville.NotNull T.Text
 pgPolicyCmdField = Orville.unboundedTextField "cmd"
 
-pgPolicyRolesField :: Orville.FieldDefinition Orville.NotNull T.Text
-pgPolicyRolesField = Orville.unboundedTextField "roles"
+-- pg_policies.roles is a name[] column, marshalled via its text
+-- representation
+pgPolicyRolesField :: Orville.FieldDefinition Orville.NotNull [T.Text]
+pgPolicyRolesField =
+  Orville.convertField
+    (Orville.tryConvertSqlType nameListToPgArrayText pgArrayTextToNameList)
+    (Orville.unboundedTextField "roles")
+
+{- | Parses the text representation of a PostgreSQL array of names (e.g. the
+  @roles@ column of @pg_policies@) into its elements. PostgreSQL renders
+  elements containing special characters (commas, braces, quotes, backslashes,
+  whitespace) double-quoted, using backslash escapes for quotes and
+  backslashes within them.
+-}
+pgArrayTextToNameList :: T.Text -> Either String [T.Text]
+pgArrayTextToNameList text =
+  let
+    quotedChunk =
+      AttoText.takeWhile1 (\c -> c /= '"' && c /= '\\')
+        <|> (AttoText.char '\\' *> (T.singleton <$> AttoText.anyChar))
+
+    quotedElement = do
+      _ <- AttoText.char '"'
+      chunks <- AttoText.many' quotedChunk
+      _ <- AttoText.char '"'
+      pure (T.concat chunks)
+
+    unquotedElement =
+      AttoText.takeWhile1 (\c -> c /= ',' && c /= '{' && c /= '}' && c /= '"' && c /= '\\')
+
+    element = quotedElement <|> unquotedElement
+
+    parser = do
+      _ <- AttoText.char '{'
+      elements <- AttoText.sepBy element (AttoText.char ',')
+      _ <- AttoText.char '}'
+      AttoText.endOfInput
+      pure elements
+  in
+    case AttoText.parseOnly parser text of
+      Left err -> Left ("Unable to decode PostgreSQL array as name list: " <> err)
+      Right names -> Right names
+
+{- | Renders a list of names in PostgreSQL's array text syntax. Every element
+  is rendered double-quoted, which is valid regardless of its content, with
+  quotes and backslashes escaped. This is the inverse of
+  'pgArrayTextToNameList'.
+-}
+nameListToPgArrayText :: [T.Text] -> T.Text
+nameListToPgArrayText names =
+  let
+    escapeChar c =
+      case c of
+        '"' -> T.pack "\\\""
+        '\\' -> T.pack "\\\\"
+        _ -> T.singleton c
+
+    quoteName name =
+      T.pack "\"" <> T.concatMap escapeChar name <> T.pack "\""
+  in
+    T.pack "{" <> T.intercalate (T.pack ",") (fmap quoteName names) <> T.pack "}"
 
 pgPolicyQualField :: Orville.FieldDefinition Orville.Nullable (Maybe T.Text)
 pgPolicyQualField = Orville.nullableField $ Orville.unboundedTextField "qual"
@@ -1839,11 +1900,6 @@ pgPoliciesTable =
 pgPolicyToDefinition :: PgPolicyRow -> Schema.PolicyDefinition
 pgPolicyToDefinition row =
   let
-    -- pg_policies.roles is a name[] column represented as text like "{role1,role2}"
-    rawRoles = pgPolicyRoles row
-    strippedRoles = T.dropWhile (== '{') . T.dropWhileEnd (== '}') $ rawRoles
-    rolesList = T.splitOn (T.pack ",") strippedRoles
-
     -- PostgreSQL reports policies with no specific roles as applying to
     -- "public". CURRENT_ROLE, CURRENT_USER and SESSION_USER never appear
     -- here because PostgreSQL resolves them to concrete roles when the
@@ -1853,7 +1909,7 @@ pgPolicyToDefinition row =
         then Schema.PolicyRolePublic
         else Schema.PolicyRoleNamed (T.unpack roleText)
 
-    roles = Set.fromList . fmap parseRole $ rolesList
+    roles = Set.fromList . fmap parseRole $ pgPolicyRoles row
 
     -- The parenthesization matches what 'Expr.policyUsingExpr' and
     -- 'Expr.policyCheckExpr' produce so the expressions compare consistently

--- a/orville-postgresql/src/Orville/PostgreSQL/AutoMigration.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/AutoMigration.hs
@@ -38,11 +38,10 @@ module Orville.PostgreSQL.AutoMigration
   )
 where
 
-import Control.Applicative ((<|>))
 import Control.Exception.Safe (Exception, throwIO)
 import Control.Monad (guard, when)
 import Control.Monad.IO.Class (liftIO)
-import qualified Data.Attoparsec.Text as AttoText
+import qualified Data.ByteString as BS
 import Data.Foldable (traverse_)
 import qualified Data.List as List
 import Data.List.NonEmpty (NonEmpty ((:|)), nonEmpty)
@@ -325,6 +324,8 @@ data MigrationDataError
   | PgCatalogInvariantViolated String
   | -- | @since 1.2.0.0
     ConflictingPolicyDefinitions Orville.TableIdentifier (Set.Set String)
+  | -- | @since 1.2.0.0
+    InvalidPolicyDefinition Orville.TableIdentifier String String
   deriving
     ( -- | @since 1.0.0.0
       Show
@@ -521,36 +522,46 @@ calculateMigrationSteps currentNamespace dbDesc existingPolicies schemaItem =
             currentNamespace
             (Orville.tableIdentifier tableDef)
 
+        qualifiedTableId =
+          setSchemaNameOnTableId currentNamespace (Orville.tableIdentifier tableDef)
+
         -- A policy cannot be both defined via 'Orville.addTablePolicies' and
         -- marked for dropping via 'Orville.dropPolicies'
         conflictingPolicyNames =
           Map.keysSet (Orville.tablePolicies tableDef)
             `Set.intersection` Orville.policiesToDrop tableDef
+
+        mkInvalidPolicyError policyDef =
+          fmap
+            (InvalidPolicyDefinition qualifiedTableId (Schema.policyDefinitionPolicyName policyDef))
+            (invalidPolicyDefinitionReason policyDef)
+
+        policyValidationError =
+          if not (Set.null conflictingPolicyNames)
+            then Just (ConflictingPolicyDefinitions qualifiedTableId conflictingPolicyNames)
+            else
+              Maybe.listToMaybe
+                . Maybe.mapMaybe mkInvalidPolicyError
+                . Map.elems
+                $ Orville.tablePolicies tableDef
       in
-        if not (Set.null conflictingPolicyNames)
-          then
-            Left $
-              ConflictingPolicyDefinitions
-                (setSchemaNameOnTableId currentNamespace (Orville.tableIdentifier tableDef))
-                conflictingPolicyNames
-          else Right $
-            case PgCatalog.lookupRelationOfKind PgCatalog.OrdinaryTable (schemaName, tableName) dbDesc of
-              Nothing ->
-                mkCreateTableSteps currentNamespace tableDef
-              Just relationDesc ->
-                mkAlterTableSteps currentNamespace existingPolicies relationDesc tableDef
+        case policyValidationError of
+          Just err -> Left err
+          Nothing ->
+            Right $
+              case PgCatalog.lookupRelationOfKind PgCatalog.OrdinaryTable (schemaName, tableName) dbDesc of
+                Nothing ->
+                  mkCreateTableSteps currentNamespace tableDef
+                Just relationDesc ->
+                  mkAlterTableSteps currentNamespace existingPolicies relationDesc tableDef
     SchemaDropTable tableId ->
       Right $
         let
           (schemaName, tableName) =
             tableIdToPgCatalogNames currentNamespace tableId
-
-          qualifiedTableId = setSchemaNameOnTableId currentNamespace tableId
-          existing = Map.findWithDefault Map.empty qualifiedTableId existingPolicies
-
-          dropPolicySteps = fmap mkDropPolicyStep $ Map.elems existing
-          mkDropPolicyStep pd = mkMigrationStepWithType DropPolicyDefinitions (Schema.mkDropPolicyExpr qualifiedTableId pd)
         in
+          -- Any policies on the table are dropped automatically by
+          -- PostgreSQL along with the table, so no policy steps are needed
           case PgCatalog.lookupRelation (schemaName, tableName) dbDesc of
             Nothing ->
               []
@@ -561,7 +572,7 @@ calculateMigrationSteps currentNamespace dbDesc existingPolicies schemaItem =
                     Nothing
                     (Orville.tableIdQualifiedName tableId)
               in
-                dropPolicySteps <> [mkMigrationStepWithType AddRemoveTablesAndColumns dropTableExpr]
+                [mkMigrationStepWithType AddRemoveTablesAndColumns dropTableExpr]
     SchemaSequence sequenceDef ->
       let
         (schemaName, sequenceName) =
@@ -902,38 +913,29 @@ mkAlterTableSteps currentNamespace existingPolicies relationDesc tableDef =
         (mkMigrationStepWithType AddPolicyDefinitions . Schema.mkCreatePolicyExpr tableId)
         (Map.elems $ Map.difference desiredPolicies existing)
 
+    -- Changed policies are always dropped and recreated rather than altered.
     -- ALTER POLICY cannot change whether a policy is permissive or
-    -- restrictive, nor the command it applies to, so policies where either
-    -- changed must be dropped and recreated instead of altered
-    requiresRecreate existingPd desiredPd =
-      Schema.policyDefinitionPermission existingPd /= Schema.policyDefinitionPermission desiredPd
-        || Schema.policyDefinitionCommand existingPd /= Schema.policyDefinitionCommand desiredPd
-
-    -- Alter policies that exist but have changed
-    alterPolicySteps =
-      [ mkMigrationStepWithType AddPolicyDefinitions (Schema.mkAlterPolicyExpr tableId desiredPd)
-      | (existingPd, desiredPd) <- matchedPolicies
-      , existingPd /= desiredPd
-      , not (requiresRecreate existingPd desiredPd)
-      ]
-
-    -- Recreate policies whose permissive/restrictive setting or command has
-    -- changed
+    -- restrictive, nor the command it applies to, nor remove a USING or
+    -- WITH CHECK clause (clauses omitted from ALTER POLICY are left
+    -- unchanged). Dropping and recreating also orders correctly against
+    -- column changes: the drop runs before columns are added or dropped and
+    -- the create runs after, so a changed policy can stop referencing a
+    -- column that is being dropped or start referencing one that is being
+    -- added.
     recreatePolicySteps =
-      concat
-        [ [ mkMigrationStepWithType DropPolicyDefinitions (Schema.mkDropPolicyExpr tableId existingPd)
-          , mkMigrationStepWithType AddPolicyDefinitions (Schema.mkCreatePolicyExpr tableId desiredPd)
-          ]
-        | (existingPd, desiredPd) <- matchedPolicies
-        , requiresRecreate existingPd desiredPd
-        ]
+      foldMap
+        ( \(existingPd, desiredPd) ->
+            [ mkMigrationStepWithType DropPolicyDefinitions (Schema.mkDropPolicyExpr tableId existingPd)
+            , mkMigrationStepWithType AddPolicyDefinitions (Schema.mkCreatePolicyExpr tableId desiredPd)
+            ]
+        )
+        (List.filter (\(existingPd, desiredPd) -> existingPd /= desiredPd) matchedPolicies)
 
     -- Drop policies that are explicitly marked for dropping
     dropPolicySteps =
-      [ mkMigrationStepWithType DropPolicyDefinitions (Schema.mkDropPolicyExpr tableId existingPd)
-      | existingPd <- Map.elems existing
-      , Set.member (Schema.policyDefinitionPolicyName existingPd) polsToDrop
-      ]
+      fmap (mkMigrationStepWithType DropPolicyDefinitions . Schema.mkDropPolicyExpr tableId)
+        . List.filter (\existingPd -> Set.member (Schema.policyDefinitionPolicyName existingPd) polsToDrop)
+        $ Map.elems existing
 
     -- Enable or disable RLS so that the table matches the table definition,
     -- regardless of whether any policies are being created, altered or
@@ -965,7 +967,6 @@ mkAlterTableSteps currentNamespace existingPolicies relationDesc tableDef =
       <> dropPolicySteps
       <> rowLevelSecuritySteps
       <> createPolicySteps
-      <> alterPolicySteps
       <> recreatePolicySteps
 
 {- | Consolidates alter table actions (which should all be related to adding and
@@ -1800,119 +1801,48 @@ findCurrentNamespace = do
 
 -- Policy migration support
 
--- | Represents a policy as discovered from the pg_policies catalog view
-data PgPolicyRow = PgPolicyRow
-  { pgPolicySchemaName :: T.Text
-  , pgPolicyTableName :: T.Text
-  , pgPolicyPolicyName :: T.Text
-  , pgPolicyPermissive :: T.Text
-  , pgPolicyCmd :: T.Text
-  , pgPolicyRoles :: [T.Text]
-  , pgPolicyQual :: Maybe T.Text
-  , pgPolicyWithCheck :: Maybe T.Text
-  }
-
-pgPolicyMarshaller :: Orville.SqlMarshaller w PgPolicyRow
-pgPolicyMarshaller =
-  PgPolicyRow
-    <$> Orville.marshallReadOnlyField pgPolicySchemaNameField
-    <*> Orville.marshallReadOnlyField pgPolicyTableNameField
-    <*> Orville.marshallReadOnlyField pgPolicyPolicyNameField
-    <*> Orville.marshallReadOnlyField pgPolicyPermissiveField
-    <*> Orville.marshallReadOnlyField pgPolicyCmdField
-    <*> Orville.marshallReadOnlyField pgPolicyRolesField
-    <*> Orville.marshallReadOnlyField pgPolicyQualField
-    <*> Orville.marshallReadOnlyField pgPolicyWithCheckField
-
-pgPolicySchemaNameField :: Orville.FieldDefinition Orville.NotNull T.Text
-pgPolicySchemaNameField = Orville.unboundedTextField "schemaname"
-
-pgPolicyTableNameField :: Orville.FieldDefinition Orville.NotNull T.Text
-pgPolicyTableNameField = Orville.unboundedTextField "tablename"
-
-pgPolicyPolicyNameField :: Orville.FieldDefinition Orville.NotNull T.Text
-pgPolicyPolicyNameField = Orville.unboundedTextField "policyname"
-
-pgPolicyPermissiveField :: Orville.FieldDefinition Orville.NotNull T.Text
-pgPolicyPermissiveField = Orville.unboundedTextField "permissive"
-
-pgPolicyCmdField :: Orville.FieldDefinition Orville.NotNull T.Text
-pgPolicyCmdField = Orville.unboundedTextField "cmd"
-
--- pg_policies.roles is a name[] column, marshalled via its text
--- representation
-pgPolicyRolesField :: Orville.FieldDefinition Orville.NotNull [T.Text]
-pgPolicyRolesField =
-  Orville.convertField
-    (Orville.tryConvertSqlType nameListToPgArrayText pgArrayTextToNameList)
-    (Orville.unboundedTextField "roles")
-
-{- | Parses the text representation of a PostgreSQL array of names (e.g. the
-  @roles@ column of @pg_policies@) into its elements. PostgreSQL renders
-  elements containing special characters (commas, braces, quotes, backslashes,
-  whitespace) double-quoted, using backslash escapes for quotes and
-  backslashes within them.
+{- | Checks a 'Schema.PolicyDefinition' for properties that PostgreSQL would
+  reject or mangle at execution time, returning a description of the first
+  problem found. Used to fail plan generation with an
+  'InvalidPolicyDefinition' before any DDL is executed.
 -}
-pgArrayTextToNameList :: T.Text -> Either String [T.Text]
-pgArrayTextToNameList text =
+invalidPolicyDefinitionReason :: Schema.PolicyDefinition -> Maybe String
+invalidPolicyDefinitionReason policyDef =
   let
-    quotedChunk =
-      AttoText.takeWhile1 (\c -> c /= '"' && c /= '\\')
-        <|> (AttoText.char '\\' *> (T.singleton <$> AttoText.anyChar))
+    command = Schema.policyDefinitionCommand policyDef
 
-    quotedElement = do
-      _ <- AttoText.char '"'
-      chunks <- AttoText.many' quotedChunk
-      _ <- AttoText.char '"'
-      pure (T.concat chunks)
+    nameByteLength =
+      BS.length . Enc.encodeUtf8 . T.pack $ Schema.policyDefinitionPolicyName policyDef
 
-    unquotedElement =
-      AttoText.takeWhile1 (\c -> c /= ',' && c /= '{' && c /= '}' && c /= '"' && c /= '\\')
+    hasUsing = Maybe.isJust (Schema.policyDefinitionUsingExpr policyDef)
+    hasCheck = Maybe.isJust (Schema.policyDefinitionCheckExpr policyDef)
 
-    element = quotedElement <|> unquotedElement
+    paramCount =
+      maybe 0 RawSql.toParamCount (Schema.policyDefinitionUsingExpr policyDef)
+        + maybe 0 RawSql.toParamCount (Schema.policyDefinitionCheckExpr policyDef)
 
-    parser = do
-      _ <- AttoText.char '{'
-      elements <- AttoText.sepBy element (AttoText.char ',')
-      _ <- AttoText.char '}'
-      AttoText.endOfInput
-      pure elements
+    problems =
+      [
+        ( nameByteLength > 63
+        , "the policy name exceeds PostgreSQL's 63-byte identifier limit and would be truncated, causing the policy to be created again on every migration run"
+        )
+      ,
+        ( command == Schema.PolicyCommandInsert && hasUsing
+        , "USING expressions are not allowed on INSERT policies"
+        )
+      ,
+        ( (command == Schema.PolicyCommandSelect || command == Schema.PolicyCommandDelete) && hasCheck
+        , "WITH CHECK expressions are not allowed on SELECT or DELETE policies"
+        )
+      ,
+        ( paramCount > 0
+        , "policy expressions cannot contain bind parameters because CREATE POLICY and ALTER POLICY are DDL; values must be rendered inline as literals"
+        )
+      ]
   in
-    case AttoText.parseOnly parser text of
-      Left err -> Left ("Unable to decode PostgreSQL array as name list: " <> err)
-      Right names -> Right names
+    fmap snd . List.find fst $ problems
 
-{- | Renders a list of names in PostgreSQL's array text syntax. Every element
-  is rendered double-quoted, which is valid regardless of its content, with
-  quotes and backslashes escaped. This is the inverse of
-  'pgArrayTextToNameList'.
--}
-nameListToPgArrayText :: [T.Text] -> T.Text
-nameListToPgArrayText names =
-  let
-    escapeChar c =
-      case c of
-        '"' -> T.pack "\\\""
-        '\\' -> T.pack "\\\\"
-        _ -> T.singleton c
-
-    quoteName name =
-      T.pack "\"" <> T.concatMap escapeChar name <> T.pack "\""
-  in
-    T.pack "{" <> T.intercalate (T.pack ",") (fmap quoteName names) <> T.pack "}"
-
-pgPolicyQualField :: Orville.FieldDefinition Orville.Nullable (Maybe T.Text)
-pgPolicyQualField = Orville.nullableField $ Orville.unboundedTextField "qual"
-
-pgPolicyWithCheckField :: Orville.FieldDefinition Orville.Nullable (Maybe T.Text)
-pgPolicyWithCheckField = Orville.nullableField $ Orville.unboundedTextField "with_check"
-
-pgPoliciesTable :: Orville.TableDefinition Orville.NoKey PgPolicyRow PgPolicyRow
-pgPoliciesTable =
-  Orville.setTableSchema "pg_catalog" $
-    Orville.mkTableDefinitionWithoutKey "pg_policies" pgPolicyMarshaller
-
-pgPolicyToDefinition :: PgPolicyRow -> Schema.PolicyDefinition
+pgPolicyToDefinition :: PgCatalog.PgPolicy -> Schema.PolicyDefinition
 pgPolicyToDefinition row =
   let
     -- PostgreSQL reports policies with no specific roles as applying to
@@ -1924,25 +1854,25 @@ pgPolicyToDefinition row =
         then Schema.PolicyRolePublic
         else Schema.PolicyRoleNamed (T.unpack roleText)
 
-    roles = Set.fromList . fmap parseRole $ pgPolicyRoles row
+    roles = Set.fromList . fmap parseRole $ PgCatalog.pgPolicyRoles row
 
     -- The parenthesization matches what 'Expr.policyUsingExpr' and
     -- 'Expr.policyCheckExpr' produce so the expressions compare consistently
     mbUsing =
-      fmap (RawSql.unsafeFromRawSql . RawSql.parenthesized . RawSql.fromText) $ pgPolicyQual row
+      fmap (RawSql.unsafeFromRawSql . RawSql.parenthesized . RawSql.fromText) $ PgCatalog.pgPolicyQual row
 
     mbCheck =
-      fmap (RawSql.unsafeFromRawSql . RawSql.parenthesized . RawSql.fromText) $ pgPolicyWithCheck row
+      fmap (RawSql.unsafeFromRawSql . RawSql.parenthesized . RawSql.fromText) $ PgCatalog.pgPolicyWithCheck row
 
     -- pg_policies.permissive contains either 'PERMISSIVE' or 'RESTRICTIVE'
     permission =
-      if T.toUpper (pgPolicyPermissive row) == T.pack "RESTRICTIVE"
+      if T.toUpper (PgCatalog.pgPolicyPermissive row) == T.pack "RESTRICTIVE"
         then Schema.PolicyRestrictive
         else Schema.PolicyPermissive
 
     -- pg_policies.cmd contains 'ALL', 'SELECT', 'INSERT', 'UPDATE' or 'DELETE'
     command =
-      case T.unpack (T.toUpper (pgPolicyCmd row)) of
+      case T.unpack (T.toUpper (PgCatalog.pgPolicyCmd row)) of
         "SELECT" -> Schema.PolicyCommandSelect
         "INSERT" -> Schema.PolicyCommandInsert
         "UPDATE" -> Schema.PolicyCommandUpdate
@@ -1950,16 +1880,19 @@ pgPolicyToDefinition row =
         _ -> Schema.PolicyCommandAll
   in
     Schema.mkPolicyDefinition
-      (T.unpack $ pgPolicyPolicyName row)
+      (T.unpack $ PgCatalog.pgPolicyPolicyName row)
       (Just permission)
       (Just command)
       (Just roles)
       mbUsing
       mbCheck
 
-{- | Query existing policies for all tables mentioned in the schema items,
-matching each table in the schema it belongs to (either the schema
-explicitly set on the table or the current namespace)
+{- | Query existing policies for the tables in the schema items that define
+policies or mark policies for dropping, matching each table in the schema it
+belongs to (either the schema explicitly set on the table or the current
+namespace). Tables that don't use policies are skipped entirely — existing
+policies on them are never touched — so schemas without policies issue no
+query at all.
 -}
 queryExistingPolicies ::
   Orville.MonadOrville m =>
@@ -1968,24 +1901,28 @@ queryExistingPolicies ::
   m (Map.Map Orville.TableIdentifier (Map.Map String Schema.PolicyDefinition))
 queryExistingPolicies currentNamespace schemaItems =
   let
+    tableUsesPolicies :: Orville.TableDefinition key writeEntity readEntity -> Bool
+    tableUsesPolicies tableDef =
+      not (Map.null (Orville.tablePolicies tableDef))
+        || not (Set.null (Orville.policiesToDrop tableDef))
+
     getPgCatalogNames item =
       case item of
-        SchemaTable tableDef ->
-          Just . tableIdToPgCatalogNames currentNamespace . Orville.tableIdentifier $ tableDef
-        SchemaDropTable tableId ->
-          Just $ tableIdToPgCatalogNames currentNamespace tableId
+        SchemaTable tableDef
+          | tableUsesPolicies tableDef ->
+              Just . tableIdToPgCatalogNames currentNamespace . Orville.tableIdentifier $ tableDef
         _ -> Nothing
 
     tableCondition (schemaName, tableName) =
-      Orville.fieldEquals pgPolicySchemaNameField (T.pack $ PgCatalog.namespaceNameToString schemaName)
-        `Orville.andExpr` Orville.fieldEquals pgPolicyTableNameField (T.pack $ PgCatalog.relationNameToString tableName)
+      Orville.fieldEquals PgCatalog.pgPolicySchemaNameField (T.pack $ PgCatalog.namespaceNameToString schemaName)
+        `Orville.andExpr` Orville.fieldEquals PgCatalog.pgPolicyTableNameField (T.pack $ PgCatalog.relationNameToString tableName)
 
     policyMapEntry row =
       let
         policyDef = pgPolicyToDefinition row
       in
-        ( Orville.setTableIdSchema (T.unpack $ pgPolicySchemaName row) $
-            Orville.unqualifiedNameToTableId (T.unpack $ pgPolicyTableName row)
+        ( Orville.setTableIdSchema (T.unpack $ PgCatalog.pgPolicySchemaName row) $
+            Orville.unqualifiedNameToTableId (T.unpack $ PgCatalog.pgPolicyTableName row)
         , Map.singleton (Schema.policyDefinitionPolicyName policyDef) policyDef
         )
   in
@@ -1997,7 +1934,7 @@ queryExistingPolicies currentNamespace schemaItems =
             ExtraNonEmpty.foldl1' Orville.orExpr $
               fmap tableCondition tableCatalogNames
 
-        pgPolicies <- Orville.findEntitiesBy pgPoliciesTable (Orville.where_ whereCondition)
+        pgPolicies <- Orville.findEntitiesBy PgCatalog.pgPoliciesTable (Orville.where_ whereCondition)
         pure . Map.fromListWith (<>) . fmap policyMapEntry $ pgPolicies
 
 -- | Sets the schema name on a table identifier if it doesn't already have one

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr.hs
@@ -1,7 +1,7 @@
 {-# OPTIONS_GHC -Wno-missing-import-lists #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2023-2025
+Copyright : Flipstone Technology Partners 2023-2026
 License   : MIT
 Stability : Stable
 
@@ -80,6 +80,7 @@ module Orville.PostgreSQL.Expr
   , module Orville.PostgreSQL.Expr.FetchClause
   , module Orville.PostgreSQL.Expr.Values
   , module Orville.PostgreSQL.Expr.TextSearch
+  , module Orville.PostgreSQL.Expr.PolicyExpr
   )
 where
 
@@ -113,6 +114,7 @@ import Orville.PostgreSQL.Expr.OffsetExpr
 import Orville.PostgreSQL.Expr.OnConflict
 import Orville.PostgreSQL.Expr.OrReplace
 import Orville.PostgreSQL.Expr.OrderBy
+import Orville.PostgreSQL.Expr.PolicyExpr
 import Orville.PostgreSQL.Expr.Query
 import Orville.PostgreSQL.Expr.ReturningExpr
 import Orville.PostgreSQL.Expr.RowLocking

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Internal/Name/PolicyName.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Internal/Name/PolicyName.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+{- |
+Copyright : Flipstone Technology Partners 2026
+License   : MIT
+Stability : Stable
+
+@since 1.2.0.0
+-}
+module Orville.PostgreSQL.Expr.Internal.Name.PolicyName
+  ( PolicyName
+  , policyName
+  ) where
+
+import Orville.PostgreSQL.Expr.Internal.Name.Identifier (Identifier, IdentifierExpression, identifier)
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+
+{- | Type to represent a SQL policy name. 'PolicyName' values constructed via
+the 'policyName' function will be properly escaped as part of the generated
+SQL. E.G.
+
+> "some_policy_name"
+
+'PolicyName' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 1.2.0.0
+-}
+newtype PolicyName
+  = PolicyName Identifier
+  deriving
+    ( -- | @since 1.2.0.0
+      RawSql.SqlExpression
+    , -- | @since 1.2.0.0
+      IdentifierExpression
+    )
+
+{- | Construct a 'PolicyName' from a 'String' with proper escaping as part of the generated SQL.
+
+@since 1.2.0.0
+-}
+policyName :: String -> PolicyName
+policyName =
+  PolicyName . identifier

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/Name.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/Name.hs
@@ -1,7 +1,7 @@
 {-# OPTIONS_GHC -Wno-missing-import-lists #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2023-2024
+Copyright : Flipstone Technology Partners 2023-2026
 License   : MIT
 Stability : Stable
 
@@ -20,6 +20,7 @@ import Orville.PostgreSQL.Expr.Internal.Name.ExtensionName as Export
 import Orville.PostgreSQL.Expr.Internal.Name.FunctionName as Export
 import Orville.PostgreSQL.Expr.Internal.Name.Identifier as Export
 import Orville.PostgreSQL.Expr.Internal.Name.IndexName as Export
+import Orville.PostgreSQL.Expr.Internal.Name.PolicyName as Export
 import Orville.PostgreSQL.Expr.Internal.Name.Qualified as Export
 import Orville.PostgreSQL.Expr.Internal.Name.SavepointName as Export
 import Orville.PostgreSQL.Expr.Internal.Name.SchemaName as Export

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/PolicyExpr.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/PolicyExpr.hs
@@ -1,0 +1,16 @@
+{-# OPTIONS_GHC -Wno-missing-import-lists #-}
+
+{- |
+Copyright : Flipstone Technology Partners 2026
+License   : MIT
+Stability : Stable
+
+@since 1.2.0.0
+-}
+module Orville.PostgreSQL.Expr.PolicyExpr
+  ( module Export
+  ) where
+
+import Orville.PostgreSQL.Expr.PolicyExpr.CreatePolicyExpr as Export
+import Orville.PostgreSQL.Expr.PolicyExpr.DropPolicyExpr as Export
+import Orville.PostgreSQL.Expr.PolicyExpr.PolicyRole as Export

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/PolicyExpr.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/PolicyExpr.hs
@@ -11,8 +11,6 @@ module Orville.PostgreSQL.Expr.PolicyExpr
   ( module Export
   ) where
 
--- The compare functions are internal helpers and are deliberately excluded
--- from the public re-export.
-import Orville.PostgreSQL.Expr.PolicyExpr.CreatePolicyExpr as Export hiding (comparePolicyCheckExpr, comparePolicyUsingExpr)
+import Orville.PostgreSQL.Expr.PolicyExpr.CreatePolicyExpr as Export
 import Orville.PostgreSQL.Expr.PolicyExpr.DropPolicyExpr as Export
 import Orville.PostgreSQL.Expr.PolicyExpr.PolicyRole as Export

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/PolicyExpr.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/PolicyExpr.hs
@@ -11,6 +11,8 @@ module Orville.PostgreSQL.Expr.PolicyExpr
   ( module Export
   ) where
 
-import Orville.PostgreSQL.Expr.PolicyExpr.CreatePolicyExpr as Export
+-- The compare functions are internal helpers and are deliberately excluded
+-- from the public re-export.
+import Orville.PostgreSQL.Expr.PolicyExpr.CreatePolicyExpr as Export hiding (comparePolicyCheckExpr, comparePolicyUsingExpr)
 import Orville.PostgreSQL.Expr.PolicyExpr.DropPolicyExpr as Export
 import Orville.PostgreSQL.Expr.PolicyExpr.PolicyRole as Export

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/PolicyExpr/CreatePolicyExpr.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/PolicyExpr/CreatePolicyExpr.hs
@@ -1,0 +1,237 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+{- |
+Copyright : Flipstone Technology Partners 2026
+License   : MIT
+Stability : Stable
+
+@since 1.2.0.0
+-}
+module Orville.PostgreSQL.Expr.PolicyExpr.CreatePolicyExpr
+  ( CreatePolicyExpr
+  , AlterPolicyExpr
+  , PolicyUsingExpr
+  , PolicyCheckExpr
+  , policyUsingExpr
+  , policyCheckExpr
+  , createPolicyExpr
+  , alterPolicyExpr
+  ) where
+
+import qualified Data.ByteString as BS
+import Data.Function (on)
+import qualified Data.Word as Word
+
+import Orville.PostgreSQL.Expr.Name (QualifiedOrUnqualified, TableName)
+import Orville.PostgreSQL.Expr.WhereClause (BooleanExpr)
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+
+import Orville.PostgreSQL.Expr.Name (PolicyName)
+import Orville.PostgreSQL.Expr.PolicyExpr.PolicyRole (PolicyRole)
+
+{- | Type to represent a SQL @CREATE POLICY@ statement. E.G.
+
+> CREATE POLICY "some_policy" ON "some_table" TO "some_role" USING (...) WITH CHECK (...)
+
+'CreatePolicyExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 1.2.0.0
+-}
+newtype CreatePolicyExpr
+  = CreatePolicyExpr RawSql.RawSql
+  deriving
+    ( -- | @since 1.2.0.0
+      RawSql.SqlExpression
+    )
+
+{- | Type to represent a SQL @ALTER POLICY@ statement. E.G.
+
+> ALTER POLICY "some_policy" ON "some_table" TO "some_role" USING (...) WITH CHECK (...)
+
+'AlterPolicyExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 1.2.0.0
+-}
+newtype AlterPolicyExpr
+  = AlterPolicyExpr RawSql.RawSql
+  deriving
+    ( -- | @since 1.2.0.0
+      RawSql.SqlExpression
+    )
+
+{- | Type to represent the expression used in the @USING@ clause of a policy,
+which restricts the rows visible to existing-row commands. See
+'policyUsingExpr' for construction.
+
+'PolicyUsingExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 1.2.0.0
+-}
+newtype PolicyUsingExpr
+  = PolicyUsingExpr RawSql.RawSql
+  deriving
+    ( -- | @since 1.2.0.0
+      RawSql.SqlExpression
+    )
+
+-- | @since 1.2.0.0
+instance Eq PolicyUsingExpr where
+  (==) = on (==) (BS.map toLowerWord8 . RawSql.toExampleBytes)
+
+-- | @since 1.2.0.0
+instance Ord PolicyUsingExpr where
+  compare = on compare (BS.map toLowerWord8 . RawSql.toExampleBytes)
+
+{- | Type to represent the expression used in the @WITH CHECK@ clause of a
+policy, which restricts the rows that new-row commands may produce. See
+'policyCheckExpr' for construction.
+
+'PolicyCheckExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 1.2.0.0
+-}
+newtype PolicyCheckExpr
+  = PolicyCheckExpr RawSql.RawSql
+  deriving
+    ( -- | @since 1.2.0.0
+      RawSql.SqlExpression
+    )
+
+-- | @since 1.2.0.0
+instance Eq PolicyCheckExpr where
+  (==) = on (==) (BS.map toLowerWord8 . RawSql.toExampleBytes)
+
+-- | @since 1.2.0.0
+instance Ord PolicyCheckExpr where
+  compare = on compare (BS.map toLowerWord8 . RawSql.toExampleBytes)
+
+{- | Constructs a 'PolicyUsingExpr' from a 'BooleanExpr'.
+
+Note that this parenthesizes the 'BooleanExpr' in order to match the @qual@
+column in @pg_policies@.
+
+@since 1.2.0.0
+-}
+policyUsingExpr :: BooleanExpr -> PolicyUsingExpr
+policyUsingExpr = PolicyUsingExpr . RawSql.parenthesized
+
+{- | Constructs a 'PolicyCheckExpr' from a 'BooleanExpr'.
+
+Note that this parenthesizes the 'BooleanExpr' in order to match the
+@with_check@ column in @pg_policies@.
+
+@since 1.2.0.0
+-}
+policyCheckExpr :: BooleanExpr -> PolicyCheckExpr
+policyCheckExpr = PolicyCheckExpr . RawSql.parenthesized
+
+{- | Constructs a 'CreatePolicyExpr' for the named policy on the given table,
+  optionally restricting it to a set of roles and applying @USING@ and
+  @WITH CHECK@ expressions.
+
+@since 1.2.0.0
+-}
+createPolicyExpr ::
+  PolicyName ->
+  QualifiedOrUnqualified TableName ->
+  Maybe [PolicyRole] ->
+  Maybe PolicyUsingExpr ->
+  Maybe PolicyCheckExpr ->
+  CreatePolicyExpr
+createPolicyExpr name tableName mbRoles mbUsing mbCheck =
+  CreatePolicyExpr
+    $ RawSql.intercalate
+      RawSql.space
+    $ [ RawSql.fromString "CREATE POLICY"
+      , RawSql.toRawSql name
+      , RawSql.fromString "ON"
+      , RawSql.toRawSql tableName
+      ]
+      <> maybe
+        []
+        ( \roles ->
+            [ RawSql.fromString "TO"
+            , RawSql.toRawSql . RawSql.intercalate RawSql.comma $ roles
+            ]
+        )
+        mbRoles
+      <> maybe
+        []
+        ( \using ->
+            [ RawSql.fromString "USING"
+            , RawSql.toRawSql using
+            ]
+        )
+        mbUsing
+      <> maybe
+        []
+        ( \check ->
+            [ RawSql.fromString "WITH CHECK"
+            , RawSql.toRawSql check
+            ]
+        )
+        mbCheck
+
+{- | Constructs an 'AlterPolicyExpr' for the named policy on the given table,
+  optionally restricting it to a set of roles and applying @USING@ and
+  @WITH CHECK@ expressions.
+
+@since 1.2.0.0
+-}
+alterPolicyExpr ::
+  PolicyName ->
+  QualifiedOrUnqualified TableName ->
+  Maybe [PolicyRole] ->
+  Maybe PolicyUsingExpr ->
+  Maybe PolicyCheckExpr ->
+  AlterPolicyExpr
+alterPolicyExpr name tableName mbRoles mbUsing mbCheck =
+  AlterPolicyExpr
+    $ RawSql.intercalate
+      RawSql.space
+    $ [ RawSql.fromString "ALTER POLICY"
+      , RawSql.toRawSql name
+      , RawSql.fromString "ON"
+      , RawSql.toRawSql tableName
+      ]
+      <> maybe
+        []
+        ( \roles ->
+            [ RawSql.fromString "TO"
+            , RawSql.toRawSql . RawSql.intercalate RawSql.comma $ roles
+            ]
+        )
+        mbRoles
+      <> maybe
+        []
+        ( \using ->
+            [ RawSql.fromString "USING"
+            , RawSql.toRawSql using
+            ]
+        )
+        mbUsing
+      <> maybe
+        []
+        ( \check ->
+            [ RawSql.fromString "WITH CHECK"
+            , RawSql.toRawSql check
+            ]
+        )
+        mbCheck
+
+{- | Convert ASCII uppercase bytes to lowercase for case-insensitive comparison.
+PostgreSQL normalizes SQL keywords to lowercase in pg_policies, so we need
+case-insensitive comparison to avoid spurious ALTER POLICY steps.
+-}
+toLowerWord8 :: Word.Word8 -> Word.Word8
+toLowerWord8 w
+  | w >= 65 && w <= 90 = w + 32
+  | otherwise = w

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/PolicyExpr/CreatePolicyExpr.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/PolicyExpr/CreatePolicyExpr.hs
@@ -42,7 +42,7 @@ import Orville.PostgreSQL.Expr.PolicyExpr.PolicyRole (PolicyRoleExpr)
 
 {- | Type to represent a SQL @CREATE POLICY@ statement. E.G.
 
-> CREATE POLICY "some_policy" ON "some_table" TO "some_role" USING (...) WITH CHECK (...)
+> CREATE POLICY "some_policy" ON "some_table" AS PERMISSIVE FOR ALL TO "some_role" USING (...) WITH CHECK (...)
 
 'CreatePolicyExpr' provides a 'RawSql.SqlExpression' instance. See
 'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
@@ -188,8 +188,7 @@ ASCII case outside quoted regions so that expressions compare consistently
 against the deparsed forms PostgreSQL returns in @pg_policies@. See
 'caseFoldOutsideQuotes' for details.
 
-This function is internal to Orville and is not exported from the public
-modules.
+@since 1.2.0.0
 -}
 comparePolicyUsingExpr :: PolicyUsingExpr -> PolicyUsingExpr -> Ordering
 comparePolicyUsingExpr =
@@ -217,8 +216,7 @@ ASCII case outside quoted regions so that expressions compare consistently
 against the deparsed forms PostgreSQL returns in @pg_policies@. See
 'caseFoldOutsideQuotes' for details.
 
-This function is internal to Orville and is not exported from the public
-modules.
+@since 1.2.0.0
 -}
 comparePolicyCheckExpr :: PolicyCheckExpr -> PolicyCheckExpr -> Ordering
 comparePolicyCheckExpr =

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/PolicyExpr/CreatePolicyExpr.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/PolicyExpr/CreatePolicyExpr.hs
@@ -10,12 +10,23 @@ Stability : Stable
 module Orville.PostgreSQL.Expr.PolicyExpr.CreatePolicyExpr
   ( CreatePolicyExpr
   , AlterPolicyExpr
+  , PolicyPermissionExpr
+  , PolicyCommandExpr
   , PolicyUsingExpr
   , PolicyCheckExpr
+  , policyPermissive
+  , policyRestrictive
+  , policyCommandAll
+  , policyCommandSelect
+  , policyCommandInsert
+  , policyCommandUpdate
+  , policyCommandDelete
   , policyUsingExpr
   , policyCheckExpr
   , createPolicyExpr
   , alterPolicyExpr
+  , comparePolicyUsingExpr
+  , comparePolicyCheckExpr
   ) where
 
 import qualified Data.ByteString as BS
@@ -27,7 +38,7 @@ import Orville.PostgreSQL.Expr.WhereClause (BooleanExpr)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 import Orville.PostgreSQL.Expr.Name (PolicyName)
-import Orville.PostgreSQL.Expr.PolicyExpr.PolicyRole (PolicyRole)
+import Orville.PostgreSQL.Expr.PolicyExpr.PolicyRole (PolicyRoleExpr)
 
 {- | Type to represent a SQL @CREATE POLICY@ statement. E.G.
 
@@ -63,6 +74,98 @@ newtype AlterPolicyExpr
       RawSql.SqlExpression
     )
 
+{- | Type to represent the @PERMISSIVE@ or @RESTRICTIVE@ keyword used in the
+@AS@ clause of a @CREATE POLICY@ statement. See 'policyPermissive' and
+'policyRestrictive' for construction.
+
+'PolicyPermissionExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 1.2.0.0
+-}
+newtype PolicyPermissionExpr
+  = PolicyPermissionExpr RawSql.RawSql
+  deriving
+    ( -- | @since 1.2.0.0
+      RawSql.SqlExpression
+    )
+
+{- | The @PERMISSIVE@ keyword for the @AS@ clause of a @CREATE POLICY@
+statement.
+
+@since 1.2.0.0
+-}
+policyPermissive :: PolicyPermissionExpr
+policyPermissive =
+  PolicyPermissionExpr (RawSql.fromString "PERMISSIVE")
+
+{- | The @RESTRICTIVE@ keyword for the @AS@ clause of a @CREATE POLICY@
+statement.
+
+@since 1.2.0.0
+-}
+policyRestrictive :: PolicyPermissionExpr
+policyRestrictive =
+  PolicyPermissionExpr (RawSql.fromString "RESTRICTIVE")
+
+{- | Type to represent the command keyword used in the @FOR@ clause of a
+@CREATE POLICY@ statement: @ALL@, @SELECT@, @INSERT@, @UPDATE@ or @DELETE@.
+See 'policyCommandAll' and friends for construction.
+
+'PolicyCommandExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 1.2.0.0
+-}
+newtype PolicyCommandExpr
+  = PolicyCommandExpr RawSql.RawSql
+  deriving
+    ( -- | @since 1.2.0.0
+      RawSql.SqlExpression
+    )
+
+{- | The @ALL@ command for the @FOR@ clause of a @CREATE POLICY@ statement.
+
+@since 1.2.0.0
+-}
+policyCommandAll :: PolicyCommandExpr
+policyCommandAll =
+  PolicyCommandExpr (RawSql.fromString "ALL")
+
+{- | The @SELECT@ command for the @FOR@ clause of a @CREATE POLICY@ statement.
+
+@since 1.2.0.0
+-}
+policyCommandSelect :: PolicyCommandExpr
+policyCommandSelect =
+  PolicyCommandExpr (RawSql.fromString "SELECT")
+
+{- | The @INSERT@ command for the @FOR@ clause of a @CREATE POLICY@ statement.
+
+@since 1.2.0.0
+-}
+policyCommandInsert :: PolicyCommandExpr
+policyCommandInsert =
+  PolicyCommandExpr (RawSql.fromString "INSERT")
+
+{- | The @UPDATE@ command for the @FOR@ clause of a @CREATE POLICY@ statement.
+
+@since 1.2.0.0
+-}
+policyCommandUpdate :: PolicyCommandExpr
+policyCommandUpdate =
+  PolicyCommandExpr (RawSql.fromString "UPDATE")
+
+{- | The @DELETE@ command for the @FOR@ clause of a @CREATE POLICY@ statement.
+
+@since 1.2.0.0
+-}
+policyCommandDelete :: PolicyCommandExpr
+policyCommandDelete =
+  PolicyCommandExpr (RawSql.fromString "DELETE")
+
 {- | Type to represent the expression used in the @USING@ clause of a policy,
 which restricts the rows visible to existing-row commands. See
 'policyUsingExpr' for construction.
@@ -80,13 +183,17 @@ newtype PolicyUsingExpr
       RawSql.SqlExpression
     )
 
--- | @since 1.2.0.0
-instance Eq PolicyUsingExpr where
-  (==) = on (==) (BS.map toLowerWord8 . RawSql.toExampleBytes)
+{- | Compares two 'PolicyUsingExpr' values by their example bytes, folding
+ASCII case outside quoted regions so that expressions compare consistently
+against the deparsed forms PostgreSQL returns in @pg_policies@. See
+'caseFoldOutsideQuotes' for details.
 
--- | @since 1.2.0.0
-instance Ord PolicyUsingExpr where
-  compare = on compare (BS.map toLowerWord8 . RawSql.toExampleBytes)
+This function is internal to Orville and is not exported from the public
+modules.
+-}
+comparePolicyUsingExpr :: PolicyUsingExpr -> PolicyUsingExpr -> Ordering
+comparePolicyUsingExpr =
+  on compare (caseFoldOutsideQuotes . RawSql.toExampleBytes)
 
 {- | Type to represent the expression used in the @WITH CHECK@ clause of a
 policy, which restricts the rows that new-row commands may produce. See
@@ -105,13 +212,17 @@ newtype PolicyCheckExpr
       RawSql.SqlExpression
     )
 
--- | @since 1.2.0.0
-instance Eq PolicyCheckExpr where
-  (==) = on (==) (BS.map toLowerWord8 . RawSql.toExampleBytes)
+{- | Compares two 'PolicyCheckExpr' values by their example bytes, folding
+ASCII case outside quoted regions so that expressions compare consistently
+against the deparsed forms PostgreSQL returns in @pg_policies@. See
+'caseFoldOutsideQuotes' for details.
 
--- | @since 1.2.0.0
-instance Ord PolicyCheckExpr where
-  compare = on compare (BS.map toLowerWord8 . RawSql.toExampleBytes)
+This function is internal to Orville and is not exported from the public
+modules.
+-}
+comparePolicyCheckExpr :: PolicyCheckExpr -> PolicyCheckExpr -> Ordering
+comparePolicyCheckExpr =
+  on compare (caseFoldOutsideQuotes . RawSql.toExampleBytes)
 
 {- | Constructs a 'PolicyUsingExpr' from a 'BooleanExpr'.
 
@@ -134,19 +245,27 @@ policyCheckExpr :: BooleanExpr -> PolicyCheckExpr
 policyCheckExpr = PolicyCheckExpr . RawSql.parenthesized
 
 {- | Constructs a 'CreatePolicyExpr' for the named policy on the given table,
-  optionally restricting it to a set of roles and applying @USING@ and
-  @WITH CHECK@ expressions.
+  optionally marking it as @PERMISSIVE@ or @RESTRICTIVE@, restricting it to a
+  command and a set of roles and applying @USING@ and @WITH CHECK@
+  expressions.
+
+  If no 'PolicyPermissionExpr' is given, no @AS@ clause is included and
+  PostgreSQL will use its default, which is @PERMISSIVE@ for current
+  PostgreSQL versions. Likewise, if no 'PolicyCommandExpr' is given, no @FOR@
+  clause is included and PostgreSQL will use its default, which is @ALL@.
 
 @since 1.2.0.0
 -}
 createPolicyExpr ::
   PolicyName ->
   QualifiedOrUnqualified TableName ->
-  Maybe [PolicyRole] ->
+  Maybe PolicyPermissionExpr ->
+  Maybe PolicyCommandExpr ->
+  Maybe [PolicyRoleExpr] ->
   Maybe PolicyUsingExpr ->
   Maybe PolicyCheckExpr ->
   CreatePolicyExpr
-createPolicyExpr name tableName mbRoles mbUsing mbCheck =
+createPolicyExpr name tableName mbPermission mbCommand mbRoles mbUsing mbCheck =
   CreatePolicyExpr
     $ RawSql.intercalate
       RawSql.space
@@ -157,39 +276,36 @@ createPolicyExpr name tableName mbRoles mbUsing mbCheck =
       ]
       <> maybe
         []
-        ( \roles ->
-            [ RawSql.fromString "TO"
-            , RawSql.toRawSql . RawSql.intercalate RawSql.comma $ roles
+        ( \permission ->
+            [ RawSql.fromString "AS"
+            , RawSql.toRawSql permission
             ]
         )
-        mbRoles
+        mbPermission
       <> maybe
         []
-        ( \using ->
-            [ RawSql.fromString "USING"
-            , RawSql.toRawSql using
+        ( \command ->
+            [ RawSql.fromString "FOR"
+            , RawSql.toRawSql command
             ]
         )
-        mbUsing
-      <> maybe
-        []
-        ( \check ->
-            [ RawSql.fromString "WITH CHECK"
-            , RawSql.toRawSql check
-            ]
-        )
-        mbCheck
+        mbCommand
+      <> policyClauses mbRoles mbUsing mbCheck
 
 {- | Constructs an 'AlterPolicyExpr' for the named policy on the given table,
   optionally restricting it to a set of roles and applying @USING@ and
   @WITH CHECK@ expressions.
+
+  Note that @ALTER POLICY@ cannot change whether a policy is @PERMISSIVE@ or
+  @RESTRICTIVE@, nor the command its @FOR@ clause names. Changing either
+  requires dropping and recreating the policy.
 
 @since 1.2.0.0
 -}
 alterPolicyExpr ::
   PolicyName ->
   QualifiedOrUnqualified TableName ->
-  Maybe [PolicyRole] ->
+  Maybe [PolicyRoleExpr] ->
   Maybe PolicyUsingExpr ->
   Maybe PolicyCheckExpr ->
   AlterPolicyExpr
@@ -202,34 +318,88 @@ alterPolicyExpr name tableName mbRoles mbUsing mbCheck =
       , RawSql.fromString "ON"
       , RawSql.toRawSql tableName
       ]
-      <> maybe
-        []
-        ( \roles ->
-            [ RawSql.fromString "TO"
-            , RawSql.toRawSql . RawSql.intercalate RawSql.comma $ roles
-            ]
-        )
-        mbRoles
-      <> maybe
-        []
-        ( \using ->
-            [ RawSql.fromString "USING"
-            , RawSql.toRawSql using
-            ]
-        )
-        mbUsing
-      <> maybe
-        []
-        ( \check ->
-            [ RawSql.fromString "WITH CHECK"
-            , RawSql.toRawSql check
-            ]
-        )
-        mbCheck
+      <> policyClauses mbRoles mbUsing mbCheck
 
-{- | Convert ASCII uppercase bytes to lowercase for case-insensitive comparison.
-PostgreSQL normalizes SQL keywords to lowercase in pg_policies, so we need
-case-insensitive comparison to avoid spurious ALTER POLICY steps.
+{- | Renders the @TO@, @USING@ and @WITH CHECK@ clauses shared by
+@CREATE POLICY@ and @ALTER POLICY@ statements.
+-}
+policyClauses ::
+  Maybe [PolicyRoleExpr] ->
+  Maybe PolicyUsingExpr ->
+  Maybe PolicyCheckExpr ->
+  [RawSql.RawSql]
+policyClauses mbRoles mbUsing mbCheck =
+  maybe
+    []
+    ( \roles ->
+        [ RawSql.fromString "TO"
+        , RawSql.intercalate RawSql.comma roles
+        ]
+    )
+    mbRoles
+    <> maybe
+      []
+      ( \using ->
+          [ RawSql.fromString "USING"
+          , RawSql.toRawSql using
+          ]
+      )
+      mbUsing
+    <> maybe
+      []
+      ( \check ->
+          [ RawSql.fromString "WITH CHECK"
+          , RawSql.toRawSql check
+          ]
+      )
+      mbCheck
+
+{- | Folds ASCII uppercase bytes to lowercase everywhere except inside
+single-quoted string literals and double-quoted identifiers. This mirrors
+PostgreSQL's own lexical rules: keywords and unquoted identifiers are
+case-insensitive (PostgreSQL renders them in its preferred case when
+deparsing expressions for @pg_policies@), while case inside string literals
+and quoted identifiers is significant and must be preserved so that policies
+differing only there still compare as different.
+
+A doubled quote inside a quoted region (@''@ or @\"\"@) is handled correctly
+without lookahead: the first quote is treated as leaving the region and the
+second as immediately re-entering it. Escape string syntax (@E'...'@) and
+dollar quoting are not recognized; PostgreSQL never produces either when
+deparsing policy expressions, so this only matters for hand-written SQL
+using those forms.
+-}
+caseFoldOutsideQuotes :: BS.ByteString -> BS.ByteString
+caseFoldOutsideQuotes =
+  let
+    step quoteState word =
+      case quoteState of
+        NotInQuote
+          | word == singleQuote -> (InSingleQuote, word)
+          | word == doubleQuote -> (InDoubleQuote, word)
+          | otherwise -> (NotInQuote, toLowerWord8 word)
+        InSingleQuote
+          | word == singleQuote -> (NotInQuote, word)
+          | otherwise -> (InSingleQuote, word)
+        InDoubleQuote
+          | word == doubleQuote -> (NotInQuote, word)
+          | otherwise -> (InDoubleQuote, word)
+  in
+    snd . BS.mapAccumL step NotInQuote
+
+data QuoteState
+  = NotInQuote
+  | InSingleQuote
+  | InDoubleQuote
+
+singleQuote :: Word.Word8
+singleQuote = 39 -- '
+
+doubleQuote :: Word.Word8
+doubleQuote = 34 -- "
+
+{- | Convert an ASCII uppercase byte to lowercase, leaving other bytes
+(including UTF-8 continuation bytes) untouched.
 -}
 toLowerWord8 :: Word.Word8 -> Word.Word8
 toLowerWord8 w

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/PolicyExpr/CreatePolicyExpr.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/PolicyExpr/CreatePolicyExpr.hs
@@ -31,6 +31,7 @@ module Orville.PostgreSQL.Expr.PolicyExpr.CreatePolicyExpr
 
 import qualified Data.ByteString as BS
 import Data.Function (on)
+import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Word as Word
 
 import Orville.PostgreSQL.Expr.Name (QualifiedOrUnqualified, TableName)
@@ -227,6 +228,13 @@ comparePolicyCheckExpr =
 Note that this parenthesizes the 'BooleanExpr' in order to match the @qual@
 column in @pg_policies@.
 
+The 'BooleanExpr' must not contain bind parameters: @CREATE POLICY@ and
+@ALTER POLICY@ are DDL statements and PostgreSQL does not accept parameters
+in them. Many Orville 'BooleanExpr' combinators (such as @fieldEquals@) pass
+values as parameters, so values used in policy expressions must be rendered
+inline as literals instead. Auto-migration rejects policy definitions whose
+expressions contain parameters when generating a plan.
+
 @since 1.2.0.0
 -}
 policyUsingExpr :: BooleanExpr -> PolicyUsingExpr
@@ -236,6 +244,9 @@ policyUsingExpr = PolicyUsingExpr . RawSql.parenthesized
 
 Note that this parenthesizes the 'BooleanExpr' in order to match the
 @with_check@ column in @pg_policies@.
+
+The 'BooleanExpr' must not contain bind parameters — see 'policyUsingExpr'
+for details.
 
 @since 1.2.0.0
 -}
@@ -259,7 +270,7 @@ createPolicyExpr ::
   QualifiedOrUnqualified TableName ->
   Maybe PolicyPermissionExpr ->
   Maybe PolicyCommandExpr ->
-  Maybe [PolicyRoleExpr] ->
+  Maybe (NonEmpty PolicyRoleExpr) ->
   Maybe PolicyUsingExpr ->
   Maybe PolicyCheckExpr ->
   CreatePolicyExpr
@@ -303,7 +314,7 @@ createPolicyExpr name tableName mbPermission mbCommand mbRoles mbUsing mbCheck =
 alterPolicyExpr ::
   PolicyName ->
   QualifiedOrUnqualified TableName ->
-  Maybe [PolicyRoleExpr] ->
+  Maybe (NonEmpty PolicyRoleExpr) ->
   Maybe PolicyUsingExpr ->
   Maybe PolicyCheckExpr ->
   AlterPolicyExpr
@@ -322,7 +333,7 @@ alterPolicyExpr name tableName mbRoles mbUsing mbCheck =
 @CREATE POLICY@ and @ALTER POLICY@ statements.
 -}
 policyClauses ::
-  Maybe [PolicyRoleExpr] ->
+  Maybe (NonEmpty PolicyRoleExpr) ->
   Maybe PolicyUsingExpr ->
   Maybe PolicyCheckExpr ->
   [RawSql.RawSql]

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/PolicyExpr/DropPolicyExpr.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/PolicyExpr/DropPolicyExpr.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+{- |
+Copyright : Flipstone Technology Partners 2026
+License   : MIT
+Stability : Stable
+
+@since 1.2.0.0
+-}
+module Orville.PostgreSQL.Expr.PolicyExpr.DropPolicyExpr
+  ( DropPolicyExpr
+  , dropPolicy
+  ) where
+
+import Orville.PostgreSQL.Expr.IfExists (IfExists)
+import Orville.PostgreSQL.Expr.Name (PolicyName, QualifiedOrUnqualified, TableName)
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+
+{- | Type to represent a SQL @DROP POLICY@ statement. E.G.
+
+> DROP POLICY IF EXISTS "some_policy" ON "some_table"
+
+'DropPolicyExpr' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 1.2.0.0
+-}
+newtype DropPolicyExpr
+  = DropPolicyExpr RawSql.RawSql
+  deriving
+    ( -- | @since 1.2.0.0
+      RawSql.SqlExpression
+    )
+
+{- | Constructs a 'DropPolicyExpr' that will drop the named policy from the
+  given table, optionally only if it exists.
+
+@since 1.2.0.0
+-}
+dropPolicy ::
+  Maybe IfExists ->
+  PolicyName ->
+  QualifiedOrUnqualified TableName ->
+  DropPolicyExpr
+dropPolicy maybeIfExists policyName tableName =
+  DropPolicyExpr
+    $ RawSql.intercalate
+      RawSql.space
+    $ [RawSql.fromString "DROP POLICY"]
+      <> maybe [] (pure . RawSql.toRawSql) maybeIfExists
+      <> [ RawSql.toRawSql policyName
+         , RawSql.fromString "ON"
+         , RawSql.toRawSql tableName
+         ]

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/PolicyExpr/PolicyRole.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/PolicyExpr/PolicyRole.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+{- |
+Copyright : Flipstone Technology Partners 2026
+License   : MIT
+Stability : Stable
+
+@since 1.2.0.0
+-}
+module Orville.PostgreSQL.Expr.PolicyExpr.PolicyRole
+  ( PolicyRole
+  , policyRole
+  ) where
+
+import Orville.PostgreSQL.Expr.Internal.Name.Identifier (Identifier, IdentifierExpression, identifier)
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+
+{- | Type to represent the name of a database role that a policy applies to, as
+used in the @TO@ clause of a @CREATE POLICY@ statement. 'PolicyRole' values
+constructed via the 'policyRole' function will be properly escaped as part of
+the generated SQL. E.G.
+
+> "some_role"
+
+'PolicyRole' provides a 'RawSql.SqlExpression' instance. See
+'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
+SQL.
+
+@since 1.2.0.0
+-}
+newtype PolicyRole
+  = PolicyRole Identifier
+  deriving
+    ( -- | @since 1.2.0.0
+      RawSql.SqlExpression
+    , -- | @since 1.2.0.0
+      IdentifierExpression
+    )
+
+{- | Construct a 'PolicyRole' from a 'String' with proper escaping as part of the generated SQL.
+
+@since 1.2.0.0
+-}
+policyRole :: String -> PolicyRole
+policyRole =
+  PolicyRole . identifier

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/PolicyExpr/PolicyRole.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/PolicyExpr/PolicyRole.hs
@@ -8,39 +8,78 @@ Stability : Stable
 @since 1.2.0.0
 -}
 module Orville.PostgreSQL.Expr.PolicyExpr.PolicyRole
-  ( PolicyRole
-  , policyRole
+  ( PolicyRoleExpr
+  , namedPolicyRole
+  , publicPolicyRole
+  , currentRolePolicyRole
+  , currentUserPolicyRole
+  , sessionUserPolicyRole
   ) where
 
-import Orville.PostgreSQL.Expr.Internal.Name.Identifier (Identifier, IdentifierExpression, identifier)
+import Orville.PostgreSQL.Expr.Internal.Name.Identifier (identifier)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
-{- | Type to represent the name of a database role that a policy applies to, as
-used in the @TO@ clause of a @CREATE POLICY@ statement. 'PolicyRole' values
-constructed via the 'policyRole' function will be properly escaped as part of
-the generated SQL. E.G.
+{- | Type to represent a role target in the @TO@ clause of a @CREATE POLICY@
+or @ALTER POLICY@ statement: either the name of a database role or one of
+the special targets @PUBLIC@, @CURRENT_ROLE@, @CURRENT_USER@ or
+@SESSION_USER@.
 
-> "some_role"
-
-'PolicyRole' provides a 'RawSql.SqlExpression' instance. See
+'PolicyRoleExpr' provides a 'RawSql.SqlExpression' instance. See
 'RawSql.unsafeSqlExpression' for how to construct a value with your own custom
 SQL.
 
 @since 1.2.0.0
 -}
-newtype PolicyRole
-  = PolicyRole Identifier
+newtype PolicyRoleExpr
+  = PolicyRoleExpr RawSql.RawSql
   deriving
     ( -- | @since 1.2.0.0
       RawSql.SqlExpression
-    , -- | @since 1.2.0.0
-      IdentifierExpression
     )
 
-{- | Construct a 'PolicyRole' from a 'String' with proper escaping as part of the generated SQL.
+{- | Construct a 'PolicyRoleExpr' referring to the database role with the given
+name, with proper escaping as part of the generated SQL. E.G.
+
+> "some_role"
 
 @since 1.2.0.0
 -}
-policyRole :: String -> PolicyRole
-policyRole =
-  PolicyRole . identifier
+namedPolicyRole :: String -> PolicyRoleExpr
+namedPolicyRole =
+  PolicyRoleExpr . RawSql.toRawSql . identifier
+
+{- | The @PUBLIC@ role target, which makes the policy apply to all roles.
+
+@since 1.2.0.0
+-}
+publicPolicyRole :: PolicyRoleExpr
+publicPolicyRole =
+  PolicyRoleExpr (RawSql.fromString "PUBLIC")
+
+{- | The @CURRENT_ROLE@ role target. PostgreSQL resolves this to the concrete
+current role at the time the statement is executed. Requires PostgreSQL 14 or
+later.
+
+@since 1.2.0.0
+-}
+currentRolePolicyRole :: PolicyRoleExpr
+currentRolePolicyRole =
+  PolicyRoleExpr (RawSql.fromString "CURRENT_ROLE")
+
+{- | The @CURRENT_USER@ role target. PostgreSQL resolves this to the concrete
+current role at the time the statement is executed.
+
+@since 1.2.0.0
+-}
+currentUserPolicyRole :: PolicyRoleExpr
+currentUserPolicyRole =
+  PolicyRoleExpr (RawSql.fromString "CURRENT_USER")
+
+{- | The @SESSION_USER@ role target. PostgreSQL resolves this to the concrete
+session role at the time the statement is executed.
+
+@since 1.2.0.0
+-}
+sessionUserPolicyRole :: PolicyRoleExpr
+sessionUserPolicyRole =
+  PolicyRoleExpr (RawSql.fromString "SESSION_USER")

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/TableDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/TableDefinition.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2023-2025
+Copyright : Flipstone Technology Partners 2023-2026
 License   : MIT
 Stability : Stable
 
@@ -35,6 +35,8 @@ module Orville.PostgreSQL.Expr.TableDefinition
   , dropTableExpr
   , TruncateTableExpr
   , truncateTablesExpr
+  , enableRowLevelSecurityExpr
+  , disableRowLevelSecurityExpr
   )
 where
 
@@ -458,3 +460,27 @@ truncateTablesExpr :: NonEmpty (QualifiedOrUnqualified TableName) -> TruncateTab
 truncateTablesExpr tableNames =
   TruncateTableExpr $
     RawSql.fromString "TRUNCATE TABLE " <> RawSql.intercalate RawSql.commaSpace tableNames
+
+{- | Constructs an 'AlterTableExpr' that will enable row level security on the
+  specified table.
+
+  @since 1.2.0.0
+-}
+enableRowLevelSecurityExpr :: QualifiedOrUnqualified TableName -> AlterTableExpr
+enableRowLevelSecurityExpr tableName =
+  AlterTableExpr $
+    RawSql.fromString "ALTER TABLE "
+      <> RawSql.toRawSql tableName
+      <> RawSql.fromString " ENABLE ROW LEVEL SECURITY"
+
+{- | Constructs an 'AlterTableExpr' that will disable row level security on the
+  specified table.
+
+  @since 1.2.0.0
+-}
+disableRowLevelSecurityExpr :: QualifiedOrUnqualified TableName -> AlterTableExpr
+disableRowLevelSecurityExpr tableName =
+  AlterTableExpr $
+    RawSql.fromString "ALTER TABLE "
+      <> RawSql.toRawSql tableName
+      <> RawSql.fromString " DISABLE ROW LEVEL SECURITY"

--- a/orville-postgresql/src/Orville/PostgreSQL/Expr/TableDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Expr/TableDefinition.hs
@@ -468,10 +468,10 @@ truncateTablesExpr tableNames =
 -}
 enableRowLevelSecurityExpr :: QualifiedOrUnqualified TableName -> AlterTableExpr
 enableRowLevelSecurityExpr tableName =
-  AlterTableExpr $
-    RawSql.fromString "ALTER TABLE "
-      <> RawSql.toRawSql tableName
-      <> RawSql.fromString " ENABLE ROW LEVEL SECURITY"
+  alterTableExpr tableName
+    . pure
+    . AlterTableAction
+    $ RawSql.fromString "ENABLE ROW LEVEL SECURITY"
 
 {- | Constructs an 'AlterTableExpr' that will disable row level security on the
   specified table.
@@ -480,7 +480,7 @@ enableRowLevelSecurityExpr tableName =
 -}
 disableRowLevelSecurityExpr :: QualifiedOrUnqualified TableName -> AlterTableExpr
 disableRowLevelSecurityExpr tableName =
-  AlterTableExpr $
-    RawSql.fromString "ALTER TABLE "
-      <> RawSql.toRawSql tableName
-      <> RawSql.fromString " DISABLE ROW LEVEL SECURITY"
+  alterTableExpr tableName
+    . pure
+    . AlterTableAction
+    $ RawSql.fromString "DISABLE ROW LEVEL SECURITY"

--- a/orville-postgresql/src/Orville/PostgreSQL/Internal/PgArrayText.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Internal/PgArrayText.hs
@@ -1,0 +1,80 @@
+{- |
+Copyright : Flipstone Technology Partners 2026
+License   : MIT
+Stability : Stable
+
+Helpers for parsing and rendering the text representation PostgreSQL uses
+for array values (e.g. @{a,b,c}@).
+
+@since 1.2.0.0
+-}
+module Orville.PostgreSQL.Internal.PgArrayText
+  ( pgArrayTextToList
+  , pgArrayTextToTextList
+  , textListToPgArrayText
+  ) where
+
+import Control.Applicative ((<|>))
+import qualified Data.Attoparsec.Text as AttoText
+import qualified Data.Text as T
+
+{- | Parses the text representation of a PostgreSQL array (@{elem,elem,...}@)
+  into its elements using the given element parser. The description is used
+  in the error message when parsing fails.
+-}
+pgArrayTextToList :: String -> AttoText.Parser a -> T.Text -> Either String [a]
+pgArrayTextToList description elementParser text =
+  let
+    parser = do
+      _ <- AttoText.char '{'
+      elements <- AttoText.sepBy elementParser (AttoText.char ',')
+      _ <- AttoText.char '}'
+      AttoText.endOfInput
+      pure elements
+  in
+    case AttoText.parseOnly parser text of
+      Left err -> Left ("Unable to decode PostgreSQL array as " <> description <> ": " <> err)
+      Right elements -> Right elements
+
+{- | Parses the text representation of a PostgreSQL array of textual values
+  (such as a @name[]@ or @text[]@ column) into its elements. PostgreSQL
+  renders elements containing special characters (commas, braces, quotes,
+  backslashes, whitespace) double-quoted, using backslash escapes for quotes
+  and backslashes within them.
+-}
+pgArrayTextToTextList :: String -> T.Text -> Either String [T.Text]
+pgArrayTextToTextList description =
+  let
+    quotedChunk =
+      AttoText.takeWhile1 (\c -> c /= '"' && c /= '\\')
+        <|> (AttoText.char '\\' *> (T.singleton <$> AttoText.anyChar))
+
+    quotedElement = do
+      _ <- AttoText.char '"'
+      chunks <- AttoText.many' quotedChunk
+      _ <- AttoText.char '"'
+      pure (T.concat chunks)
+
+    unquotedElement =
+      AttoText.takeWhile1 (\c -> c /= ',' && c /= '{' && c /= '}' && c /= '"' && c /= '\\')
+  in
+    pgArrayTextToList description (quotedElement <|> unquotedElement)
+
+{- | Renders a list of textual values in PostgreSQL's array text syntax. Every
+  element is rendered double-quoted, which is valid regardless of its
+  content, with quotes and backslashes escaped. This is the inverse of
+  'pgArrayTextToTextList'.
+-}
+textListToPgArrayText :: [T.Text] -> T.Text
+textListToPgArrayText values =
+  let
+    escapeChar c =
+      case c of
+        '"' -> T.pack "\\\""
+        '\\' -> T.pack "\\\\"
+        _ -> T.singleton c
+
+    quoteValue value =
+      T.pack "\"" <> T.concatMap escapeChar value <> T.pack "\""
+  in
+    T.pack "{" <> T.intercalate (T.pack ",") (fmap quoteValue values) <> T.pack "}"

--- a/orville-postgresql/src/Orville/PostgreSQL/PgCatalog.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/PgCatalog.hs
@@ -22,6 +22,7 @@ import Orville.PostgreSQL.PgCatalog.PgDescription as Export
 import Orville.PostgreSQL.PgCatalog.PgExtension as Export
 import Orville.PostgreSQL.PgCatalog.PgIndex as Export
 import Orville.PostgreSQL.PgCatalog.PgNamespace as Export
+import Orville.PostgreSQL.PgCatalog.PgPolicy as Export
 import Orville.PostgreSQL.PgCatalog.PgProc as Export
 import Orville.PostgreSQL.PgCatalog.PgSequence as Export
 import Orville.PostgreSQL.PgCatalog.PgTrigger as Export

--- a/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/PgClass.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/PgClass.hs
@@ -16,6 +16,7 @@ module Orville.PostgreSQL.PgCatalog.PgClass
   , relationNameField
   , namespaceOidField
   , relationKindField
+  , relationRowSecurityField
   )
 where
 
@@ -43,6 +44,8 @@ data PgClass = PgClass
   -- ^ The name of the relation.
   , pgClassRelationKind :: RelationKind
   -- ^ The kind of relation (table, view, etc).
+  , pgClassRowSecurity :: Bool
+  -- ^ Whether row-level security is enabled for the relation.
   }
 
 {- | A Haskell type for the name of the relation represented by a 'PgClass'.
@@ -113,6 +116,7 @@ pgClassMarshaller =
     <*> Orville.marshallField pgClassNamespaceOid namespaceOidField
     <*> Orville.marshallField pgClassRelationName relationNameField
     <*> Orville.marshallField pgClassRelationKind relationKindField
+    <*> Orville.marshallField pgClassRowSecurity relationRowSecurityField
 
 {- | The @relnamespace@ column of the @pg_catalog.pg_class@ table.
 
@@ -130,6 +134,14 @@ relationNameField :: Orville.FieldDefinition Orville.NotNull RelationName
 relationNameField =
   Orville.coerceField $
     Orville.unboundedTextField "relname"
+
+{- | The @relrowsecurity@ column of the @pg_catalog.pg_class@ table.
+
+@since 1.2.0.0
+-}
+relationRowSecurityField :: Orville.FieldDefinition Orville.NotNull Bool
+relationRowSecurityField =
+  Orville.booleanField "relrowsecurity"
 
 {- | The @relkind@ column of the @pg_catalog.pg_class@ table.
 

--- a/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/PgConstraint.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/PgConstraint.hs
@@ -17,7 +17,6 @@ module Orville.PostgreSQL.PgCatalog.PgConstraint
   )
 where
 
-import qualified Data.Attoparsec.Text as AttoText
 import qualified Data.List as List
 import qualified Data.String as String
 import qualified Data.Text as T
@@ -26,6 +25,7 @@ import qualified Data.Text.Lazy.Builder as LTB
 import qualified Database.PostgreSQL.LibPQ as LibPQ
 
 import qualified Orville.PostgreSQL as Orville
+import qualified Orville.PostgreSQL.Internal.PgArrayText as PgArrayText
 import Orville.PostgreSQL.PgCatalog.OidField (oidField, oidTypeField)
 import Orville.PostgreSQL.PgCatalog.PgAttribute (AttributeNumber, attributeNumberParser, attributeNumberTextBuilder)
 
@@ -307,18 +307,8 @@ constraintForeignKeyOnDeleteTypeField =
     (Orville.unboundedTextField "confdeltype")
 
 pgArrayTextToAttributeNumberList :: T.Text -> Either String [AttributeNumber]
-pgArrayTextToAttributeNumberList text =
-  let
-    parser = do
-      _ <- AttoText.char '{'
-      attNums <- AttoText.sepBy attributeNumberParser (AttoText.char ',')
-      _ <- AttoText.char '}'
-      AttoText.endOfInput
-      pure attNums
-  in
-    case AttoText.parseOnly parser text of
-      Left err -> Left ("Unable to decode PostgreSQL Array as AttributeNumber list: " <> err)
-      Right nums -> Right nums
+pgArrayTextToAttributeNumberList =
+  PgArrayText.pgArrayTextToList "AttributeNumber list" attributeNumberParser
 
 attributeNumberListToPgArrayText :: [AttributeNumber] -> T.Text
 attributeNumberListToPgArrayText attNums =

--- a/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/PgPolicy.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/PgPolicy.hs
@@ -1,0 +1,147 @@
+{- |
+Copyright : Flipstone Technology Partners 2026
+License   : MIT
+Stability : Stable
+
+@since 1.2.0.0
+-}
+module Orville.PostgreSQL.PgCatalog.PgPolicy
+  ( PgPolicy (..)
+  , pgPoliciesTable
+  , pgPolicySchemaNameField
+  , pgPolicyTableNameField
+  , pgPolicyPolicyNameField
+  , pgPolicyPermissiveField
+  , pgPolicyCmdField
+  , pgPolicyRolesField
+  , pgPolicyQualField
+  , pgPolicyWithCheckField
+  ) where
+
+import qualified Data.Text as T
+
+import qualified Orville.PostgreSQL as Orville
+import qualified Orville.PostgreSQL.Internal.PgArrayText as PgArrayText
+
+{- | The Haskell representation of data read from the @pg_catalog.pg_policies@
+  view. Rows in this view correspond to row-level security policies.
+
+  This models the @pg_policies@ view rather than the underlying @pg_policy@
+  catalog table because the view exposes the policy's @USING@ and
+  @WITH CHECK@ expressions as deparsed SQL text (via @pg_get_expr@) and its
+  roles as names rather than oids. Note that the view carries no oids, so
+  rows are identified by schema, table and policy name.
+
+@since 1.2.0.0
+-}
+data PgPolicy = PgPolicy
+  { pgPolicySchemaName :: T.Text
+  -- ^ The name of the schema containing the table the policy is on.
+  , pgPolicyTableName :: T.Text
+  -- ^ The name of the table the policy is on.
+  , pgPolicyPolicyName :: T.Text
+  -- ^ The name of the policy.
+  , pgPolicyPermissive :: T.Text
+  -- ^ Either @PERMISSIVE@ or @RESTRICTIVE@.
+  , pgPolicyCmd :: T.Text
+  {- ^ The command the policy applies to: @ALL@, @SELECT@, @INSERT@,
+  @UPDATE@ or @DELETE@.
+  -}
+  , pgPolicyRoles :: [T.Text]
+  {- ^ The names of the roles the policy applies to. Policies that apply to
+  all roles are reported as applying to the single role @public@.
+  -}
+  , pgPolicyQual :: Maybe T.Text
+  -- ^ The deparsed text of the policy's @USING@ expression, if any.
+  , pgPolicyWithCheck :: Maybe T.Text
+  -- ^ The deparsed text of the policy's @WITH CHECK@ expression, if any.
+  }
+
+{- | An Orville 'Orville.TableDefinition' for querying the
+  @pg_catalog.pg_policies@ view.
+
+@since 1.2.0.0
+-}
+pgPoliciesTable :: Orville.TableDefinition Orville.NoKey PgPolicy PgPolicy
+pgPoliciesTable =
+  Orville.setTableSchema "pg_catalog" $
+    Orville.mkTableDefinitionWithoutKey "pg_policies" pgPolicyMarshaller
+
+pgPolicyMarshaller :: Orville.SqlMarshaller w PgPolicy
+pgPolicyMarshaller =
+  PgPolicy
+    <$> Orville.marshallReadOnlyField pgPolicySchemaNameField
+    <*> Orville.marshallReadOnlyField pgPolicyTableNameField
+    <*> Orville.marshallReadOnlyField pgPolicyPolicyNameField
+    <*> Orville.marshallReadOnlyField pgPolicyPermissiveField
+    <*> Orville.marshallReadOnlyField pgPolicyCmdField
+    <*> Orville.marshallReadOnlyField pgPolicyRolesField
+    <*> Orville.marshallReadOnlyField pgPolicyQualField
+    <*> Orville.marshallReadOnlyField pgPolicyWithCheckField
+
+{- | The @schemaname@ column of the @pg_catalog.pg_policies@ view.
+
+@since 1.2.0.0
+-}
+pgPolicySchemaNameField :: Orville.FieldDefinition Orville.NotNull T.Text
+pgPolicySchemaNameField =
+  Orville.unboundedTextField "schemaname"
+
+{- | The @tablename@ column of the @pg_catalog.pg_policies@ view.
+
+@since 1.2.0.0
+-}
+pgPolicyTableNameField :: Orville.FieldDefinition Orville.NotNull T.Text
+pgPolicyTableNameField =
+  Orville.unboundedTextField "tablename"
+
+{- | The @policyname@ column of the @pg_catalog.pg_policies@ view.
+
+@since 1.2.0.0
+-}
+pgPolicyPolicyNameField :: Orville.FieldDefinition Orville.NotNull T.Text
+pgPolicyPolicyNameField =
+  Orville.unboundedTextField "policyname"
+
+{- | The @permissive@ column of the @pg_catalog.pg_policies@ view.
+
+@since 1.2.0.0
+-}
+pgPolicyPermissiveField :: Orville.FieldDefinition Orville.NotNull T.Text
+pgPolicyPermissiveField =
+  Orville.unboundedTextField "permissive"
+
+{- | The @cmd@ column of the @pg_catalog.pg_policies@ view.
+
+@since 1.2.0.0
+-}
+pgPolicyCmdField :: Orville.FieldDefinition Orville.NotNull T.Text
+pgPolicyCmdField =
+  Orville.unboundedTextField "cmd"
+
+{- | The @roles@ column of the @pg_catalog.pg_policies@ view, a @name[]@
+  column marshalled via its text representation.
+
+@since 1.2.0.0
+-}
+pgPolicyRolesField :: Orville.FieldDefinition Orville.NotNull [T.Text]
+pgPolicyRolesField =
+  Orville.convertField
+    (Orville.tryConvertSqlType PgArrayText.textListToPgArrayText (PgArrayText.pgArrayTextToTextList "role name list"))
+    (Orville.unboundedTextField "roles")
+
+{- | The @qual@ column of the @pg_catalog.pg_policies@ view.
+
+@since 1.2.0.0
+-}
+pgPolicyQualField :: Orville.FieldDefinition Orville.Nullable (Maybe T.Text)
+pgPolicyQualField =
+  Orville.nullableField $ Orville.unboundedTextField "qual"
+
+{- | The @with_check@ column of the @pg_catalog.pg_policies@ view.
+
+@since 1.2.0.0
+-}
+pgPolicyWithCheckField :: Orville.FieldDefinition Orville.Nullable (Maybe T.Text)
+pgPolicyWithCheckField =
+  Orville.nullableField $ Orville.unboundedTextField "with_check"

--- a/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/PgPolicy.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/PgCatalog/PgPolicy.hs
@@ -41,12 +41,10 @@ data PgPolicy = PgPolicy
   -- ^ The name of the table the policy is on.
   , pgPolicyPolicyName :: T.Text
   -- ^ The name of the policy.
-  , pgPolicyPermissive :: T.Text
-  -- ^ Either @PERMISSIVE@ or @RESTRICTIVE@.
-  , pgPolicyCmd :: T.Text
-  {- ^ The command the policy applies to: @ALL@, @SELECT@, @INSERT@,
-  @UPDATE@ or @DELETE@.
-  -}
+  , pgPolicyPermissive :: Orville.PolicyPermission
+  -- ^ Whether the policy is permissive or restrictive.
+  , pgPolicyCmd :: Orville.PolicyCommand
+  -- ^ The command the policy applies to.
   , pgPolicyRoles :: [T.Text]
   {- ^ The names of the roles the policy applies to. Policies that apply to
   all roles are reported as applying to the single role @public@.
@@ -103,21 +101,81 @@ pgPolicyPolicyNameField :: Orville.FieldDefinition Orville.NotNull T.Text
 pgPolicyPolicyNameField =
   Orville.unboundedTextField "policyname"
 
-{- | The @permissive@ column of the @pg_catalog.pg_policies@ view.
+{- | The @permissive@ column of the @pg_catalog.pg_policies@ view. Values
+  other than @PERMISSIVE@ or @RESTRICTIVE@ fail to decode.
 
 @since 1.2.0.0
 -}
-pgPolicyPermissiveField :: Orville.FieldDefinition Orville.NotNull T.Text
+pgPolicyPermissiveField :: Orville.FieldDefinition Orville.NotNull Orville.PolicyPermission
 pgPolicyPermissiveField =
-  Orville.unboundedTextField "permissive"
+  Orville.convertField
+    (Orville.tryConvertSqlType policyPermissionToPgText pgTextToPolicyPermission)
+    (Orville.unboundedTextField "permissive")
 
-{- | The @cmd@ column of the @pg_catalog.pg_policies@ view.
+{- | Converts an 'Orville.PolicyPermission' to the textual representation used
+  in the @permissive@ column of the @pg_catalog.pg_policies@ view.
+
+  See also 'pgTextToPolicyPermission'.
+-}
+policyPermissionToPgText :: Orville.PolicyPermission -> T.Text
+policyPermissionToPgText permission =
+  T.pack $
+    case permission of
+      Orville.PolicyPermissive -> "PERMISSIVE"
+      Orville.PolicyRestrictive -> "RESTRICTIVE"
+
+{- | Attempts to parse a value from the @permissive@ column of the
+  @pg_catalog.pg_policies@ view as an 'Orville.PolicyPermission'.
+
+  See also 'policyPermissionToPgText'.
+-}
+pgTextToPolicyPermission :: T.Text -> Either String Orville.PolicyPermission
+pgTextToPolicyPermission text =
+  case T.unpack (T.toUpper text) of
+    "PERMISSIVE" -> Right Orville.PolicyPermissive
+    "RESTRICTIVE" -> Right Orville.PolicyRestrictive
+    other -> Left ("Unrecognized PostgreSQL policy permissive value: " <> other)
+
+{- | The @cmd@ column of the @pg_catalog.pg_policies@ view. Values other than
+  @ALL@, @SELECT@, @INSERT@, @UPDATE@ or @DELETE@ fail to decode.
 
 @since 1.2.0.0
 -}
-pgPolicyCmdField :: Orville.FieldDefinition Orville.NotNull T.Text
+pgPolicyCmdField :: Orville.FieldDefinition Orville.NotNull Orville.PolicyCommand
 pgPolicyCmdField =
-  Orville.unboundedTextField "cmd"
+  Orville.convertField
+    (Orville.tryConvertSqlType policyCommandToPgText pgTextToPolicyCommand)
+    (Orville.unboundedTextField "cmd")
+
+{- | Converts an 'Orville.PolicyCommand' to the textual representation used in
+  the @cmd@ column of the @pg_catalog.pg_policies@ view.
+
+  See also 'pgTextToPolicyCommand'.
+-}
+policyCommandToPgText :: Orville.PolicyCommand -> T.Text
+policyCommandToPgText command =
+  T.pack $
+    case command of
+      Orville.PolicyCommandAll -> "ALL"
+      Orville.PolicyCommandSelect -> "SELECT"
+      Orville.PolicyCommandInsert -> "INSERT"
+      Orville.PolicyCommandUpdate -> "UPDATE"
+      Orville.PolicyCommandDelete -> "DELETE"
+
+{- | Attempts to parse a value from the @cmd@ column of the
+  @pg_catalog.pg_policies@ view as an 'Orville.PolicyCommand'.
+
+  See also 'policyCommandToPgText'.
+-}
+pgTextToPolicyCommand :: T.Text -> Either String Orville.PolicyCommand
+pgTextToPolicyCommand text =
+  case T.unpack (T.toUpper text) of
+    "ALL" -> Right Orville.PolicyCommandAll
+    "SELECT" -> Right Orville.PolicyCommandSelect
+    "INSERT" -> Right Orville.PolicyCommandInsert
+    "UPDATE" -> Right Orville.PolicyCommandUpdate
+    "DELETE" -> Right Orville.PolicyCommandDelete
+    other -> Left ("Unrecognized PostgreSQL policy command value: " <> other)
 
 {- | The @roles@ column of the @pg_catalog.pg_policies@ view, a @name[]@
   column marshalled via its text representation.

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema.hs
@@ -1,7 +1,7 @@
 {-# OPTIONS_GHC -Wno-missing-import-lists #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2023-2025
+Copyright : Flipstone Technology Partners 2023-2026
 License   : MIT
 Stability : Stable
 
@@ -21,6 +21,7 @@ module Orville.PostgreSQL.Schema
   , module Orville.PostgreSQL.Schema.ConstraintDefinition
   , module Orville.PostgreSQL.Schema.ConstraintIdentifier
   , module Orville.PostgreSQL.Schema.TriggerDefinition
+  , module Orville.PostgreSQL.Schema.PolicyDefinition
 
     -- * Defining Sequences
   , module Orville.PostgreSQL.Schema.SequenceDefinition
@@ -44,6 +45,7 @@ import Orville.PostgreSQL.Schema.ExtensionIdentifier
 import Orville.PostgreSQL.Schema.FunctionDefinition
 import Orville.PostgreSQL.Schema.FunctionIdentifier
 import Orville.PostgreSQL.Schema.IndexDefinition
+import Orville.PostgreSQL.Schema.PolicyDefinition
 import Orville.PostgreSQL.Schema.PrimaryKey
 import Orville.PostgreSQL.Schema.SequenceDefinition
 import Orville.PostgreSQL.Schema.SequenceIdentifier

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema.hs
@@ -45,6 +45,7 @@ import Orville.PostgreSQL.Schema.ExtensionIdentifier
 import Orville.PostgreSQL.Schema.FunctionDefinition
 import Orville.PostgreSQL.Schema.FunctionIdentifier
 import Orville.PostgreSQL.Schema.IndexDefinition
+
 import Orville.PostgreSQL.Schema.PolicyDefinition
 import Orville.PostgreSQL.Schema.PrimaryKey
 import Orville.PostgreSQL.Schema.SequenceDefinition

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/PolicyDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/PolicyDefinition.hs
@@ -1,0 +1,138 @@
+{- |
+Copyright : Flipstone Technology Partners 2026
+License   : MIT
+Stability : Stable
+
+@since 1.2.0.0
+-}
+module Orville.PostgreSQL.Schema.PolicyDefinition
+  ( PolicyDefinition
+  , policyDefinitionPolicyName
+  , policyDefinitionPolicyRoles
+  , policyDefinitionUsingExpr
+  , policyDefinitionCheckExpr
+  , mkPolicyDefinition
+  , mkCreatePolicyExpr
+  , mkAlterPolicyExpr
+  , mkDropPolicyExpr
+  ) where
+
+import qualified Data.List as List
+import qualified Data.Set as Set
+
+import qualified Orville.PostgreSQL.Expr as Expr
+import Orville.PostgreSQL.Schema.TableIdentifier (TableIdentifier, tableIdQualifiedName)
+
+{- | Defines a PostgreSQL row-level security policy that can be added to a table.
+
+The Using and Check Exprs are rendered for comparison against PostgreSQL's @pg_policies@ view,
+and must match the @qual@ and @with_check@ columns exactly, respectively.
+
+@since 1.2.0.0
+-}
+data PolicyDefinition = PolicyDefinition
+  { i_policyName :: String
+  , i_policyRoles :: Maybe (Set.Set String)
+  , i_usingExpr :: Maybe Expr.PolicyUsingExpr
+  , i_checkExpr :: Maybe Expr.PolicyCheckExpr
+  }
+  deriving
+    ( -- | @since 1.2.0.0
+      Eq
+    , -- | @since 1.2.0.0
+      Ord
+    )
+
+{- | Constructs a 'PolicyDefinition' from a policy name and, optionally, the set
+  of roles it applies to, a @USING@ expression and a @WITH CHECK@ expression.
+
+@since 1.2.0.0
+-}
+mkPolicyDefinition ::
+  String ->
+  Maybe (Set.Set String) ->
+  Maybe Expr.PolicyUsingExpr ->
+  Maybe Expr.PolicyCheckExpr ->
+  PolicyDefinition
+mkPolicyDefinition name mbRoles mbUsing mbCheck =
+  PolicyDefinition
+    { i_policyName = name
+    , i_policyRoles = mbRoles
+    , i_usingExpr = mbUsing
+    , i_checkExpr = mbCheck
+    }
+
+{- | Retrieves the name of the policy from a 'PolicyDefinition'.
+
+@since 1.2.0.0
+-}
+policyDefinitionPolicyName :: PolicyDefinition -> String
+policyDefinitionPolicyName =
+  i_policyName
+
+{- | Retrieves the set of roles the policy applies to, if any, from a
+  'PolicyDefinition'. 'Nothing' indicates the policy applies to all roles.
+
+@since 1.2.0.0
+-}
+policyDefinitionPolicyRoles :: PolicyDefinition -> Maybe (Set.Set String)
+policyDefinitionPolicyRoles =
+  i_policyRoles
+
+{- | Retrieves the @USING@ expression of the policy, if any, from a
+  'PolicyDefinition'.
+
+@since 1.2.0.0
+-}
+policyDefinitionUsingExpr :: PolicyDefinition -> Maybe Expr.PolicyUsingExpr
+policyDefinitionUsingExpr =
+  i_usingExpr
+
+{- | Retrieves the @WITH CHECK@ expression of the policy, if any, from a
+  'PolicyDefinition'.
+
+@since 1.2.0.0
+-}
+policyDefinitionCheckExpr :: PolicyDefinition -> Maybe Expr.PolicyCheckExpr
+policyDefinitionCheckExpr =
+  i_checkExpr
+
+{- | Builds the 'Expr.CreatePolicyExpr' that will create the given policy on the
+  table identified by the 'TableIdentifier'.
+
+@since 1.2.0.0
+-}
+mkCreatePolicyExpr :: TableIdentifier -> PolicyDefinition -> Expr.CreatePolicyExpr
+mkCreatePolicyExpr tableId policyDefinition =
+  Expr.createPolicyExpr
+    (Expr.policyName $ policyDefinitionPolicyName policyDefinition)
+    (tableIdQualifiedName tableId)
+    (List.map Expr.policyRole . Set.toList <$> i_policyRoles policyDefinition)
+    (i_usingExpr policyDefinition)
+    (i_checkExpr policyDefinition)
+
+{- | Builds the 'Expr.AlterPolicyExpr' that will update the given policy on the
+  table identified by the 'TableIdentifier' to match the 'PolicyDefinition'.
+
+@since 1.2.0.0
+-}
+mkAlterPolicyExpr :: TableIdentifier -> PolicyDefinition -> Expr.AlterPolicyExpr
+mkAlterPolicyExpr tableId policyDefinition =
+  Expr.alterPolicyExpr
+    (Expr.policyName $ policyDefinitionPolicyName policyDefinition)
+    (tableIdQualifiedName tableId)
+    (List.map Expr.policyRole . Set.toList <$> i_policyRoles policyDefinition)
+    (i_usingExpr policyDefinition)
+    (i_checkExpr policyDefinition)
+
+{- | Builds the 'Expr.DropPolicyExpr' that will drop the given policy from the
+  table identified by the 'TableIdentifier' if it exists.
+
+@since 1.2.0.0
+-}
+mkDropPolicyExpr :: TableIdentifier -> PolicyDefinition -> Expr.DropPolicyExpr
+mkDropPolicyExpr tableId policyDefinition =
+  Expr.dropPolicy
+    (Just Expr.ifExists)
+    (Expr.policyName $ policyDefinitionPolicyName policyDefinition)
+    (tableIdQualifiedName tableId)

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/PolicyDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/PolicyDefinition.hs
@@ -24,6 +24,7 @@ module Orville.PostgreSQL.Schema.PolicyDefinition
 
 import qualified Data.Functor.Classes as Classes
 import qualified Data.List as List
+import qualified Data.List.NonEmpty as NEL
 import qualified Data.Maybe as Maybe
 import qualified Data.Set as Set
 
@@ -40,8 +41,8 @@ import Orville.PostgreSQL.Schema.TableIdentifier (TableIdentifier, tableIdQualif
   parentheses it adds around operator expressions, explicit casts such as
   @::text@, and identifiers quoted only where necessary — so expressions
   should be written in that form. An expression that differs from the
-  deparsed form only cosmetically will cause auto-migration to emit an
-  @ALTER POLICY@ step on every run.
+  deparsed form only cosmetically will cause auto-migration to drop and
+  re-create the policy on every run.
 
 @since 1.2.0.0
 -}
@@ -127,7 +128,7 @@ data PolicyCommand
   created or altered, and reports the resolved role name in @pg_policies@.
   Auto-migration compares policy definitions against @pg_policies@, so a
   definition using one of these special targets will never match the existing
-  policy and will produce an @ALTER POLICY@ step on every migration run. Use
+  policy and will drop and re-create the policy on every migration run. Use
   'PolicyRoleNamed' for policies managed by auto-migration.
 
   'PolicyRoleCurrentRole' requires PostgreSQL 14 or later.
@@ -166,6 +167,13 @@ data PolicyRole
   omitted, and Orville includes the resulting clauses explicitly in the
   generated SQL.
 
+  The role set is also normalized to mirror how PostgreSQL treats role
+  targets, so that definitions compare consistently against @pg_policies@:
+  a 'PolicyRoleNamed' @"public"@ is the PUBLIC pseudo-role and becomes
+  'PolicyRolePublic', and a set containing 'PolicyRolePublic' collapses to
+  just 'PolicyRolePublic' (PostgreSQL ignores any other role targets given
+  alongside @PUBLIC@, since all roles are members of it).
+
 @since 1.2.0.0
 -}
 mkPolicyDefinition ::
@@ -178,14 +186,19 @@ mkPolicyDefinition ::
   PolicyDefinition
 mkPolicyDefinition name mbPermission mbCommand mbRoles mbUsing mbCheck =
   let
-    roles = Maybe.fromMaybe Set.empty mbRoles
+    normalizeRole role =
+      case role of
+        PolicyRoleNamed "public" -> PolicyRolePublic
+        _ -> role
+
+    roles = Set.map normalizeRole (Maybe.fromMaybe Set.empty mbRoles)
   in
     PolicyDefinition
       { i_policyName = name
       , i_policyPermission = Maybe.fromMaybe PolicyPermissive mbPermission
       , i_policyCommand = Maybe.fromMaybe PolicyCommandAll mbCommand
       , i_policyRoles =
-          if Set.null roles
+          if Set.null roles || Set.member PolicyRolePublic roles
             then Set.singleton PolicyRolePublic
             else roles
       , i_usingExpr = mbUsing
@@ -260,7 +273,7 @@ mkCreatePolicyExpr tableId policyDefinition =
     (tableIdQualifiedName tableId)
     (Just . policyPermissionExpr . policyDefinitionPermission $ policyDefinition)
     (Just . policyCommandExpr . policyDefinitionCommand $ policyDefinition)
-    (Just . List.map policyRoleExpr . Set.toList $ i_policyRoles policyDefinition)
+    (NEL.nonEmpty . List.map policyRoleExpr . Set.toList $ i_policyRoles policyDefinition)
     (i_usingExpr policyDefinition)
     (i_checkExpr policyDefinition)
 
@@ -303,7 +316,7 @@ mkAlterPolicyExpr tableId policyDefinition =
   Expr.alterPolicyExpr
     (Expr.policyName $ policyDefinitionPolicyName policyDefinition)
     (tableIdQualifiedName tableId)
-    (Just . List.map policyRoleExpr . Set.toList $ i_policyRoles policyDefinition)
+    (NEL.nonEmpty . List.map policyRoleExpr . Set.toList $ i_policyRoles policyDefinition)
     (i_usingExpr policyDefinition)
     (i_checkExpr policyDefinition)
 

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/PolicyDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/PolicyDefinition.hs
@@ -33,8 +33,15 @@ import Orville.PostgreSQL.Schema.TableIdentifier (TableIdentifier, tableIdQualif
 
 {- | Defines a PostgreSQL row-level security policy that can be added to a table.
 
-The Using and Check Exprs are rendered for comparison against PostgreSQL's @pg_policies@ view,
-and must match the @qual@ and @with_check@ columns exactly, respectively.
+  Auto-migration compares the @USING@ and @WITH CHECK@ expressions against the
+  @qual@ and @with_check@ columns of PostgreSQL's @pg_policies@ view,
+  case-insensitively outside of string literals and quoted identifiers. Those
+  columns hold the expressions as PostgreSQL deparses them — with the
+  parentheses it adds around operator expressions, explicit casts such as
+  @::text@, and identifiers quoted only where necessary — so expressions
+  should be written in that form. An expression that differs from the
+  deparsed form only cosmetically will cause auto-migration to emit an
+  @ALTER POLICY@ step on every run.
 
 @since 1.2.0.0
 -}
@@ -55,10 +62,11 @@ instance Eq PolicyDefinition where
 instance Ord PolicyDefinition where
   compare = comparePolicyDefinition
 
-{- | Compares 'PolicyDefinition's field by field, using the internal
-  case-insensitive comparisons for the @USING@ and @WITH CHECK@ expressions so
-  that definitions compare consistently against policies loaded from
-  PostgreSQL's @pg_policies@ view.
+{- | Compares 'PolicyDefinition's field by field, using
+  'CreatePolicyExpr.comparePolicyUsingExpr' and
+  'CreatePolicyExpr.comparePolicyCheckExpr' for the @USING@ and @WITH CHECK@
+  expressions so that definitions compare consistently against policies
+  loaded from PostgreSQL's @pg_policies@ view.
 -}
 comparePolicyDefinition :: PolicyDefinition -> PolicyDefinition -> Ordering
 comparePolicyDefinition left right =

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/PolicyDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/PolicyDefinition.hs
@@ -7,7 +7,12 @@ Stability : Stable
 -}
 module Orville.PostgreSQL.Schema.PolicyDefinition
   ( PolicyDefinition
+  , PolicyPermission (PolicyPermissive, PolicyRestrictive)
+  , PolicyCommand (PolicyCommandAll, PolicyCommandSelect, PolicyCommandInsert, PolicyCommandUpdate, PolicyCommandDelete)
+  , PolicyRole (PolicyRolePublic, PolicyRoleCurrentRole, PolicyRoleCurrentUser, PolicyRoleSessionUser, PolicyRoleNamed)
   , policyDefinitionPolicyName
+  , policyDefinitionPermission
+  , policyDefinitionCommand
   , policyDefinitionPolicyRoles
   , policyDefinitionUsingExpr
   , policyDefinitionCheckExpr
@@ -17,10 +22,13 @@ module Orville.PostgreSQL.Schema.PolicyDefinition
   , mkDropPolicyExpr
   ) where
 
+import qualified Data.Functor.Classes as Classes
 import qualified Data.List as List
+import qualified Data.Maybe as Maybe
 import qualified Data.Set as Set
 
 import qualified Orville.PostgreSQL.Expr as Expr
+import qualified Orville.PostgreSQL.Expr.PolicyExpr.CreatePolicyExpr as CreatePolicyExpr
 import Orville.PostgreSQL.Schema.TableIdentifier (TableIdentifier, tableIdQualifiedName)
 
 {- | Defines a PostgreSQL row-level security policy that can be added to a table.
@@ -32,35 +40,149 @@ and must match the @qual@ and @with_check@ columns exactly, respectively.
 -}
 data PolicyDefinition = PolicyDefinition
   { i_policyName :: String
-  , i_policyRoles :: Maybe (Set.Set String)
+  , i_policyPermission :: PolicyPermission
+  , i_policyCommand :: PolicyCommand
+  , i_policyRoles :: Set.Set PolicyRole
   , i_usingExpr :: Maybe Expr.PolicyUsingExpr
   , i_checkExpr :: Maybe Expr.PolicyCheckExpr
   }
+
+-- | @since 1.2.0.0
+instance Eq PolicyDefinition where
+  left == right = comparePolicyDefinition left right == EQ
+
+-- | @since 1.2.0.0
+instance Ord PolicyDefinition where
+  compare = comparePolicyDefinition
+
+{- | Compares 'PolicyDefinition's field by field, using the internal
+  case-insensitive comparisons for the @USING@ and @WITH CHECK@ expressions so
+  that definitions compare consistently against policies loaded from
+  PostgreSQL's @pg_policies@ view.
+-}
+comparePolicyDefinition :: PolicyDefinition -> PolicyDefinition -> Ordering
+comparePolicyDefinition left right =
+  compare (i_policyName left) (i_policyName right)
+    <> compare (i_policyPermission left) (i_policyPermission right)
+    <> compare (i_policyCommand left) (i_policyCommand right)
+    <> compare (i_policyRoles left) (i_policyRoles right)
+    <> Classes.liftCompare CreatePolicyExpr.comparePolicyUsingExpr (i_usingExpr left) (i_usingExpr right)
+    <> Classes.liftCompare CreatePolicyExpr.comparePolicyCheckExpr (i_checkExpr left) (i_checkExpr right)
+
+{- | Indicates whether a policy is permissive or restrictive. Rows must pass at
+  least one permissive policy and every restrictive policy that applies to a
+  query.
+
+@since 1.2.0.0
+-}
+data PolicyPermission
+  = PolicyPermissive
+  | PolicyRestrictive
   deriving
     ( -- | @since 1.2.0.0
       Eq
     , -- | @since 1.2.0.0
       Ord
+    , -- | @since 1.2.0.0
+      Show
     )
 
-{- | Constructs a 'PolicyDefinition' from a policy name and, optionally, the set
-  of roles it applies to, a @USING@ expression and a @WITH CHECK@ expression.
+{- | The command that a policy applies to, as named in the @FOR@ clause of
+  @CREATE POLICY@. 'PolicyCommandAll' applies the policy to all commands.
+
+  Note that PostgreSQL does not allow @WITH CHECK@ expressions on @SELECT@ or
+  @DELETE@ policies, nor @USING@ expressions on @INSERT@ policies.
+
+@since 1.2.0.0
+-}
+data PolicyCommand
+  = PolicyCommandAll
+  | PolicyCommandSelect
+  | PolicyCommandInsert
+  | PolicyCommandUpdate
+  | PolicyCommandDelete
+  deriving
+    ( -- | @since 1.2.0.0
+      Eq
+    , -- | @since 1.2.0.0
+      Ord
+    , -- | @since 1.2.0.0
+      Show
+    )
+
+{- | A role target that a policy applies to: a named database role or one of
+  the special targets PostgreSQL accepts in the @TO@ clause of
+  @CREATE POLICY@.
+
+  Note that PostgreSQL resolves 'PolicyRoleCurrentRole', 'PolicyRoleCurrentUser'
+  and 'PolicyRoleSessionUser' to the concrete role at the time the policy is
+  created or altered, and reports the resolved role name in @pg_policies@.
+  Auto-migration compares policy definitions against @pg_policies@, so a
+  definition using one of these special targets will never match the existing
+  policy and will produce an @ALTER POLICY@ step on every migration run. Use
+  'PolicyRoleNamed' for policies managed by auto-migration.
+
+  'PolicyRoleCurrentRole' requires PostgreSQL 14 or later.
+
+@since 1.2.0.0
+-}
+data PolicyRole
+  = PolicyRolePublic
+  | PolicyRoleCurrentRole
+  | PolicyRoleCurrentUser
+  | PolicyRoleSessionUser
+  | PolicyRoleNamed String
+  deriving
+    ( -- | @since 1.2.0.0
+      Eq
+    , -- | @since 1.2.0.0
+      Ord
+    , -- | @since 1.2.0.0
+      Show
+    )
+
+{- | Constructs a 'PolicyDefinition' from a policy name and, optionally, a
+  'PolicyPermission', a 'PolicyCommand', the set of roles it applies to, a
+  @USING@ expression and a @WITH CHECK@ expression.
+
+  If no 'PolicyPermission' is given, the policy is treated as
+  'PolicyPermissive', which is the default behavior for current PostgreSQL
+  versions when creating a policy. Orville includes the resulting
+  @AS PERMISSIVE@ or @AS RESTRICTIVE@ clause explicitly in the generated
+  @CREATE POLICY@ statement rather than relying on the PostgreSQL default.
+
+  Similarly, if no 'PolicyCommand' is given, the policy is treated as
+  'PolicyCommandAll', and if no roles (or an empty set) are given, the policy
+  is treated as applying to 'PolicyRolePublic'. Both match the default
+  behavior for current PostgreSQL versions when the @FOR@ or @TO@ clause is
+  omitted, and Orville includes the resulting clauses explicitly in the
+  generated SQL.
 
 @since 1.2.0.0
 -}
 mkPolicyDefinition ::
   String ->
-  Maybe (Set.Set String) ->
+  Maybe PolicyPermission ->
+  Maybe PolicyCommand ->
+  Maybe (Set.Set PolicyRole) ->
   Maybe Expr.PolicyUsingExpr ->
   Maybe Expr.PolicyCheckExpr ->
   PolicyDefinition
-mkPolicyDefinition name mbRoles mbUsing mbCheck =
-  PolicyDefinition
-    { i_policyName = name
-    , i_policyRoles = mbRoles
-    , i_usingExpr = mbUsing
-    , i_checkExpr = mbCheck
-    }
+mkPolicyDefinition name mbPermission mbCommand mbRoles mbUsing mbCheck =
+  let
+    roles = Maybe.fromMaybe Set.empty mbRoles
+  in
+    PolicyDefinition
+      { i_policyName = name
+      , i_policyPermission = Maybe.fromMaybe PolicyPermissive mbPermission
+      , i_policyCommand = Maybe.fromMaybe PolicyCommandAll mbCommand
+      , i_policyRoles =
+          if Set.null roles
+            then Set.singleton PolicyRolePublic
+            else roles
+      , i_usingExpr = mbUsing
+      , i_checkExpr = mbCheck
+      }
 
 {- | Retrieves the name of the policy from a 'PolicyDefinition'.
 
@@ -70,12 +192,30 @@ policyDefinitionPolicyName :: PolicyDefinition -> String
 policyDefinitionPolicyName =
   i_policyName
 
-{- | Retrieves the set of roles the policy applies to, if any, from a
-  'PolicyDefinition'. 'Nothing' indicates the policy applies to all roles.
+{- | Retrieves whether the policy is permissive or restrictive from a
+  'PolicyDefinition'.
 
 @since 1.2.0.0
 -}
-policyDefinitionPolicyRoles :: PolicyDefinition -> Maybe (Set.Set String)
+policyDefinitionPermission :: PolicyDefinition -> PolicyPermission
+policyDefinitionPermission =
+  i_policyPermission
+
+{- | Retrieves the command the policy applies to from a 'PolicyDefinition'.
+
+@since 1.2.0.0
+-}
+policyDefinitionCommand :: PolicyDefinition -> PolicyCommand
+policyDefinitionCommand =
+  i_policyCommand
+
+{- | Retrieves the set of roles the policy applies to from a
+  'PolicyDefinition'. A policy constructed without any roles applies to
+  'PolicyRolePublic'.
+
+@since 1.2.0.0
+-}
+policyDefinitionPolicyRoles :: PolicyDefinition -> Set.Set PolicyRole
 policyDefinitionPolicyRoles =
   i_policyRoles
 
@@ -100,6 +240,9 @@ policyDefinitionCheckExpr =
 {- | Builds the 'Expr.CreatePolicyExpr' that will create the given policy on the
   table identified by the 'TableIdentifier'.
 
+  The policy's 'PolicyPermission', 'PolicyCommand' and 'PolicyRole's are
+  always included explicitly as @AS@, @FOR@ and @TO@ clauses.
+
 @since 1.2.0.0
 -}
 mkCreatePolicyExpr :: TableIdentifier -> PolicyDefinition -> Expr.CreatePolicyExpr
@@ -107,12 +250,43 @@ mkCreatePolicyExpr tableId policyDefinition =
   Expr.createPolicyExpr
     (Expr.policyName $ policyDefinitionPolicyName policyDefinition)
     (tableIdQualifiedName tableId)
-    (List.map Expr.policyRole . Set.toList <$> i_policyRoles policyDefinition)
+    (Just . policyPermissionExpr . policyDefinitionPermission $ policyDefinition)
+    (Just . policyCommandExpr . policyDefinitionCommand $ policyDefinition)
+    (Just . List.map policyRoleExpr . Set.toList $ i_policyRoles policyDefinition)
     (i_usingExpr policyDefinition)
     (i_checkExpr policyDefinition)
 
+policyPermissionExpr :: PolicyPermission -> Expr.PolicyPermissionExpr
+policyPermissionExpr permission =
+  case permission of
+    PolicyPermissive -> Expr.policyPermissive
+    PolicyRestrictive -> Expr.policyRestrictive
+
+policyCommandExpr :: PolicyCommand -> Expr.PolicyCommandExpr
+policyCommandExpr command =
+  case command of
+    PolicyCommandAll -> Expr.policyCommandAll
+    PolicyCommandSelect -> Expr.policyCommandSelect
+    PolicyCommandInsert -> Expr.policyCommandInsert
+    PolicyCommandUpdate -> Expr.policyCommandUpdate
+    PolicyCommandDelete -> Expr.policyCommandDelete
+
+policyRoleExpr :: PolicyRole -> Expr.PolicyRoleExpr
+policyRoleExpr role =
+  case role of
+    PolicyRolePublic -> Expr.publicPolicyRole
+    PolicyRoleCurrentRole -> Expr.currentRolePolicyRole
+    PolicyRoleCurrentUser -> Expr.currentUserPolicyRole
+    PolicyRoleSessionUser -> Expr.sessionUserPolicyRole
+    PolicyRoleNamed name -> Expr.namedPolicyRole name
+
 {- | Builds the 'Expr.AlterPolicyExpr' that will update the given policy on the
   table identified by the 'TableIdentifier' to match the 'PolicyDefinition'.
+
+  Note that @ALTER POLICY@ cannot change whether a policy is permissive or
+  restrictive, nor the command it applies to, so the 'PolicyPermission' and
+  'PolicyCommand' of the definition are ignored here. Changing either
+  requires dropping and recreating the policy.
 
 @since 1.2.0.0
 -}
@@ -121,7 +295,7 @@ mkAlterPolicyExpr tableId policyDefinition =
   Expr.alterPolicyExpr
     (Expr.policyName $ policyDefinitionPolicyName policyDefinition)
     (tableIdQualifiedName tableId)
-    (List.map Expr.policyRole . Set.toList <$> i_policyRoles policyDefinition)
+    (Just . List.map policyRoleExpr . Set.toList $ i_policyRoles policyDefinition)
     (i_usingExpr policyDefinition)
     (i_checkExpr policyDefinition)
 

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/TableDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/TableDefinition.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE RankNTypes #-}
 
 {- |
-Copyright : Flipstone Technology Partners 2023-2025
+Copyright : Flipstone Technology Partners 2023-2026
 License   : MIT
 Stability : Stable
 
@@ -38,6 +38,12 @@ module Orville.PostgreSQL.Schema.TableDefinition
   , mkInsertColumnList
   , mkInsertSource
   , mkTableReturningClause
+  , tablePolicies
+  , addTablePolicies
+  , dropPolicies
+  , policiesToDrop
+  , tableRowLevelSecurity
+  , setRowLevelSecurityEnabled
   )
 where
 
@@ -54,6 +60,7 @@ import Orville.PostgreSQL.Marshall.FieldDefinition (FieldName, fieldColumnDefini
 import Orville.PostgreSQL.Marshall.SqlMarshaller (AnnotatedSqlMarshaller, MarshallerField (Natural, Synthetic), ReadOnlyColumnOption (ExcludeReadOnlyColumns, IncludeReadOnlyColumns), SqlMarshaller, annotateSqlMarshaller, annotateSqlMarshallerEmptyAnnotation, collectFromField, foldMarshallerFields, mapSqlMarshaller, marshallerDerivedColumns, marshallerTableConstraints, unannotatedSqlMarshaller)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import Orville.PostgreSQL.Schema.ConstraintDefinition (ConstraintDefinition, TableConstraints, addConstraint, constraintSqlExpr, emptyTableConstraints, tableConstraintDefinitions)
+import Orville.PostgreSQL.Schema.PolicyDefinition (PolicyDefinition)
 import Orville.PostgreSQL.Schema.PrimaryKey (PrimaryKey, mkPrimaryKeyExpr, primaryKeyFieldNames)
 import Orville.PostgreSQL.Schema.TableIdentifier (TableIdentifier, setTableIdSchema, tableIdQualifiedName, unqualifiedNameToTableId)
 import Orville.PostgreSQL.Schema.TriggerDefinition (TriggerDefinition, TriggerMigrationKey, triggerMigrationKey)
@@ -82,6 +89,9 @@ data TableDefinition key writeEntity readEntity = TableDefinition
   , i_tableIndexes :: Map.Map IndexMigrationKey IndexDefinition
   , i_tableTriggers :: Map.Map TriggerMigrationKey TriggerDefinition
   , i_tableComment :: Maybe T.Text
+  , i_tablePolicyDefinitions :: Set.Set PolicyDefinition
+  , i_tablePoliciesToDrop :: Set.Set String
+  , i_tableRowLevelSecurity :: Bool
   }
 
 {- | 'HasKey' is a type with no constructors. It is used only at the type level
@@ -135,6 +145,9 @@ mkTableDefinition name primaryKey marshaller =
     , i_tableIndexes = Map.empty
     , i_tableTriggers = Map.empty
     , i_tableComment = Nothing
+    , i_tablePolicyDefinitions = Set.empty
+    , i_tablePoliciesToDrop = Set.empty
+    , i_tableRowLevelSecurity = False
     }
 
 {- | Constructs a new 'TableDefinition' with the minimal fields required for
@@ -161,6 +174,9 @@ mkTableDefinitionWithoutKey name marshaller =
     , i_tableIndexes = Map.empty
     , i_tableTriggers = Map.empty
     , i_tableComment = Nothing
+    , i_tablePolicyDefinitions = Set.empty
+    , i_tablePoliciesToDrop = Set.empty
+    , i_tableRowLevelSecurity = False
     }
 
 {- | Annotates a 'TableDefinition' with a direction to drop columns if they are
@@ -362,7 +378,7 @@ tableTriggers =
 
 {- | Adds the given table triggers to the table definition.
 
-  Note: If multiple wriggers are added with the same 'Expr.TriggerName', only
+  Note: If multiple triggers are added with the same 'Expr.TriggerName', only
   the last one that is added will be part of the 'TableDefinition'. Any
   previously-added constraint with the same key is replaced by the new one.
 
@@ -642,3 +658,75 @@ collectSqlValue entry encodeRest entity =
       encodeRest entity
     Synthetic _ ->
       encodeRest entity
+
+{- | Retrieves all the table policy definitions that have been added to the table via
+  'addTablePolicyDefinitions'.
+
+@since 1.2.0.0
+-}
+tablePolicies ::
+  TableDefinition key writeEntity readEntity ->
+  Set.Set PolicyDefinition
+tablePolicies =
+  i_tablePolicyDefinitions
+
+{- | Adds the given table policy definitions to the table definition.
+
+@since 1.2.0.0
+-}
+addTablePolicies ::
+  [PolicyDefinition] ->
+  TableDefinition key writeEntity readEntity ->
+  TableDefinition key writeEntity readEntity
+addTablePolicies policyDefs tableDef =
+  tableDef
+    { i_tablePolicyDefinitions = Set.fromList policyDefs
+    }
+
+{- | Annotates a 'TableDefinition' with a direction to drop policies if they are
+  found in the database. Orville does not drop policies during auto-migration
+  unless they are explicitly requested to be dropped via 'dropPolicies'.
+
+@since 1.2.0.0
+-}
+dropPolicies ::
+  -- | Policies that should be dropped from the table
+  [String] ->
+  TableDefinition key writeEntity readEntity ->
+  TableDefinition key writeEntity readEntity
+dropPolicies policies tableDef =
+  tableDef
+    { i_tablePoliciesToDrop = i_tablePoliciesToDrop tableDef <> Set.fromList policies
+    }
+
+{- | Returns the set of policies that have been marked for dropping by 'dropPolicies'.
+
+@since 1.2.0.0
+-}
+policiesToDrop ::
+  TableDefinition key writeEntity readEntity ->
+  Set.Set String
+policiesToDrop =
+  i_tablePoliciesToDrop
+
+{- | Returns whether row level security is enabled for this table definition.
+
+@since 1.2.0.0
+-}
+tableRowLevelSecurity ::
+  TableDefinition key writeEntity readEntity ->
+  Bool
+tableRowLevelSecurity =
+  i_tableRowLevelSecurity
+
+{- | Constructs a new 'TableDefinition' with row level security enabled. This is
+  the same as 'mkTableDefinition' but with row level security turned on, which
+  will cause the auto migration to enable row level security on the table.
+
+@since 1.2.0.0
+-}
+setRowLevelSecurityEnabled ::
+  TableDefinition key writeEntity readEntity ->
+  TableDefinition key writeEntity readEntity
+setRowLevelSecurityEnabled tableDef =
+  tableDef {i_tableRowLevelSecurity = True}

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/TableDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/TableDefinition.hs
@@ -60,7 +60,7 @@ import Orville.PostgreSQL.Marshall.FieldDefinition (FieldName, fieldColumnDefini
 import Orville.PostgreSQL.Marshall.SqlMarshaller (AnnotatedSqlMarshaller, MarshallerField (Natural, Synthetic), ReadOnlyColumnOption (ExcludeReadOnlyColumns, IncludeReadOnlyColumns), SqlMarshaller, annotateSqlMarshaller, annotateSqlMarshallerEmptyAnnotation, collectFromField, foldMarshallerFields, mapSqlMarshaller, marshallerDerivedColumns, marshallerTableConstraints, unannotatedSqlMarshaller)
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 import Orville.PostgreSQL.Schema.ConstraintDefinition (ConstraintDefinition, TableConstraints, addConstraint, constraintSqlExpr, emptyTableConstraints, tableConstraintDefinitions)
-import Orville.PostgreSQL.Schema.PolicyDefinition (PolicyDefinition)
+import Orville.PostgreSQL.Schema.PolicyDefinition (PolicyDefinition, policyDefinitionPolicyName)
 import Orville.PostgreSQL.Schema.PrimaryKey (PrimaryKey, mkPrimaryKeyExpr, primaryKeyFieldNames)
 import Orville.PostgreSQL.Schema.TableIdentifier (TableIdentifier, setTableIdSchema, tableIdQualifiedName, unqualifiedNameToTableId)
 import Orville.PostgreSQL.Schema.TriggerDefinition (TriggerDefinition, TriggerMigrationKey, triggerMigrationKey)
@@ -89,7 +89,7 @@ data TableDefinition key writeEntity readEntity = TableDefinition
   , i_tableIndexes :: Map.Map IndexMigrationKey IndexDefinition
   , i_tableTriggers :: Map.Map TriggerMigrationKey TriggerDefinition
   , i_tableComment :: Maybe T.Text
-  , i_tablePolicyDefinitions :: Set.Set PolicyDefinition
+  , i_tablePolicyDefinitions :: Map.Map String PolicyDefinition
   , i_tablePoliciesToDrop :: Set.Set String
   , i_tableRowLevelSecurity :: Bool
   }
@@ -145,7 +145,7 @@ mkTableDefinition name primaryKey marshaller =
     , i_tableIndexes = Map.empty
     , i_tableTriggers = Map.empty
     , i_tableComment = Nothing
-    , i_tablePolicyDefinitions = Set.empty
+    , i_tablePolicyDefinitions = Map.empty
     , i_tablePoliciesToDrop = Set.empty
     , i_tableRowLevelSecurity = False
     }
@@ -174,7 +174,7 @@ mkTableDefinitionWithoutKey name marshaller =
     , i_tableIndexes = Map.empty
     , i_tableTriggers = Map.empty
     , i_tableComment = Nothing
-    , i_tablePolicyDefinitions = Set.empty
+    , i_tablePolicyDefinitions = Map.empty
     , i_tablePoliciesToDrop = Set.empty
     , i_tableRowLevelSecurity = False
     }
@@ -380,7 +380,7 @@ tableTriggers =
 
   Note: If multiple triggers are added with the same 'Expr.TriggerName', only
   the last one that is added will be part of the 'TableDefinition'. Any
-  previously-added constraint with the same key is replaced by the new one.
+  previously-added trigger with the same key is replaced by the new one.
 
   Also Note: Orville does not currently support migrating triggers based on
   their definition structure. If a trigger with the same name already exists
@@ -660,17 +660,21 @@ collectSqlValue entry encodeRest entity =
       encodeRest entity
 
 {- | Retrieves all the table policy definitions that have been added to the table via
-  'addTablePolicyDefinitions'.
+  'addTablePolicies', keyed by policy name.
 
 @since 1.2.0.0
 -}
 tablePolicies ::
   TableDefinition key writeEntity readEntity ->
-  Set.Set PolicyDefinition
+  Map.Map String PolicyDefinition
 tablePolicies =
   i_tablePolicyDefinitions
 
 {- | Adds the given table policy definitions to the table definition.
+
+  Note: If multiple policies are added with the same policy name, only the
+  last one that is added will be part of the 'TableDefinition'. Any
+  previously-added policy with the same name is replaced by the new one.
 
 @since 1.2.0.0
 -}
@@ -679,9 +683,13 @@ addTablePolicies ::
   TableDefinition key writeEntity readEntity ->
   TableDefinition key writeEntity readEntity
 addTablePolicies policyDefs tableDef =
-  tableDef
-    { i_tablePolicyDefinitions = Set.fromList policyDefs
-    }
+  let
+    addPolicy policyDef =
+      Map.insert (policyDefinitionPolicyName policyDef) policyDef
+  in
+    tableDef
+      { i_tablePolicyDefinitions = foldr addPolicy (i_tablePolicyDefinitions tableDef) policyDefs
+      }
 
 {- | Annotates a 'TableDefinition' with a direction to drop policies if they are
   found in the database. Orville does not drop policies during auto-migration
@@ -711,6 +719,12 @@ policiesToDrop =
 
 {- | Returns whether row level security is enabled for this table definition.
 
+  Auto-migration keeps the table in sync with this value: when it is 'True'
+  row level security will be enabled on the table if it is not already, and
+  when it is 'False' (the default) row level security will be disabled if it
+  is currently enabled on the table. In either case, no migration step is
+  emitted when the table's current setting already matches.
+
 @since 1.2.0.0
 -}
 tableRowLevelSecurity ::
@@ -719,9 +733,13 @@ tableRowLevelSecurity ::
 tableRowLevelSecurity =
   i_tableRowLevelSecurity
 
-{- | Constructs a new 'TableDefinition' with row level security enabled. This is
-  the same as 'mkTableDefinition' but with row level security turned on, which
-  will cause the auto migration to enable row level security on the table.
+{- | Marks a 'TableDefinition' as having row level security enabled, which will
+  cause auto-migration to enable row level security on the table.
+
+  Table definitions default to row level security being disabled, and
+  auto-migration will actively disable row level security on tables whose
+  definitions do not use this function. Tables that already have row level
+  security disabled are left untouched.
 
 @since 1.2.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/TableDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/TableDefinition.hs
@@ -380,7 +380,7 @@ addTableIndexes indexDefs tableDef =
       { i_tableIndexes = List.foldl' addIndex (i_tableIndexes tableDef) indexDefs
       }
 
-{- | Retrieves all the table indexes that have been added to the table via
+{- | Retrieves all the table triggers that have been added to the table via
   'addTableTriggers'.
 
 @since 1.1.0.0

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/TableDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/TableDefinition.hs
@@ -696,6 +696,10 @@ tablePolicies =
   last one that is added will be part of the 'TableDefinition'. Any
   previously-added policy with the same name is replaced by the new one.
 
+  Adding a policy that is also named in 'dropPolicies' is a conflict:
+  auto-migration will refuse to generate a plan for the table and throw an
+  'Orville.PostgreSQL.AutoMigration.MigrationDataError'.
+
 @since 1.2.0.0
 -}
 addTablePolicies ::
@@ -714,6 +718,10 @@ addTablePolicies policyDefs tableDef =
 {- | Annotates a 'TableDefinition' with a direction to drop policies if they are
   found in the database. Orville does not drop policies during auto-migration
   unless they are explicitly requested to be dropped via 'dropPolicies'.
+
+  Naming a policy here that is also added via 'addTablePolicies' is a
+  conflict: auto-migration will refuse to generate a plan for the table and
+  throw an 'Orville.PostgreSQL.AutoMigration.MigrationDataError'.
 
 @since 1.2.0.0
 -}

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/TableDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/TableDefinition.hs
@@ -47,6 +47,7 @@ module Orville.PostgreSQL.Schema.TableDefinition
   )
 where
 
+import qualified Data.List as List
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
@@ -318,6 +319,11 @@ tableConstraintsFromMarshaller =
   added will be part of the 'TableDefinition'. Any previously-added constraint
   with the same key is replaced by the new one.
 
+  Note: Versions prior to 1.2.0.0 had a bug where, when a single call included
+  multiple constraints with the same key, the first one in the list was kept
+  rather than the last. As of 1.2.0.0 the last one is kept, as described
+  above.
+
 @since 1.0.0.0
 -}
 addTableConstraints ::
@@ -325,13 +331,17 @@ addTableConstraints ::
   TableDefinition key writeEntity readEntity ->
   TableDefinition key writeEntity readEntity
 addTableConstraints constraintDefs tableDef =
-  tableDef
-    { i_tableConstraintsFromTable =
-        foldr
-          addConstraint
-          (i_tableConstraintsFromTable tableDef)
-          constraintDefs
-    }
+  let
+    addTableConstraint constraints constraintDef =
+      addConstraint constraintDef constraints
+  in
+    tableDef
+      { i_tableConstraintsFromTable =
+          List.foldl'
+            addTableConstraint
+            (i_tableConstraintsFromTable tableDef)
+            constraintDefs
+      }
 
 {- | Retrieves all the table indexes that have been added to the table via
   'addTableIndexes'.
@@ -350,6 +360,11 @@ tableIndexes =
   the last one that is added will be part of the 'TableDefinition'. Any
   previously-added index with the same key is replaced by the new one.
 
+  Note: Versions prior to 1.2.0.0 had a bug where, when a single call included
+  multiple indexes with the same key, the first one in the list was kept
+  rather than the last. As of 1.2.0.0 the last one is kept, as described
+  above.
+
 @since 1.0.0.0
 -}
 addTableIndexes ::
@@ -358,11 +373,11 @@ addTableIndexes ::
   TableDefinition key writeEntity readEntity
 addTableIndexes indexDefs tableDef =
   let
-    addIndex index =
-      Map.insert (indexMigrationKey index) index
+    addIndex indexes index =
+      Map.insert (indexMigrationKey index) index indexes
   in
     tableDef
-      { i_tableIndexes = foldr addIndex (i_tableIndexes tableDef) indexDefs
+      { i_tableIndexes = List.foldl' addIndex (i_tableIndexes tableDef) indexDefs
       }
 
 {- | Retrieves all the table indexes that have been added to the table via
@@ -382,6 +397,11 @@ tableTriggers =
   the last one that is added will be part of the 'TableDefinition'. Any
   previously-added trigger with the same key is replaced by the new one.
 
+  Note: Versions prior to 1.2.0.0 had a bug where, when a single call included
+  multiple triggers with the same name, the first one in the list was kept
+  rather than the last. As of 1.2.0.0 the last one is kept, as described
+  above.
+
   Also Note: Orville does not currently support migrating triggers based on
   their definition structure. If a trigger with the same name already exists
   on the table at the time of migration nothing will be done to updated it.
@@ -396,11 +416,11 @@ addTableTriggers ::
   TableDefinition key writeEntity readEntity
 addTableTriggers triggerDefs tableDef =
   let
-    addTrigger trigger =
-      Map.insert (triggerMigrationKey trigger) trigger
+    addTrigger triggers trigger =
+      Map.insert (triggerMigrationKey trigger) trigger triggers
   in
     tableDef
-      { i_tableTriggers = foldr addTrigger (i_tableTriggers tableDef) triggerDefs
+      { i_tableTriggers = List.foldl' addTrigger (i_tableTriggers tableDef) triggerDefs
       }
 
 {- | Returns the primary key for the table, as defined at construction via
@@ -684,11 +704,11 @@ addTablePolicies ::
   TableDefinition key writeEntity readEntity
 addTablePolicies policyDefs tableDef =
   let
-    addPolicy policyDef =
-      Map.insert (policyDefinitionPolicyName policyDef) policyDef
+    addPolicy policyMap policyDef =
+      Map.insert (policyDefinitionPolicyName policyDef) policyDef policyMap
   in
     tableDef
-      { i_tablePolicyDefinitions = foldr addPolicy (i_tablePolicyDefinitions tableDef) policyDefs
+      { i_tablePolicyDefinitions = List.foldl' addPolicy (i_tablePolicyDefinitions tableDef) policyDefs
       }
 
 {- | Annotates a 'TableDefinition' with a direction to drop policies if they are

--- a/orville-postgresql/src/Orville/PostgreSQL/Schema/TriggerDefinition.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Schema/TriggerDefinition.hs
@@ -25,7 +25,7 @@ import qualified Orville.PostgreSQL.Expr as Expr
 
 {- | Defines a trigger that can be added to a
   'Orville.PostgreSQL.TableDefinition'. Use one of the constructor functions
-  below (such as 'mkNamedTriggerDefinition') to construct the constraint
+  below (such as 'mkNamedTriggerDefinition') to construct the trigger
   definition you wish to have and then use 'Orville.PostgreSQL.addTableTriggers'
   to add them to your table definition. Orville will then add the trigger next
   time you run auto-migrations.

--- a/orville-postgresql/test/Main.hs
+++ b/orville-postgresql/test/Main.hs
@@ -27,6 +27,7 @@ import qualified Test.Expr.InsertUpdateDelete as ExprInsertUpdateDelete
 import qualified Test.Expr.Join as ExprJoin
 import qualified Test.Expr.Math as ExprMath
 import qualified Test.Expr.OrderBy as ExprOrderBy
+import qualified Test.Expr.Policy as ExprPolicy
 import qualified Test.Expr.SequenceDefinition as ExprSequenceDefinition
 import qualified Test.Expr.TableDefinition as ExprTableDefinition
 import qualified Test.Expr.TableReferenceList as ExprTableReferenceList
@@ -78,6 +79,7 @@ main = do
       , ExprMath.mathTests pool
       , ExprTime.timeTests pool
       , ExprTrigger.triggerTests pool
+      , ExprPolicy.policyTests pool
       , ExprVacuum.vacuumTests
       , ExprJoin.joinTests
       , ExprTableReferenceList.tableReferenceListTests

--- a/orville-postgresql/test/Test/AutoMigration.hs
+++ b/orville-postgresql/test/Test/AutoMigration.hs
@@ -76,6 +76,9 @@ autoMigrationTests pool =
     , prop_modifiesTableComment pool
     , prop_addsColumnCommmentsOnCreateTable pool
     , prop_modifiesColumnComments pool
+    , prop_createsMissingPolicies pool
+    , prop_dropsRequestedPolicies pool
+    , prop_altersModifiedPolicies pool
     ]
 
 prop_raisesErrorIfMigrationLockIsLocked :: Property.NamedDBProperty
@@ -1451,6 +1454,121 @@ prop_dropsUnrequestedTriggers =
     length (AutoMigration.migrationPlanSteps firstTimePlan) === 1
     fooRelation <- PgAssert.assertTableExists pool "foo"
     _ <- PgAssert.assertTriggerDoesNotExist fooRelation "before_insert_trigger"
+    migrationPlanStepStrings secondTimePlan === []
+
+prop_createsMissingPolicies :: Property.NamedDBProperty
+prop_createsMissingPolicies =
+  Property.singletonNamedDBProperty "Creates missing policies" $ \pool -> do
+    let
+      originalField = Orville.integerField "column"
+      originalTableDef =
+        Orville.mkTableDefinitionWithoutKey
+          "policy_migration_test"
+          (Orville.marshallField id originalField)
+      policyDef =
+        Orville.mkPolicyDefinition
+          "migration_test_policy"
+          Nothing
+          Nothing
+          Nothing
+      newTableDef =
+        Orville.addTablePolicies [policyDef] originalTableDef
+
+    firstTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          Orville.executeVoid Orville.DDLQuery $ TestTable.dropTableDefSql originalTableDef
+          Orville.executeVoid Orville.DDLQuery $ Schema.mkCreateTableExpr originalTableDef
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable newTableDef]
+
+    secondTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          AutoMigration.executeMigrationPlan AutoMigration.defaultOptions firstTimePlan
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable newTableDef]
+
+    length (AutoMigration.migrationPlanSteps firstTimePlan) === 1
+    migrationPlanStepStrings secondTimePlan === []
+
+prop_dropsRequestedPolicies :: Property.NamedDBProperty
+prop_dropsRequestedPolicies =
+  Property.singletonNamedDBProperty "Drops requested policies" $ \pool -> do
+    let
+      originalField = Orville.integerField "column"
+      originalTableDef =
+        Orville.mkTableDefinitionWithoutKey
+          "policy_migration_test"
+          (Orville.marshallField id originalField)
+      policyDef =
+        Orville.mkPolicyDefinition
+          "migration_test_policy"
+          Nothing
+          Nothing
+          Nothing
+      tableWithPolicy =
+        Orville.addTablePolicies [policyDef] originalTableDef
+      tableWithDrop =
+        Orville.dropPolicies ["migration_test_policy"] originalTableDef
+
+    firstTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          Orville.executeVoid Orville.DDLQuery $ TestTable.dropTableDefSql originalTableDef
+          AutoMigration.autoMigrateSchema AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithPolicy]
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithDrop]
+
+    secondTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          AutoMigration.executeMigrationPlan AutoMigration.defaultOptions firstTimePlan
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithDrop]
+
+    length (AutoMigration.migrationPlanSteps firstTimePlan) === 1
+    migrationPlanStepStrings secondTimePlan === []
+
+prop_altersModifiedPolicies :: Property.NamedDBProperty
+prop_altersModifiedPolicies =
+  Property.singletonNamedDBProperty "Alters modified policies" $ \pool -> do
+    let
+      originalField = Orville.integerField "column"
+      originalTableDef =
+        Orville.mkTableDefinitionWithoutKey
+          "policy_migration_test"
+          (Orville.marshallField id originalField)
+      policyDef =
+        Orville.mkPolicyDefinition
+          "migration_test_policy"
+          Nothing
+          Nothing
+          Nothing
+      modifiedPolicyDef =
+        Orville.mkPolicyDefinition
+          "migration_test_policy"
+          Nothing
+          (Just (Expr.policyUsingExpr (Expr.literalBooleanExpr True)))
+          Nothing
+      tableWithPolicy =
+        Orville.addTablePolicies [policyDef] originalTableDef
+      tableWithModifiedPolicy =
+        Orville.addTablePolicies [modifiedPolicyDef] originalTableDef
+
+    firstTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          Orville.executeVoid Orville.DDLQuery $ TestTable.dropTableDefSql originalTableDef
+          AutoMigration.autoMigrateSchema AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithPolicy]
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithModifiedPolicy]
+
+    HH.annotate ("First time steps: " <> show (migrationPlanStepStrings firstTimePlan))
+    length (AutoMigration.migrationPlanSteps firstTimePlan) === 1
+
+    secondTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          AutoMigration.executeMigrationPlan AutoMigration.defaultOptions firstTimePlan
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithModifiedPolicy]
+
+    HH.annotate ("Second time steps: " <> show (migrationPlanStepStrings secondTimePlan))
     migrationPlanStepStrings secondTimePlan === []
 
 prop_loadsMissingExtensions :: Property.NamedDBProperty

--- a/orville-postgresql/test/Test/AutoMigration.hs
+++ b/orville-postgresql/test/Test/AutoMigration.hs
@@ -93,6 +93,7 @@ autoMigrationTests pool =
     , prop_managesPoliciesWithMultipleRoles pool
     , prop_managesPoliciesWithQuotedRoleNames pool
     , prop_managesMultiplePoliciesOnOneTable pool
+    , prop_conflictingPolicyDefinitionsRaiseError pool
     , prop_altersPoliciesWithQuotedIdentifiers pool
     , prop_altersPoliciesWithEscapedQuoteLiterals pool
     , prop_addTablePoliciesAccumulates
@@ -2084,6 +2085,42 @@ prop_managesPoliciesWithQuotedRoleNames =
 
     HH.annotate ("First time steps: " <> show (migrationPlanStepStrings firstTimePlan))
     migrationPlanStepStrings firstTimePlan === []
+
+prop_conflictingPolicyDefinitionsRaiseError :: Property.NamedDBProperty
+prop_conflictingPolicyDefinitionsRaiseError =
+  Property.singletonNamedDBProperty "An error is raised when a policy is both defined and marked for dropping" $ \pool -> do
+    let
+      originalField = Orville.integerField "column"
+      originalTableDef =
+        Orville.mkTableDefinitionWithoutKey
+          "policy_migration_test"
+          (Orville.marshallField id originalField)
+      policyDef =
+        Orville.mkPolicyDefinition
+          "migration_test_policy"
+          Nothing
+          Nothing
+          Nothing
+          Nothing
+          Nothing
+      conflictedTableDef =
+        Orville.dropPolicies ["migration_test_policy"] $
+          Orville.addTablePolicies [policyDef] originalTableDef
+
+    result <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          Orville.executeVoid Orville.DDLQuery $ TestTable.dropTableDefSql originalTableDef
+          ExSafe.try $
+            AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable conflictedTableDef]
+
+    case result of
+      Left err -> do
+        HH.annotate (show (err :: AutoMigration.MigrationDataError))
+        HH.assert $ List.isInfixOf "migration_test_policy" (show err)
+      Right plan -> do
+        HH.annotate ("Expected plan generation to fail, but got steps: " <> show (migrationPlanStepStrings plan))
+        HH.failure
 
 prop_managesMultiplePoliciesOnOneTable :: Property.NamedDBProperty
 prop_managesMultiplePoliciesOnOneTable =

--- a/orville-postgresql/test/Test/AutoMigration.hs
+++ b/orville-postgresql/test/Test/AutoMigration.hs
@@ -91,6 +91,7 @@ autoMigrationTests pool =
     , prop_managesPolicyRoleTargets pool
     , prop_managesPoliciesWithCheckExprs pool
     , prop_managesPoliciesWithMultipleRoles pool
+    , prop_managesPoliciesWithQuotedRoleNames pool
     , prop_managesMultiplePoliciesOnOneTable pool
     , prop_altersPoliciesWithQuotedIdentifiers pool
     , prop_altersPoliciesWithEscapedQuoteLiterals pool
@@ -2034,6 +2035,50 @@ prop_managesPoliciesWithMultipleRoles =
           Orville.executeVoid Orville.DDLQuery $ TestTable.dropTableDefSql originalTableDef
           Orville.executeVoid Orville.DDLQuery $ RawSql.fromString "DROP ROLE IF EXISTS orville_migration_role"
           Orville.executeVoid Orville.DDLQuery $ RawSql.fromString "CREATE ROLE orville_migration_role"
+          AutoMigration.autoMigrateSchema AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithPolicy]
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithPolicy]
+
+    HH.annotate ("First time steps: " <> show (migrationPlanStepStrings firstTimePlan))
+    migrationPlanStepStrings firstTimePlan === []
+
+prop_managesPoliciesWithQuotedRoleNames :: Property.NamedDBProperty
+prop_managesPoliciesWithQuotedRoleNames =
+  Property.singletonNamedDBProperty "Parses policy role names containing special characters" $ \pool -> do
+    let
+      originalField = Orville.integerField "column"
+      originalTableDef =
+        Orville.mkTableDefinitionWithoutKey
+          "policy_migration_test"
+          (Orville.marshallField id originalField)
+      -- The double quote, comma and spaces force PostgreSQL to render this
+      -- role quoted and escaped in the pg_policies roles array, alongside the
+      -- unquoted orville_test element
+      weirdRoleName = "orville \"quoted\", role"
+      quotedRolePolicy =
+        Orville.mkPolicyDefinition
+          "migration_test_policy"
+          Nothing
+          Nothing
+          ( Just $
+              Set.fromList
+                [ Orville.PolicyRoleNamed weirdRoleName
+                , Orville.PolicyRoleNamed "orville_test"
+                ]
+          )
+          Nothing
+          Nothing
+      tableWithPolicy =
+        Orville.addTablePolicies [quotedRolePolicy] originalTableDef
+
+    firstTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          -- The table (and with it any policy referencing the role) must be
+          -- dropped before the role so the role drop doesn't fail on a
+          -- dependency from a previous test run
+          Orville.executeVoid Orville.DDLQuery $ TestTable.dropTableDefSql originalTableDef
+          Orville.executeVoid Orville.DDLQuery $ RawSql.fromString "DROP ROLE IF EXISTS \"orville \"\"quoted\"\", role\""
+          Orville.executeVoid Orville.DDLQuery $ RawSql.fromString "CREATE ROLE \"orville \"\"quoted\"\", role\""
           AutoMigration.autoMigrateSchema AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithPolicy]
           AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithPolicy]
 

--- a/orville-postgresql/test/Test/AutoMigration.hs
+++ b/orville-postgresql/test/Test/AutoMigration.hs
@@ -2195,6 +2195,8 @@ prop_addTablePoliciesAccumulates =
         Orville.addTablePolicies [mkNamedPolicy "policy_one" (Just Orville.PolicyRestrictive)] $
           Orville.addTablePolicies
             [ mkNamedPolicy "policy_one" Nothing
+            , -- Duplicate names within a single call: the later list element wins
+              mkNamedPolicy "policy_two" (Just Orville.PolicyRestrictive)
             , mkNamedPolicy "policy_two" Nothing
             ]
             ( Orville.mkTableDefinitionWithoutKey

--- a/orville-postgresql/test/Test/AutoMigration.hs
+++ b/orville-postgresql/test/Test/AutoMigration.hs
@@ -15,7 +15,9 @@ import Data.Int (Int32)
 import Data.List ((\\))
 import qualified Data.List as List
 import qualified Data.List.NonEmpty as NEL
+import qualified Data.Map.Strict as Map
 import qualified Data.Maybe as Maybe
+import qualified Data.Set as Set
 import qualified Data.String as String
 import qualified Data.Text as T
 import Hedgehog ((===))
@@ -79,6 +81,20 @@ autoMigrationTests pool =
     , prop_createsMissingPolicies pool
     , prop_dropsRequestedPolicies pool
     , prop_altersModifiedPolicies pool
+    , prop_createsRestrictivePolicies pool
+    , prop_recreatesPoliciesWithChangedPermission pool
+    , prop_recreatesPoliciesWithChangedCommand pool
+    , prop_managesPoliciesOnSchemaQualifiedTables pool
+    , prop_enablesRowLevelSecurityWithoutPolicyCreation pool
+    , prop_disablesRowLevelSecurityWhenNotRequested pool
+    , prop_altersPoliciesWhoseLiteralsDifferOnlyByCase pool
+    , prop_managesPolicyRoleTargets pool
+    , prop_managesPoliciesWithCheckExprs pool
+    , prop_managesPoliciesWithMultipleRoles pool
+    , prop_managesMultiplePoliciesOnOneTable pool
+    , prop_altersPoliciesWithQuotedIdentifiers pool
+    , prop_altersPoliciesWithEscapedQuoteLiterals pool
+    , prop_addTablePoliciesAccumulates
     ]
 
 prop_raisesErrorIfMigrationLockIsLocked :: Property.NamedDBProperty
@@ -1471,6 +1487,8 @@ prop_createsMissingPolicies =
           Nothing
           Nothing
           Nothing
+          Nothing
+          Nothing
       newTableDef =
         Orville.addTablePolicies [policyDef] originalTableDef
 
@@ -1502,6 +1520,8 @@ prop_dropsRequestedPolicies =
       policyDef =
         Orville.mkPolicyDefinition
           "migration_test_policy"
+          Nothing
+          Nothing
           Nothing
           Nothing
           Nothing
@@ -1541,9 +1561,13 @@ prop_altersModifiedPolicies =
           Nothing
           Nothing
           Nothing
+          Nothing
+          Nothing
       modifiedPolicyDef =
         Orville.mkPolicyDefinition
           "migration_test_policy"
+          Nothing
+          Nothing
           Nothing
           (Just (Expr.policyUsingExpr (Expr.literalBooleanExpr True)))
           Nothing
@@ -1570,6 +1594,618 @@ prop_altersModifiedPolicies =
 
     HH.annotate ("Second time steps: " <> show (migrationPlanStepStrings secondTimePlan))
     migrationPlanStepStrings secondTimePlan === []
+
+prop_createsRestrictivePolicies :: Property.NamedDBProperty
+prop_createsRestrictivePolicies =
+  Property.singletonNamedDBProperty "Creates restrictive policies" $ \pool -> do
+    let
+      originalField = Orville.integerField "column"
+      originalTableDef =
+        Orville.mkTableDefinitionWithoutKey
+          "policy_migration_test"
+          (Orville.marshallField id originalField)
+      policyDef =
+        Orville.mkPolicyDefinition
+          "migration_test_policy"
+          (Just Orville.PolicyRestrictive)
+          Nothing
+          Nothing
+          Nothing
+          Nothing
+      newTableDef =
+        Orville.addTablePolicies [policyDef] originalTableDef
+
+    firstTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          Orville.executeVoid Orville.DDLQuery $ TestTable.dropTableDefSql originalTableDef
+          Orville.executeVoid Orville.DDLQuery $ Schema.mkCreateTableExpr originalTableDef
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable newTableDef]
+
+    secondTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          AutoMigration.executeMigrationPlan AutoMigration.defaultOptions firstTimePlan
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable newTableDef]
+
+    length (AutoMigration.migrationPlanSteps firstTimePlan) === 1
+    migrationPlanStepStrings secondTimePlan === []
+
+prop_recreatesPoliciesWithChangedPermission :: Property.NamedDBProperty
+prop_recreatesPoliciesWithChangedPermission =
+  Property.singletonNamedDBProperty "Recreates policies whose permission changed" $ \pool -> do
+    let
+      originalField = Orville.integerField "column"
+      originalTableDef =
+        Orville.mkTableDefinitionWithoutKey
+          "policy_migration_test"
+          (Orville.marshallField id originalField)
+      permissivePolicyDef =
+        Orville.mkPolicyDefinition
+          "migration_test_policy"
+          Nothing
+          Nothing
+          Nothing
+          Nothing
+          Nothing
+      restrictivePolicyDef =
+        Orville.mkPolicyDefinition
+          "migration_test_policy"
+          (Just Orville.PolicyRestrictive)
+          Nothing
+          Nothing
+          Nothing
+          Nothing
+      tableWithPermissivePolicy =
+        Orville.addTablePolicies [permissivePolicyDef] originalTableDef
+      tableWithRestrictivePolicy =
+        Orville.addTablePolicies [restrictivePolicyDef] originalTableDef
+
+    firstTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          Orville.executeVoid Orville.DDLQuery $ TestTable.dropTableDefSql originalTableDef
+          AutoMigration.autoMigrateSchema AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithPermissivePolicy]
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithRestrictivePolicy]
+
+    HH.annotate ("First time steps: " <> show (migrationPlanStepStrings firstTimePlan))
+    length (AutoMigration.migrationPlanSteps firstTimePlan) === 2
+
+    secondTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          AutoMigration.executeMigrationPlan AutoMigration.defaultOptions firstTimePlan
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithRestrictivePolicy]
+
+    HH.annotate ("Second time steps: " <> show (migrationPlanStepStrings secondTimePlan))
+    migrationPlanStepStrings secondTimePlan === []
+
+prop_recreatesPoliciesWithChangedCommand :: Property.NamedDBProperty
+prop_recreatesPoliciesWithChangedCommand =
+  Property.singletonNamedDBProperty "Recreates policies whose command changed" $ \pool -> do
+    let
+      originalField = Orville.integerField "column"
+      originalTableDef =
+        Orville.mkTableDefinitionWithoutKey
+          "policy_migration_test"
+          (Orville.marshallField id originalField)
+      mkCommandPolicy command =
+        Orville.mkPolicyDefinition
+          "migration_test_policy"
+          Nothing
+          (Just command)
+          Nothing
+          Nothing
+          Nothing
+      tableWithSelectPolicy =
+        Orville.addTablePolicies [mkCommandPolicy Orville.PolicyCommandSelect] originalTableDef
+      tableWithUpdatePolicy =
+        Orville.addTablePolicies [mkCommandPolicy Orville.PolicyCommandUpdate] originalTableDef
+
+    firstTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          Orville.executeVoid Orville.DDLQuery $ TestTable.dropTableDefSql originalTableDef
+          AutoMigration.autoMigrateSchema AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithSelectPolicy]
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithSelectPolicy]
+
+    HH.annotate ("First time steps: " <> show (migrationPlanStepStrings firstTimePlan))
+    migrationPlanStepStrings firstTimePlan === []
+
+    recreatePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithUpdatePolicy]
+
+    HH.annotate ("Recreate steps: " <> show (migrationPlanStepStrings recreatePlan))
+    length (AutoMigration.migrationPlanSteps recreatePlan) === 2
+
+    secondTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          AutoMigration.executeMigrationPlan AutoMigration.defaultOptions recreatePlan
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithUpdatePolicy]
+
+    HH.annotate ("Second time steps: " <> show (migrationPlanStepStrings secondTimePlan))
+    migrationPlanStepStrings secondTimePlan === []
+
+prop_managesPoliciesOnSchemaQualifiedTables :: Property.NamedDBProperty
+prop_managesPoliciesOnSchemaQualifiedTables =
+  Property.singletonNamedDBProperty "Manages policies on tables with an explicit schema" $ \pool -> do
+    let
+      originalField = Orville.integerField "column"
+      originalTableDef =
+        Orville.setTableSchema "orville_migration_schema" $
+          Orville.mkTableDefinitionWithoutKey
+            "policy_migration_test"
+            (Orville.marshallField id originalField)
+      policyDef =
+        Orville.mkPolicyDefinition
+          "migration_test_policy"
+          Nothing
+          Nothing
+          Nothing
+          Nothing
+          Nothing
+      newTableDef =
+        Orville.addTablePolicies [policyDef] originalTableDef
+
+    firstTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          Orville.executeVoid Orville.DDLQuery $ RawSql.fromString "DROP SCHEMA IF EXISTS orville_migration_schema CASCADE"
+          Orville.executeVoid Orville.DDLQuery $ RawSql.fromString "CREATE SCHEMA orville_migration_schema"
+          Orville.executeVoid Orville.DDLQuery $ Schema.mkCreateTableExpr originalTableDef
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable newTableDef]
+
+    HH.annotate ("First time steps: " <> show (migrationPlanStepStrings firstTimePlan))
+    length (AutoMigration.migrationPlanSteps firstTimePlan) === 1
+
+    secondTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          AutoMigration.executeMigrationPlan AutoMigration.defaultOptions firstTimePlan
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable newTableDef]
+
+    HH.annotate ("Second time steps: " <> show (migrationPlanStepStrings secondTimePlan))
+    migrationPlanStepStrings secondTimePlan === []
+
+prop_enablesRowLevelSecurityWithoutPolicyCreation :: Property.NamedDBProperty
+prop_enablesRowLevelSecurityWithoutPolicyCreation =
+  Property.singletonNamedDBProperty "Enables row level security even when only dropping policies" $ \pool -> do
+    let
+      originalField = Orville.integerField "column"
+      originalTableDef =
+        Orville.mkTableDefinitionWithoutKey
+          "policy_migration_test"
+          (Orville.marshallField id originalField)
+      policyDef =
+        Orville.mkPolicyDefinition
+          "migration_test_policy"
+          Nothing
+          Nothing
+          Nothing
+          Nothing
+          Nothing
+      tableWithPolicy =
+        Orville.addTablePolicies [policyDef] originalTableDef
+      tableWithRLSAndDrop =
+        Orville.setRowLevelSecurityEnabled $
+          Orville.dropPolicies ["migration_test_policy"] originalTableDef
+
+    firstTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          Orville.executeVoid Orville.DDLQuery $ TestTable.dropTableDefSql originalTableDef
+          AutoMigration.autoMigrateSchema AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithPolicy]
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithRLSAndDrop]
+
+    HH.annotate ("First time steps: " <> show (migrationPlanStepStrings firstTimePlan))
+    length (AutoMigration.migrationPlanSteps firstTimePlan) === 2
+
+    secondTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          AutoMigration.executeMigrationPlan AutoMigration.defaultOptions firstTimePlan
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithRLSAndDrop]
+
+    HH.annotate ("Second time steps: " <> show (migrationPlanStepStrings secondTimePlan))
+    migrationPlanStepStrings secondTimePlan === []
+
+prop_disablesRowLevelSecurityWhenNotRequested :: Property.NamedDBProperty
+prop_disablesRowLevelSecurityWhenNotRequested =
+  Property.singletonNamedDBProperty "Disables row level security when the definition does not enable it" $ \pool -> do
+    let
+      originalField = Orville.integerField "column"
+      originalTableDef =
+        Orville.mkTableDefinitionWithoutKey
+          "policy_migration_test"
+          (Orville.marshallField id originalField)
+      tableWithRLS =
+        Orville.setRowLevelSecurityEnabled originalTableDef
+
+    firstTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          Orville.executeVoid Orville.DDLQuery $ TestTable.dropTableDefSql originalTableDef
+          AutoMigration.autoMigrateSchema AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithRLS]
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable originalTableDef]
+
+    HH.annotate ("First time steps: " <> show (migrationPlanStepStrings firstTimePlan))
+    length (AutoMigration.migrationPlanSteps firstTimePlan) === 1
+
+    -- Once RLS is disabled, the plan must be empty: no DISABLE statement is
+    -- emitted for a table whose relrowsecurity is already false
+    secondTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          AutoMigration.executeMigrationPlan AutoMigration.defaultOptions firstTimePlan
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable originalTableDef]
+
+    HH.annotate ("Second time steps: " <> show (migrationPlanStepStrings secondTimePlan))
+    migrationPlanStepStrings secondTimePlan === []
+
+prop_altersPoliciesWhoseLiteralsDifferOnlyByCase :: Property.NamedDBProperty
+prop_altersPoliciesWhoseLiteralsDifferOnlyByCase =
+  Property.singletonNamedDBProperty "Alters policies whose string literals differ only by case" $ \pool -> do
+    let
+      originalField = Orville.unboundedTextField "name"
+      originalTableDef =
+        Orville.mkTableDefinitionWithoutKey
+          "policy_migration_test"
+          (Orville.marshallField id originalField)
+
+      -- These expressions are written to match the deparsed form PostgreSQL
+      -- returns in pg_policies (including the parentheses PostgreSQL puts
+      -- around operator expressions) so that matching policies produce empty
+      -- plans
+      mkNamePolicy literal =
+        Orville.mkPolicyDefinition
+          "migration_test_policy"
+          Nothing
+          Nothing
+          Nothing
+          (Just . Expr.policyUsingExpr . RawSql.unsafeSqlExpression $ "(name = '" <> literal <> "'::text)")
+          Nothing
+
+      tableWithLowercaseLiteral =
+        Orville.addTablePolicies [mkNamePolicy "abc"] originalTableDef
+      tableWithUppercaseLiteral =
+        Orville.addTablePolicies [mkNamePolicy "ABC"] originalTableDef
+
+    firstTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          Orville.executeVoid Orville.DDLQuery $ TestTable.dropTableDefSql originalTableDef
+          AutoMigration.autoMigrateSchema AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithLowercaseLiteral]
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithUppercaseLiteral]
+
+    HH.annotate ("First time steps: " <> show (migrationPlanStepStrings firstTimePlan))
+    length (AutoMigration.migrationPlanSteps firstTimePlan) === 1
+
+    secondTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          AutoMigration.executeMigrationPlan AutoMigration.defaultOptions firstTimePlan
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithUppercaseLiteral]
+
+    HH.annotate ("Second time steps: " <> show (migrationPlanStepStrings secondTimePlan))
+    migrationPlanStepStrings secondTimePlan === []
+
+prop_managesPolicyRoleTargets :: Property.NamedDBProperty
+prop_managesPolicyRoleTargets =
+  Property.singletonNamedDBProperty "Creates and alters policies with role targets" $ \pool -> do
+    let
+      originalField = Orville.integerField "column"
+      originalTableDef =
+        Orville.mkTableDefinitionWithoutKey
+          "policy_migration_test"
+          (Orville.marshallField id originalField)
+      -- "orville_test" is the role the test suite connects as, so it is
+      -- guaranteed to exist
+      namedRolePolicy =
+        Orville.mkPolicyDefinition
+          "migration_test_policy"
+          Nothing
+          Nothing
+          (Just . Set.singleton $ Orville.PolicyRoleNamed "orville_test")
+          Nothing
+          Nothing
+      publicPolicy =
+        Orville.mkPolicyDefinition
+          "migration_test_policy"
+          Nothing
+          Nothing
+          (Just $ Set.singleton Orville.PolicyRolePublic)
+          Nothing
+          Nothing
+      tableWithNamedRole =
+        Orville.addTablePolicies [namedRolePolicy] originalTableDef
+      tableWithPublic =
+        Orville.addTablePolicies [publicPolicy] originalTableDef
+
+    namedRolePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          Orville.executeVoid Orville.DDLQuery $ TestTable.dropTableDefSql originalTableDef
+          AutoMigration.autoMigrateSchema AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithNamedRole]
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithNamedRole]
+
+    HH.annotate ("Named role steps: " <> show (migrationPlanStepStrings namedRolePlan))
+    migrationPlanStepStrings namedRolePlan === []
+
+    alterToPublicPlan <-
+      HH.evalIO $
+        Orville.runOrville pool $
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithPublic]
+
+    HH.annotate ("Alter to public steps: " <> show (migrationPlanStepStrings alterToPublicPlan))
+    length (AutoMigration.migrationPlanSteps alterToPublicPlan) === 1
+
+    secondTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          AutoMigration.executeMigrationPlan AutoMigration.defaultOptions alterToPublicPlan
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithPublic]
+
+    HH.annotate ("Second time steps: " <> show (migrationPlanStepStrings secondTimePlan))
+    migrationPlanStepStrings secondTimePlan === []
+
+prop_managesPoliciesWithCheckExprs :: Property.NamedDBProperty
+prop_managesPoliciesWithCheckExprs =
+  Property.singletonNamedDBProperty "Creates and alters policies with WITH CHECK expressions" $ \pool -> do
+    let
+      originalField = Orville.unboundedTextField "name"
+      originalTableDef =
+        Orville.mkTableDefinitionWithoutKey
+          "policy_migration_test"
+          (Orville.marshallField id originalField)
+      mkCheckPolicy literal =
+        Orville.mkPolicyDefinition
+          "migration_test_policy"
+          Nothing
+          Nothing
+          Nothing
+          Nothing
+          (Just . Expr.policyCheckExpr . RawSql.unsafeSqlExpression $ "(name = '" <> literal <> "'::text)")
+      tableWithAbcCheck =
+        Orville.addTablePolicies [mkCheckPolicy "abc"] originalTableDef
+      tableWithXyzCheck =
+        Orville.addTablePolicies [mkCheckPolicy "xyz"] originalTableDef
+
+    firstTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          Orville.executeVoid Orville.DDLQuery $ TestTable.dropTableDefSql originalTableDef
+          AutoMigration.autoMigrateSchema AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithAbcCheck]
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithAbcCheck]
+
+    HH.annotate ("First time steps: " <> show (migrationPlanStepStrings firstTimePlan))
+    migrationPlanStepStrings firstTimePlan === []
+
+    alterPlan <-
+      HH.evalIO $
+        Orville.runOrville pool $
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithXyzCheck]
+
+    HH.annotate ("Alter steps: " <> show (migrationPlanStepStrings alterPlan))
+    length (AutoMigration.migrationPlanSteps alterPlan) === 1
+
+    secondTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          AutoMigration.executeMigrationPlan AutoMigration.defaultOptions alterPlan
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithXyzCheck]
+
+    HH.annotate ("Second time steps: " <> show (migrationPlanStepStrings secondTimePlan))
+    migrationPlanStepStrings secondTimePlan === []
+
+prop_managesPoliciesWithMultipleRoles :: Property.NamedDBProperty
+prop_managesPoliciesWithMultipleRoles =
+  Property.singletonNamedDBProperty "Creates policies applying to multiple roles" $ \pool -> do
+    let
+      originalField = Orville.integerField "column"
+      originalTableDef =
+        Orville.mkTableDefinitionWithoutKey
+          "policy_migration_test"
+          (Orville.marshallField id originalField)
+      multiRolePolicy =
+        Orville.mkPolicyDefinition
+          "migration_test_policy"
+          Nothing
+          Nothing
+          ( Just $
+              Set.fromList
+                [ Orville.PolicyRoleNamed "orville_test"
+                , Orville.PolicyRoleNamed "orville_migration_role"
+                ]
+          )
+          Nothing
+          Nothing
+      tableWithPolicy =
+        Orville.addTablePolicies [multiRolePolicy] originalTableDef
+
+    firstTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          -- The table (and with it any policy referencing the role) must be
+          -- dropped before the role so the role drop doesn't fail on a
+          -- dependency from a previous test run
+          Orville.executeVoid Orville.DDLQuery $ TestTable.dropTableDefSql originalTableDef
+          Orville.executeVoid Orville.DDLQuery $ RawSql.fromString "DROP ROLE IF EXISTS orville_migration_role"
+          Orville.executeVoid Orville.DDLQuery $ RawSql.fromString "CREATE ROLE orville_migration_role"
+          AutoMigration.autoMigrateSchema AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithPolicy]
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithPolicy]
+
+    HH.annotate ("First time steps: " <> show (migrationPlanStepStrings firstTimePlan))
+    migrationPlanStepStrings firstTimePlan === []
+
+prop_managesMultiplePoliciesOnOneTable :: Property.NamedDBProperty
+prop_managesMultiplePoliciesOnOneTable =
+  Property.singletonNamedDBProperty "Creates, alters and drops multiple policies in one plan" $ \pool -> do
+    let
+      originalField = Orville.integerField "column"
+      originalTableDef =
+        Orville.mkTableDefinitionWithoutKey
+          "policy_migration_test"
+          (Orville.marshallField id originalField)
+      mkSimplePolicy name mbUsing =
+        Orville.mkPolicyDefinition name Nothing Nothing Nothing mbUsing Nothing
+      policyToAlter = mkSimplePolicy "migration_policy_alter" Nothing
+      alteredPolicy = mkSimplePolicy "migration_policy_alter" (Just . Expr.policyUsingExpr $ Expr.literalBooleanExpr True)
+      policyToDrop = mkSimplePolicy "migration_policy_drop" Nothing
+      policyToCreate = mkSimplePolicy "migration_policy_create" Nothing
+
+      originalTable =
+        Orville.addTablePolicies [policyToAlter, policyToDrop] originalTableDef
+      newTable =
+        Orville.dropPolicies ["migration_policy_drop"] $
+          Orville.addTablePolicies [alteredPolicy, policyToCreate] originalTableDef
+
+    firstTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          Orville.executeVoid Orville.DDLQuery $ TestTable.dropTableDefSql originalTableDef
+          AutoMigration.autoMigrateSchema AutoMigration.defaultOptions [AutoMigration.SchemaTable originalTable]
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable newTable]
+
+    HH.annotate ("First time steps: " <> show (migrationPlanStepStrings firstTimePlan))
+    length (AutoMigration.migrationPlanSteps firstTimePlan) === 3
+
+    secondTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          AutoMigration.executeMigrationPlan AutoMigration.defaultOptions firstTimePlan
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable newTable]
+
+    HH.annotate ("Second time steps: " <> show (migrationPlanStepStrings secondTimePlan))
+    migrationPlanStepStrings secondTimePlan === []
+
+prop_altersPoliciesWithQuotedIdentifiers :: Property.NamedDBProperty
+prop_altersPoliciesWithQuotedIdentifiers =
+  Property.singletonNamedDBProperty "Distinguishes quoted identifiers that differ only by case" $ \pool -> do
+    let
+      -- Two columns whose names differ only by case, both requiring quoting
+      -- in the deparsed policy expressions
+      marshaller =
+        (,)
+          <$> Orville.marshallField fst (Orville.unboundedTextField "UserId")
+          <*> Orville.marshallField snd (Orville.unboundedTextField "USERID")
+      originalTableDef =
+        Orville.mkTableDefinitionWithoutKey "policy_migration_test" marshaller
+      mkIdentPolicy columnName =
+        Orville.mkPolicyDefinition
+          "migration_test_policy"
+          Nothing
+          Nothing
+          Nothing
+          (Just . Expr.policyUsingExpr . RawSql.unsafeSqlExpression $ "(\"" <> columnName <> "\" = 'x'::text)")
+          Nothing
+      tableWithMixedCaseColumn =
+        Orville.addTablePolicies [mkIdentPolicy "UserId"] originalTableDef
+      tableWithUpperCaseColumn =
+        Orville.addTablePolicies [mkIdentPolicy "USERID"] originalTableDef
+
+    firstTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          Orville.executeVoid Orville.DDLQuery $ TestTable.dropTableDefSql originalTableDef
+          AutoMigration.autoMigrateSchema AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithMixedCaseColumn]
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithMixedCaseColumn]
+
+    HH.annotate ("First time steps: " <> show (migrationPlanStepStrings firstTimePlan))
+    migrationPlanStepStrings firstTimePlan === []
+
+    alterPlan <-
+      HH.evalIO $
+        Orville.runOrville pool $
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithUpperCaseColumn]
+
+    HH.annotate ("Alter steps: " <> show (migrationPlanStepStrings alterPlan))
+    length (AutoMigration.migrationPlanSteps alterPlan) === 1
+
+    secondTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          AutoMigration.executeMigrationPlan AutoMigration.defaultOptions alterPlan
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithUpperCaseColumn]
+
+    HH.annotate ("Second time steps: " <> show (migrationPlanStepStrings secondTimePlan))
+    migrationPlanStepStrings secondTimePlan === []
+
+prop_altersPoliciesWithEscapedQuoteLiterals :: Property.NamedDBProperty
+prop_altersPoliciesWithEscapedQuoteLiterals =
+  Property.singletonNamedDBProperty "Distinguishes literals containing escaped quotes by case" $ \pool -> do
+    let
+      originalField = Orville.unboundedTextField "name"
+      originalTableDef =
+        Orville.mkTableDefinitionWithoutKey
+          "policy_migration_test"
+          (Orville.marshallField id originalField)
+      -- The literals contain an escaped quote ('') followed by a letter that
+      -- differs only by case, so a comparison that mishandled the escaped
+      -- quote would treat the letter as being outside the literal and fold it
+      mkQuotePolicy literal =
+        Orville.mkPolicyDefinition
+          "migration_test_policy"
+          Nothing
+          Nothing
+          Nothing
+          (Just . Expr.policyUsingExpr . RawSql.unsafeSqlExpression $ "(name = '" <> literal <> "'::text)")
+          Nothing
+      tableWithUppercaseLiteral =
+        Orville.addTablePolicies [mkQuotePolicy "it''S"] originalTableDef
+      tableWithLowercaseLiteral =
+        Orville.addTablePolicies [mkQuotePolicy "it''s"] originalTableDef
+
+    firstTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          Orville.executeVoid Orville.DDLQuery $ TestTable.dropTableDefSql originalTableDef
+          AutoMigration.autoMigrateSchema AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithUppercaseLiteral]
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithUppercaseLiteral]
+
+    HH.annotate ("First time steps: " <> show (migrationPlanStepStrings firstTimePlan))
+    migrationPlanStepStrings firstTimePlan === []
+
+    alterPlan <-
+      HH.evalIO $
+        Orville.runOrville pool $
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithLowercaseLiteral]
+
+    HH.annotate ("Alter steps: " <> show (migrationPlanStepStrings alterPlan))
+    length (AutoMigration.migrationPlanSteps alterPlan) === 1
+
+    secondTimePlan <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          AutoMigration.executeMigrationPlan AutoMigration.defaultOptions alterPlan
+          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithLowercaseLiteral]
+
+    HH.annotate ("Second time steps: " <> show (migrationPlanStepStrings secondTimePlan))
+    migrationPlanStepStrings secondTimePlan === []
+
+prop_addTablePoliciesAccumulates :: Property.NamedProperty
+prop_addTablePoliciesAccumulates =
+  Property.singletonNamedProperty "addTablePolicies accumulates policies across calls, replacing by name" $ do
+    let
+      mkNamedPolicy name mbPermission =
+        Orville.mkPolicyDefinition name mbPermission Nothing Nothing Nothing Nothing
+      tableDef =
+        Orville.addTablePolicies [mkNamedPolicy "policy_one" (Just Orville.PolicyRestrictive)] $
+          Orville.addTablePolicies
+            [ mkNamedPolicy "policy_one" Nothing
+            , mkNamedPolicy "policy_two" Nothing
+            ]
+            ( Orville.mkTableDefinitionWithoutKey
+                "policy_migration_test"
+                (Orville.marshallField id (Orville.integerField "column"))
+            )
+      policies = Orville.tablePolicies tableDef
+
+    Map.keys policies === ["policy_one", "policy_two"]
+    fmap Orville.policyDefinitionPermission (Map.lookup "policy_one" policies) === Just Orville.PolicyRestrictive
+    fmap Orville.policyDefinitionPermission (Map.lookup "policy_two" policies) === Just Orville.PolicyPermissive
 
 prop_loadsMissingExtensions :: Property.NamedDBProperty
 prop_loadsMissingExtensions =

--- a/orville-postgresql/test/Test/AutoMigration.hs
+++ b/orville-postgresql/test/Test/AutoMigration.hs
@@ -80,10 +80,14 @@ autoMigrationTests pool =
     , prop_modifiesColumnComments pool
     , prop_createsMissingPolicies pool
     , prop_dropsRequestedPolicies pool
-    , prop_altersModifiedPolicies pool
+    , prop_recreatesModifiedPolicies pool
     , prop_createsRestrictivePolicies pool
     , prop_recreatesPoliciesWithChangedPermission pool
     , prop_recreatesPoliciesWithChangedCommand pool
+    , prop_recreatesPoliciesWithRemovedExpressions pool
+    , prop_recreatesPoliciesAcrossColumnChanges pool
+    , prop_invalidPolicyDefinitionsRaiseError pool
+    , prop_normalizesPublicRoleTargets pool
     , prop_managesPoliciesOnSchemaQualifiedTables pool
     , prop_enablesRowLevelSecurityWithoutPolicyCreation pool
     , prop_disablesRowLevelSecurityWhenNotRequested pool
@@ -1474,139 +1478,130 @@ prop_dropsUnrequestedTriggers =
     _ <- PgAssert.assertTriggerDoesNotExist fooRelation "before_insert_trigger"
     migrationPlanStepStrings secondTimePlan === []
 
+-- Policy migration tests. These share a common shape: set up a starting
+-- state, generate a plan for a target schema, assert the step count, execute
+-- the plan and assert that a second plan for the same schema is empty. That
+-- shape lives in 'assertPolicyMigrationConverges'.
+
+policyTestTable :: Orville.TableDefinition Orville.NoKey Int32 Int32
+policyTestTable =
+  Orville.mkTableDefinitionWithoutKey
+    "policy_migration_test"
+    (Orville.marshallField id (Orville.integerField "column"))
+
+policyTestTableWithName :: Orville.TableDefinition Orville.NoKey T.Text T.Text
+policyTestTableWithName =
+  Orville.mkTableDefinitionWithoutKey
+    "policy_migration_test"
+    (Orville.marshallField id (Orville.unboundedTextField "name"))
+
+dropPolicyTestTable :: Orville.Orville ()
+dropPolicyTestTable =
+  Orville.executeVoid Orville.DDLQuery $ TestTable.dropTableDefSql policyTestTable
+
+autoMigrateTestSchema :: [AutoMigration.SchemaItem] -> Orville.Orville ()
+autoMigrateTestSchema =
+  AutoMigration.autoMigrateSchema AutoMigration.defaultOptions
+
+mkTestPolicy :: String -> Orville.PolicyDefinition
+mkTestPolicy name =
+  Orville.mkPolicyDefinition name Nothing Nothing Nothing Nothing Nothing
+
+{- | A test policy with a USING expression given as raw SQL. The SQL should be
+  written to match the deparsed form PostgreSQL returns in pg_policies
+  (including the parentheses PostgreSQL puts around operator expressions) so
+  that matching policies produce empty plans.
+-}
+mkRawUsingPolicy :: String -> Orville.PolicyDefinition
+mkRawUsingPolicy usingSql =
+  Orville.mkPolicyDefinition
+    "migration_test_policy"
+    Nothing
+    Nothing
+    Nothing
+    (Just . Expr.policyUsingExpr $ RawSql.unsafeSqlExpression usingSql)
+    Nothing
+
+{- | Runs the given setup actions, generates a migration plan for the target
+  schema, asserts it has the expected number of steps, executes it, and
+  asserts that a second plan for the same schema is empty.
+-}
+assertPolicyMigrationConverges ::
+  Orville.ConnectionPool ->
+  Orville.Orville () ->
+  [AutoMigration.SchemaItem] ->
+  Int ->
+  HH.PropertyT IO ()
+assertPolicyMigrationConverges pool setup targetSchema expectedStepCount = do
+  plan <-
+    HH.evalIO $
+      Orville.runOrville pool $ do
+        setup
+        AutoMigration.generateMigrationPlan AutoMigration.defaultOptions targetSchema
+
+  HH.annotate ("Migration steps: " <> show (migrationPlanStepStrings plan))
+  length (AutoMigration.migrationPlanSteps plan) === expectedStepCount
+
+  secondTimePlan <-
+    HH.evalIO $
+      Orville.runOrville pool $ do
+        AutoMigration.executeMigrationPlan AutoMigration.defaultOptions plan
+        AutoMigration.generateMigrationPlan AutoMigration.defaultOptions targetSchema
+
+  HH.annotate ("Second time steps: " <> show (migrationPlanStepStrings secondTimePlan))
+  migrationPlanStepStrings secondTimePlan === []
+
 prop_createsMissingPolicies :: Property.NamedDBProperty
 prop_createsMissingPolicies =
-  Property.singletonNamedDBProperty "Creates missing policies" $ \pool -> do
-    let
-      originalField = Orville.integerField "column"
-      originalTableDef =
-        Orville.mkTableDefinitionWithoutKey
-          "policy_migration_test"
-          (Orville.marshallField id originalField)
-      policyDef =
-        Orville.mkPolicyDefinition
-          "migration_test_policy"
-          Nothing
-          Nothing
-          Nothing
-          Nothing
-          Nothing
-      newTableDef =
-        Orville.addTablePolicies [policyDef] originalTableDef
-
-    firstTimePlan <-
-      HH.evalIO $
-        Orville.runOrville pool $ do
-          Orville.executeVoid Orville.DDLQuery $ TestTable.dropTableDefSql originalTableDef
-          Orville.executeVoid Orville.DDLQuery $ Schema.mkCreateTableExpr originalTableDef
-          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable newTableDef]
-
-    secondTimePlan <-
-      HH.evalIO $
-        Orville.runOrville pool $ do
-          AutoMigration.executeMigrationPlan AutoMigration.defaultOptions firstTimePlan
-          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable newTableDef]
-
-    length (AutoMigration.migrationPlanSteps firstTimePlan) === 1
-    migrationPlanStepStrings secondTimePlan === []
+  Property.singletonNamedDBProperty "Creates missing policies" $ \pool ->
+    assertPolicyMigrationConverges
+      pool
+      ( do
+          dropPolicyTestTable
+          Orville.executeVoid Orville.DDLQuery $ Schema.mkCreateTableExpr policyTestTable
+      )
+      [AutoMigration.SchemaTable (Orville.addTablePolicies [mkTestPolicy "migration_test_policy"] policyTestTable)]
+      1
 
 prop_dropsRequestedPolicies :: Property.NamedDBProperty
 prop_dropsRequestedPolicies =
-  Property.singletonNamedDBProperty "Drops requested policies" $ \pool -> do
+  Property.singletonNamedDBProperty "Drops requested policies" $ \pool ->
+    assertPolicyMigrationConverges
+      pool
+      ( do
+          dropPolicyTestTable
+          autoMigrateTestSchema [AutoMigration.SchemaTable (Orville.addTablePolicies [mkTestPolicy "migration_test_policy"] policyTestTable)]
+      )
+      [AutoMigration.SchemaTable (Orville.dropPolicies ["migration_test_policy"] policyTestTable)]
+      1
+
+prop_recreatesModifiedPolicies :: Property.NamedDBProperty
+prop_recreatesModifiedPolicies =
+  Property.singletonNamedDBProperty "Recreates modified policies" $ \pool -> do
     let
-      originalField = Orville.integerField "column"
-      originalTableDef =
-        Orville.mkTableDefinitionWithoutKey
-          "policy_migration_test"
-          (Orville.marshallField id originalField)
-      policyDef =
+      modifiedPolicy =
         Orville.mkPolicyDefinition
           "migration_test_policy"
           Nothing
           Nothing
           Nothing
+          (Just . Expr.policyUsingExpr $ Expr.literalBooleanExpr True)
           Nothing
-          Nothing
-      tableWithPolicy =
-        Orville.addTablePolicies [policyDef] originalTableDef
-      tableWithDrop =
-        Orville.dropPolicies ["migration_test_policy"] originalTableDef
 
-    firstTimePlan <-
-      HH.evalIO $
-        Orville.runOrville pool $ do
-          Orville.executeVoid Orville.DDLQuery $ TestTable.dropTableDefSql originalTableDef
-          AutoMigration.autoMigrateSchema AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithPolicy]
-          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithDrop]
-
-    secondTimePlan <-
-      HH.evalIO $
-        Orville.runOrville pool $ do
-          AutoMigration.executeMigrationPlan AutoMigration.defaultOptions firstTimePlan
-          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithDrop]
-
-    length (AutoMigration.migrationPlanSteps firstTimePlan) === 1
-    migrationPlanStepStrings secondTimePlan === []
-
-prop_altersModifiedPolicies :: Property.NamedDBProperty
-prop_altersModifiedPolicies =
-  Property.singletonNamedDBProperty "Alters modified policies" $ \pool -> do
-    let
-      originalField = Orville.integerField "column"
-      originalTableDef =
-        Orville.mkTableDefinitionWithoutKey
-          "policy_migration_test"
-          (Orville.marshallField id originalField)
-      policyDef =
-        Orville.mkPolicyDefinition
-          "migration_test_policy"
-          Nothing
-          Nothing
-          Nothing
-          Nothing
-          Nothing
-      modifiedPolicyDef =
-        Orville.mkPolicyDefinition
-          "migration_test_policy"
-          Nothing
-          Nothing
-          Nothing
-          (Just (Expr.policyUsingExpr (Expr.literalBooleanExpr True)))
-          Nothing
-      tableWithPolicy =
-        Orville.addTablePolicies [policyDef] originalTableDef
-      tableWithModifiedPolicy =
-        Orville.addTablePolicies [modifiedPolicyDef] originalTableDef
-
-    firstTimePlan <-
-      HH.evalIO $
-        Orville.runOrville pool $ do
-          Orville.executeVoid Orville.DDLQuery $ TestTable.dropTableDefSql originalTableDef
-          AutoMigration.autoMigrateSchema AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithPolicy]
-          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithModifiedPolicy]
-
-    HH.annotate ("First time steps: " <> show (migrationPlanStepStrings firstTimePlan))
-    length (AutoMigration.migrationPlanSteps firstTimePlan) === 1
-
-    secondTimePlan <-
-      HH.evalIO $
-        Orville.runOrville pool $ do
-          AutoMigration.executeMigrationPlan AutoMigration.defaultOptions firstTimePlan
-          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithModifiedPolicy]
-
-    HH.annotate ("Second time steps: " <> show (migrationPlanStepStrings secondTimePlan))
-    migrationPlanStepStrings secondTimePlan === []
+    assertPolicyMigrationConverges
+      pool
+      ( do
+          dropPolicyTestTable
+          autoMigrateTestSchema [AutoMigration.SchemaTable (Orville.addTablePolicies [mkTestPolicy "migration_test_policy"] policyTestTable)]
+      )
+      [AutoMigration.SchemaTable (Orville.addTablePolicies [modifiedPolicy] policyTestTable)]
+      2
 
 prop_createsRestrictivePolicies :: Property.NamedDBProperty
 prop_createsRestrictivePolicies =
   Property.singletonNamedDBProperty "Creates restrictive policies" $ \pool -> do
     let
-      originalField = Orville.integerField "column"
-      originalTableDef =
-        Orville.mkTableDefinitionWithoutKey
-          "policy_migration_test"
-          (Orville.marshallField id originalField)
-      policyDef =
+      restrictivePolicy =
         Orville.mkPolicyDefinition
           "migration_test_policy"
           (Just Orville.PolicyRestrictive)
@@ -1614,43 +1609,21 @@ prop_createsRestrictivePolicies =
           Nothing
           Nothing
           Nothing
-      newTableDef =
-        Orville.addTablePolicies [policyDef] originalTableDef
 
-    firstTimePlan <-
-      HH.evalIO $
-        Orville.runOrville pool $ do
-          Orville.executeVoid Orville.DDLQuery $ TestTable.dropTableDefSql originalTableDef
-          Orville.executeVoid Orville.DDLQuery $ Schema.mkCreateTableExpr originalTableDef
-          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable newTableDef]
-
-    secondTimePlan <-
-      HH.evalIO $
-        Orville.runOrville pool $ do
-          AutoMigration.executeMigrationPlan AutoMigration.defaultOptions firstTimePlan
-          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable newTableDef]
-
-    length (AutoMigration.migrationPlanSteps firstTimePlan) === 1
-    migrationPlanStepStrings secondTimePlan === []
+    assertPolicyMigrationConverges
+      pool
+      ( do
+          dropPolicyTestTable
+          Orville.executeVoid Orville.DDLQuery $ Schema.mkCreateTableExpr policyTestTable
+      )
+      [AutoMigration.SchemaTable (Orville.addTablePolicies [restrictivePolicy] policyTestTable)]
+      1
 
 prop_recreatesPoliciesWithChangedPermission :: Property.NamedDBProperty
 prop_recreatesPoliciesWithChangedPermission =
   Property.singletonNamedDBProperty "Recreates policies whose permission changed" $ \pool -> do
     let
-      originalField = Orville.integerField "column"
-      originalTableDef =
-        Orville.mkTableDefinitionWithoutKey
-          "policy_migration_test"
-          (Orville.marshallField id originalField)
-      permissivePolicyDef =
-        Orville.mkPolicyDefinition
-          "migration_test_policy"
-          Nothing
-          Nothing
-          Nothing
-          Nothing
-          Nothing
-      restrictivePolicyDef =
+      restrictivePolicy =
         Orville.mkPolicyDefinition
           "migration_test_policy"
           (Just Orville.PolicyRestrictive)
@@ -1658,39 +1631,20 @@ prop_recreatesPoliciesWithChangedPermission =
           Nothing
           Nothing
           Nothing
-      tableWithPermissivePolicy =
-        Orville.addTablePolicies [permissivePolicyDef] originalTableDef
-      tableWithRestrictivePolicy =
-        Orville.addTablePolicies [restrictivePolicyDef] originalTableDef
 
-    firstTimePlan <-
-      HH.evalIO $
-        Orville.runOrville pool $ do
-          Orville.executeVoid Orville.DDLQuery $ TestTable.dropTableDefSql originalTableDef
-          AutoMigration.autoMigrateSchema AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithPermissivePolicy]
-          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithRestrictivePolicy]
-
-    HH.annotate ("First time steps: " <> show (migrationPlanStepStrings firstTimePlan))
-    length (AutoMigration.migrationPlanSteps firstTimePlan) === 2
-
-    secondTimePlan <-
-      HH.evalIO $
-        Orville.runOrville pool $ do
-          AutoMigration.executeMigrationPlan AutoMigration.defaultOptions firstTimePlan
-          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithRestrictivePolicy]
-
-    HH.annotate ("Second time steps: " <> show (migrationPlanStepStrings secondTimePlan))
-    migrationPlanStepStrings secondTimePlan === []
+    assertPolicyMigrationConverges
+      pool
+      ( do
+          dropPolicyTestTable
+          autoMigrateTestSchema [AutoMigration.SchemaTable (Orville.addTablePolicies [mkTestPolicy "migration_test_policy"] policyTestTable)]
+      )
+      [AutoMigration.SchemaTable (Orville.addTablePolicies [restrictivePolicy] policyTestTable)]
+      2
 
 prop_recreatesPoliciesWithChangedCommand :: Property.NamedDBProperty
 prop_recreatesPoliciesWithChangedCommand =
   Property.singletonNamedDBProperty "Recreates policies whose command changed" $ \pool -> do
     let
-      originalField = Orville.integerField "column"
-      originalTableDef =
-        Orville.mkTableDefinitionWithoutKey
-          "policy_migration_test"
-          (Orville.marshallField id originalField)
       mkCommandPolicy command =
         Orville.mkPolicyDefinition
           "migration_test_policy"
@@ -1699,269 +1653,244 @@ prop_recreatesPoliciesWithChangedCommand =
           Nothing
           Nothing
           Nothing
-      tableWithSelectPolicy =
-        Orville.addTablePolicies [mkCommandPolicy Orville.PolicyCommandSelect] originalTableDef
-      tableWithUpdatePolicy =
-        Orville.addTablePolicies [mkCommandPolicy Orville.PolicyCommandUpdate] originalTableDef
 
-    firstTimePlan <-
-      HH.evalIO $
-        Orville.runOrville pool $ do
-          Orville.executeVoid Orville.DDLQuery $ TestTable.dropTableDefSql originalTableDef
-          AutoMigration.autoMigrateSchema AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithSelectPolicy]
-          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithSelectPolicy]
+    assertPolicyMigrationConverges
+      pool
+      ( do
+          dropPolicyTestTable
+          autoMigrateTestSchema [AutoMigration.SchemaTable (Orville.addTablePolicies [mkCommandPolicy Orville.PolicyCommandSelect] policyTestTable)]
+      )
+      [AutoMigration.SchemaTable (Orville.addTablePolicies [mkCommandPolicy Orville.PolicyCommandUpdate] policyTestTable)]
+      2
 
-    HH.annotate ("First time steps: " <> show (migrationPlanStepStrings firstTimePlan))
-    migrationPlanStepStrings firstTimePlan === []
+prop_recreatesPoliciesWithRemovedExpressions :: Property.NamedDBProperty
+prop_recreatesPoliciesWithRemovedExpressions =
+  Property.singletonNamedDBProperty "Recreates policies whose USING expression is removed" $ \pool -> do
+    let
+      policyWithUsing =
+        Orville.mkPolicyDefinition
+          "migration_test_policy"
+          Nothing
+          Nothing
+          Nothing
+          (Just . Expr.policyUsingExpr $ Expr.literalBooleanExpr True)
+          Nothing
 
-    recreatePlan <-
-      HH.evalIO $
-        Orville.runOrville pool $
-          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithUpdatePolicy]
+    -- ALTER POLICY cannot remove a USING clause, so this change requires the
+    -- policy to be dropped and recreated
+    assertPolicyMigrationConverges
+      pool
+      ( do
+          dropPolicyTestTable
+          autoMigrateTestSchema [AutoMigration.SchemaTable (Orville.addTablePolicies [policyWithUsing] policyTestTable)]
+      )
+      [AutoMigration.SchemaTable (Orville.addTablePolicies [mkTestPolicy "migration_test_policy"] policyTestTable)]
+      2
 
-    HH.annotate ("Recreate steps: " <> show (migrationPlanStepStrings recreatePlan))
-    length (AutoMigration.migrationPlanSteps recreatePlan) === 2
+prop_recreatesPoliciesAcrossColumnChanges :: Property.NamedDBProperty
+prop_recreatesPoliciesAcrossColumnChanges =
+  Property.singletonNamedDBProperty "Recreates a changed policy so a column it referenced can be dropped" $ \pool -> do
+    let
+      twoColumnTable =
+        Orville.mkTableDefinitionWithoutKey
+          "policy_migration_test"
+          ( (,)
+              <$> Orville.marshallField fst (Orville.integerField "column")
+              <*> Orville.marshallField snd (Orville.unboundedTextField "name")
+          )
+      tableWithNamePolicy =
+        Orville.addTablePolicies [mkRawUsingPolicy "(name = 'abc'::text)"] twoColumnTable
+      tableWithColumnPolicy =
+        Orville.addTablePolicies
+          [mkRawUsingPolicy "(\"column\" > 0)"]
+          (Orville.dropColumns ["name"] policyTestTable)
 
-    secondTimePlan <-
-      HH.evalIO $
-        Orville.runOrville pool $ do
-          AutoMigration.executeMigrationPlan AutoMigration.defaultOptions recreatePlan
-          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithUpdatePolicy]
+    -- The policy drop must run before the column drop, and the recreate
+    -- after it, or PostgreSQL rejects dropping a column the policy
+    -- references. Expected steps: drop policy, drop column, create policy.
+    assertPolicyMigrationConverges
+      pool
+      ( do
+          dropPolicyTestTable
+          autoMigrateTestSchema [AutoMigration.SchemaTable tableWithNamePolicy]
+      )
+      [AutoMigration.SchemaTable tableWithColumnPolicy]
+      3
 
-    HH.annotate ("Second time steps: " <> show (migrationPlanStepStrings secondTimePlan))
-    migrationPlanStepStrings secondTimePlan === []
+prop_invalidPolicyDefinitionsRaiseError :: Property.NamedDBProperty
+prop_invalidPolicyDefinitionsRaiseError =
+  Property.singletonNamedDBProperty "An error is raised for policy definitions PostgreSQL would reject" $ \pool -> do
+    let
+      usingTrue = Just . Expr.policyUsingExpr $ Expr.literalBooleanExpr True
+      checkTrue = Just . Expr.policyCheckExpr $ Expr.literalBooleanExpr True
+
+      invalidPolicies =
+        [ -- USING is not allowed on INSERT policies
+          Orville.mkPolicyDefinition "migration_test_policy" Nothing (Just Orville.PolicyCommandInsert) Nothing usingTrue Nothing
+        , -- WITH CHECK is not allowed on SELECT policies
+          Orville.mkPolicyDefinition "migration_test_policy" Nothing (Just Orville.PolicyCommandSelect) Nothing Nothing checkTrue
+        , -- Names longer than PostgreSQL's 63-byte identifier limit would be truncated
+          Orville.mkPolicyDefinition (List.replicate 70 'x') Nothing Nothing Nothing Nothing Nothing
+        , -- Bind parameters cannot be used in DDL
+          Orville.mkPolicyDefinition "migration_test_policy" Nothing Nothing Nothing (Just . Expr.policyUsingExpr $ Orville.fieldEquals (Orville.integerField "column") 1) Nothing
+        ]
+
+      assertRaisesInvalidPolicyError policyDef = do
+        result <-
+          HH.evalIO $
+            Orville.runOrville pool $
+              ExSafe.try $
+                AutoMigration.generateMigrationPlan
+                  AutoMigration.defaultOptions
+                  [AutoMigration.SchemaTable (Orville.addTablePolicies [policyDef] policyTestTable)]
+
+        case result of
+          Left err -> do
+            HH.annotate (show (err :: AutoMigration.MigrationDataError))
+            HH.assert $ List.isInfixOf "InvalidPolicyDefinition" (show err)
+          Right plan -> do
+            HH.annotate ("Expected plan generation to fail, but got steps: " <> show (migrationPlanStepStrings plan))
+            HH.failure
+
+    HH.evalIO $ Orville.runOrville pool dropPolicyTestTable
+    Fold.traverse_ assertRaisesInvalidPolicyError invalidPolicies
+
+prop_normalizesPublicRoleTargets :: Property.NamedDBProperty
+prop_normalizesPublicRoleTargets =
+  Property.singletonNamedDBProperty "Normalizes PUBLIC role targets the way PostgreSQL does" $ \pool -> do
+    let
+      mkRolesPolicy roles =
+        Orville.mkPolicyDefinition
+          "migration_test_policy"
+          Nothing
+          Nothing
+          (Just $ Set.fromList roles)
+          Nothing
+          Nothing
+
+    -- PostgreSQL treats a quoted "public" role target as the PUBLIC
+    -- pseudo-role, and ignores other targets given alongside PUBLIC
+    Orville.policyDefinitionPolicyRoles (mkRolesPolicy [Orville.PolicyRoleNamed "public"])
+      === Set.singleton Orville.PolicyRolePublic
+    Orville.policyDefinitionPolicyRoles (mkRolesPolicy [Orville.PolicyRolePublic, Orville.PolicyRoleNamed "orville_test"])
+      === Set.singleton Orville.PolicyRolePublic
+
+    -- A definition mixing PUBLIC with named roles must converge rather than
+    -- fighting PostgreSQL's collapse of the role list forever
+    let
+      tableWithMixedRoles =
+        Orville.addTablePolicies
+          [mkRolesPolicy [Orville.PolicyRolePublic, Orville.PolicyRoleNamed "orville_test"]]
+          policyTestTable
+
+    assertPolicyMigrationConverges
+      pool
+      ( do
+          dropPolicyTestTable
+          autoMigrateTestSchema [AutoMigration.SchemaTable tableWithMixedRoles]
+      )
+      [AutoMigration.SchemaTable tableWithMixedRoles]
+      0
 
 prop_managesPoliciesOnSchemaQualifiedTables :: Property.NamedDBProperty
 prop_managesPoliciesOnSchemaQualifiedTables =
   Property.singletonNamedDBProperty "Manages policies on tables with an explicit schema" $ \pool -> do
     let
-      originalField = Orville.integerField "column"
-      originalTableDef =
-        Orville.setTableSchema "orville_migration_schema" $
-          Orville.mkTableDefinitionWithoutKey
-            "policy_migration_test"
-            (Orville.marshallField id originalField)
-      policyDef =
-        Orville.mkPolicyDefinition
-          "migration_test_policy"
-          Nothing
-          Nothing
-          Nothing
-          Nothing
-          Nothing
-      newTableDef =
-        Orville.addTablePolicies [policyDef] originalTableDef
+      qualifiedTable =
+        Orville.setTableSchema "orville_migration_schema" policyTestTable
 
-    firstTimePlan <-
-      HH.evalIO $
-        Orville.runOrville pool $ do
+    assertPolicyMigrationConverges
+      pool
+      ( do
           Orville.executeVoid Orville.DDLQuery $ RawSql.fromString "DROP SCHEMA IF EXISTS orville_migration_schema CASCADE"
           Orville.executeVoid Orville.DDLQuery $ RawSql.fromString "CREATE SCHEMA orville_migration_schema"
-          Orville.executeVoid Orville.DDLQuery $ Schema.mkCreateTableExpr originalTableDef
-          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable newTableDef]
-
-    HH.annotate ("First time steps: " <> show (migrationPlanStepStrings firstTimePlan))
-    length (AutoMigration.migrationPlanSteps firstTimePlan) === 1
-
-    secondTimePlan <-
-      HH.evalIO $
-        Orville.runOrville pool $ do
-          AutoMigration.executeMigrationPlan AutoMigration.defaultOptions firstTimePlan
-          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable newTableDef]
-
-    HH.annotate ("Second time steps: " <> show (migrationPlanStepStrings secondTimePlan))
-    migrationPlanStepStrings secondTimePlan === []
+          Orville.executeVoid Orville.DDLQuery $ Schema.mkCreateTableExpr qualifiedTable
+      )
+      [AutoMigration.SchemaTable (Orville.addTablePolicies [mkTestPolicy "migration_test_policy"] qualifiedTable)]
+      1
 
 prop_enablesRowLevelSecurityWithoutPolicyCreation :: Property.NamedDBProperty
 prop_enablesRowLevelSecurityWithoutPolicyCreation =
-  Property.singletonNamedDBProperty "Enables row level security even when only dropping policies" $ \pool -> do
-    let
-      originalField = Orville.integerField "column"
-      originalTableDef =
-        Orville.mkTableDefinitionWithoutKey
-          "policy_migration_test"
-          (Orville.marshallField id originalField)
-      policyDef =
-        Orville.mkPolicyDefinition
-          "migration_test_policy"
-          Nothing
-          Nothing
-          Nothing
-          Nothing
-          Nothing
-      tableWithPolicy =
-        Orville.addTablePolicies [policyDef] originalTableDef
-      tableWithRLSAndDrop =
-        Orville.setRowLevelSecurityEnabled $
-          Orville.dropPolicies ["migration_test_policy"] originalTableDef
-
-    firstTimePlan <-
-      HH.evalIO $
-        Orville.runOrville pool $ do
-          Orville.executeVoid Orville.DDLQuery $ TestTable.dropTableDefSql originalTableDef
-          AutoMigration.autoMigrateSchema AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithPolicy]
-          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithRLSAndDrop]
-
-    HH.annotate ("First time steps: " <> show (migrationPlanStepStrings firstTimePlan))
-    length (AutoMigration.migrationPlanSteps firstTimePlan) === 2
-
-    secondTimePlan <-
-      HH.evalIO $
-        Orville.runOrville pool $ do
-          AutoMigration.executeMigrationPlan AutoMigration.defaultOptions firstTimePlan
-          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithRLSAndDrop]
-
-    HH.annotate ("Second time steps: " <> show (migrationPlanStepStrings secondTimePlan))
-    migrationPlanStepStrings secondTimePlan === []
+  Property.singletonNamedDBProperty "Enables row level security even when only dropping policies" $ \pool ->
+    -- The expected steps are the policy drop plus the RLS enable
+    assertPolicyMigrationConverges
+      pool
+      ( do
+          dropPolicyTestTable
+          autoMigrateTestSchema [AutoMigration.SchemaTable (Orville.addTablePolicies [mkTestPolicy "migration_test_policy"] policyTestTable)]
+      )
+      [ AutoMigration.SchemaTable
+          ( Orville.setRowLevelSecurityEnabled $
+              Orville.dropPolicies ["migration_test_policy"] policyTestTable
+          )
+      ]
+      2
 
 prop_disablesRowLevelSecurityWhenNotRequested :: Property.NamedDBProperty
 prop_disablesRowLevelSecurityWhenNotRequested =
-  Property.singletonNamedDBProperty "Disables row level security when the definition does not enable it" $ \pool -> do
-    let
-      originalField = Orville.integerField "column"
-      originalTableDef =
-        Orville.mkTableDefinitionWithoutKey
-          "policy_migration_test"
-          (Orville.marshallField id originalField)
-      tableWithRLS =
-        Orville.setRowLevelSecurityEnabled originalTableDef
-
-    firstTimePlan <-
-      HH.evalIO $
-        Orville.runOrville pool $ do
-          Orville.executeVoid Orville.DDLQuery $ TestTable.dropTableDefSql originalTableDef
-          AutoMigration.autoMigrateSchema AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithRLS]
-          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable originalTableDef]
-
-    HH.annotate ("First time steps: " <> show (migrationPlanStepStrings firstTimePlan))
-    length (AutoMigration.migrationPlanSteps firstTimePlan) === 1
-
-    -- Once RLS is disabled, the plan must be empty: no DISABLE statement is
-    -- emitted for a table whose relrowsecurity is already false
-    secondTimePlan <-
-      HH.evalIO $
-        Orville.runOrville pool $ do
-          AutoMigration.executeMigrationPlan AutoMigration.defaultOptions firstTimePlan
-          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable originalTableDef]
-
-    HH.annotate ("Second time steps: " <> show (migrationPlanStepStrings secondTimePlan))
-    migrationPlanStepStrings secondTimePlan === []
+  Property.singletonNamedDBProperty "Disables row level security when the definition does not enable it" $ \pool ->
+    -- Once RLS is disabled the second plan must be empty: no DISABLE
+    -- statement is emitted for a table whose relrowsecurity is already false
+    assertPolicyMigrationConverges
+      pool
+      ( do
+          dropPolicyTestTable
+          autoMigrateTestSchema [AutoMigration.SchemaTable (Orville.setRowLevelSecurityEnabled policyTestTable)]
+      )
+      [AutoMigration.SchemaTable policyTestTable]
+      1
 
 prop_altersPoliciesWhoseLiteralsDifferOnlyByCase :: Property.NamedDBProperty
 prop_altersPoliciesWhoseLiteralsDifferOnlyByCase =
-  Property.singletonNamedDBProperty "Alters policies whose string literals differ only by case" $ \pool -> do
+  Property.singletonNamedDBProperty "Distinguishes policies whose string literals differ only by case" $ \pool -> do
     let
-      originalField = Orville.unboundedTextField "name"
-      originalTableDef =
-        Orville.mkTableDefinitionWithoutKey
-          "policy_migration_test"
-          (Orville.marshallField id originalField)
-
-      -- These expressions are written to match the deparsed form PostgreSQL
-      -- returns in pg_policies (including the parentheses PostgreSQL puts
-      -- around operator expressions) so that matching policies produce empty
-      -- plans
       mkNamePolicy literal =
-        Orville.mkPolicyDefinition
-          "migration_test_policy"
-          Nothing
-          Nothing
-          Nothing
-          (Just . Expr.policyUsingExpr . RawSql.unsafeSqlExpression $ "(name = '" <> literal <> "'::text)")
-          Nothing
+        mkRawUsingPolicy ("(name = '" <> literal <> "'::text)")
 
-      tableWithLowercaseLiteral =
-        Orville.addTablePolicies [mkNamePolicy "abc"] originalTableDef
-      tableWithUppercaseLiteral =
-        Orville.addTablePolicies [mkNamePolicy "ABC"] originalTableDef
-
-    firstTimePlan <-
-      HH.evalIO $
-        Orville.runOrville pool $ do
-          Orville.executeVoid Orville.DDLQuery $ TestTable.dropTableDefSql originalTableDef
-          AutoMigration.autoMigrateSchema AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithLowercaseLiteral]
-          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithUppercaseLiteral]
-
-    HH.annotate ("First time steps: " <> show (migrationPlanStepStrings firstTimePlan))
-    length (AutoMigration.migrationPlanSteps firstTimePlan) === 1
-
-    secondTimePlan <-
-      HH.evalIO $
-        Orville.runOrville pool $ do
-          AutoMigration.executeMigrationPlan AutoMigration.defaultOptions firstTimePlan
-          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithUppercaseLiteral]
-
-    HH.annotate ("Second time steps: " <> show (migrationPlanStepStrings secondTimePlan))
-    migrationPlanStepStrings secondTimePlan === []
+    assertPolicyMigrationConverges
+      pool
+      ( do
+          dropPolicyTestTable
+          autoMigrateTestSchema [AutoMigration.SchemaTable (Orville.addTablePolicies [mkNamePolicy "abc"] policyTestTableWithName)]
+      )
+      [AutoMigration.SchemaTable (Orville.addTablePolicies [mkNamePolicy "ABC"] policyTestTableWithName)]
+      2
 
 prop_managesPolicyRoleTargets :: Property.NamedDBProperty
 prop_managesPolicyRoleTargets =
-  Property.singletonNamedDBProperty "Creates and alters policies with role targets" $ \pool -> do
+  Property.singletonNamedDBProperty "Creates and recreates policies with role targets" $ \pool -> do
     let
-      originalField = Orville.integerField "column"
-      originalTableDef =
-        Orville.mkTableDefinitionWithoutKey
-          "policy_migration_test"
-          (Orville.marshallField id originalField)
+      mkRolePolicy role =
+        Orville.mkPolicyDefinition
+          "migration_test_policy"
+          Nothing
+          Nothing
+          (Just $ Set.singleton role)
+          Nothing
+          Nothing
       -- "orville_test" is the role the test suite connects as, so it is
       -- guaranteed to exist
-      namedRolePolicy =
-        Orville.mkPolicyDefinition
-          "migration_test_policy"
-          Nothing
-          Nothing
-          (Just . Set.singleton $ Orville.PolicyRoleNamed "orville_test")
-          Nothing
-          Nothing
-      publicPolicy =
-        Orville.mkPolicyDefinition
-          "migration_test_policy"
-          Nothing
-          Nothing
-          (Just $ Set.singleton Orville.PolicyRolePublic)
-          Nothing
-          Nothing
-      tableWithNamedRole =
-        Orville.addTablePolicies [namedRolePolicy] originalTableDef
-      tableWithPublic =
-        Orville.addTablePolicies [publicPolicy] originalTableDef
+      namedRoleSchema =
+        [AutoMigration.SchemaTable (Orville.addTablePolicies [mkRolePolicy (Orville.PolicyRoleNamed "orville_test")] policyTestTable)]
+      publicSchema =
+        [AutoMigration.SchemaTable (Orville.addTablePolicies [mkRolePolicy Orville.PolicyRolePublic] policyTestTable)]
 
-    namedRolePlan <-
-      HH.evalIO $
-        Orville.runOrville pool $ do
-          Orville.executeVoid Orville.DDLQuery $ TestTable.dropTableDefSql originalTableDef
-          AutoMigration.autoMigrateSchema AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithNamedRole]
-          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithNamedRole]
+    assertPolicyMigrationConverges
+      pool
+      ( do
+          dropPolicyTestTable
+          autoMigrateTestSchema namedRoleSchema
+      )
+      namedRoleSchema
+      0
 
-    HH.annotate ("Named role steps: " <> show (migrationPlanStepStrings namedRolePlan))
-    migrationPlanStepStrings namedRolePlan === []
-
-    alterToPublicPlan <-
-      HH.evalIO $
-        Orville.runOrville pool $
-          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithPublic]
-
-    HH.annotate ("Alter to public steps: " <> show (migrationPlanStepStrings alterToPublicPlan))
-    length (AutoMigration.migrationPlanSteps alterToPublicPlan) === 1
-
-    secondTimePlan <-
-      HH.evalIO $
-        Orville.runOrville pool $ do
-          AutoMigration.executeMigrationPlan AutoMigration.defaultOptions alterToPublicPlan
-          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithPublic]
-
-    HH.annotate ("Second time steps: " <> show (migrationPlanStepStrings secondTimePlan))
-    migrationPlanStepStrings secondTimePlan === []
+    assertPolicyMigrationConverges pool (pure ()) publicSchema 2
 
 prop_managesPoliciesWithCheckExprs :: Property.NamedDBProperty
 prop_managesPoliciesWithCheckExprs =
-  Property.singletonNamedDBProperty "Creates and alters policies with WITH CHECK expressions" $ \pool -> do
+  Property.singletonNamedDBProperty "Creates and recreates policies with WITH CHECK expressions" $ \pool -> do
     let
-      originalField = Orville.unboundedTextField "name"
-      originalTableDef =
-        Orville.mkTableDefinitionWithoutKey
-          "policy_migration_test"
-          (Orville.marshallField id originalField)
+      -- Written to match the deparsed form PostgreSQL returns in pg_policies
       mkCheckPolicy literal =
         Orville.mkPolicyDefinition
           "migration_test_policy"
@@ -1970,47 +1899,26 @@ prop_managesPoliciesWithCheckExprs =
           Nothing
           Nothing
           (Just . Expr.policyCheckExpr . RawSql.unsafeSqlExpression $ "(name = '" <> literal <> "'::text)")
-      tableWithAbcCheck =
-        Orville.addTablePolicies [mkCheckPolicy "abc"] originalTableDef
-      tableWithXyzCheck =
-        Orville.addTablePolicies [mkCheckPolicy "xyz"] originalTableDef
+      abcSchema =
+        [AutoMigration.SchemaTable (Orville.addTablePolicies [mkCheckPolicy "abc"] policyTestTableWithName)]
+      xyzSchema =
+        [AutoMigration.SchemaTable (Orville.addTablePolicies [mkCheckPolicy "xyz"] policyTestTableWithName)]
 
-    firstTimePlan <-
-      HH.evalIO $
-        Orville.runOrville pool $ do
-          Orville.executeVoid Orville.DDLQuery $ TestTable.dropTableDefSql originalTableDef
-          AutoMigration.autoMigrateSchema AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithAbcCheck]
-          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithAbcCheck]
+    assertPolicyMigrationConverges
+      pool
+      ( do
+          dropPolicyTestTable
+          autoMigrateTestSchema abcSchema
+      )
+      abcSchema
+      0
 
-    HH.annotate ("First time steps: " <> show (migrationPlanStepStrings firstTimePlan))
-    migrationPlanStepStrings firstTimePlan === []
-
-    alterPlan <-
-      HH.evalIO $
-        Orville.runOrville pool $
-          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithXyzCheck]
-
-    HH.annotate ("Alter steps: " <> show (migrationPlanStepStrings alterPlan))
-    length (AutoMigration.migrationPlanSteps alterPlan) === 1
-
-    secondTimePlan <-
-      HH.evalIO $
-        Orville.runOrville pool $ do
-          AutoMigration.executeMigrationPlan AutoMigration.defaultOptions alterPlan
-          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithXyzCheck]
-
-    HH.annotate ("Second time steps: " <> show (migrationPlanStepStrings secondTimePlan))
-    migrationPlanStepStrings secondTimePlan === []
+    assertPolicyMigrationConverges pool (pure ()) xyzSchema 2
 
 prop_managesPoliciesWithMultipleRoles :: Property.NamedDBProperty
 prop_managesPoliciesWithMultipleRoles =
   Property.singletonNamedDBProperty "Creates policies applying to multiple roles" $ \pool -> do
     let
-      originalField = Orville.integerField "column"
-      originalTableDef =
-        Orville.mkTableDefinitionWithoutKey
-          "policy_migration_test"
-          (Orville.marshallField id originalField)
       multiRolePolicy =
         Orville.mkPolicyDefinition
           "migration_test_policy"
@@ -2025,32 +1933,26 @@ prop_managesPoliciesWithMultipleRoles =
           Nothing
           Nothing
       tableWithPolicy =
-        Orville.addTablePolicies [multiRolePolicy] originalTableDef
+        Orville.addTablePolicies [multiRolePolicy] policyTestTable
 
-    firstTimePlan <-
-      HH.evalIO $
-        Orville.runOrville pool $ do
+    assertPolicyMigrationConverges
+      pool
+      ( do
           -- The table (and with it any policy referencing the role) must be
           -- dropped before the role so the role drop doesn't fail on a
           -- dependency from a previous test run
-          Orville.executeVoid Orville.DDLQuery $ TestTable.dropTableDefSql originalTableDef
+          dropPolicyTestTable
           Orville.executeVoid Orville.DDLQuery $ RawSql.fromString "DROP ROLE IF EXISTS orville_migration_role"
           Orville.executeVoid Orville.DDLQuery $ RawSql.fromString "CREATE ROLE orville_migration_role"
-          AutoMigration.autoMigrateSchema AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithPolicy]
-          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithPolicy]
-
-    HH.annotate ("First time steps: " <> show (migrationPlanStepStrings firstTimePlan))
-    migrationPlanStepStrings firstTimePlan === []
+          autoMigrateTestSchema [AutoMigration.SchemaTable tableWithPolicy]
+      )
+      [AutoMigration.SchemaTable tableWithPolicy]
+      0
 
 prop_managesPoliciesWithQuotedRoleNames :: Property.NamedDBProperty
 prop_managesPoliciesWithQuotedRoleNames =
   Property.singletonNamedDBProperty "Parses policy role names containing special characters" $ \pool -> do
     let
-      originalField = Orville.integerField "column"
-      originalTableDef =
-        Orville.mkTableDefinitionWithoutKey
-          "policy_migration_test"
-          (Orville.marshallField id originalField)
       -- The double quote, comma and spaces force PostgreSQL to render this
       -- role quoted and escaped in the pg_policies roles array, alongside the
       -- unquoted orville_test element
@@ -2069,48 +1971,31 @@ prop_managesPoliciesWithQuotedRoleNames =
           Nothing
           Nothing
       tableWithPolicy =
-        Orville.addTablePolicies [quotedRolePolicy] originalTableDef
+        Orville.addTablePolicies [quotedRolePolicy] policyTestTable
 
-    firstTimePlan <-
-      HH.evalIO $
-        Orville.runOrville pool $ do
-          -- The table (and with it any policy referencing the role) must be
-          -- dropped before the role so the role drop doesn't fail on a
-          -- dependency from a previous test run
-          Orville.executeVoid Orville.DDLQuery $ TestTable.dropTableDefSql originalTableDef
+    assertPolicyMigrationConverges
+      pool
+      ( do
+          dropPolicyTestTable
           Orville.executeVoid Orville.DDLQuery $ RawSql.fromString "DROP ROLE IF EXISTS \"orville \"\"quoted\"\", role\""
           Orville.executeVoid Orville.DDLQuery $ RawSql.fromString "CREATE ROLE \"orville \"\"quoted\"\", role\""
-          AutoMigration.autoMigrateSchema AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithPolicy]
-          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithPolicy]
-
-    HH.annotate ("First time steps: " <> show (migrationPlanStepStrings firstTimePlan))
-    migrationPlanStepStrings firstTimePlan === []
+          autoMigrateTestSchema [AutoMigration.SchemaTable tableWithPolicy]
+      )
+      [AutoMigration.SchemaTable tableWithPolicy]
+      0
 
 prop_conflictingPolicyDefinitionsRaiseError :: Property.NamedDBProperty
 prop_conflictingPolicyDefinitionsRaiseError =
   Property.singletonNamedDBProperty "An error is raised when a policy is both defined and marked for dropping" $ \pool -> do
     let
-      originalField = Orville.integerField "column"
-      originalTableDef =
-        Orville.mkTableDefinitionWithoutKey
-          "policy_migration_test"
-          (Orville.marshallField id originalField)
-      policyDef =
-        Orville.mkPolicyDefinition
-          "migration_test_policy"
-          Nothing
-          Nothing
-          Nothing
-          Nothing
-          Nothing
       conflictedTableDef =
         Orville.dropPolicies ["migration_test_policy"] $
-          Orville.addTablePolicies [policyDef] originalTableDef
+          Orville.addTablePolicies [mkTestPolicy "migration_test_policy"] policyTestTable
 
     result <-
       HH.evalIO $
         Orville.runOrville pool $ do
-          Orville.executeVoid Orville.DDLQuery $ TestTable.dropTableDefSql originalTableDef
+          dropPolicyTestTable
           ExSafe.try $
             AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable conflictedTableDef]
 
@@ -2124,44 +2009,38 @@ prop_conflictingPolicyDefinitionsRaiseError =
 
 prop_managesMultiplePoliciesOnOneTable :: Property.NamedDBProperty
 prop_managesMultiplePoliciesOnOneTable =
-  Property.singletonNamedDBProperty "Creates, alters and drops multiple policies in one plan" $ \pool -> do
+  Property.singletonNamedDBProperty "Creates, recreates and drops multiple policies in one plan" $ \pool -> do
     let
-      originalField = Orville.integerField "column"
-      originalTableDef =
-        Orville.mkTableDefinitionWithoutKey
-          "policy_migration_test"
-          (Orville.marshallField id originalField)
-      mkSimplePolicy name mbUsing =
-        Orville.mkPolicyDefinition name Nothing Nothing Nothing mbUsing Nothing
-      policyToAlter = mkSimplePolicy "migration_policy_alter" Nothing
-      alteredPolicy = mkSimplePolicy "migration_policy_alter" (Just . Expr.policyUsingExpr $ Expr.literalBooleanExpr True)
-      policyToDrop = mkSimplePolicy "migration_policy_drop" Nothing
-      policyToCreate = mkSimplePolicy "migration_policy_create" Nothing
+      recreatedPolicy =
+        Orville.mkPolicyDefinition
+          "migration_policy_recreate"
+          Nothing
+          Nothing
+          Nothing
+          (Just . Expr.policyUsingExpr $ Expr.literalBooleanExpr True)
+          Nothing
 
-      originalTable =
-        Orville.addTablePolicies [policyToAlter, policyToDrop] originalTableDef
-      newTable =
-        Orville.dropPolicies ["migration_policy_drop"] $
-          Orville.addTablePolicies [alteredPolicy, policyToCreate] originalTableDef
+      originalSchema =
+        [ AutoMigration.SchemaTable
+            (Orville.addTablePolicies [mkTestPolicy "migration_policy_recreate", mkTestPolicy "migration_policy_drop"] policyTestTable)
+        ]
+      -- One plan must recreate migration_policy_recreate (two steps), drop
+      -- migration_policy_drop and create migration_policy_create
+      newSchema =
+        [ AutoMigration.SchemaTable
+            ( Orville.dropPolicies ["migration_policy_drop"] $
+                Orville.addTablePolicies [recreatedPolicy, mkTestPolicy "migration_policy_create"] policyTestTable
+            )
+        ]
 
-    firstTimePlan <-
-      HH.evalIO $
-        Orville.runOrville pool $ do
-          Orville.executeVoid Orville.DDLQuery $ TestTable.dropTableDefSql originalTableDef
-          AutoMigration.autoMigrateSchema AutoMigration.defaultOptions [AutoMigration.SchemaTable originalTable]
-          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable newTable]
-
-    HH.annotate ("First time steps: " <> show (migrationPlanStepStrings firstTimePlan))
-    length (AutoMigration.migrationPlanSteps firstTimePlan) === 3
-
-    secondTimePlan <-
-      HH.evalIO $
-        Orville.runOrville pool $ do
-          AutoMigration.executeMigrationPlan AutoMigration.defaultOptions firstTimePlan
-          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable newTable]
-
-    HH.annotate ("Second time steps: " <> show (migrationPlanStepStrings secondTimePlan))
-    migrationPlanStepStrings secondTimePlan === []
+    assertPolicyMigrationConverges
+      pool
+      ( do
+          dropPolicyTestTable
+          autoMigrateTestSchema originalSchema
+      )
+      newSchema
+      4
 
 prop_altersPoliciesWithQuotedIdentifiers :: Property.NamedDBProperty
 prop_altersPoliciesWithQuotedIdentifiers =
@@ -2169,103 +2048,55 @@ prop_altersPoliciesWithQuotedIdentifiers =
     let
       -- Two columns whose names differ only by case, both requiring quoting
       -- in the deparsed policy expressions
-      marshaller =
-        (,)
-          <$> Orville.marshallField fst (Orville.unboundedTextField "UserId")
-          <*> Orville.marshallField snd (Orville.unboundedTextField "USERID")
-      originalTableDef =
-        Orville.mkTableDefinitionWithoutKey "policy_migration_test" marshaller
+      quotedColumnsTable =
+        Orville.mkTableDefinitionWithoutKey
+          "policy_migration_test"
+          ( (,)
+              <$> Orville.marshallField fst (Orville.unboundedTextField "UserId")
+              <*> Orville.marshallField snd (Orville.unboundedTextField "USERID")
+          )
       mkIdentPolicy columnName =
-        Orville.mkPolicyDefinition
-          "migration_test_policy"
-          Nothing
-          Nothing
-          Nothing
-          (Just . Expr.policyUsingExpr . RawSql.unsafeSqlExpression $ "(\"" <> columnName <> "\" = 'x'::text)")
-          Nothing
-      tableWithMixedCaseColumn =
-        Orville.addTablePolicies [mkIdentPolicy "UserId"] originalTableDef
-      tableWithUpperCaseColumn =
-        Orville.addTablePolicies [mkIdentPolicy "USERID"] originalTableDef
+        mkRawUsingPolicy ("(\"" <> columnName <> "\" = 'x'::text)")
+      mixedCaseSchema =
+        [AutoMigration.SchemaTable (Orville.addTablePolicies [mkIdentPolicy "UserId"] quotedColumnsTable)]
+      upperCaseSchema =
+        [AutoMigration.SchemaTable (Orville.addTablePolicies [mkIdentPolicy "USERID"] quotedColumnsTable)]
 
-    firstTimePlan <-
-      HH.evalIO $
-        Orville.runOrville pool $ do
-          Orville.executeVoid Orville.DDLQuery $ TestTable.dropTableDefSql originalTableDef
-          AutoMigration.autoMigrateSchema AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithMixedCaseColumn]
-          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithMixedCaseColumn]
+    assertPolicyMigrationConverges
+      pool
+      ( do
+          dropPolicyTestTable
+          autoMigrateTestSchema mixedCaseSchema
+      )
+      mixedCaseSchema
+      0
 
-    HH.annotate ("First time steps: " <> show (migrationPlanStepStrings firstTimePlan))
-    migrationPlanStepStrings firstTimePlan === []
-
-    alterPlan <-
-      HH.evalIO $
-        Orville.runOrville pool $
-          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithUpperCaseColumn]
-
-    HH.annotate ("Alter steps: " <> show (migrationPlanStepStrings alterPlan))
-    length (AutoMigration.migrationPlanSteps alterPlan) === 1
-
-    secondTimePlan <-
-      HH.evalIO $
-        Orville.runOrville pool $ do
-          AutoMigration.executeMigrationPlan AutoMigration.defaultOptions alterPlan
-          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithUpperCaseColumn]
-
-    HH.annotate ("Second time steps: " <> show (migrationPlanStepStrings secondTimePlan))
-    migrationPlanStepStrings secondTimePlan === []
+    assertPolicyMigrationConverges pool (pure ()) upperCaseSchema 2
 
 prop_altersPoliciesWithEscapedQuoteLiterals :: Property.NamedDBProperty
 prop_altersPoliciesWithEscapedQuoteLiterals =
   Property.singletonNamedDBProperty "Distinguishes literals containing escaped quotes by case" $ \pool -> do
     let
-      originalField = Orville.unboundedTextField "name"
-      originalTableDef =
-        Orville.mkTableDefinitionWithoutKey
-          "policy_migration_test"
-          (Orville.marshallField id originalField)
       -- The literals contain an escaped quote ('') followed by a letter that
       -- differs only by case, so a comparison that mishandled the escaped
       -- quote would treat the letter as being outside the literal and fold it
       mkQuotePolicy literal =
-        Orville.mkPolicyDefinition
-          "migration_test_policy"
-          Nothing
-          Nothing
-          Nothing
-          (Just . Expr.policyUsingExpr . RawSql.unsafeSqlExpression $ "(name = '" <> literal <> "'::text)")
-          Nothing
-      tableWithUppercaseLiteral =
-        Orville.addTablePolicies [mkQuotePolicy "it''S"] originalTableDef
-      tableWithLowercaseLiteral =
-        Orville.addTablePolicies [mkQuotePolicy "it''s"] originalTableDef
+        mkRawUsingPolicy ("(name = '" <> literal <> "'::text)")
+      upperSchema =
+        [AutoMigration.SchemaTable (Orville.addTablePolicies [mkQuotePolicy "it''S"] policyTestTableWithName)]
+      lowerSchema =
+        [AutoMigration.SchemaTable (Orville.addTablePolicies [mkQuotePolicy "it''s"] policyTestTableWithName)]
 
-    firstTimePlan <-
-      HH.evalIO $
-        Orville.runOrville pool $ do
-          Orville.executeVoid Orville.DDLQuery $ TestTable.dropTableDefSql originalTableDef
-          AutoMigration.autoMigrateSchema AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithUppercaseLiteral]
-          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithUppercaseLiteral]
+    assertPolicyMigrationConverges
+      pool
+      ( do
+          dropPolicyTestTable
+          autoMigrateTestSchema upperSchema
+      )
+      upperSchema
+      0
 
-    HH.annotate ("First time steps: " <> show (migrationPlanStepStrings firstTimePlan))
-    migrationPlanStepStrings firstTimePlan === []
-
-    alterPlan <-
-      HH.evalIO $
-        Orville.runOrville pool $
-          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithLowercaseLiteral]
-
-    HH.annotate ("Alter steps: " <> show (migrationPlanStepStrings alterPlan))
-    length (AutoMigration.migrationPlanSteps alterPlan) === 1
-
-    secondTimePlan <-
-      HH.evalIO $
-        Orville.runOrville pool $ do
-          AutoMigration.executeMigrationPlan AutoMigration.defaultOptions alterPlan
-          AutoMigration.generateMigrationPlan AutoMigration.defaultOptions [AutoMigration.SchemaTable tableWithLowercaseLiteral]
-
-    HH.annotate ("Second time steps: " <> show (migrationPlanStepStrings secondTimePlan))
-    migrationPlanStepStrings secondTimePlan === []
+    assertPolicyMigrationConverges pool (pure ()) lowerSchema 2
 
 prop_addTablePoliciesAccumulates :: Property.NamedProperty
 prop_addTablePoliciesAccumulates =
@@ -2281,10 +2112,7 @@ prop_addTablePoliciesAccumulates =
               mkNamedPolicy "policy_two" (Just Orville.PolicyRestrictive)
             , mkNamedPolicy "policy_two" Nothing
             ]
-            ( Orville.mkTableDefinitionWithoutKey
-                "policy_migration_test"
-                (Orville.marshallField id (Orville.integerField "column"))
-            )
+            policyTestTable
       policies = Orville.tablePolicies tableDef
 
     Map.keys policies === ["policy_one", "policy_two"]

--- a/orville-postgresql/test/Test/Expr/Policy.hs
+++ b/orville-postgresql/test/Test/Expr/Policy.hs
@@ -3,12 +3,14 @@ module Test.Expr.Policy
   ) where
 
 import qualified Data.List as List
+import Data.List.NonEmpty (NonEmpty ((:|)))
 import qualified Data.Text as T
 import Hedgehog ((===))
 import qualified Hedgehog as HH
 
 import qualified Orville.PostgreSQL as Orville
 import qualified Orville.PostgreSQL.Expr as Expr
+import qualified Orville.PostgreSQL.PgCatalog as PgCatalog
 import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
 
 import qualified Test.Property as Property
@@ -25,7 +27,7 @@ policyTests pool =
 
 prop_createPolicyWithAllClauses :: Property.NamedDBProperty
 prop_createPolicyWithAllClauses =
-  Property.singletonNamedDBProperty "creates a policy with AS, TO, USING and WITH CHECK clauses" $ \pool -> do
+  Property.singletonNamedDBProperty "creates a policy with AS, FOR, TO, USING and WITH CHECK clauses" $ \pool -> do
     let
       createPolicy =
         Expr.createPolicyExpr
@@ -33,7 +35,7 @@ prop_createPolicyWithAllClauses =
           testTableName
           (Just Expr.policyRestrictive)
           (Just Expr.policyCommandUpdate)
-          (Just [Expr.namedPolicyRole "orville_test"])
+          (Just (Expr.namedPolicyRole "orville_test" :| []))
           (Just . Expr.policyUsingExpr $ Expr.literalBooleanExpr True)
           (Just . Expr.policyCheckExpr $ Expr.literalBooleanExpr False)
 
@@ -44,10 +46,10 @@ prop_createPolicyWithAllClauses =
           Orville.executeVoid Orville.DDLQuery createPolicy
           findTestPolicies
 
-    fmap policyRowPolicyName policies === [T.pack "expr_test_policy"]
-    fmap policyRowPermissive policies === [T.pack "RESTRICTIVE"]
-    fmap policyRowCmd policies === [T.pack "UPDATE"]
-    fmap policyRowRoles policies === [T.pack "{orville_test}"]
+    fmap PgCatalog.pgPolicyPolicyName policies === [T.pack "expr_test_policy"]
+    fmap PgCatalog.pgPolicyPermissive policies === [T.pack "RESTRICTIVE"]
+    fmap PgCatalog.pgPolicyCmd policies === [T.pack "UPDATE"]
+    fmap PgCatalog.pgPolicyRoles policies === [[T.pack "orville_test"]]
 
 prop_specialRoleTargets :: Property.NamedDBProperty
 prop_specialRoleTargets =
@@ -59,7 +61,7 @@ prop_specialRoleTargets =
           testTableName
           Nothing
           Nothing
-          (Just [role])
+          (Just (role :| []))
           Nothing
           Nothing
 
@@ -76,14 +78,12 @@ prop_specialRoleTargets =
     -- PostgreSQL resolves CURRENT_ROLE, CURRENT_USER and SESSION_USER to the
     -- concrete role at the time the policy is created. The test suite
     -- connects as "orville_test".
-    fmap policyRowRoles (List.sortOn policyRowPolicyName policies)
-      === fmap
-        T.pack
-        [ "{orville_test}"
-        , "{orville_test}"
-        , "{orville_test}"
-        , "{public}"
-        ]
+    fmap PgCatalog.pgPolicyRoles (List.sortOn PgCatalog.pgPolicyPolicyName policies)
+      === [ [T.pack "orville_test"]
+          , [T.pack "orville_test"]
+          , [T.pack "orville_test"]
+          , [T.pack "public"]
+          ]
 
 prop_alterPolicy :: Property.NamedDBProperty
 prop_alterPolicy =
@@ -95,7 +95,7 @@ prop_alterPolicy =
           testTableName
           Nothing
           Nothing
-          (Just [Expr.namedPolicyRole "orville_test"])
+          (Just (Expr.namedPolicyRole "orville_test" :| []))
           (Just . Expr.policyUsingExpr $ Expr.literalBooleanExpr True)
           Nothing
 
@@ -103,7 +103,7 @@ prop_alterPolicy =
         Expr.alterPolicyExpr
           (Expr.policyName "expr_test_policy")
           testTableName
-          (Just [Expr.publicPolicyRole])
+          (Just (Expr.publicPolicyRole :| []))
           (Just . Expr.policyUsingExpr $ Expr.literalBooleanExpr False)
           (Just . Expr.policyCheckExpr $ Expr.literalBooleanExpr True)
 
@@ -115,7 +115,7 @@ prop_alterPolicy =
           Orville.executeVoid Orville.DDLQuery alterPolicy
           findTestPolicies
 
-    fmap policyRowRoles policies === [T.pack "{public}"]
+    fmap PgCatalog.pgPolicyRoles policies === [[T.pack "public"]]
 
 prop_dropPolicyIfExists :: Property.NamedDBProperty
 prop_dropPolicyIfExists =
@@ -142,7 +142,7 @@ prop_dropPolicyIfExists =
             Expr.dropPolicy Nothing (Expr.policyName "expr_test_policy") testTableName
           findTestPolicies
 
-    fmap policyRowPolicyName policies === []
+    fmap PgCatalog.pgPolicyPolicyName policies === []
 
 testTableName :: Expr.QualifiedOrUnqualified Expr.TableName
 testTableName =
@@ -153,27 +153,7 @@ recreateTestTable = do
   Orville.executeVoid Orville.DDLQuery $ RawSql.fromString "DROP TABLE IF EXISTS expr_policy_test"
   Orville.executeVoid Orville.DDLQuery $ RawSql.fromString "CREATE TABLE expr_policy_test (name TEXT)"
 
-findTestPolicies :: Orville.Orville [PolicyRow]
+findTestPolicies :: Orville.Orville [PgCatalog.PgPolicy]
 findTestPolicies =
-  Orville.findEntitiesBy pgPoliciesTable . Orville.where_ $
-    Orville.fieldEquals (Orville.unboundedTextField "tablename") (T.pack "expr_policy_test")
-
-data PolicyRow = PolicyRow
-  { policyRowPolicyName :: T.Text
-  , policyRowPermissive :: T.Text
-  , policyRowCmd :: T.Text
-  , policyRowRoles :: T.Text
-  }
-
-pgPoliciesTable :: Orville.TableDefinition Orville.NoKey PolicyRow PolicyRow
-pgPoliciesTable =
-  Orville.setTableSchema "pg_catalog" $
-    Orville.mkTableDefinitionWithoutKey "pg_policies" policyRowMarshaller
-
-policyRowMarshaller :: Orville.SqlMarshaller w PolicyRow
-policyRowMarshaller =
-  PolicyRow
-    <$> Orville.marshallReadOnlyField (Orville.unboundedTextField "policyname")
-    <*> Orville.marshallReadOnlyField (Orville.unboundedTextField "permissive")
-    <*> Orville.marshallReadOnlyField (Orville.unboundedTextField "cmd")
-    <*> Orville.marshallReadOnlyField (Orville.unboundedTextField "roles")
+  Orville.findEntitiesBy PgCatalog.pgPoliciesTable . Orville.where_ $
+    Orville.fieldEquals PgCatalog.pgPolicyTableNameField (T.pack "expr_policy_test")

--- a/orville-postgresql/test/Test/Expr/Policy.hs
+++ b/orville-postgresql/test/Test/Expr/Policy.hs
@@ -1,0 +1,179 @@
+module Test.Expr.Policy
+  ( policyTests
+  ) where
+
+import qualified Data.List as List
+import qualified Data.Text as T
+import Hedgehog ((===))
+import qualified Hedgehog as HH
+
+import qualified Orville.PostgreSQL as Orville
+import qualified Orville.PostgreSQL.Expr as Expr
+import qualified Orville.PostgreSQL.Raw.RawSql as RawSql
+
+import qualified Test.Property as Property
+
+policyTests :: Orville.ConnectionPool -> Property.Group
+policyTests pool =
+  Property.group
+    "Expr - Policy"
+    [ prop_createPolicyWithAllClauses pool
+    , prop_specialRoleTargets pool
+    , prop_alterPolicy pool
+    , prop_dropPolicyIfExists pool
+    ]
+
+prop_createPolicyWithAllClauses :: Property.NamedDBProperty
+prop_createPolicyWithAllClauses =
+  Property.singletonNamedDBProperty "creates a policy with AS, TO, USING and WITH CHECK clauses" $ \pool -> do
+    let
+      createPolicy =
+        Expr.createPolicyExpr
+          (Expr.policyName "expr_test_policy")
+          testTableName
+          (Just Expr.policyRestrictive)
+          (Just Expr.policyCommandUpdate)
+          (Just [Expr.namedPolicyRole "orville_test"])
+          (Just . Expr.policyUsingExpr $ Expr.literalBooleanExpr True)
+          (Just . Expr.policyCheckExpr $ Expr.literalBooleanExpr False)
+
+    policies <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          recreateTestTable
+          Orville.executeVoid Orville.DDLQuery createPolicy
+          findTestPolicies
+
+    fmap policyRowPolicyName policies === [T.pack "expr_test_policy"]
+    fmap policyRowPermissive policies === [T.pack "RESTRICTIVE"]
+    fmap policyRowCmd policies === [T.pack "UPDATE"]
+    fmap policyRowRoles policies === [T.pack "{orville_test}"]
+
+prop_specialRoleTargets :: Property.NamedDBProperty
+prop_specialRoleTargets =
+  Property.singletonNamedDBProperty "creates policies with the special role targets" $ \pool -> do
+    let
+      mkPolicy name role =
+        Expr.createPolicyExpr
+          (Expr.policyName name)
+          testTableName
+          Nothing
+          Nothing
+          (Just [role])
+          Nothing
+          Nothing
+
+    policies <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          recreateTestTable
+          Orville.executeVoid Orville.DDLQuery $ mkPolicy "policy_a_current_role" Expr.currentRolePolicyRole
+          Orville.executeVoid Orville.DDLQuery $ mkPolicy "policy_b_current_user" Expr.currentUserPolicyRole
+          Orville.executeVoid Orville.DDLQuery $ mkPolicy "policy_c_session_user" Expr.sessionUserPolicyRole
+          Orville.executeVoid Orville.DDLQuery $ mkPolicy "policy_d_public" Expr.publicPolicyRole
+          findTestPolicies
+
+    -- PostgreSQL resolves CURRENT_ROLE, CURRENT_USER and SESSION_USER to the
+    -- concrete role at the time the policy is created. The test suite
+    -- connects as "orville_test".
+    fmap policyRowRoles (List.sortOn policyRowPolicyName policies)
+      === fmap
+        T.pack
+        [ "{orville_test}"
+        , "{orville_test}"
+        , "{orville_test}"
+        , "{public}"
+        ]
+
+prop_alterPolicy :: Property.NamedDBProperty
+prop_alterPolicy =
+  Property.singletonNamedDBProperty "alters the roles and expressions of a policy" $ \pool -> do
+    let
+      createPolicy =
+        Expr.createPolicyExpr
+          (Expr.policyName "expr_test_policy")
+          testTableName
+          Nothing
+          Nothing
+          (Just [Expr.namedPolicyRole "orville_test"])
+          (Just . Expr.policyUsingExpr $ Expr.literalBooleanExpr True)
+          Nothing
+
+      alterPolicy =
+        Expr.alterPolicyExpr
+          (Expr.policyName "expr_test_policy")
+          testTableName
+          (Just [Expr.publicPolicyRole])
+          (Just . Expr.policyUsingExpr $ Expr.literalBooleanExpr False)
+          (Just . Expr.policyCheckExpr $ Expr.literalBooleanExpr True)
+
+    policies <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          recreateTestTable
+          Orville.executeVoid Orville.DDLQuery createPolicy
+          Orville.executeVoid Orville.DDLQuery alterPolicy
+          findTestPolicies
+
+    fmap policyRowRoles policies === [T.pack "{public}"]
+
+prop_dropPolicyIfExists :: Property.NamedDBProperty
+prop_dropPolicyIfExists =
+  Property.singletonNamedDBProperty "drops policies, tolerating missing ones with IF EXISTS" $ \pool -> do
+    let
+      createPolicy =
+        Expr.createPolicyExpr
+          (Expr.policyName "expr_test_policy")
+          testTableName
+          Nothing
+          Nothing
+          Nothing
+          Nothing
+          Nothing
+
+    policies <-
+      HH.evalIO $
+        Orville.runOrville pool $ do
+          recreateTestTable
+          Orville.executeVoid Orville.DDLQuery $
+            Expr.dropPolicy (Just Expr.ifExists) (Expr.policyName "nonexistent_policy") testTableName
+          Orville.executeVoid Orville.DDLQuery createPolicy
+          Orville.executeVoid Orville.DDLQuery $
+            Expr.dropPolicy Nothing (Expr.policyName "expr_test_policy") testTableName
+          findTestPolicies
+
+    fmap policyRowPolicyName policies === []
+
+testTableName :: Expr.QualifiedOrUnqualified Expr.TableName
+testTableName =
+  Expr.unqualified (Expr.tableName "expr_policy_test")
+
+recreateTestTable :: Orville.Orville ()
+recreateTestTable = do
+  Orville.executeVoid Orville.DDLQuery $ RawSql.fromString "DROP TABLE IF EXISTS expr_policy_test"
+  Orville.executeVoid Orville.DDLQuery $ RawSql.fromString "CREATE TABLE expr_policy_test (name TEXT)"
+
+findTestPolicies :: Orville.Orville [PolicyRow]
+findTestPolicies =
+  Orville.findEntitiesBy pgPoliciesTable . Orville.where_ $
+    Orville.fieldEquals (Orville.unboundedTextField "tablename") (T.pack "expr_policy_test")
+
+data PolicyRow = PolicyRow
+  { policyRowPolicyName :: T.Text
+  , policyRowPermissive :: T.Text
+  , policyRowCmd :: T.Text
+  , policyRowRoles :: T.Text
+  }
+
+pgPoliciesTable :: Orville.TableDefinition Orville.NoKey PolicyRow PolicyRow
+pgPoliciesTable =
+  Orville.setTableSchema "pg_catalog" $
+    Orville.mkTableDefinitionWithoutKey "pg_policies" policyRowMarshaller
+
+policyRowMarshaller :: Orville.SqlMarshaller w PolicyRow
+policyRowMarshaller =
+  PolicyRow
+    <$> Orville.marshallReadOnlyField (Orville.unboundedTextField "policyname")
+    <*> Orville.marshallReadOnlyField (Orville.unboundedTextField "permissive")
+    <*> Orville.marshallReadOnlyField (Orville.unboundedTextField "cmd")
+    <*> Orville.marshallReadOnlyField (Orville.unboundedTextField "roles")

--- a/orville-postgresql/test/Test/Expr/Policy.hs
+++ b/orville-postgresql/test/Test/Expr/Policy.hs
@@ -47,8 +47,8 @@ prop_createPolicyWithAllClauses =
           findTestPolicies
 
     fmap PgCatalog.pgPolicyPolicyName policies === [T.pack "expr_test_policy"]
-    fmap PgCatalog.pgPolicyPermissive policies === [T.pack "RESTRICTIVE"]
-    fmap PgCatalog.pgPolicyCmd policies === [T.pack "UPDATE"]
+    fmap PgCatalog.pgPolicyPermissive policies === [Orville.PolicyRestrictive]
+    fmap PgCatalog.pgPolicyCmd policies === [Orville.PolicyCommandUpdate]
     fmap PgCatalog.pgPolicyRoles policies === [[T.pack "orville_test"]]
 
 prop_specialRoleTargets :: Property.NamedDBProperty


### PR DESCRIPTION
This commit adds support for adding and dropping polciies from a table. Additionally, you can set an attribute on tables to enable row-level security.