### PR TITLE
Add MonadMask to deriving list of Orville monad

### DIFF
--- a/orville-postgresql/orville-postgresql.cabal
+++ b/orville-postgresql/orville-postgresql.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           orville-postgresql
-version:        1.1.1.0.2
+version:        1.1.1.0.3
 synopsis:       A Haskell library for PostgreSQL
 description:    Orville's goal is to provide a powerful API for applications to access PostgreSQL databases with minimal use of sophisticated language techniques or extensions. See https://github.com/flipstone/orville for more details.
 category:       database, library, postgresql

--- a/orville-postgresql/package.yaml
+++ b/orville-postgresql/package.yaml
@@ -1,6 +1,6 @@
 ---
 name: orville-postgresql
-version: '1.1.1.0.2' # Development version, breaking changes included, release scheduled to be 1.2.0.0
+version: '1.1.1.0.3' # Development version, breaking changes included, release scheduled to be 1.2.0.0
 synopsis: A Haskell library for PostgreSQL
 description:
   Orville's goal is to provide a powerful API for applications to access

--- a/orville-postgresql/src/Orville/PostgreSQL/Monad/Orville.hs
+++ b/orville-postgresql/src/Orville/PostgreSQL/Monad/Orville.hs
@@ -46,6 +46,8 @@ newtype Orville a = Orville
     , HasOrvilleState.HasOrvilleState
     , ExSafe.MonadThrow
     , ExSafe.MonadCatch
+    , -- | @since 1.2.0.0
+      ExSafe.MonadMask
     )
 
 {- | Runs an 'Orville' operation in the 'IO' monad using the given connection


### PR DESCRIPTION
This adds MonadMask to the deriving clause of the Orville monad. This makes it more conveniant to use `finally` when using this monad.